### PR TITLE
Fix GitHub Actions pytest import path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,10 +6,12 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    env:
+      PYTHONPATH: .
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
           python-version: "3.11"
-      - run: pip install -e .[dev]
-      - run: pytest -q
+      - run: python -m pip install -e '.[dev]'
+      - run: python -m pytest -q


### PR DESCRIPTION
## Summary
- set PYTHONPATH=. for the test job so tests can import src.* modules
- switch CI commands to python -m pip and python -m pytest

## Validation
- source .venv/bin/activate && PYTHONPATH=. python -m pytest -q