### PR TITLE
Implement partition replay backfill through run_pipeline

### DIFF
--- a/src/orchestration/backfill.py
+++ b/src/orchestration/backfill.py
@@ -1,2 +1,108 @@
-def run_backfill(start_date: str, end_date: str) -> None:
-    print(f"Backfilling from {start_date} to {end_date}")
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from typing import Any
+
+import duckdb
+
+from ..storage.partitioning import partition_path
+from ..storage.storage_config import load_storage_config
+from .run_pipeline import run_pipeline
+
+_HOURLY_WINDOW_ALIASES = {"hourly", "hour", "1h"}
+_DEFAULT_THRESHOLDS_PATH = Path("config/risk_thresholds.yaml")
+_DEFAULT_STORAGE_CONFIG_PATH = Path("config/storage.yaml")
+_REPLAY_COLUMNS = ["event_id", "symbol", "price", "volume", "ts_event", "ts_ingest", "source"]
+
+
+def _parse_datetime(value: str) -> datetime:
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise ValueError(f"Invalid datetime '{value}'. Use ISO-8601 format.") from exc
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed
+
+
+def _window_delta(window: str) -> timedelta:
+    if window.strip().lower() not in _HOURLY_WINDOW_ALIASES:
+        raise ValueError("Unsupported window. Use 'hourly'.")
+    return timedelta(hours=1)
+
+
+def _load_partition_records(partition_dir: Path) -> list[dict[str, Any]]:
+    parquet_files = sorted(partition_dir.glob("*.parquet"))
+    if not parquet_files:
+        return []
+
+    escaped_paths = [str(path).replace("'", "''") for path in parquet_files]
+    quoted_paths = ", ".join(f"'{path}'" for path in escaped_paths)
+    select_list = ", ".join(_REPLAY_COLUMNS)
+    with duckdb.connect() as conn:
+        df = conn.execute(
+            "SELECT "
+            f"{select_list} "
+            f"FROM read_parquet([{quoted_paths}], union_by_name=true) "
+            "ORDER BY ts_ingest, event_id"
+        ).df()
+    return json.loads(df.to_json(orient="records", date_format="iso"))
+
+
+def run_backfill(
+    start_date: str,
+    end_date: str,
+    window: str,
+    *,
+    thresholds_path: Path = _DEFAULT_THRESHOLDS_PATH,
+    late_seconds: int = 300,
+    window_minutes: int = 5,
+    vol_window: int = 5,
+    storage_config_path: Path = _DEFAULT_STORAGE_CONFIG_PATH,
+) -> list[dict[str, Any]]:
+    start_ts = _parse_datetime(start_date)
+    end_ts = _parse_datetime(end_date)
+    if end_ts < start_ts:
+        raise ValueError("end_date must be greater than or equal to start_date")
+
+    step = _window_delta(window)
+    current = start_ts.replace(minute=0, second=0, microsecond=0)
+
+    storage = load_storage_config(storage_config_path)["storage"]
+    raw_dataset_dir = Path(storage["raw"]["base_path"]) / storage["raw"]["dataset"]
+
+    replay_summaries: list[dict[str, Any]] = []
+    with TemporaryDirectory(prefix="backfill_") as tmp_dir:
+        while current <= end_ts:
+            partition = partition_path(current)
+            records = _load_partition_records(raw_dataset_dir / partition)
+
+            if records:
+                input_path = Path(tmp_dir) / f"{current.strftime('%Y%m%dT%H%M%SZ')}.json"
+                with input_path.open("w", encoding="utf-8") as handle:
+                    json.dump(records, handle)
+
+                summary = run_pipeline(
+                    input_path=input_path,
+                    thresholds_path=thresholds_path,
+                    late_seconds=late_seconds,
+                    window_minutes=window_minutes,
+                    vol_window=vol_window,
+                    storage_config_path=storage_config_path,
+                )
+                replay_summaries.append(
+                    {
+                        "partition": partition,
+                        "window_start": current.isoformat(),
+                        "window": window,
+                        "records_replayed": len(records),
+                        **summary,
+                    }
+                )
+
+            current += step
+
+    return replay_summaries

--- a/tests/integration/test_backfill.py
+++ b/tests/integration/test_backfill.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+
+import yaml
+
+from src.orchestration.backfill import run_backfill
+from src.storage.s3_writer import write_records
+
+
+def _build_storage_config(tmp_path: Path) -> dict:
+    return {
+        "storage": {
+            "base_dir": str(tmp_path),
+            "raw": {
+                "base_path": str(tmp_path / "raw"),
+                "dataset": "market_events",
+            },
+            "curated": {
+                "base_path": str(tmp_path / "curated"),
+                "datasets": {
+                    "returns_1m": "returns_1m",
+                    "volatility_5m": "volatility_5m",
+                    "data_quality_metrics": "data_quality_metrics",
+                    "risk_summary": "risk_summary",
+                },
+            },
+            "format": "parquet",
+            "partitioning": {
+                "granularity": "hourly",
+            },
+        }
+    }
+
+
+def _seed_raw_partitions(storage_config: dict) -> None:
+    records = [
+        {
+            "event_id": "evt-1",
+            "symbol": "AAPL",
+            "price": 100.0,
+            "volume": 10,
+            "ts_event": datetime(2025, 1, 20, 10, 1, tzinfo=timezone.utc),
+            "ts_ingest": datetime(2025, 1, 20, 10, 1, tzinfo=timezone.utc),
+            "source": "stooq",
+        },
+        {
+            "event_id": "evt-2",
+            "symbol": "AAPL",
+            "price": 101.0,
+            "volume": 11,
+            "ts_event": datetime(2025, 1, 20, 10, 2, tzinfo=timezone.utc),
+            "ts_ingest": datetime(2025, 1, 20, 10, 2, tzinfo=timezone.utc),
+            "source": "stooq",
+        },
+        {
+            "event_id": "evt-3",
+            "symbol": "AAPL",
+            "price": 102.0,
+            "volume": 12,
+            "ts_event": datetime(2025, 1, 20, 10, 3, tzinfo=timezone.utc),
+            "ts_ingest": datetime(2025, 1, 20, 10, 3, tzinfo=timezone.utc),
+            "source": "stooq",
+        },
+        {
+            "event_id": "evt-4",
+            "symbol": "MSFT",
+            "price": 240.0,
+            "volume": 9,
+            "ts_event": datetime(2025, 1, 20, 11, 1, tzinfo=timezone.utc),
+            "ts_ingest": datetime(2025, 1, 20, 11, 1, tzinfo=timezone.utc),
+            "source": "stooq",
+        },
+        {
+            "event_id": "evt-5",
+            "symbol": "MSFT",
+            "price": 242.0,
+            "volume": 10,
+            "ts_event": datetime(2025, 1, 20, 11, 2, tzinfo=timezone.utc),
+            "ts_ingest": datetime(2025, 1, 20, 11, 2, tzinfo=timezone.utc),
+            "source": "stooq",
+        },
+        {
+            "event_id": "evt-6",
+            "symbol": "MSFT",
+            "price": 241.0,
+            "volume": 8,
+            "ts_event": datetime(2025, 1, 20, 11, 3, tzinfo=timezone.utc),
+            "ts_ingest": datetime(2025, 1, 20, 11, 3, tzinfo=timezone.utc),
+            "source": "stooq",
+        },
+    ]
+    write_records(records, kind="raw", storage_config=storage_config)
+
+
+def test_run_backfill_replays_hourly_partitions_and_is_idempotent(tmp_path: Path) -> None:
+    storage_config = _build_storage_config(tmp_path)
+    storage_config_path = tmp_path / "storage.yaml"
+    with storage_config_path.open("w", encoding="utf-8") as handle:
+        yaml.safe_dump(storage_config, handle, sort_keys=False)
+
+    _seed_raw_partitions(storage_config)
+
+    first = run_backfill(
+        "2025-01-20T10:00:00Z",
+        "2025-01-20T11:00:00Z",
+        "hourly",
+        storage_config_path=storage_config_path,
+        thresholds_path=Path("config/risk_thresholds.yaml"),
+        vol_window=2,
+    )
+    assert len(first) == 2
+    assert {summary["partition"] for summary in first} == {
+        "year=2025/month=01/day=20/hour=10",
+        "year=2025/month=01/day=20/hour=11",
+    }
+    assert all(summary["records_replayed"] == 3 for summary in first)
+    assert all(summary["raw_events"] == 0 for summary in first)
+    assert all(summary["curated_records"] > 0 for summary in first)
+
+    second = run_backfill(
+        "2025-01-20T10:00:00Z",
+        "2025-01-20T11:00:00Z",
+        "hourly",
+        storage_config_path=storage_config_path,
+        thresholds_path=Path("config/risk_thresholds.yaml"),
+        vol_window=2,
+    )
+    assert len(second) == 2
+    assert all(summary["raw_events"] == 0 for summary in second)
+    assert all(summary["curated_records"] == 0 for summary in second)


### PR DESCRIPTION
## Summary
- implement backfill replay loop that walks hourly partitions between start/end and replays each partition through run_pipeline
- load partition parquet input with schema projection and union_by_name for robust replay
- add integration test covering hourly replay and rerun idempotency
- keep raw writes schema-stable by computing window_start in the analytics dataframe only

## Validation
- PYTHONPATH=. .venv/bin/pytest -q