### PR TITLE
add required field data quality checks

### DIFF
--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -20,3 +20,17 @@
 2. volatility_5m
 3. data_quality_metrics
 4. risk_summary
+
+## Data Quality Metrics
+
+`data_quality_metrics` includes required-field validation evidence for each pipeline run:
+
+```json
+{
+  "required_fields_checked": 7,
+  "missing_required_field_count": 0,
+  "missing_required_record_count": 0,
+  "missing_required_fields_by_name": "{\"event_id\": 0, \"price\": 0, \"source\": 0, \"symbol\": 0, \"ts_event\": 0, \"ts_ingest\": 0, \"volume\": 0}",
+  "required_fields_status": "ok"
+}
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,3 +25,4 @@ line-length = 100
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+pythonpath = ["."]

--- a/sql/data_quality_checks.sql
+++ b/sql/data_quality_checks.sql
@@ -1,2 +1,11 @@
 -- Example data quality checks
--- SELECT COUNT(*) FROM raw_events WHERE ts_event IS NULL;
+-- Required-field validation status emitted by the pipeline.
+SELECT
+  ts_ingest,
+  required_fields_status,
+  required_fields_checked,
+  missing_required_field_count,
+  missing_required_record_count,
+  missing_required_fields_by_name
+FROM data_quality_metrics
+WHERE required_fields_status <> 'ok';

--- a/src/analytics/data_quality.py
+++ b/src/analytics/data_quality.py
@@ -1,4 +1,30 @@
+from __future__ import annotations
+
+from typing import Any
+
+
 def late_rate(late_count: int, total: int) -> float:
     if total == 0:
         return 0.0
     return late_count / total
+
+
+def required_field_metrics(
+    records: list[dict[str, Any]],
+    required_fields: list[str],
+) -> dict[str, Any]:
+    missing_by_field = {
+        field: sum(1 for record in records if field not in record) for field in required_fields
+    }
+    failed_record_count = sum(
+        1 for record in records if any(field not in record for field in required_fields)
+    )
+    missing_field_count = sum(missing_by_field.values())
+
+    return {
+        "required_fields_checked": len(required_fields),
+        "missing_by_field": missing_by_field,
+        "missing_field_count": missing_field_count,
+        "failed_record_count": failed_record_count,
+        "status": "critical" if failed_record_count else "ok",
+    }

--- a/src/orchestration/run_pipeline.py
+++ b/src/orchestration/run_pipeline.py
@@ -8,11 +8,12 @@ from typing import Any
 
 import pandas as pd
 
-from ..analytics.data_quality import late_rate
+from ..analytics.data_quality import late_rate, required_field_metrics
 from ..analytics.risk_metrics import value_at_risk
 from ..analytics.returns import compute_returns
 from ..analytics.volatility import rolling_volatility
 from ..common.config import load_yaml
+from ..common.exceptions import ValidationError
 from ..ingestion.schemas import MarketEvent
 from ..processing.deduplicator import dedupe_events
 from ..processing.normaliser import normalize_symbol
@@ -178,6 +179,18 @@ def run_pipeline(
     raw_payloads = _load_input(input_path)
     storage_config = load_storage_config(storage_config_path)
 
+    required_field_quality = required_field_metrics(raw_payloads, REQUIRED_FIELDS)
+    if required_field_quality["failed_record_count"]:
+        missing_by_field = {
+            field: count
+            for field, count in required_field_quality["missing_by_field"].items()
+            if count
+        }
+        raise ValidationError(
+            "Missing required fields in "
+            f"{required_field_quality['failed_record_count']} records: {missing_by_field}"
+        )
+
     validated = [_validate_and_normalize(payload) for payload in raw_payloads]
     deduped = dedupe_events(validated, key="event_id")
 
@@ -259,6 +272,14 @@ def run_pipeline(
             "late_events": late_count,
             "late_rate": late_rate_value,
             "duplicate_rate": duplicate_rate,
+            "required_fields_checked": required_field_quality["required_fields_checked"],
+            "missing_required_field_count": required_field_quality["missing_field_count"],
+            "missing_required_record_count": required_field_quality["failed_record_count"],
+            "missing_required_fields_by_name": json.dumps(
+                required_field_quality["missing_by_field"],
+                sort_keys=True,
+            ),
+            "required_fields_status": required_field_quality["status"],
             "late_status": late_status,
             "duplicate_status": duplicate_status,
             "ts_ingest": metric_ts,
@@ -333,6 +354,9 @@ def run_pipeline(
         "partitions": partitions,
         "late_rate": late_rate_value,
         "duplicate_rate": duplicate_rate,
+        "required_fields_status": required_field_quality["status"],
+        "missing_required_field_count": required_field_quality["missing_field_count"],
+        "missing_required_record_count": required_field_quality["failed_record_count"],
         "volatility_latest": volatility_latest,
         "value_at_risk": var_latest,
         "volatility_status": volatility_status,

--- a/tests/integration/test_run_pipeline_curated.py
+++ b/tests/integration/test_run_pipeline_curated.py
@@ -8,7 +8,7 @@ import duckdb
 import pytest
 import yaml
 
-from src.common.exceptions import OverlapError
+from src.common.exceptions import OverlapError, ValidationError
 from src.orchestration.locks import acquire_partition_locks, release_partition_locks
 from src.orchestration.run_pipeline import run_pipeline
 
@@ -21,6 +21,14 @@ def _count_parquet_rows(dataset_dir: Path) -> int:
     quoted = ", ".join(f"'{path}'" for path in escaped_paths)
     with duckdb.connect() as conn:
         return int(conn.execute(f"SELECT COUNT(*) FROM read_parquet([{quoted}])").fetchone()[0])
+
+
+def _read_parquet_rows(dataset_dir: Path) -> list[dict]:
+    parquet_files = sorted(dataset_dir.rglob("*.parquet"))
+    escaped_paths = [str(path).replace("'", "''") for path in parquet_files]
+    quoted = ", ".join(f"'{path}'" for path in escaped_paths)
+    with duckdb.connect() as conn:
+        return conn.execute(f"SELECT * FROM read_parquet([{quoted}])").df().to_dict("records")
 
 
 def test_run_pipeline_materializes_all_curated_datasets(tmp_path: Path) -> None:
@@ -136,6 +144,9 @@ def test_run_pipeline_materializes_all_curated_datasets(tmp_path: Path) -> None:
         "risk_summary": 2,
     }
     assert summary["curated_records"] == 9
+    assert summary["required_fields_status"] == "ok"
+    assert summary["missing_required_field_count"] == 0
+    assert summary["missing_required_record_count"] == 0
     assert set(summary["volatility_latest"]) == {"AAPL", "MSFT"}
     assert set(summary["value_at_risk"]) == {"AAPL", "MSFT"}
 
@@ -143,6 +154,73 @@ def test_run_pipeline_materializes_all_curated_datasets(tmp_path: Path) -> None:
     assert _count_parquet_rows(tmp_path / "curated" / "volatility_5m") == 2
     assert _count_parquet_rows(tmp_path / "curated" / "data_quality_metrics") == 1
     assert _count_parquet_rows(tmp_path / "curated" / "risk_summary") == 2
+
+    data_quality_rows = _read_parquet_rows(tmp_path / "curated" / "data_quality_metrics")
+    assert data_quality_rows[0]["required_fields_status"] == "ok"
+    assert data_quality_rows[0]["required_fields_checked"] == 7
+    assert data_quality_rows[0]["missing_required_field_count"] == 0
+    assert data_quality_rows[0]["missing_required_record_count"] == 0
+
+
+def test_run_pipeline_rejects_missing_required_fields(tmp_path: Path) -> None:
+    storage_config = {
+        "storage": {
+            "base_dir": str(tmp_path),
+            "raw": {
+                "base_path": str(tmp_path / "raw"),
+                "dataset": "market_events",
+            },
+            "curated": {
+                "base_path": str(tmp_path / "curated"),
+                "datasets": {
+                    "returns_1m": "returns_1m",
+                    "volatility_5m": "volatility_5m",
+                    "data_quality_metrics": "data_quality_metrics",
+                    "risk_summary": "risk_summary",
+                },
+            },
+            "format": "parquet",
+            "partitioning": {
+                "granularity": "hourly",
+            },
+        }
+    }
+    storage_config_path = tmp_path / "storage.yaml"
+    with storage_config_path.open("w", encoding="utf-8") as handle:
+        yaml.safe_dump(storage_config, handle, sort_keys=False)
+
+    events = [
+        {
+            "event_id": "evt-1",
+            "symbol": "AAPL",
+            "price": 100.0,
+            "volume": 10,
+            "ts_event": "2025-01-20T10:01:00Z",
+            "ts_ingest": "2025-01-20T10:01:05Z",
+            "source": "stooq",
+        },
+        {
+            "event_id": "evt-2",
+            "symbol": "AAPL",
+            "price": 101.0,
+            "volume": 11,
+            "ts_event": "2025-01-20T10:02:00Z",
+            "ts_ingest": "2025-01-20T10:02:04Z",
+        },
+    ]
+    input_path = tmp_path / "events.json"
+    with input_path.open("w", encoding="utf-8") as handle:
+        json.dump(events, handle)
+
+    with pytest.raises(ValidationError, match="Missing required fields in 1 records"):
+        run_pipeline(
+            input_path=input_path,
+            thresholds_path=Path("config/risk_thresholds.yaml"),
+            late_seconds=60,
+            window_minutes=5,
+            vol_window=2,
+            storage_config_path=storage_config_path,
+        )
 
 
 def test_run_pipeline_blocks_when_partition_is_locked(tmp_path: Path) -> None:

--- a/tests/unit/test_data_quality.py
+++ b/tests/unit/test_data_quality.py
@@ -1,0 +1,27 @@
+from src.analytics.data_quality import late_rate, required_field_metrics
+
+
+def test_late_rate_handles_empty_total() -> None:
+    assert late_rate(3, 0) == 0.0
+
+
+def test_required_field_metrics_counts_missing_fields_by_record() -> None:
+    records = [
+        {"event_id": "evt-1", "symbol": "AAPL", "price": 100.0},
+        {"event_id": "evt-2", "price": 101.0},
+        {"symbol": "MSFT", "price": 240.0},
+    ]
+
+    result = required_field_metrics(records, ["event_id", "symbol", "price"])
+
+    assert result == {
+        "required_fields_checked": 3,
+        "missing_by_field": {
+            "event_id": 1,
+            "symbol": 1,
+            "price": 0,
+        },
+        "missing_field_count": 2,
+        "failed_record_count": 2,
+        "status": "critical",
+    }


### PR DESCRIPTION
## Summary

Adds the first data-quality increment for required market-event fields.

## Changes

- Adds a reusable required-field metrics helper.
- Runs required-field checks before pipeline normalization and raises an aggregated validation error for malformed inputs.
- Emits required-field status and missing-field counts into the pipeline summary and `data_quality_metrics` curated output.
- Adds SQL/docs examples for required-field validation evidence.
- Configures pytest so the documented `pytest -q` command can import the local `src` package.

## Validation

- `.venv/bin/ruff check .`
- `.venv/bin/pytest -q`