### PR TITLE
add null rate data quality checks

### DIFF
--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -23,7 +23,7 @@
 
 ## Data Quality Metrics
 
-`data_quality_metrics` includes required-field validation evidence for each pipeline run:
+`data_quality_metrics` includes required-field and null-rate validation evidence for each pipeline run:
 
 ```json
 {
@@ -31,6 +31,13 @@
   "missing_required_field_count": 0,
   "missing_required_record_count": 0,
   "missing_required_fields_by_name": "{\"event_id\": 0, \"price\": 0, \"source\": 0, \"symbol\": 0, \"ts_event\": 0, \"ts_ingest\": 0, \"volume\": 0}",
-  "required_fields_status": "ok"
+  "required_fields_status": "ok",
+  "null_fields_checked": 7,
+  "null_field_count": 0,
+  "null_record_count": 0,
+  "max_null_rate": 0.0,
+  "null_fields_by_name": "{\"event_id\": 0, \"price\": 0, \"source\": 0, \"symbol\": 0, \"ts_event\": 0, \"ts_ingest\": 0, \"volume\": 0}",
+  "null_rates_by_name": "{\"event_id\": 0.0, \"price\": 0.0, \"source\": 0.0, \"symbol\": 0.0, \"ts_event\": 0.0, \"ts_ingest\": 0.0, \"volume\": 0.0}",
+  "null_rate_status": "ok"
 }
 ```

--- a/sql/data_quality_checks.sql
+++ b/sql/data_quality_checks.sql
@@ -6,6 +6,14 @@ SELECT
   required_fields_checked,
   missing_required_field_count,
   missing_required_record_count,
-  missing_required_fields_by_name
+  missing_required_fields_by_name,
+  null_rate_status,
+  null_fields_checked,
+  null_field_count,
+  null_record_count,
+  max_null_rate,
+  null_fields_by_name,
+  null_rates_by_name
 FROM data_quality_metrics
-WHERE required_fields_status <> 'ok';
+WHERE required_fields_status <> 'ok'
+  OR null_rate_status <> 'ok';

--- a/src/analytics/data_quality.py
+++ b/src/analytics/data_quality.py
@@ -28,3 +28,32 @@ def required_field_metrics(
         "failed_record_count": failed_record_count,
         "status": "critical" if failed_record_count else "ok",
     }
+
+
+def null_field_metrics(
+    records: list[dict[str, Any]],
+    fields: list[str],
+) -> dict[str, Any]:
+    total_records = len(records)
+    nulls_by_field = {
+        field: sum(1 for record in records if field in record and record[field] is None)
+        for field in fields
+    }
+    null_rates_by_field = {
+        field: 0.0 if total_records == 0 else count / total_records
+        for field, count in nulls_by_field.items()
+    }
+    failed_record_count = sum(
+        1 for record in records if any(field in record and record[field] is None for field in fields)
+    )
+    null_field_count = sum(nulls_by_field.values())
+
+    return {
+        "fields_checked": len(fields),
+        "nulls_by_field": nulls_by_field,
+        "null_rates_by_field": null_rates_by_field,
+        "null_field_count": null_field_count,
+        "failed_record_count": failed_record_count,
+        "max_null_rate": max(null_rates_by_field.values(), default=0.0),
+        "status": "critical" if failed_record_count else "ok",
+    }

--- a/src/orchestration/run_pipeline.py
+++ b/src/orchestration/run_pipeline.py
@@ -8,7 +8,7 @@ from typing import Any
 
 import pandas as pd
 
-from ..analytics.data_quality import late_rate, required_field_metrics
+from ..analytics.data_quality import late_rate, null_field_metrics, required_field_metrics
 from ..analytics.risk_metrics import value_at_risk
 from ..analytics.returns import compute_returns
 from ..analytics.volatility import rolling_volatility
@@ -191,6 +191,16 @@ def run_pipeline(
             f"{required_field_quality['failed_record_count']} records: {missing_by_field}"
         )
 
+    null_field_quality = null_field_metrics(raw_payloads, REQUIRED_FIELDS)
+    if null_field_quality["failed_record_count"]:
+        nulls_by_field = {
+            field: count for field, count in null_field_quality["nulls_by_field"].items() if count
+        }
+        raise ValidationError(
+            "Null required field values in "
+            f"{null_field_quality['failed_record_count']} records: {nulls_by_field}"
+        )
+
     validated = [_validate_and_normalize(payload) for payload in raw_payloads]
     deduped = dedupe_events(validated, key="event_id")
 
@@ -280,6 +290,19 @@ def run_pipeline(
                 sort_keys=True,
             ),
             "required_fields_status": required_field_quality["status"],
+            "null_fields_checked": null_field_quality["fields_checked"],
+            "null_field_count": null_field_quality["null_field_count"],
+            "null_record_count": null_field_quality["failed_record_count"],
+            "max_null_rate": null_field_quality["max_null_rate"],
+            "null_fields_by_name": json.dumps(
+                null_field_quality["nulls_by_field"],
+                sort_keys=True,
+            ),
+            "null_rates_by_name": json.dumps(
+                null_field_quality["null_rates_by_field"],
+                sort_keys=True,
+            ),
+            "null_rate_status": null_field_quality["status"],
             "late_status": late_status,
             "duplicate_status": duplicate_status,
             "ts_ingest": metric_ts,
@@ -357,6 +380,10 @@ def run_pipeline(
         "required_fields_status": required_field_quality["status"],
         "missing_required_field_count": required_field_quality["missing_field_count"],
         "missing_required_record_count": required_field_quality["failed_record_count"],
+        "null_rate_status": null_field_quality["status"],
+        "null_field_count": null_field_quality["null_field_count"],
+        "null_record_count": null_field_quality["failed_record_count"],
+        "max_null_rate": null_field_quality["max_null_rate"],
         "volatility_latest": volatility_latest,
         "value_at_risk": var_latest,
         "volatility_status": volatility_status,

--- a/tests/integration/test_run_pipeline_curated.py
+++ b/tests/integration/test_run_pipeline_curated.py
@@ -147,6 +147,10 @@ def test_run_pipeline_materializes_all_curated_datasets(tmp_path: Path) -> None:
     assert summary["required_fields_status"] == "ok"
     assert summary["missing_required_field_count"] == 0
     assert summary["missing_required_record_count"] == 0
+    assert summary["null_rate_status"] == "ok"
+    assert summary["null_field_count"] == 0
+    assert summary["null_record_count"] == 0
+    assert summary["max_null_rate"] == 0.0
     assert set(summary["volatility_latest"]) == {"AAPL", "MSFT"}
     assert set(summary["value_at_risk"]) == {"AAPL", "MSFT"}
 
@@ -160,6 +164,11 @@ def test_run_pipeline_materializes_all_curated_datasets(tmp_path: Path) -> None:
     assert data_quality_rows[0]["required_fields_checked"] == 7
     assert data_quality_rows[0]["missing_required_field_count"] == 0
     assert data_quality_rows[0]["missing_required_record_count"] == 0
+    assert data_quality_rows[0]["null_rate_status"] == "ok"
+    assert data_quality_rows[0]["null_fields_checked"] == 7
+    assert data_quality_rows[0]["null_field_count"] == 0
+    assert data_quality_rows[0]["null_record_count"] == 0
+    assert data_quality_rows[0]["max_null_rate"] == 0.0
 
 
 def test_run_pipeline_rejects_missing_required_fields(tmp_path: Path) -> None:
@@ -213,6 +222,68 @@ def test_run_pipeline_rejects_missing_required_fields(tmp_path: Path) -> None:
         json.dump(events, handle)
 
     with pytest.raises(ValidationError, match="Missing required fields in 1 records"):
+        run_pipeline(
+            input_path=input_path,
+            thresholds_path=Path("config/risk_thresholds.yaml"),
+            late_seconds=60,
+            window_minutes=5,
+            vol_window=2,
+            storage_config_path=storage_config_path,
+        )
+
+
+def test_run_pipeline_rejects_null_required_fields(tmp_path: Path) -> None:
+    storage_config = {
+        "storage": {
+            "base_dir": str(tmp_path),
+            "raw": {
+                "base_path": str(tmp_path / "raw"),
+                "dataset": "market_events",
+            },
+            "curated": {
+                "base_path": str(tmp_path / "curated"),
+                "datasets": {
+                    "returns_1m": "returns_1m",
+                    "volatility_5m": "volatility_5m",
+                    "data_quality_metrics": "data_quality_metrics",
+                    "risk_summary": "risk_summary",
+                },
+            },
+            "format": "parquet",
+            "partitioning": {
+                "granularity": "hourly",
+            },
+        }
+    }
+    storage_config_path = tmp_path / "storage.yaml"
+    with storage_config_path.open("w", encoding="utf-8") as handle:
+        yaml.safe_dump(storage_config, handle, sort_keys=False)
+
+    events = [
+        {
+            "event_id": "evt-1",
+            "symbol": "AAPL",
+            "price": 100.0,
+            "volume": 10,
+            "ts_event": "2025-01-20T10:01:00Z",
+            "ts_ingest": "2025-01-20T10:01:05Z",
+            "source": "stooq",
+        },
+        {
+            "event_id": "evt-2",
+            "symbol": "AAPL",
+            "price": None,
+            "volume": 11,
+            "ts_event": "2025-01-20T10:02:00Z",
+            "ts_ingest": "2025-01-20T10:02:04Z",
+            "source": "stooq",
+        },
+    ]
+    input_path = tmp_path / "events.json"
+    with input_path.open("w", encoding="utf-8") as handle:
+        json.dump(events, handle)
+
+    with pytest.raises(ValidationError, match="Null required field values in 1 records"):
         run_pipeline(
             input_path=input_path,
             thresholds_path=Path("config/risk_thresholds.yaml"),

--- a/tests/unit/test_data_quality.py
+++ b/tests/unit/test_data_quality.py
@@ -1,4 +1,4 @@
-from src.analytics.data_quality import late_rate, required_field_metrics
+from src.analytics.data_quality import late_rate, null_field_metrics, required_field_metrics
 
 
 def test_late_rate_handles_empty_total() -> None:
@@ -23,5 +23,33 @@ def test_required_field_metrics_counts_missing_fields_by_record() -> None:
         },
         "missing_field_count": 2,
         "failed_record_count": 2,
+        "status": "critical",
+    }
+
+
+def test_null_field_metrics_counts_null_values_by_field() -> None:
+    records = [
+        {"event_id": "evt-1", "symbol": "AAPL", "price": 100.0},
+        {"event_id": "evt-2", "symbol": None, "price": 101.0},
+        {"event_id": "evt-3", "symbol": "MSFT", "price": None},
+    ]
+
+    result = null_field_metrics(records, ["event_id", "symbol", "price"])
+
+    assert result == {
+        "fields_checked": 3,
+        "nulls_by_field": {
+            "event_id": 0,
+            "symbol": 1,
+            "price": 1,
+        },
+        "null_rates_by_field": {
+            "event_id": 0.0,
+            "symbol": 1 / 3,
+            "price": 1 / 3,
+        },
+        "null_field_count": 2,
+        "failed_record_count": 2,
+        "max_null_rate": 1 / 3,
         "status": "critical",
     }


### PR DESCRIPTION
## Summary

Adds the next data-quality increment: null-value evidence for required market-event fields.

## Changes

- Adds a reusable null-field metrics helper with per-field null counts and rates.
- Runs null checks before schema normalization so null required fields fail with an aggregated validation error.
- Emits null-rate status, counts, max rate, and per-field JSON evidence into the pipeline summary and `data_quality_metrics` output.
- Updates the data-quality SQL example and data model docs.
- Adds unit and integration coverage for valid and invalid null-field cases.

## Validation

- `.venv/bin/ruff check .`
- `.venv/bin/pytest -q`