### PR TITLE
Add data quality value validity metrics

### DIFF
--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -24,6 +24,8 @@
 ## Data Quality Metrics
 
 `data_quality_metrics` includes required-field and null-rate validation evidence for each pipeline run:
+It also records value-validity evidence for market fields that must stay in range
+(`price > 0` and `volume >= 0`).
 
 ```json
 {
@@ -38,6 +40,11 @@
   "max_null_rate": 0.0,
   "null_fields_by_name": "{\"event_id\": 0, \"price\": 0, \"source\": 0, \"symbol\": 0, \"ts_event\": 0, \"ts_ingest\": 0, \"volume\": 0}",
   "null_rates_by_name": "{\"event_id\": 0.0, \"price\": 0.0, \"source\": 0.0, \"symbol\": 0.0, \"ts_event\": 0.0, \"ts_ingest\": 0.0, \"volume\": 0.0}",
-  "null_rate_status": "ok"
+  "null_rate_status": "ok",
+  "value_fields_checked": 2,
+  "invalid_value_count": 0,
+  "invalid_value_record_count": 0,
+  "invalid_values_by_name": "{\"price\": 0, \"volume\": 0}",
+  "value_validity_status": "ok"
 }
 ```

--- a/sql/data_quality_checks.sql
+++ b/sql/data_quality_checks.sql
@@ -13,7 +13,13 @@ SELECT
   null_record_count,
   max_null_rate,
   null_fields_by_name,
-  null_rates_by_name
+  null_rates_by_name,
+  value_validity_status,
+  value_fields_checked,
+  invalid_value_count,
+  invalid_value_record_count,
+  invalid_values_by_name
 FROM data_quality_metrics
 WHERE required_fields_status <> 'ok'
-  OR null_rate_status <> 'ok';
+  OR null_rate_status <> 'ok'
+  OR value_validity_status <> 'ok';

--- a/src/analytics/data_quality.py
+++ b/src/analytics/data_quality.py
@@ -57,3 +57,59 @@ def null_field_metrics(
         "max_null_rate": max(null_rates_by_field.values(), default=0.0),
         "status": "critical" if failed_record_count else "ok",
     }
+
+
+def numeric_range_metrics(
+    records: list[dict[str, Any]],
+    rules: dict[str, dict[str, float]],
+) -> dict[str, Any]:
+    invalid_by_field = {field: 0 for field in rules}
+    failed_record_count = 0
+
+    for record in records:
+        record_failed = False
+        for field, rule in rules.items():
+            if field not in record or record[field] is None:
+                continue
+
+            value = record[field]
+            if (
+                isinstance(value, bool)
+                or not isinstance(value, (int, float))
+                or _is_outside_range(float(value), rule)
+            ):
+                invalid_by_field[field] += 1
+                record_failed = True
+
+        if record_failed:
+            failed_record_count += 1
+
+    invalid_field_count = sum(invalid_by_field.values())
+
+    return {
+        "fields_checked": len(rules),
+        "invalid_by_field": invalid_by_field,
+        "invalid_field_count": invalid_field_count,
+        "failed_record_count": failed_record_count,
+        "status": "critical" if failed_record_count else "ok",
+    }
+
+
+def _is_outside_range(value: float, rule: dict[str, float]) -> bool:
+    min_inclusive = rule.get("min_inclusive")
+    if min_inclusive is not None and value < min_inclusive:
+        return True
+
+    min_exclusive = rule.get("min_exclusive")
+    if min_exclusive is not None and value <= min_exclusive:
+        return True
+
+    max_inclusive = rule.get("max_inclusive")
+    if max_inclusive is not None and value > max_inclusive:
+        return True
+
+    max_exclusive = rule.get("max_exclusive")
+    if max_exclusive is not None and value >= max_exclusive:
+        return True
+
+    return False

--- a/src/orchestration/run_pipeline.py
+++ b/src/orchestration/run_pipeline.py
@@ -8,7 +8,12 @@ from typing import Any
 
 import pandas as pd
 
-from ..analytics.data_quality import late_rate, null_field_metrics, required_field_metrics
+from ..analytics.data_quality import (
+    late_rate,
+    null_field_metrics,
+    numeric_range_metrics,
+    required_field_metrics,
+)
 from ..analytics.risk_metrics import value_at_risk
 from ..analytics.returns import compute_returns
 from ..analytics.volatility import rolling_volatility
@@ -25,6 +30,10 @@ from ..storage.storage_config import load_storage_config
 from .locks import acquire_partition_locks, release_partition_locks
 
 REQUIRED_FIELDS = ["event_id", "symbol", "price", "volume", "ts_event", "ts_ingest", "source"]
+VALUE_RULES = {
+    "price": {"min_exclusive": 0.0},
+    "volume": {"min_inclusive": 0.0},
+}
 
 
 def _parse_args() -> argparse.Namespace:
@@ -201,6 +210,16 @@ def run_pipeline(
             f"{null_field_quality['failed_record_count']} records: {nulls_by_field}"
         )
 
+    value_quality = numeric_range_metrics(raw_payloads, VALUE_RULES)
+    if value_quality["failed_record_count"]:
+        invalid_by_field = {
+            field: count for field, count in value_quality["invalid_by_field"].items() if count
+        }
+        raise ValidationError(
+            "Invalid numeric field values in "
+            f"{value_quality['failed_record_count']} records: {invalid_by_field}"
+        )
+
     validated = [_validate_and_normalize(payload) for payload in raw_payloads]
     deduped = dedupe_events(validated, key="event_id")
 
@@ -303,6 +322,14 @@ def run_pipeline(
                 sort_keys=True,
             ),
             "null_rate_status": null_field_quality["status"],
+            "value_fields_checked": value_quality["fields_checked"],
+            "invalid_value_count": value_quality["invalid_field_count"],
+            "invalid_value_record_count": value_quality["failed_record_count"],
+            "invalid_values_by_name": json.dumps(
+                value_quality["invalid_by_field"],
+                sort_keys=True,
+            ),
+            "value_validity_status": value_quality["status"],
             "late_status": late_status,
             "duplicate_status": duplicate_status,
             "ts_ingest": metric_ts,
@@ -384,6 +411,9 @@ def run_pipeline(
         "null_field_count": null_field_quality["null_field_count"],
         "null_record_count": null_field_quality["failed_record_count"],
         "max_null_rate": null_field_quality["max_null_rate"],
+        "value_validity_status": value_quality["status"],
+        "invalid_value_count": value_quality["invalid_field_count"],
+        "invalid_value_record_count": value_quality["failed_record_count"],
         "volatility_latest": volatility_latest,
         "value_at_risk": var_latest,
         "volatility_status": volatility_status,

--- a/tests/integration/test_run_pipeline_curated.py
+++ b/tests/integration/test_run_pipeline_curated.py
@@ -151,6 +151,9 @@ def test_run_pipeline_materializes_all_curated_datasets(tmp_path: Path) -> None:
     assert summary["null_field_count"] == 0
     assert summary["null_record_count"] == 0
     assert summary["max_null_rate"] == 0.0
+    assert summary["value_validity_status"] == "ok"
+    assert summary["invalid_value_count"] == 0
+    assert summary["invalid_value_record_count"] == 0
     assert set(summary["volatility_latest"]) == {"AAPL", "MSFT"}
     assert set(summary["value_at_risk"]) == {"AAPL", "MSFT"}
 
@@ -169,6 +172,10 @@ def test_run_pipeline_materializes_all_curated_datasets(tmp_path: Path) -> None:
     assert data_quality_rows[0]["null_field_count"] == 0
     assert data_quality_rows[0]["null_record_count"] == 0
     assert data_quality_rows[0]["max_null_rate"] == 0.0
+    assert data_quality_rows[0]["value_validity_status"] == "ok"
+    assert data_quality_rows[0]["value_fields_checked"] == 2
+    assert data_quality_rows[0]["invalid_value_count"] == 0
+    assert data_quality_rows[0]["invalid_value_record_count"] == 0
 
 
 def test_run_pipeline_rejects_missing_required_fields(tmp_path: Path) -> None:
@@ -284,6 +291,77 @@ def test_run_pipeline_rejects_null_required_fields(tmp_path: Path) -> None:
         json.dump(events, handle)
 
     with pytest.raises(ValidationError, match="Null required field values in 1 records"):
+        run_pipeline(
+            input_path=input_path,
+            thresholds_path=Path("config/risk_thresholds.yaml"),
+            late_seconds=60,
+            window_minutes=5,
+            vol_window=2,
+            storage_config_path=storage_config_path,
+        )
+
+
+def test_run_pipeline_rejects_invalid_numeric_field_values(tmp_path: Path) -> None:
+    storage_config = {
+        "storage": {
+            "base_dir": str(tmp_path),
+            "raw": {
+                "base_path": str(tmp_path / "raw"),
+                "dataset": "market_events",
+            },
+            "curated": {
+                "base_path": str(tmp_path / "curated"),
+                "datasets": {
+                    "returns_1m": "returns_1m",
+                    "volatility_5m": "volatility_5m",
+                    "data_quality_metrics": "data_quality_metrics",
+                    "risk_summary": "risk_summary",
+                },
+            },
+            "format": "parquet",
+            "partitioning": {
+                "granularity": "hourly",
+            },
+        }
+    }
+    storage_config_path = tmp_path / "storage.yaml"
+    with storage_config_path.open("w", encoding="utf-8") as handle:
+        yaml.safe_dump(storage_config, handle, sort_keys=False)
+
+    events = [
+        {
+            "event_id": "evt-1",
+            "symbol": "AAPL",
+            "price": 100.0,
+            "volume": 10,
+            "ts_event": "2025-01-20T10:01:00Z",
+            "ts_ingest": "2025-01-20T10:01:05Z",
+            "source": "stooq",
+        },
+        {
+            "event_id": "evt-2",
+            "symbol": "AAPL",
+            "price": 0.0,
+            "volume": 11,
+            "ts_event": "2025-01-20T10:02:00Z",
+            "ts_ingest": "2025-01-20T10:02:04Z",
+            "source": "stooq",
+        },
+        {
+            "event_id": "evt-3",
+            "symbol": "MSFT",
+            "price": 240.0,
+            "volume": -1,
+            "ts_event": "2025-01-20T10:03:00Z",
+            "ts_ingest": "2025-01-20T10:03:04Z",
+            "source": "stooq",
+        },
+    ]
+    input_path = tmp_path / "events.json"
+    with input_path.open("w", encoding="utf-8") as handle:
+        json.dump(events, handle)
+
+    with pytest.raises(ValidationError, match="Invalid numeric field values in 2 records"):
         run_pipeline(
             input_path=input_path,
             thresholds_path=Path("config/risk_thresholds.yaml"),

--- a/tests/unit/test_data_quality.py
+++ b/tests/unit/test_data_quality.py
@@ -1,4 +1,9 @@
-from src.analytics.data_quality import late_rate, null_field_metrics, required_field_metrics
+from src.analytics.data_quality import (
+    late_rate,
+    null_field_metrics,
+    numeric_range_metrics,
+    required_field_metrics,
+)
 
 
 def test_late_rate_handles_empty_total() -> None:
@@ -51,5 +56,34 @@ def test_null_field_metrics_counts_null_values_by_field() -> None:
         "null_field_count": 2,
         "failed_record_count": 2,
         "max_null_rate": 1 / 3,
+        "status": "critical",
+    }
+
+
+def test_numeric_range_metrics_counts_invalid_values_by_field_and_record() -> None:
+    records = [
+        {"event_id": "evt-1", "price": 100.0, "volume": 10},
+        {"event_id": "evt-2", "price": 0.0, "volume": 5},
+        {"event_id": "evt-3", "price": -1.0, "volume": -2},
+        {"event_id": "evt-4", "price": "101.0", "volume": True},
+        {"event_id": "evt-5", "price": None},
+    ]
+
+    result = numeric_range_metrics(
+        records,
+        {
+            "price": {"min_exclusive": 0.0},
+            "volume": {"min_inclusive": 0.0},
+        },
+    )
+
+    assert result == {
+        "fields_checked": 2,
+        "invalid_by_field": {
+            "price": 3,
+            "volume": 2,
+        },
+        "invalid_field_count": 5,
+        "failed_record_count": 3,
         "status": "critical",
     }


### PR DESCRIPTION
## Summary
- Add numeric range data-quality metrics for market values.
- Reject events with non-positive prices or negative volumes before analytics run.
- Surface value-validity fields in the data-quality dataset, SQL check, and data model docs.

## Validation
- `.venv/bin/pytest -q`
- `.venv/bin/ruff check .`