### PR TITLE
Add market data ingestion loader

### DIFF
--- a/src/ingestion/__init__.py
+++ b/src/ingestion/__init__.py
@@ -1,0 +1,3 @@
+from .market_data_loader import load_market_events, market_events_to_records
+
+__all__ = ["load_market_events", "market_events_to_records"]

--- a/src/ingestion/market_data_loader.py
+++ b/src/ingestion/market_data_loader.py
@@ -1,0 +1,245 @@
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable
+
+from pydantic import ValidationError as PydanticValidationError
+
+from ..common.exceptions import IngestionError
+from ..common.time import utc_now
+from ..processing.normaliser import normalize_symbol
+from .schemas import MarketEvent
+
+FIELD_ALIASES = {
+    "event_id": ("event_id", "id"),
+    "symbol": ("symbol", "ticker", "instrument"),
+    "price": ("price", "close", "last", "last_price"),
+    "volume": ("volume", "trade_volume"),
+    "ts_event": ("ts_event", "event_time", "timestamp", "datetime", "date"),
+    "ts_ingest": ("ts_ingest", "ingest_time", "ingested_at"),
+    "source": ("source", "provider"),
+}
+
+
+def _normalise_key(key: str) -> str:
+    return key.strip().lower().replace(" ", "_").replace("-", "_")
+
+
+def _normalise_row(row: dict[str, Any]) -> dict[str, Any]:
+    return {_normalise_key(str(key)): value for key, value in row.items() if key is not None}
+
+
+def _first_present(row: dict[str, Any], field_name: str) -> Any:
+    for alias in FIELD_ALIASES[field_name]:
+        value = row.get(alias)
+        if value not in (None, ""):
+            return value
+    return None
+
+
+def _parse_datetime(value: Any, *, field_name: str) -> datetime:
+    if isinstance(value, datetime):
+        parsed = value
+    elif isinstance(value, str):
+        try:
+            parsed = datetime.fromisoformat(value.strip().replace("Z", "+00:00"))
+        except ValueError as exc:
+            raise IngestionError(f"{field_name} must be an ISO-8601 timestamp") from exc
+    else:
+        raise IngestionError(f"{field_name} must be a datetime or ISO-8601 string")
+
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _coerce_float(value: Any, *, field_name: str) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError) as exc:
+        raise IngestionError(f"{field_name} must be numeric") from exc
+
+
+def _coerce_int(value: Any, *, field_name: str) -> int:
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError) as exc:
+        raise IngestionError(f"{field_name} must be numeric") from exc
+
+    if not parsed.is_integer():
+        raise IngestionError(f"{field_name} must be a whole number")
+    return int(parsed)
+
+
+def _stable_event_id(
+    *,
+    symbol: str,
+    price: float,
+    volume: int,
+    ts_event: datetime,
+    source: str,
+) -> str:
+    payload = {
+        "price": price,
+        "source": source,
+        "symbol": symbol,
+        "ts_event": ts_event.isoformat(),
+        "volume": volume,
+    }
+    digest = hashlib.sha256(
+        json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    ).hexdigest()[:16]
+    return f"market-{digest}"
+
+
+def _read_csv(path: Path) -> list[dict[str, Any]]:
+    with path.open("r", encoding="utf-8", newline="") as handle:
+        return list(csv.DictReader(handle))
+
+
+def _read_json(path: Path) -> list[dict[str, Any]]:
+    with path.open("r", encoding="utf-8") as handle:
+        payload = json.load(handle)
+
+    if not isinstance(payload, list) or any(not isinstance(row, dict) for row in payload):
+        raise IngestionError("JSON market data must be a list of objects")
+    return payload
+
+
+def _read_json_lines(path: Path) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    with path.open("r", encoding="utf-8") as handle:
+        for line_number, line in enumerate(handle, start=1):
+            if not line.strip():
+                continue
+            row = json.loads(line)
+            if not isinstance(row, dict):
+                raise IngestionError(f"Line {line_number} is not an object")
+            rows.append(row)
+    return rows
+
+
+def _read_landed_rows(path: Path) -> list[dict[str, Any]]:
+    suffix = path.suffix.lower()
+    if suffix == ".csv":
+        return _read_csv(path)
+    if suffix == ".json":
+        return _read_json(path)
+    if suffix in {".jsonl", ".ndjson"}:
+        return _read_json_lines(path)
+    raise IngestionError(f"Unsupported market data file type: {suffix}")
+
+
+def build_market_event_from_row(
+    row: dict[str, Any],
+    *,
+    default_source: str = "stooq",
+    ingested_at: datetime | None = None,
+) -> MarketEvent:
+    normalised = _normalise_row(row)
+    source = str(_first_present(normalised, "source") or default_source)
+    symbol_value = _first_present(normalised, "symbol")
+    price_value = _first_present(normalised, "price")
+    volume_value = _first_present(normalised, "volume")
+    ts_event_value = _first_present(normalised, "ts_event")
+    ts_ingest_value = _first_present(normalised, "ts_ingest")
+
+    missing = [
+        name
+        for name, value in {
+            "symbol": symbol_value,
+            "price": price_value,
+            "volume": volume_value,
+            "ts_event": ts_event_value,
+        }.items()
+        if value in (None, "")
+    ]
+    if missing:
+        raise IngestionError(f"Missing required market data fields: {missing}")
+
+    symbol = normalize_symbol(str(symbol_value))
+    price = _coerce_float(price_value, field_name="price")
+    volume = _coerce_int(volume_value, field_name="volume")
+    ts_event = _parse_datetime(ts_event_value, field_name="ts_event")
+    if ts_ingest_value not in (None, ""):
+        ts_ingest = _parse_datetime(ts_ingest_value, field_name="ts_ingest")
+    elif ingested_at is not None:
+        ts_ingest = _parse_datetime(ingested_at, field_name="ingested_at")
+    else:
+        ts_ingest = utc_now()
+
+    event_id = _first_present(normalised, "event_id") or _stable_event_id(
+        symbol=symbol,
+        price=price,
+        volume=volume,
+        ts_event=ts_event,
+        source=source,
+    )
+
+    try:
+        return MarketEvent(
+            event_id=str(event_id),
+            symbol=symbol,
+            price=price,
+            volume=volume,
+            ts_event=ts_event,
+            ts_ingest=ts_ingest,
+            source=source,
+        )
+    except PydanticValidationError as exc:
+        raise IngestionError(f"Invalid market data row: {exc}") from exc
+
+
+def load_market_events(
+    path: Path,
+    *,
+    default_source: str = "stooq",
+    ingested_at: datetime | None = None,
+) -> list[MarketEvent]:
+    rows = _read_landed_rows(path)
+    return [
+        build_market_event_from_row(row, default_source=default_source, ingested_at=ingested_at)
+        for row in rows
+    ]
+
+
+def market_events_to_records(events: Iterable[MarketEvent]) -> list[dict[str, Any]]:
+    return [event.model_dump() for event in events]
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Convert landed market data into market events.")
+    parser.add_argument("input", type=Path, help="CSV, JSON, JSONL, or NDJSON market data file.")
+    parser.add_argument("--source", default="stooq", help="Default source when rows omit source.")
+    parser.add_argument("--output", type=Path, help="Optional JSON output path.")
+    parser.add_argument("--ingested-at", help="Optional ISO-8601 ingest timestamp.")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = _parse_args()
+    ingested_at = (
+        _parse_datetime(args.ingested_at, field_name="ingested_at")
+        if args.ingested_at is not None
+        else None
+    )
+    events = load_market_events(args.input, default_source=args.source, ingested_at=ingested_at)
+    payload = [event.model_dump(mode="json") for event in events]
+
+    if args.output is None:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+        return
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    with args.output.open("w", encoding="utf-8") as handle:
+        json.dump(payload, handle, indent=2, sort_keys=True)
+        handle.write("\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/ingestion/test_market_data_loader.py
+++ b/tests/unit/ingestion/test_market_data_loader.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from src.common.exceptions import IngestionError
+from src.ingestion.market_data_loader import (
+    build_market_event_from_row,
+    load_market_events,
+    market_events_to_records,
+)
+
+
+def test_load_market_events_from_csv_generates_stable_ids(tmp_path: Path) -> None:
+    path = tmp_path / "market.csv"
+    path.write_text(
+        "ticker,close,volume,timestamp\n"
+        " aapl ,189.32,1200,2025-01-20T10:01:00Z\n"
+        "MSFT,410.5,900,2025-01-20T10:02:00Z\n",
+        encoding="utf-8",
+    )
+    ingested_at = datetime(2025, 1, 20, 10, 3, tzinfo=timezone.utc)
+
+    first = load_market_events(path, ingested_at=ingested_at)
+    second = load_market_events(path, ingested_at=ingested_at)
+
+    assert [event.symbol for event in first] == ["AAPL", "MSFT"]
+    assert [event.event_id for event in first] == [event.event_id for event in second]
+    assert first[0].event_id.startswith("market-")
+    assert first[0].source == "stooq"
+    assert first[0].ts_ingest == ingested_at
+
+
+def test_load_market_events_from_json_lines_preserves_supplied_ids(tmp_path: Path) -> None:
+    path = tmp_path / "market.jsonl"
+    rows = [
+        {
+            "event_id": "evt-1",
+            "symbol": "AAPL",
+            "price": 189.32,
+            "volume": 1200,
+            "ts_event": "2025-01-20T10:01:00Z",
+            "ts_ingest": "2025-01-20T10:01:03Z",
+            "source": "polygon",
+        },
+        {
+            "id": "evt-2",
+            "instrument": "msft",
+            "last_price": "410.5",
+            "trade_volume": "900",
+            "event_time": "2025-01-20T10:02:00+00:00",
+        },
+    ]
+    path.write_text("\n".join(json.dumps(row) for row in rows), encoding="utf-8")
+
+    events = load_market_events(path)
+
+    assert [event.event_id for event in events] == ["evt-1", "evt-2"]
+    assert events[0].source == "polygon"
+    assert events[1].symbol == "MSFT"
+    assert events[1].price == 410.5
+    assert events[1].volume == 900
+
+
+def test_market_events_to_records_returns_pipeline_records(tmp_path: Path) -> None:
+    path = tmp_path / "market.json"
+    path.write_text(
+        json.dumps(
+            [
+                {
+                    "symbol": "AAPL",
+                    "price": 189.32,
+                    "volume": 1200,
+                    "ts_event": "2025-01-20T10:01:00Z",
+                }
+            ]
+        ),
+        encoding="utf-8",
+    )
+    ingested_at = datetime(2025, 1, 20, 10, 3, tzinfo=timezone.utc)
+
+    records = market_events_to_records(load_market_events(path, ingested_at=ingested_at))
+
+    assert records == [
+        {
+            "event_id": records[0]["event_id"],
+            "symbol": "AAPL",
+            "price": 189.32,
+            "volume": 1200,
+            "ts_event": datetime(2025, 1, 20, 10, 1, tzinfo=timezone.utc),
+            "ts_ingest": ingested_at,
+            "source": "stooq",
+        }
+    ]
+
+
+def test_build_market_event_from_row_rejects_missing_required_fields() -> None:
+    with pytest.raises(IngestionError, match="Missing required market data fields"):
+        build_market_event_from_row({"symbol": "AAPL", "price": 189.32})
+
+
+def test_load_market_events_rejects_unsupported_file_type(tmp_path: Path) -> None:
+    path = tmp_path / "market.txt"
+    path.write_text("symbol=AAPL", encoding="utf-8")
+
+    with pytest.raises(IngestionError, match="Unsupported market data file type"):
+        load_market_events(path)


### PR DESCRIPTION
## Summary
- Add a market data loader under src/ingestion for CSV, JSON, JSONL, and NDJSON inputs.
- Normalize landed rows into canonical MarketEvent records with stable generated IDs when source rows omit one.
- Add focused ingestion unit tests under tests/unit/ingestion.

## Validation
- .venv/bin/pytest -q
- .venv/bin/ruff check .