### PR TITLE
Add external risk signal pipeline integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,14 @@ Provide your own JSON events (list of objects) if desired:
 python -m src.orchestration.run_pipeline --input tests/fixtures/sample_events.json
 ```
 
+Include landed external risk signals to enrich the risk summary:
+
+```bash
+python -m src.orchestration.run_pipeline \
+  --input tests/fixtures/sample_events.json \
+  --signals path/to/signals.json
+```
+
 ## Data Sources
 
 This project is designed for free, legal, and finance-credible sources. Examples:

--- a/config/storage.yaml
+++ b/config/storage.yaml
@@ -10,6 +10,7 @@ storage:
       volatility_5m: "volatility_5m"
       data_quality_metrics: "data_quality_metrics"
       risk_summary: "risk_summary"
+      external_signal_summary: "external_signal_summary"
   format: "parquet"
   partitioning:
     granularity: "hourly"

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -5,7 +5,7 @@ The platform is organized into four layers:
 1. Ingestion: market data and external risk signals
 2. Raw storage: immutable, partitioned event storage
 3. Processing: validation, deduplication, normalization, and windowing
-4. Analytics: returns, volatility, data quality, and risk summaries
+4. Analytics: returns, volatility, external signal summaries, data quality, and risk summaries
 
 The design emphasizes:
 

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -14,12 +14,32 @@
 }
 ```
 
+## External Signal Schema
+
+```json
+{
+  "signal_id": "uuid",
+  "name": "VIX",
+  "value": 18.4,
+  "ts_event": "2025-01-20T10:01:00Z",
+  "ts_ingest": "2025-01-20T10:01:03Z",
+  "source": "cboe"
+}
+```
+
 ## Curated Outputs
 
 1. returns_1m
 2. volatility_5m
 3. data_quality_metrics
 4. risk_summary
+5. external_signal_summary
+
+## External Signal Summary
+
+`external_signal_summary` stores the latest value for each signal name and source included
+in a pipeline run. `risk_summary` rows include the total external signal count and latest
+signal context when a signal input is supplied.
 
 ## Data Quality Metrics
 

--- a/src/ingestion/external_signal_producer.py
+++ b/src/ingestion/external_signal_producer.py
@@ -1,5 +1,27 @@
-from datetime import datetime
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable
+
 from pydantic import BaseModel
+from pydantic import ValidationError as PydanticValidationError
+
+from ..common.exceptions import IngestionError
+from ..common.time import utc_now
+
+FIELD_ALIASES = {
+    "signal_id": ("signal_id", "event_id", "id"),
+    "name": ("name", "signal", "indicator", "metric"),
+    "value": ("value", "reading", "level", "score"),
+    "ts_event": ("ts_event", "event_time", "timestamp", "datetime", "date"),
+    "ts_ingest": ("ts_ingest", "ingest_time", "ingested_at"),
+    "source": ("source", "provider"),
+}
 
 
 class ExternalSignal(BaseModel):
@@ -7,4 +29,214 @@ class ExternalSignal(BaseModel):
     name: str
     value: float
     ts_event: datetime
+    ts_ingest: datetime
     source: str
+
+
+def _normalise_key(key: str) -> str:
+    return key.strip().lower().replace(" ", "_").replace("-", "_")
+
+
+def _normalise_signal_name(name: str) -> str:
+    return name.strip().replace(" ", "_").replace("-", "_").upper()
+
+
+def _normalise_row(row: dict[str, Any]) -> dict[str, Any]:
+    return {_normalise_key(str(key)): value for key, value in row.items() if key is not None}
+
+
+def _first_present(row: dict[str, Any], field_name: str) -> Any:
+    for alias in FIELD_ALIASES[field_name]:
+        value = row.get(alias)
+        if value not in (None, ""):
+            return value
+    return None
+
+
+def _parse_datetime(value: Any, *, field_name: str) -> datetime:
+    if isinstance(value, datetime):
+        parsed = value
+    elif isinstance(value, str):
+        try:
+            parsed = datetime.fromisoformat(value.strip().replace("Z", "+00:00"))
+        except ValueError as exc:
+            raise IngestionError(f"{field_name} must be an ISO-8601 timestamp") from exc
+    else:
+        raise IngestionError(f"{field_name} must be a datetime or ISO-8601 string")
+
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _coerce_float(value: Any, *, field_name: str) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError) as exc:
+        raise IngestionError(f"{field_name} must be numeric") from exc
+
+
+def _stable_signal_id(
+    *,
+    name: str,
+    value: float,
+    ts_event: datetime,
+    source: str,
+) -> str:
+    payload = {
+        "name": name,
+        "source": source,
+        "ts_event": ts_event.isoformat(),
+        "value": value,
+    }
+    digest = hashlib.sha256(
+        json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    ).hexdigest()[:16]
+    return f"signal-{digest}"
+
+
+def _read_csv(path: Path) -> list[dict[str, Any]]:
+    with path.open("r", encoding="utf-8", newline="") as handle:
+        return list(csv.DictReader(handle))
+
+
+def _read_json(path: Path) -> list[dict[str, Any]]:
+    with path.open("r", encoding="utf-8") as handle:
+        payload = json.load(handle)
+
+    if not isinstance(payload, list) or any(not isinstance(row, dict) for row in payload):
+        raise IngestionError("JSON external signals must be a list of objects")
+    return payload
+
+
+def _read_json_lines(path: Path) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    with path.open("r", encoding="utf-8") as handle:
+        for line_number, line in enumerate(handle, start=1):
+            if not line.strip():
+                continue
+            row = json.loads(line)
+            if not isinstance(row, dict):
+                raise IngestionError(f"Line {line_number} is not an object")
+            rows.append(row)
+    return rows
+
+
+def _read_landed_rows(path: Path) -> list[dict[str, Any]]:
+    suffix = path.suffix.lower()
+    if suffix == ".csv":
+        return _read_csv(path)
+    if suffix == ".json":
+        return _read_json(path)
+    if suffix in {".jsonl", ".ndjson"}:
+        return _read_json_lines(path)
+    raise IngestionError(f"Unsupported external signal file type: {suffix}")
+
+
+def build_external_signal_from_row(
+    row: dict[str, Any],
+    *,
+    default_source: str = "fred",
+    ingested_at: datetime | None = None,
+) -> ExternalSignal:
+    normalised = _normalise_row(row)
+    source = str(_first_present(normalised, "source") or default_source)
+    name_value = _first_present(normalised, "name")
+    signal_value = _first_present(normalised, "value")
+    ts_event_value = _first_present(normalised, "ts_event")
+    ts_ingest_value = _first_present(normalised, "ts_ingest")
+
+    missing = [
+        name
+        for name, value in {
+            "name": name_value,
+            "value": signal_value,
+            "ts_event": ts_event_value,
+        }.items()
+        if value in (None, "")
+    ]
+    if missing:
+        raise IngestionError(f"Missing required external signal fields: {missing}")
+
+    name = _normalise_signal_name(str(name_value))
+    value = _coerce_float(signal_value, field_name="value")
+    ts_event = _parse_datetime(ts_event_value, field_name="ts_event")
+    if ts_ingest_value not in (None, ""):
+        ts_ingest = _parse_datetime(ts_ingest_value, field_name="ts_ingest")
+    elif ingested_at is not None:
+        ts_ingest = _parse_datetime(ingested_at, field_name="ingested_at")
+    else:
+        ts_ingest = utc_now()
+
+    signal_id = _first_present(normalised, "signal_id") or _stable_signal_id(
+        name=name,
+        value=value,
+        ts_event=ts_event,
+        source=source,
+    )
+
+    try:
+        return ExternalSignal(
+            signal_id=str(signal_id),
+            name=name,
+            value=value,
+            ts_event=ts_event,
+            ts_ingest=ts_ingest,
+            source=source,
+        )
+    except PydanticValidationError as exc:
+        raise IngestionError(f"Invalid external signal row: {exc}") from exc
+
+
+def load_external_signals(
+    path: Path,
+    *,
+    default_source: str = "fred",
+    ingested_at: datetime | None = None,
+) -> list[ExternalSignal]:
+    rows = _read_landed_rows(path)
+    return [
+        build_external_signal_from_row(
+            row,
+            default_source=default_source,
+            ingested_at=ingested_at,
+        )
+        for row in rows
+    ]
+
+
+def external_signals_to_records(signals: Iterable[ExternalSignal]) -> list[dict[str, Any]]:
+    return [signal.model_dump() for signal in signals]
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Convert landed external signals into records.")
+    parser.add_argument("input", type=Path, help="CSV, JSON, JSONL, or NDJSON signal file.")
+    parser.add_argument("--source", default="fred", help="Default source when rows omit source.")
+    parser.add_argument("--output", type=Path, help="Optional JSON output path.")
+    parser.add_argument("--ingested-at", help="Optional ISO-8601 ingest timestamp.")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = _parse_args()
+    ingested_at = (
+        _parse_datetime(args.ingested_at, field_name="ingested_at")
+        if args.ingested_at is not None
+        else None
+    )
+    signals = load_external_signals(args.input, default_source=args.source, ingested_at=ingested_at)
+    payload = [signal.model_dump(mode="json") for signal in signals]
+
+    if args.output is None:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+        return
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    with args.output.open("w", encoding="utf-8") as handle:
+        json.dump(payload, handle, indent=2, sort_keys=True)
+        handle.write("\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/orchestration/run_pipeline.py
+++ b/src/orchestration/run_pipeline.py
@@ -19,6 +19,10 @@ from ..analytics.returns import compute_returns
 from ..analytics.volatility import rolling_volatility
 from ..common.config import load_yaml
 from ..common.exceptions import ValidationError
+from ..ingestion.external_signal_producer import (
+    external_signals_to_records,
+    load_external_signals,
+)
 from ..ingestion.schemas import MarketEvent
 from ..processing.deduplicator import dedupe_events
 from ..processing.normaliser import normalize_symbol
@@ -42,6 +46,11 @@ def _parse_args() -> argparse.Namespace:
         "--input",
         type=Path,
         help="Optional path to a JSON list of market events.",
+    )
+    parser.add_argument(
+        "--signals",
+        type=Path,
+        help="Optional path to CSV, JSON, JSONL, or NDJSON external risk signals.",
     )
     parser.add_argument(
         "--thresholds",
@@ -147,6 +156,12 @@ def _load_input(path: Path | None) -> list[dict[str, Any]]:
     return data
 
 
+def _load_external_signal_records(path: Path | None) -> list[dict[str, Any]]:
+    if path is None:
+        return []
+    return external_signals_to_records(load_external_signals(path))
+
+
 def _validate_and_normalize(payload: dict[str, Any]) -> dict[str, Any]:
     require_fields(payload, REQUIRED_FIELDS)
     payload = dict(payload)
@@ -175,6 +190,62 @@ def _latest_metric_timestamp(events: list[dict[str, Any]]) -> datetime:
     return max(event["ts_ingest"] for event in events)
 
 
+def _latest_external_signal_summary(records: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    latest_by_signal: dict[tuple[str, str], dict[str, Any]] = {}
+    for record in records:
+        key = (record["name"], record["source"])
+        current = latest_by_signal.get(key)
+        if current is None or (
+            record["ts_event"],
+            record["ts_ingest"],
+            record["signal_id"],
+        ) > (
+            current["ts_event"],
+            current["ts_ingest"],
+            current["signal_id"],
+        ):
+            latest_by_signal[key] = record
+
+    return [
+        {
+            "name": record["name"],
+            "source": record["source"],
+            "latest_value": record["value"],
+            "latest_signal_id": record["signal_id"],
+            "latest_ts_event": record["ts_event"],
+            "ts_ingest": record["ts_ingest"],
+        }
+        for record in sorted(
+            latest_by_signal.values(),
+            key=lambda item: (item["name"], item["source"]),
+        )
+    ]
+
+
+def _latest_external_signal_context(records: list[dict[str, Any]]) -> dict[str, Any]:
+    context: dict[str, Any] = {"external_signal_count": len(records)}
+    if not records:
+        return context
+
+    latest = max(
+        records,
+        key=lambda record: (
+            record["ts_event"],
+            record["ts_ingest"],
+            record["signal_id"],
+        ),
+    )
+    context.update(
+        {
+            "latest_external_signal_name": latest["name"],
+            "latest_external_signal_value": latest["value"],
+            "latest_external_signal_source": latest["source"],
+            "latest_external_signal_ts_event": latest["ts_event"],
+        }
+    )
+    return context
+
+
 def run_pipeline(
     input_path: Path | None,
     thresholds_path: Path,
@@ -182,10 +253,12 @@ def run_pipeline(
     window_minutes: int,
     vol_window: int,
     storage_config_path: Path,
+    signals_path: Path | None = None,
     lock_owner: str | None = None,
     lock_stale_seconds: int | None = None,
 ) -> dict[str, Any]:
     raw_payloads = _load_input(input_path)
+    external_signal_records = _load_external_signal_records(signals_path)
     storage_config = load_storage_config(storage_config_path)
 
     required_field_quality = required_field_metrics(raw_payloads, REQUIRED_FIELDS)
@@ -292,7 +365,9 @@ def run_pipeline(
     }
 
     raw_dataset = storage_config["storage"]["raw"]["dataset"]
-    metric_ts = _latest_metric_timestamp(deduped)
+    external_signal_summary_records = _latest_external_signal_summary(external_signal_records)
+    external_signal_context = _latest_external_signal_context(external_signal_records)
+    metric_ts = _latest_metric_timestamp([*deduped, *external_signal_records])
     data_quality_records = [
         {
             "total_events": total_events,
@@ -347,11 +422,20 @@ def run_pipeline(
             "late_status": late_status,
             "duplicate_status": duplicate_status,
             "ts_ingest": metric_ts,
+            **external_signal_context,
         }
         for symbol in risk_symbols
     ]
 
-    partitions = sorted({partition_path(event["ts_ingest"]) for event in deduped})
+    records_to_lock = [
+        *deduped,
+        *returns_records,
+        *volatility_records,
+        *data_quality_records,
+        *risk_summary_records,
+        *external_signal_summary_records,
+    ]
+    partitions = sorted({partition_path(record["ts_ingest"]) for record in records_to_lock})
     lock_paths: list[Path] = []
     try:
         lock_paths = acquire_partition_locks(
@@ -393,6 +477,13 @@ def run_pipeline(
                 storage_config=storage_config,
             ),
         }
+        if external_signal_summary_records:
+            curated_writes["external_signal_summary"] = write_records(
+                external_signal_summary_records,
+                kind="curated",
+                dataset="external_signal_summary",
+                storage_config=storage_config,
+            )
         curated_written = sum(curated_writes.values())
     finally:
         release_partition_locks(lock_paths)
@@ -419,6 +510,10 @@ def run_pipeline(
         "volatility_status": volatility_status,
         "late_status": late_status,
         "duplicate_status": duplicate_status,
+        "external_signal_count": len(external_signal_records),
+        "external_signals_latest": {
+            record["name"]: record["latest_value"] for record in external_signal_summary_records
+        },
     }
 
 
@@ -426,6 +521,7 @@ def main() -> None:
     args = _parse_args()
     summary = run_pipeline(
         input_path=args.input,
+        signals_path=args.signals,
         thresholds_path=args.thresholds,
         late_seconds=args.late_seconds,
         window_minutes=args.window_minutes,
@@ -449,6 +545,7 @@ def main() -> None:
     print(f"Volatility latest: {summary['volatility_latest']}")
     print(f"Volatility status: {summary['volatility_status']}")
     print(f"Value-at-Risk (95%): {summary['value_at_risk']}")
+    print(f"External signals: {summary['external_signal_count']}")
 
 
 if __name__ == "__main__":

--- a/tests/integration/test_run_pipeline_curated.py
+++ b/tests/integration/test_run_pipeline_curated.py
@@ -518,3 +518,123 @@ def test_run_pipeline_replaces_stale_partition_lock(tmp_path: Path) -> None:
 
     assert summary["raw_events"] == 2
     assert not lock_path.exists()
+
+
+def test_run_pipeline_materializes_external_signal_summary(tmp_path: Path) -> None:
+    storage_config = {
+        "storage": {
+            "base_dir": str(tmp_path),
+            "raw": {
+                "base_path": str(tmp_path / "raw"),
+                "dataset": "market_events",
+            },
+            "curated": {
+                "base_path": str(tmp_path / "curated"),
+                "datasets": {
+                    "returns_1m": "returns_1m",
+                    "volatility_5m": "volatility_5m",
+                    "data_quality_metrics": "data_quality_metrics",
+                    "risk_summary": "risk_summary",
+                    "external_signal_summary": "external_signal_summary",
+                },
+            },
+            "format": "parquet",
+            "partitioning": {
+                "granularity": "hourly",
+            },
+        }
+    }
+    storage_config_path = tmp_path / "storage.yaml"
+    with storage_config_path.open("w", encoding="utf-8") as handle:
+        yaml.safe_dump(storage_config, handle, sort_keys=False)
+
+    events = [
+        {
+            "event_id": "evt-1",
+            "symbol": "AAPL",
+            "price": 100.0,
+            "volume": 10,
+            "ts_event": "2025-01-20T10:01:00Z",
+            "ts_ingest": "2025-01-20T10:01:05Z",
+            "source": "stooq",
+        },
+        {
+            "event_id": "evt-2",
+            "symbol": "AAPL",
+            "price": 101.0,
+            "volume": 11,
+            "ts_event": "2025-01-20T10:02:00Z",
+            "ts_ingest": "2025-01-20T10:02:04Z",
+            "source": "stooq",
+        },
+        {
+            "event_id": "evt-3",
+            "symbol": "AAPL",
+            "price": 102.0,
+            "volume": 12,
+            "ts_event": "2025-01-20T10:03:00Z",
+            "ts_ingest": "2025-01-20T10:03:04Z",
+            "source": "stooq",
+        },
+    ]
+    signals = [
+        {
+            "signal_id": "sig-vix-1",
+            "name": "vix",
+            "value": 18.4,
+            "ts_event": "2025-01-20T10:01:00Z",
+            "ts_ingest": "2025-01-20T10:01:10Z",
+            "source": "cboe",
+        },
+        {
+            "signal_id": "sig-vix-2",
+            "name": "vix",
+            "value": 19.1,
+            "ts_event": "2025-01-20T10:04:00Z",
+            "ts_ingest": "2025-01-20T10:04:10Z",
+            "source": "cboe",
+        },
+        {
+            "signal_id": "sig-spread-1",
+            "name": "credit-spread",
+            "value": 1.25,
+            "ts_event": "2025-01-20T10:02:00Z",
+            "ts_ingest": "2025-01-20T10:02:10Z",
+            "source": "fred",
+        },
+    ]
+    input_path = tmp_path / "events.json"
+    signals_path = tmp_path / "signals.json"
+    with input_path.open("w", encoding="utf-8") as handle:
+        json.dump(events, handle)
+    with signals_path.open("w", encoding="utf-8") as handle:
+        json.dump(signals, handle)
+
+    summary = run_pipeline(
+        input_path=input_path,
+        signals_path=signals_path,
+        thresholds_path=Path("config/risk_thresholds.yaml"),
+        late_seconds=60,
+        window_minutes=5,
+        vol_window=2,
+        storage_config_path=storage_config_path,
+    )
+
+    assert summary["external_signal_count"] == 3
+    assert summary["external_signals_latest"] == {
+        "CREDIT_SPREAD": 1.25,
+        "VIX": 19.1,
+    }
+    assert summary["curated_records_by_dataset"]["external_signal_summary"] == 2
+
+    signal_rows = _read_parquet_rows(tmp_path / "curated" / "external_signal_summary")
+    signal_by_name = {row["name"]: row for row in signal_rows}
+    assert set(signal_by_name) == {"CREDIT_SPREAD", "VIX"}
+    assert signal_by_name["VIX"]["latest_signal_id"] == "sig-vix-2"
+    assert signal_by_name["VIX"]["latest_value"] == 19.1
+
+    risk_rows = _read_parquet_rows(tmp_path / "curated" / "risk_summary")
+    assert risk_rows[0]["external_signal_count"] == 3
+    assert risk_rows[0]["latest_external_signal_name"] == "VIX"
+    assert risk_rows[0]["latest_external_signal_value"] == 19.1
+    assert risk_rows[0]["latest_external_signal_source"] == "cboe"

--- a/tests/unit/ingestion/test_external_signal_producer.py
+++ b/tests/unit/ingestion/test_external_signal_producer.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from src.common.exceptions import IngestionError
+from src.ingestion.external_signal_producer import (
+    build_external_signal_from_row,
+    external_signals_to_records,
+    load_external_signals,
+)
+
+
+def test_load_external_signals_from_json_lines_generates_stable_ids(tmp_path: Path) -> None:
+    path = tmp_path / "signals.jsonl"
+    rows = [
+        {
+            "indicator": " vix ",
+            "reading": "18.4",
+            "timestamp": "2025-01-20T10:00:00Z",
+        },
+        {
+            "signal_id": "sig-fed-1",
+            "name": "fed-funds",
+            "value": 4.5,
+            "ts_event": "2025-01-20T10:01:00Z",
+            "provider": "fred",
+        },
+    ]
+    path.write_text("\n".join(json.dumps(row) for row in rows), encoding="utf-8")
+    ingested_at = datetime(2025, 1, 20, 10, 3, tzinfo=timezone.utc)
+
+    first = load_external_signals(path, ingested_at=ingested_at)
+    second = load_external_signals(path, ingested_at=ingested_at)
+
+    assert [signal.name for signal in first] == ["VIX", "FED_FUNDS"]
+    assert [signal.signal_id for signal in first] == [signal.signal_id for signal in second]
+    assert first[0].signal_id.startswith("signal-")
+    assert first[0].source == "fred"
+    assert first[0].ts_ingest == ingested_at
+    assert first[1].signal_id == "sig-fed-1"
+
+
+def test_external_signals_to_records_returns_pipeline_records(tmp_path: Path) -> None:
+    path = tmp_path / "signals.csv"
+    path.write_text(
+        "name,value,ts_event\n"
+        "credit-spread,1.25,2025-01-20T10:01:00Z\n",
+        encoding="utf-8",
+    )
+    ingested_at = datetime(2025, 1, 20, 10, 3, tzinfo=timezone.utc)
+
+    records = external_signals_to_records(load_external_signals(path, ingested_at=ingested_at))
+
+    assert records == [
+        {
+            "signal_id": records[0]["signal_id"],
+            "name": "CREDIT_SPREAD",
+            "value": 1.25,
+            "ts_event": datetime(2025, 1, 20, 10, 1, tzinfo=timezone.utc),
+            "ts_ingest": ingested_at,
+            "source": "fred",
+        }
+    ]
+
+
+def test_build_external_signal_from_row_rejects_missing_required_fields() -> None:
+    with pytest.raises(IngestionError, match="Missing required external signal fields"):
+        build_external_signal_from_row({"name": "VIX", "value": 18.4})
+
+
+def test_load_external_signals_rejects_unsupported_file_type(tmp_path: Path) -> None:
+    path = tmp_path / "signals.txt"
+    path.write_text("name=VIX", encoding="utf-8")
+
+    with pytest.raises(IngestionError, match="Unsupported external signal file type"):
+        load_external_signals(path)


### PR DESCRIPTION
## Summary
- Add landed external signal loading for CSV, JSON, JSONL, and NDJSON files.
- Wire optional signal inputs into the pipeline and materialize `external_signal_summary`.
- Include latest signal context in risk summaries and document the new schema.

## Validation
- `.venv/bin/ruff check .`
- `.venv/bin/pytest -q`
