### PR TITLE
Add deploy structure

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,9 @@
+.git/
+.github/
 .venv/
+.pytest_cache/
+.ruff_cache/
+.mypy_cache/
 __pycache__/
 *.pyc
 *.pyo
@@ -6,9 +11,9 @@ __pycache__/
 *.egg-info/
 build/
 dist/
-.pytest_cache/
-.mypy_cache/
-.ruff_cache/
 .DS_Store
 .idea/
 .vscode/
+data/
+infra/
+tests/

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,98 @@
+name: deploy
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: "Target GitHub environment and Kubernetes overlay."
+        required: true
+        type: choice
+        options:
+          - dev
+          - prod
+      run_now:
+        description: "Create a one-off Job from the CronJob after deploy."
+        required: true
+        default: false
+        type: boolean
+
+permissions:
+  contents: read
+
+concurrency:
+  group: deploy-${{ inputs.environment }}
+  cancel-in-progress: false
+
+env:
+  IMAGE_TAG: ${{ github.sha }}-${{ github.run_attempt }}
+  NAMESPACE: financial-risk-${{ inputs.environment }}
+
+jobs:
+  build:
+    name: Build image
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
+    permissions:
+      contents: read
+      id-token: write
+    outputs:
+      image_uri: ${{ steps.image.outputs.image_uri }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ vars.AWS_ROLE_TO_ASSUME }}
+          aws-region: ${{ vars.AWS_REGION }}
+
+      - uses: aws-actions/amazon-ecr-login@v2
+
+      - uses: docker/setup-buildx-action@v3
+
+      - id: image
+        run: echo "image_uri=${{ vars.ECR_REPOSITORY_URI }}:${IMAGE_TAG}" >> "$GITHUB_OUTPUT"
+
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.image.outputs.image_uri }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  deploy:
+    name: Deploy Kubernetes workload
+    runs-on: ubuntu-latest
+    needs: build
+    environment: ${{ inputs.environment }}
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ vars.AWS_ROLE_TO_ASSUME }}
+          aws-region: ${{ vars.AWS_REGION }}
+
+      - run: |
+          aws eks update-kubeconfig \
+            --name "${{ vars.EKS_CLUSTER_NAME }}" \
+            --region "${{ vars.AWS_REGION }}"
+
+      - run: kubectl apply -k "deploy/kubernetes/overlays/${{ inputs.environment }}"
+
+      - run: |
+          kubectl set image \
+            cronjob/risk-pipeline-live \
+            pipeline="${{ needs.build.outputs.image_uri }}" \
+            --namespace "${NAMESPACE}"
+
+      - if: ${{ inputs.run_now }}
+        run: |
+          kubectl create job "risk-pipeline-live-${GITHUB_RUN_ID}" \
+            --from=cronjob/risk-pipeline-live \
+            --namespace "${NAMESPACE}"
+
+      - run: kubectl get cronjob risk-pipeline-live --namespace "${NAMESPACE}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+FROM python:3.11-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1
+
+WORKDIR /app
+
+RUN groupadd --system --gid 10001 app \
+    && useradd --system --uid 10001 --gid app --home-dir /app --shell /usr/sbin/nologin app
+
+COPY pyproject.toml README.md ./
+COPY src ./src
+COPY config ./config
+COPY sql ./sql
+
+RUN python -m pip install --upgrade pip \
+    && python -m pip install .
+
+USER 10001:10001
+
+CMD ["python", "-m", "src.orchestration.run_pipeline"]

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: lint test format
+.PHONY: lint test format docker-build k8s-render-dev k8s-render-prod
 
 lint:
 	ruff check .
@@ -8,3 +8,12 @@ format:
 
 test:
 	pytest -q
+
+docker-build:
+	docker build -t financial-risk-data-platform:local .
+
+k8s-render-dev:
+	kubectl kustomize deploy/kubernetes/overlays/dev
+
+k8s-render-prod:
+	kubectl kustomize deploy/kubernetes/overlays/prod

--- a/README.md
+++ b/README.md
@@ -63,6 +63,11 @@ See `docs/data-model.md` for event schemas.
 
 See `docs/architecture.md` for the end-to-end design.
 
+## Deployment
+
+The deployment scaffold uses Docker, GitHub Actions, Amazon ECR, and Kubernetes
+CronJobs with separate `dev` and `prod` overlays. See `deploy/README.md`.
+
 ## Notes
 
 This is a portfolio-grade platform scaffold. All modules are intentionally small but structured for expansion.

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,0 +1,91 @@
+# Deployment
+
+This project runs as a batch workload, so the deploy target is a Kubernetes
+`CronJob` rather than a long-running `Deployment`.
+
+## Structure
+
+```text
+Dockerfile
+.dockerignore
+.github/workflows/deploy.yml
+deploy/kubernetes/base/
+deploy/kubernetes/overlays/dev/
+deploy/kubernetes/overlays/prod/
+infra/terraform/ecr.tf
+infra/terraform/iam.tf
+```
+
+## Recommended Flow
+
+1. Build the Python pipeline into an immutable Docker image.
+2. Push the image to Amazon ECR with a unique workflow tag.
+3. Deploy the relevant Kubernetes overlay: `dev` or `prod`.
+4. Update the `risk-pipeline-live` CronJob image to the immutable tag.
+5. Optionally create a one-off Job from the CronJob for an immediate run.
+
+The deploy workflow is manual by design. GitHub Environments should control who
+can deploy to `dev` and `prod`, with required reviewers for production.
+
+## Required GitHub Environment Variables
+
+Create these variables in each GitHub Environment:
+
+```text
+AWS_REGION
+AWS_ROLE_TO_ASSUME
+ECR_REPOSITORY_URI
+EKS_CLUSTER_NAME
+```
+
+Use separate AWS roles for `dev` and `prod`. The Terraform deploy-role scaffold
+trusts GitHub OIDC subjects scoped to `repo:<owner>/<repo>:environment:<name>`.
+
+## Access Controls
+
+Access controls should be layered:
+
+1. GitHub Environment protection rules for deployment approval.
+2. GitHub OIDC to AWS IAM roles instead of long-lived AWS keys.
+3. ECR immutable tags and image scanning on push.
+4. Separate Kubernetes namespaces for `dev` and `prod`.
+5. A dedicated `risk-pipeline` Kubernetes service account per namespace.
+6. No Kubernetes RBAC grants for the runtime service account unless the app
+   needs Kubernetes API access.
+7. A deny-ingress NetworkPolicy because this workload does not serve traffic.
+8. Pod security settings: non-root user, dropped capabilities, read-only root
+   filesystem, explicit CPU and memory requests/limits.
+
+For EKS, map the GitHub deploy role to Kubernetes permissions with EKS access
+entries or Kubernetes RBAC. The runtime service account annotations in the
+overlays are placeholders and should be replaced with real environment-specific
+IAM role ARNs.
+
+## Commands
+
+Build locally:
+
+```bash
+docker build -t financial-risk-data-platform:local .
+```
+
+Render or apply an overlay:
+
+```bash
+kubectl apply -k deploy/kubernetes/overlays/dev
+kubectl apply -k deploy/kubernetes/overlays/prod
+```
+
+Run the deploy workflow:
+
+```bash
+gh workflow run deploy.yml -f environment=dev -f run_now=true
+```
+
+## References
+
+- GitHub OIDC for AWS: https://docs.github.com/en/actions/how-tos/security-for-github-actions/security-hardening-your-deployments/configuring-openid-connect-in-amazon-web-services
+- GitHub deployment environments: https://docs.github.com/en/actions/reference/deployments-and-environments
+- Docker builds in GitHub Actions: https://docs.docker.com/build/ci/github-actions/
+- Kubernetes CronJobs: https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/
+- EKS access entries: https://docs.aws.amazon.com/eks/latest/userguide/access-entries.html

--- a/deploy/kubernetes/base/cronjob-live.yaml
+++ b/deploy/kubernetes/base/cronjob-live.yaml
@@ -1,0 +1,76 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: risk-pipeline-live
+  labels:
+    app.kubernetes.io/component: pipeline-runner
+spec:
+  schedule: "*/15 * * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 2
+      activeDeadlineSeconds: 900
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/component: pipeline-runner
+        spec:
+          serviceAccountName: risk-pipeline
+          restartPolicy: Never
+          securityContext:
+            fsGroup: 10001
+            runAsGroup: 10001
+            runAsNonRoot: true
+            runAsUser: 10001
+            seccompProfile:
+              type: RuntimeDefault
+          containers:
+            - name: pipeline
+              image: financial-risk-data-platform:latest
+              imagePullPolicy: IfNotPresent
+              command:
+                - python
+                - -m
+                - src.orchestration.run_pipeline
+              args:
+                - --storage-config
+                - /app/config/storage.yaml
+                - --thresholds
+                - /app/config/risk_thresholds.yaml
+                - --summary-json
+                - /tmp/pipeline-summary.json
+              env:
+                - name: PYTHONUNBUFFERED
+                  value: "1"
+              resources:
+                requests:
+                  cpu: 250m
+                  memory: 512Mi
+                limits:
+                  cpu: "1"
+                  memory: 1Gi
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
+                readOnlyRootFilesystem: true
+              volumeMounts:
+                - name: risk-config
+                  mountPath: /app/config
+                  readOnly: true
+                - name: runtime-data
+                  mountPath: /app/data
+                - name: tmp
+                  mountPath: /tmp
+          volumes:
+            - name: risk-config
+              configMap:
+                name: risk-config
+            - name: runtime-data
+              emptyDir: {}
+            - name: tmp
+              emptyDir: {}

--- a/deploy/kubernetes/base/kustomization.yaml
+++ b/deploy/kubernetes/base/kustomization.yaml
@@ -1,0 +1,21 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+commonLabels:
+  app.kubernetes.io/name: financial-risk-data-platform
+  app.kubernetes.io/part-of: financial-risk-data-platform
+
+resources:
+  - service-account.yaml
+  - cronjob-live.yaml
+  - network-policy.yaml
+
+configMapGenerator:
+  - name: risk-config
+    files:
+      - storage.yaml=../../../config/storage.yaml
+      - risk_thresholds.yaml=../../../config/risk_thresholds.yaml
+      - symbols.yaml=../../../config/symbols.yaml
+
+generatorOptions:
+  disableNameSuffixHash: true

--- a/deploy/kubernetes/base/network-policy.yaml
+++ b/deploy/kubernetes/base/network-policy.yaml
@@ -1,0 +1,12 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: risk-pipeline-deny-ingress
+  labels:
+    app.kubernetes.io/component: pipeline-runner
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/component: pipeline-runner
+  policyTypes:
+    - Ingress

--- a/deploy/kubernetes/base/service-account.yaml
+++ b/deploy/kubernetes/base/service-account.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: risk-pipeline
+  labels:
+    app.kubernetes.io/component: pipeline-runner
+automountServiceAccountToken: true

--- a/deploy/kubernetes/overlays/dev/cronjob-patch.yaml
+++ b/deploy/kubernetes/overlays/dev/cronjob-patch.yaml
@@ -1,0 +1,7 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: risk-pipeline-live
+spec:
+  schedule: "*/30 * * * *"
+  suspend: false

--- a/deploy/kubernetes/overlays/dev/kustomization.yaml
+++ b/deploy/kubernetes/overlays/dev/kustomization.yaml
@@ -1,0 +1,17 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: financial-risk-dev
+
+resources:
+  - namespace.yaml
+  - ../../base
+
+images:
+  - name: financial-risk-data-platform
+    newName: 000000000000.dkr.ecr.us-east-1.amazonaws.com/financial-risk-data-platform
+    newTag: bootstrap
+
+patches:
+  - path: service-account-patch.yaml
+  - path: cronjob-patch.yaml

--- a/deploy/kubernetes/overlays/dev/namespace.yaml
+++ b/deploy/kubernetes/overlays/dev/namespace.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: financial-risk-dev
+  labels:
+    app.kubernetes.io/name: financial-risk-data-platform
+    environment: dev

--- a/deploy/kubernetes/overlays/dev/service-account-patch.yaml
+++ b/deploy/kubernetes/overlays/dev/service-account-patch.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: risk-pipeline
+  annotations:
+    eks.amazonaws.com/role-arn: arn:aws:iam::000000000000:role/financial-risk-dev-pipeline

--- a/deploy/kubernetes/overlays/prod/cronjob-patch.yaml
+++ b/deploy/kubernetes/overlays/prod/cronjob-patch.yaml
@@ -1,0 +1,7 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: risk-pipeline-live
+spec:
+  schedule: "*/15 * * * *"
+  suspend: false

--- a/deploy/kubernetes/overlays/prod/kustomization.yaml
+++ b/deploy/kubernetes/overlays/prod/kustomization.yaml
@@ -1,0 +1,17 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: financial-risk-prod
+
+resources:
+  - namespace.yaml
+  - ../../base
+
+images:
+  - name: financial-risk-data-platform
+    newName: 000000000000.dkr.ecr.us-east-1.amazonaws.com/financial-risk-data-platform
+    newTag: bootstrap
+
+patches:
+  - path: service-account-patch.yaml
+  - path: cronjob-patch.yaml

--- a/deploy/kubernetes/overlays/prod/namespace.yaml
+++ b/deploy/kubernetes/overlays/prod/namespace.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: financial-risk-prod
+  labels:
+    app.kubernetes.io/name: financial-risk-data-platform
+    environment: prod

--- a/deploy/kubernetes/overlays/prod/service-account-patch.yaml
+++ b/deploy/kubernetes/overlays/prod/service-account-patch.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: risk-pipeline
+  annotations:
+    eks.amazonaws.com/role-arn: arn:aws:iam::000000000000:role/financial-risk-prod-pipeline

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -12,3 +12,9 @@ The design emphasizes:
 1. Reproducibility and deterministic backfills
 2. Explicit trade-offs between cost and latency
 3. Strong schema validation at ingestion
+
+## Deployment Model
+
+The deploy scaffold packages the pipeline as a Docker image and runs it as a
+Kubernetes CronJob. GitHub Actions builds and pushes immutable images to ECR,
+then applies the matching Kustomize overlay for the selected environment.

--- a/infra/terraform/ecr.tf
+++ b/infra/terraform/ecr.tf
@@ -1,0 +1,41 @@
+resource "aws_ecr_repository" "pipeline" {
+  name                 = var.ecr_repository_name
+  image_tag_mutability = "IMMUTABLE"
+
+  image_scanning_configuration {
+    scan_on_push = true
+  }
+
+  encryption_configuration {
+    encryption_type = "AES256"
+  }
+
+  tags = {
+    Project = var.project_name
+  }
+}
+
+resource "aws_ecr_lifecycle_policy" "pipeline" {
+  repository = aws_ecr_repository.pipeline.name
+
+  policy = jsonencode({
+    rules = [
+      {
+        rulePriority = 1
+        description  = "Keep the latest 30 images"
+        selection = {
+          tagStatus   = "any"
+          countType   = "imageCountMoreThan"
+          countNumber = 30
+        }
+        action = {
+          type = "expire"
+        }
+      }
+    ]
+  })
+}
+
+output "pipeline_ecr_repository_url" {
+  value = aws_ecr_repository.pipeline.repository_url
+}

--- a/infra/terraform/iam.tf
+++ b/infra/terraform/iam.tf
@@ -1,1 +1,87 @@
-# IAM roles and policies would be defined here
+locals {
+  create_github_deploy_roles = var.github_oidc_provider_arn != ""
+  eks_cluster_resources      = var.eks_cluster_arn == "" ? ["*"] : [var.eks_cluster_arn]
+}
+
+resource "aws_iam_role" "github_deploy" {
+  for_each = local.create_github_deploy_roles ? var.github_deploy_environments : toset([])
+
+  name = "${var.project_name}-${each.key}-github-deploy"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Principal = {
+          Federated = var.github_oidc_provider_arn
+        }
+        Action = "sts:AssumeRoleWithWebIdentity"
+        Condition = {
+          StringEquals = {
+            "token.actions.githubusercontent.com:aud" = "sts.amazonaws.com"
+          }
+          StringLike = {
+            "token.actions.githubusercontent.com:sub" = "repo:${var.github_repository}:environment:${each.key}"
+          }
+        }
+      }
+    ]
+  })
+
+  tags = {
+    Project     = var.project_name
+    Environment = each.key
+  }
+}
+
+resource "aws_iam_policy" "github_deploy" {
+  for_each = aws_iam_role.github_deploy
+
+  name = "${var.project_name}-${each.key}-github-deploy"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "ecr:GetAuthorizationToken"
+        ]
+        Resource = "*"
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "ecr:BatchCheckLayerAvailability",
+          "ecr:CompleteLayerUpload",
+          "ecr:DescribeRepositories",
+          "ecr:InitiateLayerUpload",
+          "ecr:PutImage",
+          "ecr:UploadLayerPart"
+        ]
+        Resource = aws_ecr_repository.pipeline.arn
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "eks:DescribeCluster"
+        ]
+        Resource = local.eks_cluster_resources
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "github_deploy" {
+  for_each = aws_iam_role.github_deploy
+
+  role       = each.value.name
+  policy_arn = aws_iam_policy.github_deploy[each.key].arn
+}
+
+output "github_deploy_role_arns" {
+  value = {
+    for environment, role in aws_iam_role.github_deploy : environment => role.arn
+  }
+}

--- a/infra/terraform/variables.tf
+++ b/infra/terraform/variables.tf
@@ -1,4 +1,36 @@
 variable "aws_region" {
-  type = string
+  type    = string
   default = "us-east-1"
+}
+
+variable "project_name" {
+  type    = string
+  default = "financial-risk-data-platform"
+}
+
+variable "ecr_repository_name" {
+  type    = string
+  default = "financial-risk-data-platform"
+}
+
+variable "github_repository" {
+  type    = string
+  default = "alexmarinos87/financial-risk-data-platform"
+}
+
+variable "github_oidc_provider_arn" {
+  type        = string
+  default     = ""
+  description = "Existing GitHub Actions OIDC provider ARN. Leave empty to skip deploy role creation."
+}
+
+variable "github_deploy_environments" {
+  type    = set(string)
+  default = ["dev", "prod"]
+}
+
+variable "eks_cluster_arn" {
+  type        = string
+  default     = ""
+  description = "Optional EKS cluster ARN to scope DescribeCluster access."
 }


### PR DESCRIPTION
## Summary
- Add Docker packaging for the pipeline runtime.
- Add Kubernetes CronJob manifests with dev and prod overlays.
- Add a manual GitHub Actions deploy workflow for building, pushing, and applying environment-specific manifests.
- Add ECR and GitHub OIDC deploy role scaffolding in Terraform.

## Validation
- YAML workflow and manifest parsing
- `.venv/bin/ruff check .`
- `.venv/bin/pytest -q`
