### PR TITLE
Prepare demo setup and generated data hygiene

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@ __pycache__/
 *.egg-info/
 build/
 dist/
+data/
+.demo/
 .benchmarks/
 .pytest_cache/
 .mypy_cache/

--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,24 @@
-.PHONY: lint test format benchmark-io docker-build k8s-render-dev k8s-render-prod
+PYTHON ?= .venv/bin/python
+PIP ?= $(PYTHON) -m pip
+
+.PHONY: setup lint test format benchmark-io docker-build k8s-render-dev k8s-render-prod clean-generated
+
+setup:
+	python3 -m venv .venv
+	$(PIP) install --upgrade pip
+	$(PIP) install -e '.[dev]'
 
 lint:
-	ruff check .
+	$(PYTHON) -m ruff check .
 
 format:
-	ruff check . --fix
+	$(PYTHON) -m ruff check . --fix
 
 test:
-	pytest -q
+	$(PYTHON) -m pytest -q
 
 benchmark-io:
-	python -m src.benchmarks.io_engine_benchmark --summary-json .benchmarks/io_engine/summary.json
+	$(PYTHON) -m src.benchmarks.io_engine_benchmark --summary-json .benchmarks/io_engine/summary.json
 
 docker-build:
 	docker build -t financial-risk-data-platform:local .
@@ -20,3 +28,6 @@ k8s-render-dev:
 
 k8s-render-prod:
 	kubectl kustomize deploy/kubernetes/overlays/prod
+
+clean-generated:
+	rm -rf data .demo .benchmarks .pytest_cache .mypy_cache .ruff_cache

--- a/README.md
+++ b/README.md
@@ -21,10 +21,20 @@ This repo is intentionally structured to resemble real internal data platforms a
 Example commands:
 
 ```bash
-python -m venv .venv
-source .venv/bin/activate
-pip install -e .
-pytest -q
+make setup
+make test
+```
+
+The Makefile uses `.venv/bin/python` by default, so commands can be run
+without activating the virtual environment after `make setup`.
+
+If you prefer to run the commands manually:
+
+```bash
+python3 -m venv .venv
+.venv/bin/python -m pip install --upgrade pip
+.venv/bin/python -m pip install -e '.[dev]'
+.venv/bin/python -m pytest -q
 ```
 
 ## Run The Demo Pipeline
@@ -32,19 +42,31 @@ pytest -q
 Run a local end-to-end pipeline with a small sample dataset:
 
 ```bash
-python -m src.orchestration.run_pipeline
+.venv/bin/python -m src.orchestration.run_pipeline
 ```
 
 Provide your own JSON events (list of objects) if desired:
 
 ```bash
-python -m src.orchestration.run_pipeline --input tests/fixtures/sample_events.json
+.venv/bin/python -m src.orchestration.run_pipeline --input tests/fixtures/sample_events.json
+```
+
+For a fuller local walkthrough with duplicates, a late event, and curated
+metrics:
+
+```bash
+make clean-generated
+.venv/bin/python -m src.orchestration.run_pipeline \
+  --input tests/fixtures/demo_events.json \
+  --late-seconds 60 \
+  --vol-window 2 \
+  --summary-json .demo/pipeline-summary.json
 ```
 
 Include landed external risk signals to enrich the risk summary:
 
 ```bash
-python -m src.orchestration.run_pipeline \
+.venv/bin/python -m src.orchestration.run_pipeline \
   --input tests/fixtures/sample_events.json \
   --signals path/to/signals.json
 ```
@@ -72,6 +94,14 @@ make benchmark-io
 ```
 
 See `docs/performance-benchmark.md` for details.
+
+## Generated Files
+
+Local pipeline runs write generated parquet output under `data/`. Demo summaries
+can be written under `.demo/`. Both paths are ignored by git so repeatable runs
+do not pollute commits. Keep reusable sample inputs under `tests/fixtures/`.
+Use `make clean-generated` to remove local outputs and caches before a fresh
+demo run.
 
 ## Deployment
 

--- a/docs/demo-script.md
+++ b/docs/demo-script.md
@@ -1,0 +1,100 @@
+# Data Engineering Demo Script
+
+Use this as a short walkthrough for a technical conversation. The goal is to
+show pipeline engineering judgement: clear inputs, deterministic processing,
+observable data quality, repeatable storage layout, and recovery behaviour.
+
+## Setup Check
+
+```bash
+make setup
+make test
+```
+
+Expected result: the test suite passes from a clean checkout after dependency
+installation.
+
+## Three-Minute Walkthrough
+
+1. Start with the purpose.
+
+   This project is a production-style batch data pipeline. It takes market
+   events and optional external risk signals, validates and normalises them,
+   writes immutable raw records, and publishes curated outputs for downstream
+   consumption.
+
+2. Show the pipeline entry point.
+
+   Point to `src/orchestration/run_pipeline.py`. The important sequence is:
+   load input, validate required fields, reject null or invalid numeric values,
+   normalise symbols, deduplicate by `event_id`, compute curated metrics, lock
+   affected partitions, and write partitioned parquet outputs.
+
+3. Run the sample pipeline.
+
+   ```bash
+   make clean-generated
+   .venv/bin/python -m src.orchestration.run_pipeline \
+     --input tests/fixtures/demo_events.json \
+     --late-seconds 60 \
+     --vol-window 2 \
+     --summary-json .demo/pipeline-summary.json
+   ```
+
+   Call out the summary values: raw events written, curated records written,
+   duplicate rate, late rate, data quality status, affected partitions, and
+   latest risk metrics.
+
+4. Show storage reliability.
+
+   Point to `src/storage/s3_writer.py`. Writes are grouped by ingest-time
+   partitions, use stable content-derived batch names, write to a temporary file
+   first, and skip an existing target file. The same input can be replayed
+   without duplicating files.
+
+5. Show recovery and backfills.
+
+   Point to `src/orchestration/backfill.py` and `src/orchestration/locks.py`.
+   Backfills replay raw hourly partitions, maintain resume state, and use
+   partition locks to avoid overlapping live and backfill writes.
+
+6. Show operational readiness.
+
+   Point to `.github/workflows/ci.yml`, `Dockerfile`, and `deploy/README.md`.
+   The repo has automated tests, container packaging, and a Kubernetes CronJob
+   deployment model with separate dev and prod overlays.
+
+## Questions To Be Ready For
+
+What happens if the upstream sends duplicates?
+
+The pipeline deduplicates on `event_id`, tracks duplicate rate in
+`data_quality_metrics`, and uses deterministic batch filenames so replaying the
+same payload does not create duplicate files.
+
+What happens if a required field is missing or null?
+
+The pipeline calculates data quality metrics first, then raises a validation
+error with field-level counts. Bad records do not silently flow into curated
+outputs.
+
+How would this map to a PostgreSQL warehouse?
+
+The raw parquet layer would remain the durable landing zone. Curated outputs
+such as returns, volatility, data quality metrics, and risk summaries would be
+loaded into warehouse tables with primary keys based on business keys and
+window timestamps. Ops-facing SQL would read from those curated tables, not
+from raw source payloads.
+
+How would this map to an ELT connector tool?
+
+The connector would handle extraction and landing from source systems. This
+repo covers the downstream contract: schema checks, normalisation,
+deduplication, partitioning, transformation, data quality evidence, and
+repeatable backfill behaviour.
+
+What would you improve next?
+
+Add PostgreSQL DDL and warehouse load tests, add a source-document flattening
+example for nested upstream records, and expose data quality alerts from the
+pipeline summary.

--- a/src/orchestration/run_pipeline.py
+++ b/src/orchestration/run_pipeline.py
@@ -530,6 +530,7 @@ def main() -> None:
         lock_stale_seconds=args.lock_stale_seconds,
     )
     if args.summary_json is not None:
+        args.summary_json.parent.mkdir(parents=True, exist_ok=True)
         with args.summary_json.open("w", encoding="utf-8") as handle:
             json.dump(summary, handle, indent=2, sort_keys=True, default=str)
 

--- a/tests/fixtures/demo_events.json
+++ b/tests/fixtures/demo_events.json
@@ -1,0 +1,65 @@
+[
+  {
+    "event_id": "evt-1",
+    "symbol": "AAPL",
+    "price": 100.0,
+    "volume": 10,
+    "ts_event": "2025-01-20T10:01:00Z",
+    "ts_ingest": "2025-01-20T10:01:05Z",
+    "source": "stooq"
+  },
+  {
+    "event_id": "evt-2",
+    "symbol": "AAPL",
+    "price": 101.0,
+    "volume": 11,
+    "ts_event": "2025-01-20T10:02:00Z",
+    "ts_ingest": "2025-01-20T10:02:04Z",
+    "source": "stooq"
+  },
+  {
+    "event_id": "evt-3",
+    "symbol": "AAPL",
+    "price": 102.0,
+    "volume": 12,
+    "ts_event": "2025-01-20T10:03:00Z",
+    "ts_ingest": "2025-01-20T10:03:04Z",
+    "source": "stooq"
+  },
+  {
+    "event_id": "evt-4",
+    "symbol": "MSFT",
+    "price": 240.0,
+    "volume": 9,
+    "ts_event": "2025-01-20T10:01:00Z",
+    "ts_ingest": "2025-01-20T10:01:03Z",
+    "source": "stooq"
+  },
+  {
+    "event_id": "evt-5",
+    "symbol": "MSFT",
+    "price": 242.0,
+    "volume": 10,
+    "ts_event": "2025-01-20T10:02:00Z",
+    "ts_ingest": "2025-01-20T10:07:00Z",
+    "source": "stooq"
+  },
+  {
+    "event_id": "evt-6",
+    "symbol": "MSFT",
+    "price": 241.0,
+    "volume": 8,
+    "ts_event": "2025-01-20T10:03:00Z",
+    "ts_ingest": "2025-01-20T10:03:05Z",
+    "source": "stooq"
+  },
+  {
+    "event_id": "evt-6",
+    "symbol": "MSFT",
+    "price": 241.0,
+    "volume": 8,
+    "ts_event": "2025-01-20T10:03:00Z",
+    "ts_ingest": "2025-01-20T10:03:05Z",
+    "source": "stooq"
+  }
+]

--- a/tests/integration/test_run_pipeline_curated.py
+++ b/tests/integration/test_run_pipeline_curated.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import sys
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
@@ -10,6 +11,7 @@ import yaml
 
 from src.common.exceptions import OverlapError, ValidationError
 from src.orchestration.locks import acquire_partition_locks, release_partition_locks
+from src.orchestration.run_pipeline import main as run_pipeline_main
 from src.orchestration.run_pipeline import run_pipeline
 
 
@@ -29,6 +31,69 @@ def _read_parquet_rows(dataset_dir: Path) -> list[dict]:
     quoted = ", ".join(f"'{path}'" for path in escaped_paths)
     with duckdb.connect() as conn:
         return conn.execute(f"SELECT * FROM read_parquet([{quoted}])").df().to_dict("records")
+
+
+def test_run_pipeline_cli_creates_summary_parent_directory(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    storage_config = {
+        "storage": {
+            "base_dir": str(tmp_path),
+            "raw": {
+                "base_path": str(tmp_path / "raw"),
+                "dataset": "market_events",
+            },
+            "curated": {
+                "base_path": str(tmp_path / "curated"),
+                "datasets": {
+                    "returns_1m": "returns_1m",
+                    "volatility_5m": "volatility_5m",
+                    "data_quality_metrics": "data_quality_metrics",
+                    "risk_summary": "risk_summary",
+                },
+            },
+            "format": "parquet",
+            "partitioning": {
+                "granularity": "hourly",
+            },
+        }
+    }
+    storage_config_path = tmp_path / "storage.yaml"
+    with storage_config_path.open("w", encoding="utf-8") as handle:
+        yaml.safe_dump(storage_config, handle, sort_keys=False)
+
+    summary_path = tmp_path / ".demo" / "pipeline-summary.json"
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "run_pipeline",
+            "--input",
+            "tests/fixtures/demo_events.json",
+            "--storage-config",
+            str(storage_config_path),
+            "--late-seconds",
+            "60",
+            "--vol-window",
+            "2",
+            "--summary-json",
+            str(summary_path),
+        ],
+    )
+
+    run_pipeline_main()
+
+    captured = capsys.readouterr()
+    assert "Pipeline run summary" in captured.out
+    with summary_path.open("r", encoding="utf-8") as handle:
+        summary = json.load(handle)
+    assert summary["raw_events"] == 6
+    assert summary["curated_records"] == 9
+    assert summary["required_fields_status"] == "ok"
+    assert summary["late_rate"] > 0.0
+    assert summary["duplicate_rate"] > 0.0
 
 
 def test_run_pipeline_materializes_all_curated_datasets(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- Add reproducible local setup and test commands through the Makefile.
- Ignore generated pipeline outputs and add a cleanup target for fresh demo runs.
- Add a data engineering demo walkthrough and richer demo fixture.
- Create summary output directories automatically and cover that CLI behaviour with a regression test.

## Validation

- `make format`
- `make lint`
- `make clean-generated && .venv/bin/python -m src.orchestration.run_pipeline --input tests/fixtures/demo_events.json --late-seconds 60 --vol-window 2 --summary-json .demo/pipeline-summary.json`
- `make test` - 38 passed