### PR TITLE
Add warehouse readiness preparation notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,15 @@ See `docs/data-model.md` for event schemas.
 
 See `docs/architecture.md` for the end-to-end design.
 
+Additional preparation notes:
+
+1. `docs/demo-script.md` for a short technical walkthrough
+2. `docs/preparation-plan.md` for interview preparation
+3. `docs/elt-mapping.md` for connector-based ELT mapping
+4. `docs/source-document-mapping.md` for nested source document flattening
+5. `docs/lambda-s3-orchestration.md` for AWS orchestration mapping
+6. `sql/postgres_schema.sql` and `sql/ops_queries.sql` for PostgreSQL examples
+
 ## Performance Benchmark
 
 Run the local I/O benchmark to compare CSV scans with partitioned Parquet scans:

--- a/docs/demo-script.md
+++ b/docs/demo-script.md
@@ -64,6 +64,14 @@ installation.
    The repo has automated tests, container packaging, and a Kubernetes CronJob
    deployment model with separate dev and prod overlays.
 
+7. Show the warehouse and orchestration mapping if the conversation goes there.
+
+   Point to `sql/postgres_schema.sql`, `sql/ops_queries.sql`,
+   `docs/elt-mapping.md`, `docs/source-document-mapping.md`, and
+   `docs/lambda-s3-orchestration.md`. These files explain how the local
+   pipeline maps to a connector-based ELT flow, nested upstream records,
+   PostgreSQL serving tables, and an S3/Lambda orchestration pattern.
+
 ## Questions To Be Ready For
 
 What happens if the upstream sends duplicates?

--- a/docs/elt-mapping.md
+++ b/docs/elt-mapping.md
@@ -1,0 +1,93 @@
+# ELT Connector Mapping
+
+This note explains how the project maps to an ELT connector workflow such as
+Airbyte, Fivetran, or Stitch.
+
+## Current Project Shape
+
+The local pipeline owns these responsibilities:
+
+1. Load source payloads from JSON fixtures or local producer output.
+2. Validate required fields and reject invalid records.
+3. Normalise symbols and timestamps.
+4. Deduplicate by stable event identifiers.
+5. Write immutable raw records.
+6. Produce curated outputs for downstream consumption.
+7. Emit data quality evidence for each run.
+8. Support deterministic backfills from raw partitions.
+
+## Connector-Based Production Shape
+
+In a connector-based deployment, the extraction boundary moves earlier in the
+flow:
+
+```text
+source system
+  -> ELT connector
+  -> raw landing tables or raw object storage
+  -> validation and normalisation
+  -> curated warehouse tables
+  -> ops-facing SQL and dashboards
+```
+
+The connector would own:
+
+1. Source authentication.
+2. Incremental extraction.
+3. Source cursor state.
+4. Initial raw landing.
+5. Basic sync monitoring.
+
+This project would still own:
+
+1. The downstream data contract.
+2. Business-level validation.
+3. Deduplication and replay safety.
+4. Curated transformation logic.
+5. Data quality metrics.
+6. Backfill and recovery behaviour.
+7. Ops-facing warehouse outputs.
+
+## Airbyte-Style Flow
+
+An Airbyte-style setup would use a source connector to land source records into
+raw tables or S3. The pipeline would then read the landed data and apply the
+same deterministic processing path used locally.
+
+Example mapping:
+
+| Project concept | ELT connector equivalent |
+| --- | --- |
+| `tests/fixtures/demo_events.json` | Raw records landed by a connector sync |
+| `MarketEvent` schema validation | Post-sync contract validation |
+| `dedupe_events` | Downstream deduplication by source event key |
+| Partitioned parquet writes | Raw or curated object-storage landing zone |
+| `risk_platform.*` tables | Warehouse tables for operational consumers |
+| Backfill replay | Historical sync plus deterministic transformation replay |
+
+## Warehouse Loading
+
+For PostgreSQL, the recommended pattern is:
+
+1. Load each batch into a temporary or staging table.
+2. Validate row counts and key fields.
+3. Use `INSERT ... ON CONFLICT` into curated tables.
+4. Record load metrics and failures.
+5. Keep raw records available for replay.
+
+See:
+
+```text
+sql/postgres_schema.sql
+sql/ops_queries.sql
+```
+
+## Trade-Offs
+
+Using a connector reduces bespoke extraction code but does not remove the need
+for downstream engineering. Business rules, schema drift handling, replay
+safety, and data quality checks still need to be owned close to the warehouse
+contract.
+
+The project deliberately keeps those concerns explicit so they can be tested and
+discussed independently from the extraction tool.

--- a/docs/lambda-s3-orchestration.md
+++ b/docs/lambda-s3-orchestration.md
@@ -1,0 +1,112 @@
+# Lambda And S3 Orchestration
+
+This note shows how the local pipeline maps to a small AWS workflow using S3
+and Lambda.
+
+## Local Shape
+
+The local demo writes partitioned parquet output under:
+
+```text
+data/raw/
+data/curated/
+```
+
+The same layout maps directly to S3 prefixes:
+
+```text
+s3://<raw-bucket>/market_events/year=YYYY/month=MM/day=DD/hour=HH/
+s3://<curated-bucket>/returns_1m/year=YYYY/month=MM/day=DD/hour=HH/
+s3://<curated-bucket>/volatility_5m/year=YYYY/month=MM/day=DD/hour=HH/
+s3://<curated-bucket>/data_quality_metrics/year=YYYY/month=MM/day=DD/hour=HH/
+s3://<curated-bucket>/risk_summary/year=YYYY/month=MM/day=DD/hour=HH/
+```
+
+## Small-Batch Lambda Flow
+
+```text
+source extract lands file in S3
+  -> S3 ObjectCreated event
+  -> Lambda validates event metadata
+  -> Lambda starts the pipeline for the affected partition
+  -> raw and curated outputs are written to S3
+  -> summary JSON is emitted for monitoring
+```
+
+Lambda is a good fit for small batches, orchestration glue, and validation
+around object events. Larger transformations should move to a container task,
+Glue job, or scheduled Kubernetes job.
+
+## Example Handler Shape
+
+```python
+from pathlib import Path
+
+from src.orchestration.run_pipeline import run_pipeline
+
+
+def handler(event, context):
+    records = event.get("Records", [])
+    if not records:
+        raise ValueError("No S3 records received")
+
+    summaries = []
+    for record in records:
+        bucket = record["s3"]["bucket"]["name"]
+        key = record["s3"]["object"]["key"]
+
+        input_path = download_to_tmp(bucket, key)
+        summary = run_pipeline(
+            input_path=Path(input_path),
+            thresholds_path=Path("/var/task/config/risk_thresholds.yaml"),
+            late_seconds=300,
+            window_minutes=5,
+            vol_window=5,
+            storage_config_path=Path("/var/task/config/storage.yaml"),
+            lock_owner=f"lambda:{context.aws_request_id}",
+        )
+        summaries.append({"bucket": bucket, "key": key, "summary": summary})
+
+    publish_run_summary(summaries)
+    return {"processed": len(summaries), "summaries": summaries}
+```
+
+The helper functions would own S3 download and monitoring output. The core
+pipeline logic remains testable outside AWS.
+
+## Reliability Considerations
+
+1. Use idempotent target paths so retries do not duplicate output.
+2. Preserve raw source files for replay.
+3. Lock partitions while a live job or backfill is writing.
+4. Emit run summaries with row counts, duplicate rate, late rate, and quality
+   status.
+5. Route failed events to a dead-letter queue.
+6. Use CloudWatch alarms on failed invocations and stale output.
+7. Keep transformation code independent from the Lambda handler.
+
+## When Not To Use Lambda
+
+Use a scheduled container, Kubernetes CronJob, or Glue job when:
+
+1. Batch size regularly exceeds Lambda memory or timeout limits.
+2. Transformations require distributed processing.
+3. The job needs heavy Python dependencies or long warm-up time.
+4. Backfills must replay many partitions in one run.
+
+The current repository already includes a Kubernetes CronJob deployment scaffold
+for that heavier scheduled-batch path.
+
+## Interview Talking Point
+
+The practical split is:
+
+```text
+Lambda: small orchestration and event handling
+S3: durable raw and curated storage
+PostgreSQL: operational warehouse serving layer
+Scheduled job: larger batch and backfill processing
+```
+
+That split keeps the pipeline simple while giving each component a clear
+responsibility.

--- a/docs/preparation-plan.md
+++ b/docs/preparation-plan.md
@@ -1,0 +1,187 @@
+# Interview Preparation Plan
+
+This plan is focused on presenting the project as evidence of practical data
+engineering judgement: reliable pipelines, warehouse-ready outputs, operational
+recovery, and clear stakeholder communication.
+
+## Positioning
+
+Use the repo as a production-style data pipeline showcase, not as a finance or
+analytics project.
+
+Core message:
+
+> This project shows how I think about pipeline reliability: schema validation,
+> deduplication, partitioned storage, data quality evidence, idempotent writes,
+> backfills, and deployment readiness.
+
+Avoid overstating direct experience with tools that are not implemented here.
+For Airbyte, PostgreSQL, MongoDB, and dbt, explain the transferable concepts and
+where they would fit into the design.
+
+## Today: Thursday 4 June 2026
+
+Goal: make the repo clean, runnable, and easy to demonstrate.
+
+Completed preparation items:
+
+1. Add reproducible local setup through `make setup`.
+2. Make tests runnable through `make test`.
+3. Ignore generated local output under `data/` and `.demo/`.
+4. Add `make clean-generated` for fresh demo runs.
+5. Add a richer demo fixture with duplicates, a late event, and curated metrics.
+6. Add a walkthrough in `docs/demo-script.md`.
+7. Fix summary JSON output so parent directories are created automatically.
+8. Add regression coverage for the CLI summary output path.
+
+Validation commands:
+
+```bash
+make setup
+make format
+make lint
+make clean-generated
+.venv/bin/python -m src.orchestration.run_pipeline \
+  --input tests/fixtures/demo_events.json \
+  --late-seconds 60 \
+  --vol-window 2 \
+  --summary-json .demo/pipeline-summary.json
+make test
+```
+
+Expected result:
+
+```text
+38 passed
+```
+
+## Friday 5 June 2026
+
+Goal: close the Zinc-specific gaps without overclaiming.
+
+Completed early on Thursday 4 June 2026:
+
+1. PostgreSQL warehouse DDL for curated outputs.
+2. Ops-facing SQL queries for data quality, recent pipeline status, and curated
+   summary consumption.
+3. A short note mapping the project to an Airbyte-style ELT flow.
+4. A short note showing how nested upstream MongoDB-style documents would be
+   flattened into warehouse-ready records.
+5. A Lambda and S3 orchestration note showing how the local pipeline maps to a
+   small cloud workflow.
+
+Suggested files:
+
+```text
+sql/postgres_schema.sql
+sql/ops_queries.sql
+docs/elt-mapping.md
+docs/source-document-mapping.md
+docs/lambda-s3-orchestration.md
+```
+
+Validation focus:
+
+1. The SQL should be explainable as a warehouse contract, not as a claim that a
+   managed PostgreSQL instance is already deployed.
+2. The ELT mapping should explain where a connector fits without claiming direct
+   production use.
+3. The source document mapping should show clear thinking about nested source
+   data, primary keys, timestamps, and validation.
+4. The Lambda/S3 note should show orchestration judgement and the limits of
+   Lambda for larger workloads.
+
+## Weekend: 6-7 June 2026
+
+Goal: rehearse concise stories rather than memorising code.
+
+Prepare four stories:
+
+1. Pipeline reliability.
+
+   Explain validation, deduplication, partition locks, idempotent writes, and
+   why these choices reduce operational risk.
+
+2. Data quality failure.
+
+   Explain how missing fields, null values, invalid numeric values, duplicate
+   rate, and late rate are detected and surfaced.
+
+3. Backfill and recovery.
+
+   Explain replaying raw hourly partitions, resume state, and preventing
+   overlap between live and backfill jobs.
+
+4. Stakeholder translation.
+
+   Explain how an ops requirement becomes a warehouse-ready curated table and a
+   small set of SQL queries.
+
+For each story, use this structure:
+
+```text
+Situation: what problem existed
+Decision: what design choice was made
+Trade-off: what was gained and what was accepted
+Result: how it can be observed or tested
+```
+
+## Monday 8 June 2026
+
+Goal: light review only.
+
+Do:
+
+1. Run the demo once from a clean checkout state.
+2. Re-read `docs/demo-script.md`.
+3. Review the four interview stories.
+4. Prepare two questions for the interviewer.
+
+Do not:
+
+1. Add new features immediately before the interview.
+2. Change dependencies unless something is broken.
+3. Lead with finance analytics. Lead with engineering reliability.
+
+## Demo Flow
+
+Run:
+
+```bash
+make clean-generated
+.venv/bin/python -m src.orchestration.run_pipeline \
+  --input tests/fixtures/demo_events.json \
+  --late-seconds 60 \
+  --vol-window 2 \
+  --summary-json .demo/pipeline-summary.json
+```
+
+Talk through:
+
+1. Input events include duplicates and a late event.
+2. Validation rejects bad payloads before curated outputs are produced.
+3. Deduplication reduces repeated upstream records.
+4. Partitioned parquet output gives deterministic local storage.
+5. Data quality metrics expose late and duplicate rates.
+6. Backfill logic can replay raw partitions and resume safely.
+7. CI and deployment scaffolding show how the workload would be operated.
+
+## Interview Questions To Prepare
+
+Good questions to ask:
+
+1. What are the most common failure modes in the current data pipelines?
+2. How do ops users consume warehouse data today: direct SQL, internal tools, or
+   scheduled extracts?
+3. Which part of the warehouse needs the most ownership in the first 90 days?
+4. How much transformation currently lives in Airbyte, PostgreSQL SQL, dbt, or
+   application code?
+5. What does good pipeline reliability look like at Zinc: freshness, accuracy,
+   observability, recovery time, or cost?
+
+## Key Reminder
+
+The strongest angle is not knowing every tool in the advert. The strongest
+angle is showing that the fundamentals are solid: SQL thinking, reliable data
+movement, validation, ownership, Git discipline, AWS/S3 familiarity, and clear
+communication with non-technical stakeholders.

--- a/docs/source-document-mapping.md
+++ b/docs/source-document-mapping.md
@@ -1,0 +1,118 @@
+# Source Document Mapping
+
+This note shows how nested upstream documents can be flattened into the
+warehouse-ready event shape used by the pipeline.
+
+## Example Upstream Document
+
+```json
+{
+  "_id": "665f4a731d7f2d9f0a9d0001",
+  "candidateId": "cand_123",
+  "check": {
+    "id": "check_987",
+    "type": "employment_reference",
+    "status": "completed"
+  },
+  "employer": {
+    "name": "Example Ltd",
+    "country": "GB"
+  },
+  "timestamps": {
+    "createdAt": "2026-06-04T09:01:00Z",
+    "updatedAt": "2026-06-04T09:05:30Z",
+    "completedAt": "2026-06-04T09:05:00Z"
+  },
+  "source": "application"
+}
+```
+
+## Flattened Warehouse Record
+
+```json
+{
+  "source_document_id": "665f4a731d7f2d9f0a9d0001",
+  "candidate_id": "cand_123",
+  "check_id": "check_987",
+  "check_type": "employment_reference",
+  "check_status": "completed",
+  "employer_name": "Example Ltd",
+  "employer_country": "GB",
+  "ts_created": "2026-06-04T09:01:00Z",
+  "ts_updated": "2026-06-04T09:05:30Z",
+  "ts_completed": "2026-06-04T09:05:00Z",
+  "source": "application"
+}
+```
+
+## Mapping Rules
+
+| Source path | Warehouse column | Rule |
+| --- | --- | --- |
+| `_id` | `source_document_id` | Preserve as source primary key |
+| `candidateId` | `candidate_id` | Rename to snake case |
+| `check.id` | `check_id` | Flatten nested identifier |
+| `check.type` | `check_type` | Flatten nested attribute |
+| `check.status` | `check_status` | Keep source status value |
+| `employer.name` | `employer_name` | Flatten nested object |
+| `employer.country` | `employer_country` | Keep ISO-like country value |
+| `timestamps.createdAt` | `ts_created` | Parse as UTC timestamp |
+| `timestamps.updatedAt` | `ts_updated` | Parse as UTC timestamp |
+| `timestamps.completedAt` | `ts_completed` | Nullable business timestamp |
+| `source` | `source` | Preserve source system label |
+
+## Validation Rules
+
+Required fields:
+
+```text
+source_document_id
+candidate_id
+check_id
+check_type
+check_status
+ts_created
+ts_updated
+source
+```
+
+Useful checks:
+
+1. `ts_updated >= ts_created`.
+2. `ts_completed IS NULL OR ts_completed >= ts_created`.
+3. `check_status` belongs to the accepted status set.
+4. `source_document_id` is unique in the raw table.
+5. `check_id` is stable across re-syncs.
+
+## Incremental Loading
+
+For a document source, use `timestamps.updatedAt` as the extraction cursor when
+available. Keep `_id` as the stable source key and use it for idempotent loading.
+
+The warehouse load pattern mirrors the event pipeline:
+
+1. Land raw documents or flattened raw rows.
+2. Validate required fields and timestamp ordering.
+3. Deduplicate by source key.
+4. Load curated tables with `ON CONFLICT`.
+5. Emit data quality metrics for missing fields, invalid statuses, and stale
+   source updates.
+
+## Relationship To This Project
+
+The project uses market events as a simple domain because the records are easy
+to understand. The same engineering pattern applies to nested operational
+documents:
+
+```text
+nested source record
+  -> flattened raw contract
+  -> validation
+  -> deduplication
+  -> curated warehouse tables
+  -> operational SQL
+```
+
+The important point is not the domain. The important point is maintaining a
+clear contract between source data, transformation code, and warehouse
+consumers.

--- a/sql/ops_queries.sql
+++ b/sql/ops_queries.sql
@@ -1,0 +1,171 @@
+-- Operational PostgreSQL queries for warehouse consumers.
+-- These assume the schema in sql/postgres_schema.sql has been applied.
+
+-- 1. Latest pipeline health snapshot.
+SELECT
+    ts_ingest,
+    total_events,
+    deduped_events,
+    duplicate_events,
+    ROUND((duplicate_rate * 100)::numeric, 2) AS duplicate_rate_pct,
+    late_events,
+    ROUND((late_rate * 100)::numeric, 2) AS late_rate_pct,
+    required_fields_status,
+    null_rate_status,
+    value_validity_status,
+    late_status,
+    duplicate_status
+FROM risk_platform.latest_data_quality_status;
+
+-- 2. Recent non-OK data quality checks for incident review.
+SELECT
+    ts_ingest,
+    total_events,
+    missing_required_record_count,
+    null_record_count,
+    invalid_value_record_count,
+    duplicate_events,
+    late_events,
+    required_fields_status,
+    null_rate_status,
+    value_validity_status,
+    late_status,
+    duplicate_status
+FROM risk_platform.data_quality_metrics
+WHERE required_fields_status <> 'ok'
+   OR null_rate_status <> 'ok'
+   OR value_validity_status <> 'ok'
+   OR late_status <> 'ok'
+   OR duplicate_status <> 'ok'
+ORDER BY ts_ingest DESC
+LIMIT 50;
+
+-- 3. Latest risk summary for ops dashboards.
+SELECT
+    symbol,
+    ts_ingest,
+    volatility_5m,
+    value_at_risk_95,
+    volatility_status,
+    late_status,
+    duplicate_status,
+    external_signal_count
+FROM risk_platform.latest_risk_summary
+ORDER BY symbol;
+
+-- 4. Symbols with recent elevated risk or quality status.
+SELECT
+    symbol,
+    ts_ingest,
+    volatility_status,
+    late_status,
+    duplicate_status,
+    volatility_5m,
+    value_at_risk_95
+FROM risk_platform.risk_summary
+WHERE ts_ingest >= now() - interval '24 hours'
+  AND (
+      volatility_status <> 'ok'
+      OR late_status <> 'ok'
+      OR duplicate_status <> 'ok'
+  )
+ORDER BY ts_ingest DESC, symbol;
+
+-- 5. Warehouse freshness check by curated table.
+SELECT
+    table_name,
+    latest_ts_ingest,
+    now() - latest_ts_ingest AS age
+FROM (
+    SELECT 'returns_1m' AS table_name, MAX(ts_ingest) AS latest_ts_ingest
+    FROM risk_platform.returns_1m
+    UNION ALL
+    SELECT 'volatility_5m', MAX(ts_ingest)
+    FROM risk_platform.volatility_5m
+    UNION ALL
+    SELECT 'risk_summary', MAX(ts_ingest)
+    FROM risk_platform.risk_summary
+    UNION ALL
+    SELECT 'data_quality_metrics', MAX(ts_ingest)
+    FROM risk_platform.data_quality_metrics
+) freshness
+ORDER BY latest_ts_ingest NULLS FIRST;
+
+-- 6. Idempotent raw event load pattern from a staging table.
+INSERT INTO risk_platform.market_events_raw (
+    event_id,
+    symbol,
+    price,
+    volume,
+    ts_event,
+    ts_ingest,
+    source
+)
+SELECT
+    event_id,
+    UPPER(symbol) AS symbol,
+    price,
+    volume,
+    ts_event,
+    ts_ingest,
+    source
+FROM staging.market_events_raw_batch
+ON CONFLICT (event_id) DO UPDATE
+SET
+    symbol = EXCLUDED.symbol,
+    price = EXCLUDED.price,
+    volume = EXCLUDED.volume,
+    ts_event = EXCLUDED.ts_event,
+    ts_ingest = EXCLUDED.ts_ingest,
+    source = EXCLUDED.source,
+    loaded_at = now()
+WHERE risk_platform.market_events_raw.ts_ingest <= EXCLUDED.ts_ingest;
+
+-- 7. Idempotent risk summary load pattern from a staging table.
+INSERT INTO risk_platform.risk_summary (
+    symbol,
+    ts_ingest,
+    volatility_5m,
+    value_at_risk_95,
+    volatility_status,
+    late_rate,
+    duplicate_rate,
+    late_status,
+    duplicate_status,
+    external_signal_count,
+    latest_external_signal_name,
+    latest_external_signal_value,
+    latest_external_signal_source,
+    latest_external_signal_ts_event
+)
+SELECT
+    symbol,
+    ts_ingest,
+    volatility_5m,
+    value_at_risk_95,
+    volatility_status,
+    late_rate,
+    duplicate_rate,
+    late_status,
+    duplicate_status,
+    external_signal_count,
+    latest_external_signal_name,
+    latest_external_signal_value,
+    latest_external_signal_source,
+    latest_external_signal_ts_event
+FROM staging.risk_summary_batch
+ON CONFLICT (symbol, ts_ingest) DO UPDATE
+SET
+    volatility_5m = EXCLUDED.volatility_5m,
+    value_at_risk_95 = EXCLUDED.value_at_risk_95,
+    volatility_status = EXCLUDED.volatility_status,
+    late_rate = EXCLUDED.late_rate,
+    duplicate_rate = EXCLUDED.duplicate_rate,
+    late_status = EXCLUDED.late_status,
+    duplicate_status = EXCLUDED.duplicate_status,
+    external_signal_count = EXCLUDED.external_signal_count,
+    latest_external_signal_name = EXCLUDED.latest_external_signal_name,
+    latest_external_signal_value = EXCLUDED.latest_external_signal_value,
+    latest_external_signal_source = EXCLUDED.latest_external_signal_source,
+    latest_external_signal_ts_event = EXCLUDED.latest_external_signal_ts_event,
+    loaded_at = now();

--- a/sql/postgres_schema.sql
+++ b/sql/postgres_schema.sql
@@ -1,0 +1,167 @@
+-- PostgreSQL warehouse schema for curated pipeline outputs.
+-- The parquet data lake remains the durable landing zone; these tables model
+-- the warehouse-facing contract for operational consumers.
+
+CREATE SCHEMA IF NOT EXISTS risk_platform;
+
+CREATE TABLE IF NOT EXISTS risk_platform.market_events_raw (
+    event_id TEXT PRIMARY KEY,
+    symbol TEXT NOT NULL,
+    price NUMERIC(18, 6) NOT NULL CHECK (price > 0),
+    volume BIGINT NOT NULL CHECK (volume >= 0),
+    ts_event TIMESTAMPTZ NOT NULL,
+    ts_ingest TIMESTAMPTZ NOT NULL,
+    source TEXT NOT NULL,
+    loaded_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_market_events_raw_symbol_event_time
+    ON risk_platform.market_events_raw (symbol, ts_event DESC);
+
+CREATE INDEX IF NOT EXISTS idx_market_events_raw_ingest_time
+    ON risk_platform.market_events_raw (ts_ingest DESC);
+
+CREATE TABLE IF NOT EXISTS risk_platform.returns_1m (
+    symbol TEXT NOT NULL,
+    ts_event TIMESTAMPTZ NOT NULL,
+    window_start TIMESTAMPTZ NOT NULL,
+    return_1m DOUBLE PRECISION NOT NULL,
+    ts_ingest TIMESTAMPTZ NOT NULL,
+    loaded_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (symbol, ts_event)
+);
+
+CREATE INDEX IF NOT EXISTS idx_returns_1m_window
+    ON risk_platform.returns_1m (window_start DESC, symbol);
+
+CREATE TABLE IF NOT EXISTS risk_platform.volatility_5m (
+    symbol TEXT NOT NULL,
+    ts_event TIMESTAMPTZ NOT NULL,
+    window_start TIMESTAMPTZ NOT NULL,
+    volatility_5m DOUBLE PRECISION NOT NULL,
+    ts_ingest TIMESTAMPTZ NOT NULL,
+    loaded_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (symbol, ts_event)
+);
+
+CREATE INDEX IF NOT EXISTS idx_volatility_5m_window
+    ON risk_platform.volatility_5m (window_start DESC, symbol);
+
+CREATE TABLE IF NOT EXISTS risk_platform.data_quality_metrics (
+    metric_id BIGSERIAL PRIMARY KEY,
+    total_events INTEGER NOT NULL CHECK (total_events >= 0),
+    deduped_events INTEGER NOT NULL CHECK (deduped_events >= 0),
+    duplicate_events INTEGER NOT NULL CHECK (duplicate_events >= 0),
+    late_events INTEGER NOT NULL CHECK (late_events >= 0),
+    late_rate DOUBLE PRECISION NOT NULL CHECK (late_rate >= 0),
+    duplicate_rate DOUBLE PRECISION NOT NULL CHECK (duplicate_rate >= 0),
+    required_fields_checked INTEGER NOT NULL CHECK (required_fields_checked >= 0),
+    missing_required_field_count INTEGER NOT NULL CHECK (missing_required_field_count >= 0),
+    missing_required_record_count INTEGER NOT NULL CHECK (missing_required_record_count >= 0),
+    missing_required_fields_by_name JSONB NOT NULL,
+    required_fields_status TEXT NOT NULL CHECK (required_fields_status IN ('ok', 'warn', 'critical')),
+    null_fields_checked INTEGER NOT NULL CHECK (null_fields_checked >= 0),
+    null_field_count INTEGER NOT NULL CHECK (null_field_count >= 0),
+    null_record_count INTEGER NOT NULL CHECK (null_record_count >= 0),
+    max_null_rate DOUBLE PRECISION NOT NULL CHECK (max_null_rate >= 0),
+    null_fields_by_name JSONB NOT NULL,
+    null_rates_by_name JSONB NOT NULL,
+    null_rate_status TEXT NOT NULL CHECK (null_rate_status IN ('ok', 'warn', 'critical')),
+    value_fields_checked INTEGER NOT NULL CHECK (value_fields_checked >= 0),
+    invalid_value_count INTEGER NOT NULL CHECK (invalid_value_count >= 0),
+    invalid_value_record_count INTEGER NOT NULL CHECK (invalid_value_record_count >= 0),
+    invalid_values_by_name JSONB NOT NULL,
+    value_validity_status TEXT NOT NULL CHECK (value_validity_status IN ('ok', 'warn', 'critical')),
+    late_status TEXT NOT NULL CHECK (late_status IN ('ok', 'warn', 'critical')),
+    duplicate_status TEXT NOT NULL CHECK (duplicate_status IN ('ok', 'warn', 'critical')),
+    ts_ingest TIMESTAMPTZ NOT NULL,
+    loaded_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_data_quality_metrics_ingest_time
+    ON risk_platform.data_quality_metrics (ts_ingest DESC);
+
+CREATE INDEX IF NOT EXISTS idx_data_quality_metrics_status
+    ON risk_platform.data_quality_metrics (
+        required_fields_status,
+        null_rate_status,
+        value_validity_status,
+        late_status,
+        duplicate_status
+    );
+
+CREATE TABLE IF NOT EXISTS risk_platform.risk_summary (
+    symbol TEXT NOT NULL,
+    ts_ingest TIMESTAMPTZ NOT NULL,
+    volatility_5m DOUBLE PRECISION,
+    value_at_risk_95 DOUBLE PRECISION,
+    volatility_status TEXT NOT NULL CHECK (volatility_status IN ('ok', 'warn', 'critical', 'no_data')),
+    late_rate DOUBLE PRECISION NOT NULL CHECK (late_rate >= 0),
+    duplicate_rate DOUBLE PRECISION NOT NULL CHECK (duplicate_rate >= 0),
+    late_status TEXT NOT NULL CHECK (late_status IN ('ok', 'warn', 'critical')),
+    duplicate_status TEXT NOT NULL CHECK (duplicate_status IN ('ok', 'warn', 'critical')),
+    external_signal_count INTEGER NOT NULL DEFAULT 0 CHECK (external_signal_count >= 0),
+    latest_external_signal_name TEXT,
+    latest_external_signal_value DOUBLE PRECISION,
+    latest_external_signal_source TEXT,
+    latest_external_signal_ts_event TIMESTAMPTZ,
+    loaded_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (symbol, ts_ingest)
+);
+
+CREATE INDEX IF NOT EXISTS idx_risk_summary_latest
+    ON risk_platform.risk_summary (ts_ingest DESC, symbol);
+
+CREATE INDEX IF NOT EXISTS idx_risk_summary_status
+    ON risk_platform.risk_summary (volatility_status, late_status, duplicate_status);
+
+CREATE TABLE IF NOT EXISTS risk_platform.external_signal_summary (
+    name TEXT NOT NULL,
+    source TEXT NOT NULL,
+    latest_value DOUBLE PRECISION NOT NULL,
+    latest_signal_id TEXT NOT NULL,
+    latest_ts_event TIMESTAMPTZ NOT NULL,
+    ts_ingest TIMESTAMPTZ NOT NULL,
+    loaded_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (name, source, latest_signal_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_external_signal_summary_latest
+    ON risk_platform.external_signal_summary (latest_ts_event DESC, name, source);
+
+CREATE OR REPLACE VIEW risk_platform.latest_risk_summary AS
+SELECT DISTINCT ON (symbol)
+    symbol,
+    ts_ingest,
+    volatility_5m,
+    value_at_risk_95,
+    volatility_status,
+    late_rate,
+    duplicate_rate,
+    late_status,
+    duplicate_status,
+    external_signal_count,
+    latest_external_signal_name,
+    latest_external_signal_value,
+    latest_external_signal_source,
+    latest_external_signal_ts_event
+FROM risk_platform.risk_summary
+ORDER BY symbol, ts_ingest DESC;
+
+CREATE OR REPLACE VIEW risk_platform.latest_data_quality_status AS
+SELECT
+    ts_ingest,
+    total_events,
+    deduped_events,
+    duplicate_events,
+    late_events,
+    late_rate,
+    duplicate_rate,
+    required_fields_status,
+    null_rate_status,
+    value_validity_status,
+    late_status,
+    duplicate_status
+FROM risk_platform.data_quality_metrics
+ORDER BY ts_ingest DESC
+LIMIT 1;


### PR DESCRIPTION
## Summary

- Add PostgreSQL warehouse schema examples for raw and curated pipeline outputs.
- Add operational SQL queries for pipeline health, freshness, risk summaries, and idempotent loads.
- Add preparation notes for ELT connector mapping, nested source document flattening, and Lambda/S3 orchestration.
- Link the preparation materials from the README and demo walkthrough.

## Validation

- `make lint`
- `make test` - 38 passed