### PR TITLE
Add PostgreSQL and MongoDB playground

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 PYTHON ?= .venv/bin/python
 PIP ?= $(PYTHON) -m pip
 
-.PHONY: setup lint test format benchmark-io docker-build k8s-render-dev k8s-render-prod clean-generated
+.PHONY: setup lint test format benchmark-io docker-build k8s-render-dev k8s-render-prod clean-generated local-db-up local-db-down local-db-logs postgres-shell mongo-shell
 
 setup:
 	python3 -m venv .venv
@@ -31,3 +31,18 @@ k8s-render-prod:
 
 clean-generated:
 	rm -rf data .demo .benchmarks .pytest_cache .mypy_cache .ruff_cache
+
+local-db-up:
+	docker compose up -d postgres mongo
+
+local-db-down:
+	docker compose down -v
+
+local-db-logs:
+	docker compose logs -f postgres mongo
+
+postgres-shell:
+	docker compose exec postgres psql -U risk_user -d risk_platform
+
+mongo-shell:
+	docker compose exec mongo mongosh risk_source

--- a/README.md
+++ b/README.md
@@ -93,8 +93,23 @@ Additional preparation notes:
 4. `docs/mock-interview.md` for timed interview practice
 5. `docs/elt-mapping.md` for connector-based ELT mapping
 6. `docs/source-document-mapping.md` for nested source document flattening
-7. `docs/lambda-s3-orchestration.md` for AWS orchestration mapping
-8. `sql/postgres_schema.sql` and `sql/ops_queries.sql` for PostgreSQL examples
+7. `docs/postgres-mongodb-walkthrough.md` for local source-to-warehouse inspection
+8. `docs/lambda-s3-orchestration.md` for AWS orchestration mapping
+9. `sql/postgres_schema.sql` and `sql/ops_queries.sql` for PostgreSQL examples
+
+## Local Database Playground
+
+An optional Docker Compose playground starts PostgreSQL and MongoDB with seeded
+demo data:
+
+```bash
+make local-db-up
+make postgres-shell
+make mongo-shell
+make local-db-down
+```
+
+See `docs/postgres-mongodb-walkthrough.md` for the inspection commands.
 
 ## Performance Benchmark
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,35 @@
+services:
+  postgres:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_DB: risk_platform
+      POSTGRES_USER: risk_user
+      POSTGRES_PASSWORD: risk_password
+    ports:
+      - "5433:5432"
+    volumes:
+      - ./sql/postgres_schema.sql:/docker-entrypoint-initdb.d/01_schema.sql:ro
+      - ./sql/postgres_demo_data.sql:/docker-entrypoint-initdb.d/02_demo_data.sql:ro
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U risk_user -d risk_platform"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  mongo:
+    image: mongo:7
+    environment:
+      MONGO_INITDB_DATABASE: risk_source
+    ports:
+      - "27018:27017"
+    volumes:
+      - ./mongo/init:/docker-entrypoint-initdb.d:ro
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "mongosh --quiet --eval 'db.adminCommand({ ping: 1 }).ok' | grep 1",
+        ]
+      interval: 5s
+      timeout: 5s
+      retries: 10

--- a/docs/postgres-mongodb-walkthrough.md
+++ b/docs/postgres-mongodb-walkthrough.md
@@ -1,0 +1,269 @@
+# PostgreSQL And MongoDB Walkthrough
+
+This note makes the source and warehouse roles explicit.
+
+## Mental Model
+
+MongoDB is the upstream operational source shape:
+
+1. Documents are nested and application-oriented.
+2. A single document can hold related fields that would become multiple
+   warehouse columns.
+3. Incremental extraction usually depends on a stable `_id` and an update
+   timestamp.
+4. The source shape is useful for the application, but not ideal for ops SQL.
+
+PostgreSQL is the warehouse-serving shape:
+
+1. Data is flattened into tables with clear columns.
+2. Primary keys and `ON CONFLICT` make loads idempotent.
+3. Indexes and views make common ops questions fast and repeatable.
+4. SQL consumers should not need to understand raw nested source payloads.
+
+The pipeline sits between them:
+
+```text
+MongoDB-style source documents
+  -> connector or extract job
+  -> raw landing
+  -> validation and flattening
+  -> deduplication
+  -> curated PostgreSQL tables
+  -> ops queries and dashboards
+```
+
+## Optional Local Playground
+
+Start PostgreSQL and MongoDB locally:
+
+```bash
+make local-db-up
+```
+
+Stop and remove local containers and volumes:
+
+```bash
+make local-db-down
+```
+
+PostgreSQL is exposed on local port `5433`.
+MongoDB is exposed on local port `27018`.
+
+Credentials for the local PostgreSQL container:
+
+```text
+database: risk_platform
+username: risk_user
+password: risk_password
+```
+
+These credentials are only for the local Docker playground.
+
+## Inspect MongoDB Source Documents
+
+Open a MongoDB shell:
+
+```bash
+make mongo-shell
+```
+
+List source collections:
+
+```javascript
+show collections
+```
+
+Inspect nested source documents:
+
+```javascript
+db.background_checks.find({}, { _id: 1, candidateId: 1, check: 1, timestamps: 1 }).pretty()
+```
+
+The important thing to notice is the nested shape:
+
+```text
+check.id
+check.type
+check.status
+timestamps.createdAt
+timestamps.updatedAt
+timestamps.completedAt
+```
+
+Flatten a nested document into a warehouse-ready shape:
+
+```javascript
+db.background_checks.aggregate([
+  {
+    $project: {
+      _id: 0,
+      source_document_id: { $toString: "$_id" },
+      candidate_id: "$candidateId",
+      check_id: "$check.id",
+      check_type: "$check.type",
+      check_status: "$check.status",
+      employer_name: "$employer.name",
+      employer_country: "$employer.country",
+      ts_created: "$timestamps.createdAt",
+      ts_updated: "$timestamps.updatedAt",
+      ts_completed: "$timestamps.completedAt",
+      source: "$source"
+    }
+  }
+])
+```
+
+Inspect the market-event source shape:
+
+```javascript
+db.market_events_source.find({}, { _id: 0 }).pretty()
+```
+
+Find duplicate business events in MongoDB:
+
+```javascript
+db.market_events_source.aggregate([
+  { $group: { _id: "$eventId", count: { $sum: 1 } } },
+  { $match: { count: { $gt: 1 } } }
+])
+```
+
+This is the source-side version of the deduplication problem handled by the
+pipeline.
+
+## Inspect PostgreSQL Warehouse Tables
+
+Open a PostgreSQL shell:
+
+```bash
+make postgres-shell
+```
+
+List schemas and tables:
+
+```sql
+\dn
+\dt risk_platform.*
+\dt staging.*
+```
+
+Inspect raw landed events:
+
+```sql
+SELECT event_id, symbol, price, volume, ts_event, ts_ingest, source
+FROM risk_platform.market_events_raw
+ORDER BY ts_event, event_id;
+```
+
+Inspect the latest quality status:
+
+```sql
+SELECT *
+FROM risk_platform.latest_data_quality_status;
+```
+
+Inspect latest curated summaries:
+
+```sql
+SELECT *
+FROM risk_platform.latest_risk_summary
+ORDER BY symbol;
+```
+
+Check warehouse freshness:
+
+```sql
+SELECT
+    table_name,
+    latest_ts_ingest,
+    now() - latest_ts_ingest AS age
+FROM (
+    SELECT 'returns_1m' AS table_name, MAX(ts_ingest) AS latest_ts_ingest
+    FROM risk_platform.returns_1m
+    UNION ALL
+    SELECT 'volatility_5m', MAX(ts_ingest)
+    FROM risk_platform.volatility_5m
+    UNION ALL
+    SELECT 'risk_summary', MAX(ts_ingest)
+    FROM risk_platform.risk_summary
+    UNION ALL
+    SELECT 'data_quality_metrics', MAX(ts_ingest)
+    FROM risk_platform.data_quality_metrics
+) freshness
+ORDER BY latest_ts_ingest NULLS FIRST;
+```
+
+## See Idempotent Loading In PostgreSQL
+
+The staging table includes an existing event and a new event:
+
+```sql
+SELECT *
+FROM staging.market_events_raw_batch
+ORDER BY event_id;
+```
+
+Load from staging into the raw table:
+
+```sql
+INSERT INTO risk_platform.market_events_raw (
+    event_id,
+    symbol,
+    price,
+    volume,
+    ts_event,
+    ts_ingest,
+    source
+)
+SELECT
+    event_id,
+    UPPER(symbol) AS symbol,
+    price,
+    volume,
+    ts_event,
+    ts_ingest,
+    source
+FROM staging.market_events_raw_batch
+ON CONFLICT (event_id) DO UPDATE
+SET
+    symbol = EXCLUDED.symbol,
+    price = EXCLUDED.price,
+    volume = EXCLUDED.volume,
+    ts_event = EXCLUDED.ts_event,
+    ts_ingest = EXCLUDED.ts_ingest,
+    source = EXCLUDED.source,
+    loaded_at = now()
+WHERE risk_platform.market_events_raw.ts_ingest <= EXCLUDED.ts_ingest;
+```
+
+Then inspect the result:
+
+```sql
+SELECT event_id, symbol, price, volume, ts_ingest
+FROM risk_platform.market_events_raw
+ORDER BY event_id;
+```
+
+What to notice:
+
+1. Existing `evt-6` is not duplicated.
+2. New `evt-7` is inserted.
+3. Symbols are normalised to uppercase during the load.
+4. The primary key is the guardrail that makes the load repeatable.
+
+## How This Maps To The Interview
+
+Use this wording:
+
+> MongoDB is where I expect nested source documents and update cursors. I would
+> preserve the source id, flatten into a raw contract, validate timestamps and
+> required fields, then load curated PostgreSQL tables with primary keys and
+> idempotent `ON CONFLICT` logic.
+
+The important distinction:
+
+```text
+MongoDB: source shape, nested, application-friendly, cursor-driven extraction
+PostgreSQL: serving shape, relational, query-friendly, constrained tables
+Pipeline: contract enforcement, quality checks, deduplication, replay
+```

--- a/mongo/init/01_demo_documents.js
+++ b/mongo/init/01_demo_documents.js
@@ -1,0 +1,101 @@
+db = db.getSiblingDB("risk_source");
+
+db.background_checks.drop();
+db.background_checks.insertMany([
+  {
+    _id: ObjectId("665f4a731d7f2d9f0a9d0001"),
+    candidateId: "cand_123",
+    check: {
+      id: "check_987",
+      type: "employment_reference",
+      status: "completed",
+    },
+    employer: {
+      name: "Example Ltd",
+      country: "GB",
+    },
+    timestamps: {
+      createdAt: ISODate("2026-06-04T09:01:00Z"),
+      updatedAt: ISODate("2026-06-04T09:05:30Z"),
+      completedAt: ISODate("2026-06-04T09:05:00Z"),
+    },
+    source: "application",
+  },
+  {
+    _id: ObjectId("665f4a731d7f2d9f0a9d0002"),
+    candidateId: "cand_456",
+    check: {
+      id: "check_988",
+      type: "right_to_work",
+      status: "in_progress",
+    },
+    employer: {
+      name: "Sample Co",
+      country: "GB",
+    },
+    timestamps: {
+      createdAt: ISODate("2026-06-04T10:15:00Z"),
+      updatedAt: ISODate("2026-06-04T10:18:20Z"),
+      completedAt: null,
+    },
+    source: "application",
+  },
+]);
+
+db.background_checks.createIndex({ "timestamps.updatedAt": 1 });
+db.background_checks.createIndex({ "check.id": 1 }, { unique: true });
+
+db.market_events_source.drop();
+db.market_events_source.insertMany([
+  {
+    _id: ObjectId("665f4a731d7f2d9f0a9d0101"),
+    eventId: "evt-1",
+    instrument: {
+      symbol: "AAPL",
+    },
+    trade: {
+      price: 100.0,
+      volume: 10,
+    },
+    timestamps: {
+      event: ISODate("2025-01-20T10:01:00Z"),
+      ingest: ISODate("2025-01-20T10:01:05Z"),
+    },
+    provider: "stooq",
+  },
+  {
+    _id: ObjectId("665f4a731d7f2d9f0a9d0102"),
+    eventId: "evt-2",
+    instrument: {
+      symbol: "AAPL",
+    },
+    trade: {
+      price: 101.0,
+      volume: 11,
+    },
+    timestamps: {
+      event: ISODate("2025-01-20T10:02:00Z"),
+      ingest: ISODate("2025-01-20T10:02:04Z"),
+    },
+    provider: "stooq",
+  },
+  {
+    _id: ObjectId("665f4a731d7f2d9f0a9d0103"),
+    eventId: "evt-2",
+    instrument: {
+      symbol: "AAPL",
+    },
+    trade: {
+      price: 101.0,
+      volume: 11,
+    },
+    timestamps: {
+      event: ISODate("2025-01-20T10:02:00Z"),
+      ingest: ISODate("2025-01-20T10:02:04Z"),
+    },
+    provider: "stooq",
+  },
+]);
+
+db.market_events_source.createIndex({ eventId: 1 });
+db.market_events_source.createIndex({ "timestamps.ingest": 1 });

--- a/sql/postgres_demo_data.sql
+++ b/sql/postgres_demo_data.sql
@@ -1,0 +1,196 @@
+-- Local PostgreSQL demo data matching tests/fixtures/demo_events.json.
+-- This makes the warehouse-serving layer inspectable without running a full
+-- ingestion-to-warehouse load.
+
+CREATE SCHEMA IF NOT EXISTS staging;
+
+CREATE TABLE IF NOT EXISTS staging.market_events_raw_batch (
+    event_id TEXT,
+    symbol TEXT,
+    price NUMERIC(18, 6),
+    volume BIGINT,
+    ts_event TIMESTAMPTZ,
+    ts_ingest TIMESTAMPTZ,
+    source TEXT
+);
+
+CREATE TABLE IF NOT EXISTS staging.risk_summary_batch (
+    symbol TEXT,
+    ts_ingest TIMESTAMPTZ,
+    volatility_5m DOUBLE PRECISION,
+    value_at_risk_95 DOUBLE PRECISION,
+    volatility_status TEXT,
+    late_rate DOUBLE PRECISION,
+    duplicate_rate DOUBLE PRECISION,
+    late_status TEXT,
+    duplicate_status TEXT,
+    external_signal_count INTEGER,
+    latest_external_signal_name TEXT,
+    latest_external_signal_value DOUBLE PRECISION,
+    latest_external_signal_source TEXT,
+    latest_external_signal_ts_event TIMESTAMPTZ
+);
+
+TRUNCATE TABLE
+    staging.market_events_raw_batch,
+    staging.risk_summary_batch,
+    risk_platform.external_signal_summary,
+    risk_platform.risk_summary,
+    risk_platform.data_quality_metrics,
+    risk_platform.volatility_5m,
+    risk_platform.returns_1m,
+    risk_platform.market_events_raw
+RESTART IDENTITY;
+
+INSERT INTO risk_platform.market_events_raw (
+    event_id,
+    symbol,
+    price,
+    volume,
+    ts_event,
+    ts_ingest,
+    source
+)
+VALUES
+    ('evt-1', 'AAPL', 100.0, 10, '2025-01-20T10:01:00Z', '2025-01-20T10:01:05Z', 'stooq'),
+    ('evt-2', 'AAPL', 101.0, 11, '2025-01-20T10:02:00Z', '2025-01-20T10:02:04Z', 'stooq'),
+    ('evt-3', 'AAPL', 102.0, 12, '2025-01-20T10:03:00Z', '2025-01-20T10:03:04Z', 'stooq'),
+    ('evt-4', 'MSFT', 240.0, 9, '2025-01-20T10:01:00Z', '2025-01-20T10:01:03Z', 'stooq'),
+    ('evt-5', 'MSFT', 242.0, 10, '2025-01-20T10:02:00Z', '2025-01-20T10:07:00Z', 'stooq'),
+    ('evt-6', 'MSFT', 241.0, 8, '2025-01-20T10:03:00Z', '2025-01-20T10:03:05Z', 'stooq')
+ON CONFLICT (event_id) DO NOTHING;
+
+INSERT INTO risk_platform.returns_1m (
+    symbol,
+    ts_event,
+    window_start,
+    return_1m,
+    ts_ingest
+)
+VALUES
+    ('AAPL', '2025-01-20T10:02:00Z', '2025-01-20T10:00:00Z', 0.010000000000000009, '2025-01-20T10:02:04Z'),
+    ('AAPL', '2025-01-20T10:03:00Z', '2025-01-20T10:00:00Z', 0.00990099009900991, '2025-01-20T10:03:04Z'),
+    ('MSFT', '2025-01-20T10:02:00Z', '2025-01-20T10:00:00Z', 0.008333333333333304, '2025-01-20T10:07:00Z'),
+    ('MSFT', '2025-01-20T10:03:00Z', '2025-01-20T10:00:00Z', -0.004132231404958664, '2025-01-20T10:03:05Z')
+ON CONFLICT (symbol, ts_event) DO NOTHING;
+
+INSERT INTO risk_platform.volatility_5m (
+    symbol,
+    ts_event,
+    window_start,
+    volatility_5m,
+    ts_ingest
+)
+VALUES
+    ('AAPL', '2025-01-20T10:03:00Z', '2025-01-20T10:00:00Z', 0.00007001057239470774, '2025-01-20T10:03:04Z'),
+    ('MSFT', '2025-01-20T10:03:00Z', '2025-01-20T10:00:00Z', 0.00881448535776616, '2025-01-20T10:03:05Z')
+ON CONFLICT (symbol, ts_event) DO NOTHING;
+
+INSERT INTO risk_platform.data_quality_metrics (
+    total_events,
+    deduped_events,
+    duplicate_events,
+    late_events,
+    late_rate,
+    duplicate_rate,
+    required_fields_checked,
+    missing_required_field_count,
+    missing_required_record_count,
+    missing_required_fields_by_name,
+    required_fields_status,
+    null_fields_checked,
+    null_field_count,
+    null_record_count,
+    max_null_rate,
+    null_fields_by_name,
+    null_rates_by_name,
+    null_rate_status,
+    value_fields_checked,
+    invalid_value_count,
+    invalid_value_record_count,
+    invalid_values_by_name,
+    value_validity_status,
+    late_status,
+    duplicate_status,
+    ts_ingest
+)
+VALUES (
+    7,
+    6,
+    1,
+    1,
+    0.16666666666666666,
+    0.1428571428571429,
+    7,
+    0,
+    0,
+    '{"event_id": 0, "price": 0, "source": 0, "symbol": 0, "ts_event": 0, "ts_ingest": 0, "volume": 0}'::jsonb,
+    'ok',
+    7,
+    0,
+    0,
+    0.0,
+    '{"event_id": 0, "price": 0, "source": 0, "symbol": 0, "ts_event": 0, "ts_ingest": 0, "volume": 0}'::jsonb,
+    '{"event_id": 0.0, "price": 0.0, "source": 0.0, "symbol": 0.0, "ts_event": 0.0, "ts_ingest": 0.0, "volume": 0.0}'::jsonb,
+    'ok',
+    2,
+    0,
+    0,
+    '{"price": 0, "volume": 0}'::jsonb,
+    'ok',
+    'critical',
+    'critical',
+    '2025-01-20T10:07:00Z'
+);
+
+INSERT INTO risk_platform.risk_summary (
+    symbol,
+    ts_ingest,
+    volatility_5m,
+    value_at_risk_95,
+    volatility_status,
+    late_rate,
+    duplicate_rate,
+    late_status,
+    duplicate_status,
+    external_signal_count
+)
+VALUES
+    (
+        'AAPL',
+        '2025-01-20T10:07:00Z',
+        0.00007001057239470774,
+        0.009905940594059415,
+        'ok',
+        0.16666666666666666,
+        0.1428571428571429,
+        'critical',
+        'critical',
+        0
+    ),
+    (
+        'MSFT',
+        '2025-01-20T10:07:00Z',
+        0.00881448535776616,
+        -0.003508953168044065,
+        'ok',
+        0.16666666666666666,
+        0.1428571428571429,
+        'critical',
+        'critical',
+        0
+    )
+ON CONFLICT (symbol, ts_ingest) DO NOTHING;
+
+INSERT INTO staging.market_events_raw_batch (
+    event_id,
+    symbol,
+    price,
+    volume,
+    ts_event,
+    ts_ingest,
+    source
+)
+VALUES
+    ('evt-6', 'msft', 241.0, 8, '2025-01-20T10:03:00Z', '2025-01-20T10:03:05Z', 'stooq'),
+    ('evt-7', 'goog', 188.5, 15, '2025-01-20T10:04:00Z', '2025-01-20T10:04:03Z', 'stooq');


### PR DESCRIPTION
## Summary

- Add a Docker Compose playground for local PostgreSQL and MongoDB inspection.
- Seed PostgreSQL with warehouse-style tables and demo data matching the pipeline fixture.
- Seed MongoDB with nested source documents and duplicate market-event examples.
- Add a walkthrough explaining MongoDB source shape, PostgreSQL serving shape, and the pipeline responsibilities between them.
- Add Makefile targets for starting, stopping, and opening database shells.

## Validation

- `docker-compose.yml` parsed successfully with Python YAML
- `make lint`
- `make test` - 38 passed

Docker is not installed in the local shell used for this change, so the containers were not started here.