### PR TITLE
Add data consistency and managed database scaffold

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,9 @@
 PYTHON ?= .venv/bin/python
 PIP ?= $(PYTHON) -m pip
 
-.PHONY: setup lint test format benchmark-io docker-build k8s-render-dev k8s-render-prod clean-generated local-db-up local-db-down local-db-logs postgres-shell mongo-shell
+LOCAL_POSTGRES_DSN ?= postgresql://risk_user:risk_password@localhost:5433/risk_platform
+
+.PHONY: setup lint test format benchmark-io docker-build k8s-render-dev k8s-render-prod clean-generated local-db-up local-db-down local-db-wait local-db-logs postgres-shell mongo-shell run-demo load-postgres-demo load-postgres-dry-run check-postgres-consistency consistency-demo
 
 setup:
 	python3 -m venv .venv
@@ -38,6 +40,12 @@ local-db-up:
 local-db-down:
 	docker compose down -v
 
+local-db-wait:
+	@until docker compose exec -T postgres pg_isready -U risk_user -d risk_platform >/dev/null 2>&1; do \
+		echo "Waiting for PostgreSQL..."; \
+		sleep 1; \
+	done
+
 local-db-logs:
 	docker compose logs -f postgres mongo
 
@@ -46,3 +54,21 @@ postgres-shell:
 
 mongo-shell:
 	docker compose exec mongo mongosh risk_source
+
+run-demo:
+	$(PYTHON) -m src.orchestration.run_pipeline \
+		--input tests/fixtures/demo_events.json \
+		--late-seconds 60 \
+		--vol-window 2 \
+		--summary-json .demo/pipeline-summary.json
+
+load-postgres-demo:
+	$(PYTHON) -m src.warehouse.postgres_loader --dsn "$(LOCAL_POSTGRES_DSN)"
+
+load-postgres-dry-run:
+	$(PYTHON) -m src.warehouse.postgres_loader --dry-run
+
+check-postgres-consistency:
+	docker compose exec -T postgres psql -U risk_user -d risk_platform < sql/consistency_checks.sql
+
+consistency-demo: clean-generated run-demo local-db-wait load-postgres-demo check-postgres-consistency

--- a/README.md
+++ b/README.md
@@ -94,8 +94,10 @@ Additional preparation notes:
 5. `docs/elt-mapping.md` for connector-based ELT mapping
 6. `docs/source-document-mapping.md` for nested source document flattening
 7. `docs/postgres-mongodb-walkthrough.md` for local source-to-warehouse inspection
-8. `docs/lambda-s3-orchestration.md` for AWS orchestration mapping
-9. `sql/postgres_schema.sql` and `sql/ops_queries.sql` for PostgreSQL examples
+8. `docs/data-consistency-walkthrough.md` for source-to-warehouse reconciliation
+9. `docs/aws-managed-databases.md` for disabled-by-default RDS/Aurora/DocumentDB IaC
+10. `docs/lambda-s3-orchestration.md` for AWS orchestration mapping
+11. `sql/postgres_schema.sql` and `sql/ops_queries.sql` for PostgreSQL examples
 
 ## Local Database Playground
 
@@ -104,12 +106,14 @@ demo data:
 
 ```bash
 make local-db-up
+make consistency-demo
 make postgres-shell
 make mongo-shell
 make local-db-down
 ```
 
-See `docs/postgres-mongodb-walkthrough.md` for the inspection commands.
+See `docs/postgres-mongodb-walkthrough.md` for inspection commands and
+`docs/data-consistency-walkthrough.md` for the full reconciliation flow.
 
 ## Performance Benchmark
 

--- a/docs/aws-managed-databases.md
+++ b/docs/aws-managed-databases.md
@@ -1,0 +1,129 @@
+# AWS Managed Database Scaffold
+
+This project includes disabled-by-default Terraform for managed AWS databases.
+It is intended as infrastructure design evidence, not something to leave running
+unattended.
+
+## What Is Included
+
+PostgreSQL serving options:
+
+1. Single-instance RDS PostgreSQL.
+2. Aurora PostgreSQL Serverless v2.
+
+Document source option:
+
+1. Amazon DocumentDB for MongoDB-compatible source documents.
+
+Supporting resources:
+
+1. Private subnet groups.
+2. Database security groups.
+3. Encrypted storage.
+4. AWS-managed master password for RDS/Aurora PostgreSQL.
+5. Disabled-by-default creation flags to avoid accidental cost.
+
+## Default Behaviour
+
+The defaults create no managed databases:
+
+```hcl
+create_rds_postgres      = false
+create_aurora_postgres   = false
+create_documentdb_cluster = false
+```
+
+This means `terraform plan` can include the scaffolding without creating RDS,
+Aurora, or DocumentDB until an environment explicitly opts in.
+
+## Example RDS PostgreSQL Opt-In
+
+```hcl
+environment = "dev"
+
+vpc_id             = "vpc-xxxxxxxx"
+private_subnet_ids = ["subnet-aaa", "subnet-bbb"]
+
+create_rds_postgres = true
+
+database_allowed_cidr_blocks = [
+  "10.0.0.0/16"
+]
+```
+
+RDS PostgreSQL is the simplest first managed target for this project because it
+maps directly to the local PostgreSQL playground and the `risk_platform` schema.
+
+## Example Aurora PostgreSQL Opt-In
+
+```hcl
+environment = "dev"
+
+vpc_id             = "vpc-xxxxxxxx"
+private_subnet_ids = ["subnet-aaa", "subnet-bbb"]
+
+create_aurora_postgres = true
+aurora_min_acu         = 0.5
+aurora_max_acu         = 1
+aurora_instance_count  = 1
+```
+
+Aurora is more production-like, but it is also more infrastructure than this
+portfolio workload needs. Use it to discuss scaling and managed operations, not
+as the first thing to deploy.
+
+## Example DocumentDB Opt-In
+
+```hcl
+environment = "dev"
+
+vpc_id             = "vpc-xxxxxxxx"
+private_subnet_ids = ["subnet-aaa", "subnet-bbb"]
+
+create_documentdb_cluster  = true
+documentdb_master_password = "replace-with-secure-value"
+
+database_allowed_cidr_blocks = [
+  "10.0.0.0/16"
+]
+```
+
+DocumentDB is MongoDB-compatible, but it is not identical to MongoDB. For this
+repo, the important design point is the source pattern:
+
+```text
+nested source documents
+  -> incremental extraction
+  -> flattening and validation
+  -> warehouse serving tables
+```
+
+## Cost And Safety Notes
+
+1. Keep all creation flags set to `false` unless deliberately testing.
+2. Use private subnets and avoid public database access.
+3. Keep `database_allowed_cidr_blocks` narrow.
+4. Set a budget alarm before applying any managed database resources.
+5. Destroy test resources immediately after validation.
+6. Prefer RDS PostgreSQL first if the goal is to demonstrate warehouse serving.
+7. Use DocumentDB only when testing source-document behaviour is worth the cost.
+
+## How It Maps To The Local Playground
+
+| Local | AWS |
+| --- | --- |
+| Docker PostgreSQL | RDS PostgreSQL or Aurora PostgreSQL |
+| Docker MongoDB | Amazon DocumentDB |
+| `sql/postgres_schema.sql` | Database migration/init script |
+| `src.warehouse.postgres_loader` | Batch load job or scheduled task |
+| `sql/consistency_checks.sql` | Reconciliation/monitoring query |
+
+## Interview Explanation
+
+Use this version:
+
+> I kept managed databases as disabled-by-default Terraform because RDS, Aurora,
+> and DocumentDB have real running costs. The local Docker playground proves the
+> source-to-warehouse contract. The Terraform shows how I would move the same
+> pattern into AWS using private subnets, security groups, encrypted storage,
+> and opt-in creation flags.

--- a/docs/data-consistency-walkthrough.md
+++ b/docs/data-consistency-walkthrough.md
@@ -1,0 +1,238 @@
+# Data Consistency Walkthrough
+
+This walkthrough connects the local source, pipeline, and warehouse pieces into
+one consistency story.
+
+## Goal
+
+Show that the same demo data can be traced through each layer:
+
+```text
+MongoDB-style source documents
+  -> pipeline input fixture
+  -> raw parquet output
+  -> curated parquet output
+  -> PostgreSQL warehouse tables
+  -> reconciliation checks
+```
+
+The expected demo counts are:
+
+| Layer | Expected |
+| --- | ---: |
+| Source records | 7 |
+| Distinct event IDs | 6 |
+| Duplicate records | 1 |
+| Late records | 1 |
+| Raw warehouse events | 6 |
+| `returns_1m` rows | 4 |
+| `volatility_5m` rows | 2 |
+| `risk_summary` rows | 2 |
+| Data quality rows | 1 |
+
+## Start Local Databases
+
+```bash
+make local-db-up
+```
+
+This starts:
+
+1. PostgreSQL on local port `5433`.
+2. MongoDB on local port `27018`.
+
+PostgreSQL is seeded with warehouse-style demo data. MongoDB is seeded with
+nested source documents, including one duplicate market event.
+
+## Run The Pipeline
+
+```bash
+make clean-generated
+make run-demo
+```
+
+Expected summary:
+
+```text
+Raw events written: 6
+Curated records written: 9
+Late rate: 16.67% (status: critical)
+Duplicate rate: 14.29% (status: critical)
+```
+
+## Dry-Run The PostgreSQL Loader
+
+```bash
+make load-postgres-dry-run
+```
+
+This reads local parquet output and prints the rows that would be loaded into
+each PostgreSQL table. It does not connect to PostgreSQL.
+
+## Load Pipeline Output Into PostgreSQL
+
+```bash
+make load-postgres-demo
+```
+
+The loader reads:
+
+```text
+data/raw/market_events/
+data/curated/returns_1m/
+data/curated/volatility_5m/
+data/curated/data_quality_metrics/
+data/curated/risk_summary/
+data/curated/external_signal_summary/
+```
+
+It upserts into:
+
+```text
+risk_platform.market_events_raw
+risk_platform.returns_1m
+risk_platform.volatility_5m
+risk_platform.data_quality_metrics
+risk_platform.risk_summary
+risk_platform.external_signal_summary
+```
+
+The local connection string is:
+
+```text
+postgresql://risk_user:risk_password@localhost:5433/risk_platform
+```
+
+Override it with:
+
+```bash
+make load-postgres-demo LOCAL_POSTGRES_DSN='postgresql://user:password@host:5432/database'
+```
+
+## Run Consistency Checks
+
+```bash
+make check-postgres-consistency
+```
+
+The checks compare:
+
+1. Source audit record count to latest data quality `total_events`.
+2. Distinct source event IDs to raw warehouse events.
+3. Source duplicate records to data quality duplicate count.
+4. Source late records to data quality late count.
+5. Raw events to data quality deduped count.
+6. Curated table row counts to expected demo counts.
+7. Latest late and duplicate statuses to expected critical statuses.
+
+Every row should return `status = pass`.
+
+## One-Command Local Consistency Demo
+
+With local PostgreSQL already running:
+
+```bash
+make consistency-demo
+```
+
+This runs:
+
+```text
+clean-generated
+run-demo
+load-postgres-demo
+check-postgres-consistency
+```
+
+## Inspect MongoDB Source Shape
+
+```bash
+make mongo-shell
+```
+
+Find duplicate source business events:
+
+```javascript
+db.market_events_source.aggregate([
+  { $group: { _id: "$eventId", count: { $sum: 1 } } },
+  { $match: { count: { $gt: 1 } } }
+])
+```
+
+Flatten source events into pipeline-shaped records:
+
+```javascript
+db.market_events_source.aggregate([
+  {
+    $project: {
+      _id: 0,
+      event_id: "$eventId",
+      symbol: "$instrument.symbol",
+      price: "$trade.price",
+      volume: "$trade.volume",
+      ts_event: "$timestamps.event",
+      ts_ingest: "$timestamps.ingest",
+      source: "$provider"
+    }
+  }
+])
+```
+
+## Inspect PostgreSQL Warehouse Shape
+
+```bash
+make postgres-shell
+```
+
+Latest quality status:
+
+```sql
+SELECT *
+FROM risk_platform.latest_data_quality_status;
+```
+
+Raw to curated counts:
+
+```sql
+SELECT 'raw' AS table_name, COUNT(*) FROM risk_platform.market_events_raw
+UNION ALL
+SELECT 'returns_1m', COUNT(*) FROM risk_platform.returns_1m
+UNION ALL
+SELECT 'volatility_5m', COUNT(*) FROM risk_platform.volatility_5m
+UNION ALL
+SELECT 'risk_summary', COUNT(*) FROM risk_platform.risk_summary
+UNION ALL
+SELECT 'data_quality_metrics', COUNT(*) FROM risk_platform.data_quality_metrics;
+```
+
+## Interview Explanation
+
+Use this version:
+
+> I made the source-to-warehouse consistency explicit. The source has 7 records,
+> including one duplicate business event and one late event. The pipeline
+> deduplicates to 6 raw events, produces 9 curated records, loads those into
+> PostgreSQL with idempotent upserts, and the consistency SQL checks that source
+> counts, raw counts, curated counts, and data quality metrics agree.
+
+The key point:
+
+```text
+MongoDB source shape is not the same thing as PostgreSQL serving shape.
+The pipeline owns the contract between them.
+```
+
+## AWS Follow-On
+
+The same pattern can be moved to AWS:
+
+```text
+Amazon DocumentDB
+  -> extract or connector job
+  -> validation and flattening
+  -> RDS PostgreSQL or Aurora PostgreSQL
+  -> consistency checks
+```
+
+See `docs/aws-managed-databases.md` for the disabled-by-default Terraform
+scaffold.

--- a/docs/postgres-mongodb-walkthrough.md
+++ b/docs/postgres-mongodb-walkthrough.md
@@ -131,6 +131,25 @@ db.market_events_source.aggregate([
 This is the source-side version of the deduplication problem handled by the
 pipeline.
 
+Flatten source events into the pipeline input shape:
+
+```javascript
+db.market_events_source.aggregate([
+  {
+    $project: {
+      _id: 0,
+      event_id: "$eventId",
+      symbol: "$instrument.symbol",
+      price: "$trade.price",
+      volume: "$trade.volume",
+      ts_event: "$timestamps.event",
+      ts_ingest: "$timestamps.ingest",
+      source: "$provider"
+    }
+  }
+])
+```
+
 ## Inspect PostgreSQL Warehouse Tables
 
 Open a PostgreSQL shell:
@@ -267,3 +286,6 @@ MongoDB: source shape, nested, application-friendly, cursor-driven extraction
 PostgreSQL: serving shape, relational, query-friendly, constrained tables
 Pipeline: contract enforcement, quality checks, deduplication, replay
 ```
+
+For the full source-to-warehouse consistency loop, see
+`docs/data-consistency-walkthrough.md`.

--- a/infra/terraform/aurora.tf
+++ b/infra/terraform/aurora.tf
@@ -1,0 +1,50 @@
+resource "aws_rds_cluster" "aurora_postgres" {
+  count = var.create_aurora_postgres ? 1 : 0
+
+  cluster_identifier = "${var.project_name}-${var.environment}-aurora-postgres"
+  engine             = "aurora-postgresql"
+  engine_version     = var.aurora_postgres_engine_version
+  database_name      = var.postgres_database_name
+  master_username    = var.postgres_master_username
+
+  manage_master_user_password = true
+
+  db_subnet_group_name   = aws_db_subnet_group.postgres[0].name
+  vpc_security_group_ids = [aws_security_group.postgres[0].id]
+  storage_encrypted      = true
+
+  serverlessv2_scaling_configuration {
+    min_capacity = var.aurora_min_acu
+    max_capacity = var.aurora_max_acu
+  }
+
+  backup_retention_period = 1
+  deletion_protection     = var.database_deletion_protection
+  skip_final_snapshot     = true
+
+  tags = {
+    Project     = var.project_name
+    Environment = var.environment
+    Workload    = "warehouse"
+  }
+}
+
+resource "aws_rds_cluster_instance" "aurora_postgres" {
+  count = var.create_aurora_postgres ? var.aurora_instance_count : 0
+
+  identifier         = "${var.project_name}-${var.environment}-aurora-postgres-${count.index + 1}"
+  cluster_identifier = aws_rds_cluster.aurora_postgres[0].id
+  instance_class     = "db.serverless"
+  engine             = aws_rds_cluster.aurora_postgres[0].engine
+  engine_version     = aws_rds_cluster.aurora_postgres[0].engine_version
+
+  tags = {
+    Project     = var.project_name
+    Environment = var.environment
+    Workload    = "warehouse"
+  }
+}
+
+output "aurora_postgres_endpoint" {
+  value = try(aws_rds_cluster.aurora_postgres[0].endpoint, null)
+}

--- a/infra/terraform/database_networking.tf
+++ b/infra/terraform/database_networking.tf
@@ -1,0 +1,90 @@
+locals {
+  create_postgres_network   = var.create_rds_postgres || var.create_aurora_postgres
+  create_documentdb_network = var.create_documentdb_cluster
+}
+
+resource "aws_security_group" "postgres" {
+  count = local.create_postgres_network ? 1 : 0
+
+  name        = "${var.project_name}-${var.environment}-postgres"
+  description = "PostgreSQL access for ${var.project_name} ${var.environment}"
+  vpc_id      = var.vpc_id
+
+  dynamic "ingress" {
+    for_each = var.database_allowed_cidr_blocks
+    content {
+      description = "PostgreSQL client access"
+      from_port   = 5432
+      to_port     = 5432
+      protocol    = "tcp"
+      cidr_blocks = [ingress.value]
+    }
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Project     = var.project_name
+    Environment = var.environment
+  }
+}
+
+resource "aws_db_subnet_group" "postgres" {
+  count = local.create_postgres_network ? 1 : 0
+
+  name       = "${var.project_name}-${var.environment}-postgres"
+  subnet_ids = var.private_subnet_ids
+
+  tags = {
+    Project     = var.project_name
+    Environment = var.environment
+  }
+}
+
+resource "aws_security_group" "documentdb" {
+  count = local.create_documentdb_network ? 1 : 0
+
+  name        = "${var.project_name}-${var.environment}-documentdb"
+  description = "DocumentDB access for ${var.project_name} ${var.environment}"
+  vpc_id      = var.vpc_id
+
+  dynamic "ingress" {
+    for_each = var.database_allowed_cidr_blocks
+    content {
+      description = "DocumentDB client access"
+      from_port   = 27017
+      to_port     = 27017
+      protocol    = "tcp"
+      cidr_blocks = [ingress.value]
+    }
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Project     = var.project_name
+    Environment = var.environment
+  }
+}
+
+resource "aws_docdb_subnet_group" "documentdb" {
+  count = local.create_documentdb_network ? 1 : 0
+
+  name       = "${var.project_name}-${var.environment}-documentdb"
+  subnet_ids = var.private_subnet_ids
+
+  tags = {
+    Project     = var.project_name
+    Environment = var.environment
+  }
+}

--- a/infra/terraform/documentdb.tf
+++ b/infra/terraform/documentdb.tf
@@ -1,0 +1,41 @@
+resource "aws_docdb_cluster" "source" {
+  count = var.create_documentdb_cluster ? 1 : 0
+
+  cluster_identifier = "${var.project_name}-${var.environment}-documentdb"
+  engine             = "docdb"
+
+  master_username = var.documentdb_master_username
+  master_password = var.documentdb_master_password
+
+  db_subnet_group_name   = aws_docdb_subnet_group.documentdb[0].name
+  vpc_security_group_ids = [aws_security_group.documentdb[0].id]
+  storage_encrypted      = true
+
+  backup_retention_period = 1
+  deletion_protection     = var.database_deletion_protection
+  skip_final_snapshot     = true
+
+  tags = {
+    Project     = var.project_name
+    Environment = var.environment
+    Workload    = "source-documents"
+  }
+}
+
+resource "aws_docdb_cluster_instance" "source" {
+  count = var.create_documentdb_cluster ? var.documentdb_instance_count : 0
+
+  identifier         = "${var.project_name}-${var.environment}-documentdb-${count.index + 1}"
+  cluster_identifier = aws_docdb_cluster.source[0].id
+  instance_class     = var.documentdb_instance_class
+
+  tags = {
+    Project     = var.project_name
+    Environment = var.environment
+    Workload    = "source-documents"
+  }
+}
+
+output "documentdb_endpoint" {
+  value = try(aws_docdb_cluster.source[0].endpoint, null)
+}

--- a/infra/terraform/rds.tf
+++ b/infra/terraform/rds.tf
@@ -1,0 +1,39 @@
+resource "aws_db_instance" "postgres" {
+  count = var.create_rds_postgres ? 1 : 0
+
+  identifier = "${var.project_name}-${var.environment}-postgres"
+
+  engine         = "postgres"
+  instance_class = var.rds_postgres_instance_class
+
+  allocated_storage     = var.rds_postgres_allocated_storage_gb
+  max_allocated_storage = max(var.rds_postgres_allocated_storage_gb, 100)
+  storage_encrypted     = true
+  storage_type          = "gp3"
+
+  db_name  = var.postgres_database_name
+  username = var.postgres_master_username
+
+  manage_master_user_password = true
+
+  db_subnet_group_name   = aws_db_subnet_group.postgres[0].name
+  vpc_security_group_ids = [aws_security_group.postgres[0].id]
+  publicly_accessible    = false
+
+  backup_retention_period = 1
+  deletion_protection     = var.database_deletion_protection
+  skip_final_snapshot     = true
+
+  auto_minor_version_upgrade = true
+  copy_tags_to_snapshot      = true
+
+  tags = {
+    Project     = var.project_name
+    Environment = var.environment
+    Workload    = "warehouse"
+  }
+}
+
+output "rds_postgres_endpoint" {
+  value = try(aws_db_instance.postgres[0].address, null)
+}

--- a/infra/terraform/variables.tf
+++ b/infra/terraform/variables.tf
@@ -34,3 +34,113 @@ variable "eks_cluster_arn" {
   default     = ""
   description = "Optional EKS cluster ARN to scope DescribeCluster access."
 }
+
+variable "environment" {
+  type    = string
+  default = "dev"
+}
+
+variable "vpc_id" {
+  type        = string
+  default     = ""
+  description = "VPC ID for optional managed database resources."
+}
+
+variable "private_subnet_ids" {
+  type        = list(string)
+  default     = []
+  description = "Private subnet IDs for optional RDS, Aurora, and DocumentDB resources."
+}
+
+variable "database_allowed_cidr_blocks" {
+  type        = list(string)
+  default     = []
+  description = "CIDR blocks allowed to connect to optional database security groups. Keep empty unless deliberately testing."
+}
+
+variable "create_rds_postgres" {
+  type        = bool
+  default     = false
+  description = "Create an optional single-instance RDS PostgreSQL warehouse. Disabled by default to avoid cost."
+}
+
+variable "create_aurora_postgres" {
+  type        = bool
+  default     = false
+  description = "Create an optional Aurora PostgreSQL cluster. Disabled by default to avoid cost."
+}
+
+variable "create_documentdb_cluster" {
+  type        = bool
+  default     = false
+  description = "Create an optional Amazon DocumentDB cluster. Disabled by default to avoid cost."
+}
+
+variable "postgres_database_name" {
+  type    = string
+  default = "risk_platform"
+}
+
+variable "postgres_master_username" {
+  type    = string
+  default = "risk_admin"
+}
+
+variable "rds_postgres_instance_class" {
+  type    = string
+  default = "db.t4g.micro"
+}
+
+variable "rds_postgres_allocated_storage_gb" {
+  type    = number
+  default = 20
+}
+
+variable "database_deletion_protection" {
+  type        = bool
+  default     = false
+  description = "Enable deletion protection for optional managed databases."
+}
+
+variable "aurora_postgres_engine_version" {
+  type        = string
+  default     = null
+  description = "Optional Aurora PostgreSQL engine version. Leave null to let AWS choose the default supported version."
+}
+
+variable "aurora_min_acu" {
+  type    = number
+  default = 0.5
+}
+
+variable "aurora_max_acu" {
+  type    = number
+  default = 1
+}
+
+variable "aurora_instance_count" {
+  type    = number
+  default = 1
+}
+
+variable "documentdb_master_username" {
+  type    = string
+  default = "docdb_admin"
+}
+
+variable "documentdb_master_password" {
+  type        = string
+  default     = ""
+  sensitive   = true
+  description = "Master password for optional DocumentDB. Required only when create_documentdb_cluster is true."
+}
+
+variable "documentdb_instance_class" {
+  type    = string
+  default = "db.t4g.medium"
+}
+
+variable "documentdb_instance_count" {
+  type    = number
+  default = 1
+}

--- a/mongo/init/01_demo_documents.js
+++ b/mongo/init/01_demo_documents.js
@@ -81,6 +81,70 @@ db.market_events_source.insertMany([
   },
   {
     _id: ObjectId("665f4a731d7f2d9f0a9d0103"),
+    eventId: "evt-3",
+    instrument: {
+      symbol: "AAPL",
+    },
+    trade: {
+      price: 102.0,
+      volume: 12,
+    },
+    timestamps: {
+      event: ISODate("2025-01-20T10:03:00Z"),
+      ingest: ISODate("2025-01-20T10:03:04Z"),
+    },
+    provider: "stooq",
+  },
+  {
+    _id: ObjectId("665f4a731d7f2d9f0a9d0104"),
+    eventId: "evt-4",
+    instrument: {
+      symbol: "MSFT",
+    },
+    trade: {
+      price: 240.0,
+      volume: 9,
+    },
+    timestamps: {
+      event: ISODate("2025-01-20T10:01:00Z"),
+      ingest: ISODate("2025-01-20T10:01:03Z"),
+    },
+    provider: "stooq",
+  },
+  {
+    _id: ObjectId("665f4a731d7f2d9f0a9d0105"),
+    eventId: "evt-5",
+    instrument: {
+      symbol: "MSFT",
+    },
+    trade: {
+      price: 242.0,
+      volume: 10,
+    },
+    timestamps: {
+      event: ISODate("2025-01-20T10:02:00Z"),
+      ingest: ISODate("2025-01-20T10:07:00Z"),
+    },
+    provider: "stooq",
+  },
+  {
+    _id: ObjectId("665f4a731d7f2d9f0a9d0106"),
+    eventId: "evt-6",
+    instrument: {
+      symbol: "MSFT",
+    },
+    trade: {
+      price: 241.0,
+      volume: 8,
+    },
+    timestamps: {
+      event: ISODate("2025-01-20T10:03:00Z"),
+      ingest: ISODate("2025-01-20T10:03:05Z"),
+    },
+    provider: "stooq",
+  },
+  {
+    _id: ObjectId("665f4a731d7f2d9f0a9d0107"),
     eventId: "evt-2",
     instrument: {
       symbol: "AAPL",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
   "pandas>=2.2",
   "numpy>=1.26",
   "duckdb>=0.10",
+  "psycopg[binary]>=3.2",
 ]
 
 [project.optional-dependencies]

--- a/sql/consistency_checks.sql
+++ b/sql/consistency_checks.sql
@@ -1,0 +1,109 @@
+-- Reconciliation checks for the local MongoDB -> pipeline -> PostgreSQL demo.
+-- These checks assume sql/postgres_schema.sql and sql/postgres_demo_data.sql
+-- have been applied, or that pipeline outputs have been loaded with
+-- src.warehouse.postgres_loader.
+
+WITH latest_source_audit AS (
+    SELECT *
+    FROM staging.source_event_audit
+    ORDER BY audit_ts DESC
+    LIMIT 1
+),
+latest_quality AS (
+    SELECT *
+    FROM risk_platform.data_quality_metrics
+    ORDER BY ts_ingest DESC
+    LIMIT 1
+),
+warehouse_counts AS (
+    SELECT
+        (SELECT COUNT(*) FROM risk_platform.market_events_raw) AS raw_events,
+        (SELECT COUNT(*) FROM risk_platform.returns_1m) AS returns_1m,
+        (SELECT COUNT(*) FROM risk_platform.volatility_5m) AS volatility_5m,
+        (SELECT COUNT(*) FROM risk_platform.risk_summary) AS risk_summary,
+        (SELECT COUNT(*) FROM risk_platform.data_quality_metrics) AS data_quality_runs
+)
+SELECT
+    'source_records_to_quality_total' AS check_name,
+    source_records::text AS expected,
+    total_events::text AS actual,
+    CASE WHEN source_records = total_events THEN 'pass' ELSE 'fail' END AS status
+FROM latest_source_audit, latest_quality
+
+UNION ALL
+
+SELECT
+    'distinct_event_ids_to_raw_events',
+    distinct_event_ids::text,
+    raw_events::text,
+    CASE WHEN distinct_event_ids = raw_events THEN 'pass' ELSE 'fail' END
+FROM latest_source_audit, warehouse_counts
+
+UNION ALL
+
+SELECT
+    'duplicate_records_to_quality_duplicates',
+    duplicate_records::text,
+    duplicate_events::text,
+    CASE WHEN duplicate_records = duplicate_events THEN 'pass' ELSE 'fail' END
+FROM latest_source_audit, latest_quality
+
+UNION ALL
+
+SELECT
+    'late_records_to_quality_late_events',
+    expected_late_events::text,
+    late_events::text,
+    CASE WHEN expected_late_events = late_events THEN 'pass' ELSE 'fail' END
+FROM latest_source_audit, latest_quality
+
+UNION ALL
+
+SELECT
+    'raw_events_to_quality_deduped_events',
+    deduped_events::text,
+    raw_events::text,
+    CASE WHEN deduped_events = raw_events THEN 'pass' ELSE 'fail' END
+FROM latest_quality, warehouse_counts
+
+UNION ALL
+
+SELECT
+    'returns_rows_expected',
+    '4',
+    returns_1m::text,
+    CASE WHEN returns_1m = 4 THEN 'pass' ELSE 'fail' END
+FROM warehouse_counts
+
+UNION ALL
+
+SELECT
+    'volatility_rows_expected',
+    '2',
+    volatility_5m::text,
+    CASE WHEN volatility_5m = 2 THEN 'pass' ELSE 'fail' END
+FROM warehouse_counts
+
+UNION ALL
+
+SELECT
+    'risk_summary_rows_expected',
+    '2',
+    risk_summary::text,
+    CASE WHEN risk_summary = 2 THEN 'pass' ELSE 'fail' END
+FROM warehouse_counts
+
+UNION ALL
+
+SELECT
+    'latest_quality_status_expected',
+    'late=critical, duplicate=critical',
+    CONCAT('late=', late_status, ', duplicate=', duplicate_status),
+    CASE
+        WHEN late_status = 'critical' AND duplicate_status = 'critical'
+        THEN 'pass'
+        ELSE 'fail'
+    END
+FROM latest_quality
+
+ORDER BY check_name;

--- a/sql/postgres_demo_data.sql
+++ b/sql/postgres_demo_data.sql
@@ -31,9 +31,20 @@ CREATE TABLE IF NOT EXISTS staging.risk_summary_batch (
     latest_external_signal_ts_event TIMESTAMPTZ
 );
 
+CREATE TABLE IF NOT EXISTS staging.source_event_audit (
+    audit_id BIGSERIAL PRIMARY KEY,
+    source_name TEXT NOT NULL,
+    source_records INTEGER NOT NULL CHECK (source_records >= 0),
+    distinct_event_ids INTEGER NOT NULL CHECK (distinct_event_ids >= 0),
+    duplicate_records INTEGER NOT NULL CHECK (duplicate_records >= 0),
+    expected_late_events INTEGER NOT NULL CHECK (expected_late_events >= 0),
+    audit_ts TIMESTAMPTZ NOT NULL
+);
+
 TRUNCATE TABLE
     staging.market_events_raw_batch,
     staging.risk_summary_batch,
+    staging.source_event_audit,
     risk_platform.external_signal_summary,
     risk_platform.risk_summary,
     risk_platform.data_quality_metrics,
@@ -194,3 +205,20 @@ INSERT INTO staging.market_events_raw_batch (
 VALUES
     ('evt-6', 'msft', 241.0, 8, '2025-01-20T10:03:00Z', '2025-01-20T10:03:05Z', 'stooq'),
     ('evt-7', 'goog', 188.5, 15, '2025-01-20T10:04:00Z', '2025-01-20T10:04:03Z', 'stooq');
+
+INSERT INTO staging.source_event_audit (
+    source_name,
+    source_records,
+    distinct_event_ids,
+    duplicate_records,
+    expected_late_events,
+    audit_ts
+)
+VALUES (
+    'mongo.market_events_source',
+    7,
+    6,
+    1,
+    1,
+    '2025-01-20T10:07:00Z'
+);

--- a/sql/postgres_schema.sql
+++ b/sql/postgres_schema.sql
@@ -75,7 +75,8 @@ CREATE TABLE IF NOT EXISTS risk_platform.data_quality_metrics (
     late_status TEXT NOT NULL CHECK (late_status IN ('ok', 'warn', 'critical')),
     duplicate_status TEXT NOT NULL CHECK (duplicate_status IN ('ok', 'warn', 'critical')),
     ts_ingest TIMESTAMPTZ NOT NULL,
-    loaded_at TIMESTAMPTZ NOT NULL DEFAULT now()
+    loaded_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    UNIQUE (ts_ingest)
 );
 
 CREATE INDEX IF NOT EXISTS idx_data_quality_metrics_ingest_time

--- a/src/warehouse/__init__.py
+++ b/src/warehouse/__init__.py
@@ -1,0 +1,1 @@
+"""Warehouse loading helpers."""

--- a/src/warehouse/postgres_loader.py
+++ b/src/warehouse/postgres_loader.py
@@ -1,0 +1,302 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from dataclasses import dataclass, field
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+import duckdb
+import pandas as pd
+
+from src.storage.storage_config import load_storage_config
+
+DEFAULT_POSTGRES_DSN = "postgresql://risk_user:risk_password@localhost:5433/risk_platform"
+
+
+@dataclass(frozen=True)
+class TableLoadSpec:
+    dataset_key: str
+    table_name: str
+    columns: tuple[str, ...]
+    conflict_columns: tuple[str, ...]
+    storage_kind: str = "curated"
+    jsonb_columns: frozenset[str] = field(default_factory=frozenset)
+
+    @property
+    def update_columns(self) -> tuple[str, ...]:
+        return tuple(column for column in self.columns if column not in self.conflict_columns)
+
+
+LOAD_SPECS = (
+    TableLoadSpec(
+        dataset_key="market_events",
+        table_name="market_events_raw",
+        storage_kind="raw",
+        columns=("event_id", "symbol", "price", "volume", "ts_event", "ts_ingest", "source"),
+        conflict_columns=("event_id",),
+    ),
+    TableLoadSpec(
+        dataset_key="returns_1m",
+        table_name="returns_1m",
+        columns=("symbol", "ts_event", "window_start", "return_1m", "ts_ingest"),
+        conflict_columns=("symbol", "ts_event"),
+    ),
+    TableLoadSpec(
+        dataset_key="volatility_5m",
+        table_name="volatility_5m",
+        columns=("symbol", "ts_event", "window_start", "volatility_5m", "ts_ingest"),
+        conflict_columns=("symbol", "ts_event"),
+    ),
+    TableLoadSpec(
+        dataset_key="data_quality_metrics",
+        table_name="data_quality_metrics",
+        columns=(
+            "total_events",
+            "deduped_events",
+            "duplicate_events",
+            "late_events",
+            "late_rate",
+            "duplicate_rate",
+            "required_fields_checked",
+            "missing_required_field_count",
+            "missing_required_record_count",
+            "missing_required_fields_by_name",
+            "required_fields_status",
+            "null_fields_checked",
+            "null_field_count",
+            "null_record_count",
+            "max_null_rate",
+            "null_fields_by_name",
+            "null_rates_by_name",
+            "null_rate_status",
+            "value_fields_checked",
+            "invalid_value_count",
+            "invalid_value_record_count",
+            "invalid_values_by_name",
+            "value_validity_status",
+            "late_status",
+            "duplicate_status",
+            "ts_ingest",
+        ),
+        conflict_columns=("ts_ingest",),
+        jsonb_columns=frozenset(
+            {
+                "missing_required_fields_by_name",
+                "null_fields_by_name",
+                "null_rates_by_name",
+                "invalid_values_by_name",
+            }
+        ),
+    ),
+    TableLoadSpec(
+        dataset_key="risk_summary",
+        table_name="risk_summary",
+        columns=(
+            "symbol",
+            "ts_ingest",
+            "volatility_5m",
+            "value_at_risk_95",
+            "volatility_status",
+            "late_rate",
+            "duplicate_rate",
+            "late_status",
+            "duplicate_status",
+            "external_signal_count",
+            "latest_external_signal_name",
+            "latest_external_signal_value",
+            "latest_external_signal_source",
+            "latest_external_signal_ts_event",
+        ),
+        conflict_columns=("symbol", "ts_ingest"),
+    ),
+    TableLoadSpec(
+        dataset_key="external_signal_summary",
+        table_name="external_signal_summary",
+        columns=(
+            "name",
+            "source",
+            "latest_value",
+            "latest_signal_id",
+            "latest_ts_event",
+            "ts_ingest",
+        ),
+        conflict_columns=("name", "source", "latest_signal_id"),
+    ),
+)
+
+
+def _dataset_dir(storage_config: dict[str, Any], spec: TableLoadSpec) -> Path:
+    storage = storage_config["storage"]
+    if spec.storage_kind == "raw":
+        return Path(storage["raw"]["base_path"]) / storage["raw"]["dataset"]
+    dataset_name = storage["curated"]["datasets"][spec.dataset_key]
+    return Path(storage["curated"]["base_path"]) / dataset_name
+
+
+def _read_dataset_records(dataset_dir: Path, columns: tuple[str, ...]) -> list[dict[str, Any]]:
+    parquet_files = sorted(dataset_dir.rglob("*.parquet"))
+    if not parquet_files:
+        return []
+
+    escaped_paths = [str(path).replace("'", "''") for path in parquet_files]
+    quoted_paths = ", ".join(f"'{path}'" for path in escaped_paths)
+    with duckdb.connect() as conn:
+        df = conn.execute(
+            f"SELECT * FROM read_parquet([{quoted_paths}], union_by_name=true)"
+        ).df()
+
+    for column in columns:
+        if column not in df.columns:
+            df[column] = None
+    df = df.loc[:, list(columns)]
+    return [
+        {key: _normalise_value(value) for key, value in record.items()}
+        for record in df.to_dict("records")
+    ]
+
+
+def _normalise_value(value: Any) -> Any:
+    if value is None:
+        return None
+    if isinstance(value, float) and pd.isna(value):
+        return None
+    if pd.isna(value) is True:
+        return None
+    if hasattr(value, "to_pydatetime"):
+        return value.to_pydatetime()
+    if isinstance(value, pd.Timestamp):
+        return value.to_pydatetime()
+    return value
+
+
+def collect_load_batches(
+    storage_config_path: Path = Path("config/storage.yaml"),
+) -> dict[str, list[dict[str, Any]]]:
+    storage_config = load_storage_config(storage_config_path)
+    batches: dict[str, list[dict[str, Any]]] = {}
+    for spec in LOAD_SPECS:
+        batches[spec.table_name] = _read_dataset_records(
+            _dataset_dir(storage_config, spec),
+            spec.columns,
+        )
+    return batches
+
+
+def build_upsert_sql(spec: TableLoadSpec, schema_name: str = "risk_platform") -> str:
+    quoted_columns = ", ".join(_quote_identifier(column) for column in spec.columns)
+    placeholders = ", ".join(["%s"] * len(spec.columns))
+    conflict_columns = ", ".join(_quote_identifier(column) for column in spec.conflict_columns)
+    updates = ", ".join(
+        f"{_quote_identifier(column)} = EXCLUDED.{_quote_identifier(column)}"
+        for column in spec.update_columns
+    )
+    return (
+        f"INSERT INTO {_quote_identifier(schema_name)}.{_quote_identifier(spec.table_name)} "
+        f"({quoted_columns}) VALUES ({placeholders}) "
+        f"ON CONFLICT ({conflict_columns}) DO UPDATE SET {updates}, loaded_at = now()"
+    )
+
+
+def load_batches_to_postgres(
+    *,
+    dsn: str,
+    storage_config_path: Path = Path("config/storage.yaml"),
+    schema_name: str = "risk_platform",
+    dry_run: bool = False,
+) -> dict[str, int]:
+    batches = collect_load_batches(storage_config_path)
+    counts = {table_name: len(records) for table_name, records in batches.items()}
+    if dry_run:
+        return counts
+
+    try:
+        import psycopg
+        from psycopg.types.json import Jsonb
+    except ImportError as exc:
+        raise RuntimeError(
+            "PostgreSQL loading requires psycopg. Run `make setup` to install dependencies."
+        ) from exc
+
+    specs_by_table = {spec.table_name: spec for spec in LOAD_SPECS}
+    with psycopg.connect(dsn) as conn:
+        with conn.cursor() as cursor:
+            for table_name, records in batches.items():
+                if not records:
+                    continue
+                spec = specs_by_table[table_name]
+                statement = build_upsert_sql(spec, schema_name=schema_name)
+                rows = [
+                    tuple(
+                        _postgres_value(
+                            record[column],
+                            jsonb=column in spec.jsonb_columns,
+                            jsonb_wrapper=Jsonb,
+                        )
+                        for column in spec.columns
+                    )
+                    for record in records
+                ]
+                cursor.executemany(statement, rows)
+        conn.commit()
+    return counts
+
+
+def _postgres_value(value: Any, *, jsonb: bool, jsonb_wrapper: Any) -> Any:
+    if not jsonb or value is None:
+        return value
+    if isinstance(value, str):
+        value = json.loads(value)
+    return jsonb_wrapper(value)
+
+
+def _quote_identifier(value: str) -> str:
+    escaped = value.replace('"', '""')
+    return f'"{escaped}"'
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Load local parquet pipeline outputs into PostgreSQL warehouse tables."
+    )
+    parser.add_argument(
+        "--dsn",
+        default=os.environ.get("WAREHOUSE_POSTGRES_DSN", DEFAULT_POSTGRES_DSN),
+        help="PostgreSQL connection string. Defaults to WAREHOUSE_POSTGRES_DSN or the local Docker DSN.",
+    )
+    parser.add_argument(
+        "--storage-config",
+        type=Path,
+        default=Path("config/storage.yaml"),
+        help="Path to storage configuration YAML.",
+    )
+    parser.add_argument(
+        "--schema",
+        default="risk_platform",
+        help="Target PostgreSQL schema.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print planned row counts without connecting to PostgreSQL.",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = _parse_args()
+    counts = load_batches_to_postgres(
+        dsn=args.dsn,
+        storage_config_path=args.storage_config,
+        schema_name=args.schema,
+        dry_run=args.dry_run,
+    )
+    print(f"Warehouse load summary at {datetime.utcnow().isoformat()}Z")
+    for table_name, count in sorted(counts.items()):
+        print(f"{table_name}: {count}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/test_postgres_loader.py
+++ b/tests/unit/test_postgres_loader.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import yaml
+
+from src.orchestration.run_pipeline import run_pipeline
+from src.warehouse.postgres_loader import (
+    LOAD_SPECS,
+    TableLoadSpec,
+    build_upsert_sql,
+    collect_load_batches,
+    load_batches_to_postgres,
+)
+
+
+def _write_storage_config(tmp_path: Path) -> Path:
+    storage_config = {
+        "storage": {
+            "base_dir": str(tmp_path),
+            "raw": {
+                "base_path": str(tmp_path / "raw"),
+                "dataset": "market_events",
+            },
+            "curated": {
+                "base_path": str(tmp_path / "curated"),
+                "datasets": {
+                    "returns_1m": "returns_1m",
+                    "volatility_5m": "volatility_5m",
+                    "data_quality_metrics": "data_quality_metrics",
+                    "risk_summary": "risk_summary",
+                    "external_signal_summary": "external_signal_summary",
+                },
+            },
+            "format": "parquet",
+            "partitioning": {
+                "granularity": "hourly",
+            },
+        }
+    }
+    storage_config_path = tmp_path / "storage.yaml"
+    with storage_config_path.open("w", encoding="utf-8") as handle:
+        yaml.safe_dump(storage_config, handle, sort_keys=False)
+    return storage_config_path
+
+
+def _write_demo_input(tmp_path: Path) -> Path:
+    source = Path("tests/fixtures/demo_events.json")
+    target = tmp_path / "demo_events.json"
+    with source.open("r", encoding="utf-8") as handle:
+        payload = json.load(handle)
+    with target.open("w", encoding="utf-8") as handle:
+        json.dump(payload, handle)
+    return target
+
+
+def test_collect_load_batches_matches_demo_pipeline_outputs(tmp_path: Path) -> None:
+    storage_config_path = _write_storage_config(tmp_path)
+    input_path = _write_demo_input(tmp_path)
+
+    run_pipeline(
+        input_path=input_path,
+        thresholds_path=Path("config/risk_thresholds.yaml"),
+        late_seconds=60,
+        window_minutes=5,
+        vol_window=2,
+        storage_config_path=storage_config_path,
+    )
+
+    batches = collect_load_batches(storage_config_path)
+
+    assert {key: len(value) for key, value in batches.items()} == {
+        "market_events_raw": 6,
+        "returns_1m": 4,
+        "volatility_5m": 2,
+        "data_quality_metrics": 1,
+        "risk_summary": 2,
+        "external_signal_summary": 0,
+    }
+    assert batches["risk_summary"][0]["external_signal_count"] == 0
+    assert "latest_external_signal_name" in batches["risk_summary"][0]
+
+
+def test_load_batches_to_postgres_dry_run_returns_counts(tmp_path: Path) -> None:
+    storage_config_path = _write_storage_config(tmp_path)
+    input_path = _write_demo_input(tmp_path)
+    run_pipeline(
+        input_path=input_path,
+        thresholds_path=Path("config/risk_thresholds.yaml"),
+        late_seconds=60,
+        window_minutes=5,
+        vol_window=2,
+        storage_config_path=storage_config_path,
+    )
+
+    counts = load_batches_to_postgres(
+        dsn="postgresql://example",
+        storage_config_path=storage_config_path,
+        dry_run=True,
+    )
+
+    assert counts["market_events_raw"] == 6
+    assert counts["data_quality_metrics"] == 1
+
+
+def test_build_upsert_sql_quotes_identifiers_and_conflict_key() -> None:
+    statement = build_upsert_sql(
+        TableLoadSpec(
+            dataset_key="example",
+            table_name="target_table",
+            columns=("event_id", "value"),
+            conflict_columns=("event_id",),
+        )
+    )
+
+    assert 'INSERT INTO "risk_platform"."target_table"' in statement
+    assert '("event_id", "value")' in statement
+    assert 'ON CONFLICT ("event_id") DO UPDATE' in statement
+    assert '"value" = EXCLUDED."value"' in statement
+
+
+def test_all_load_specs_have_update_columns() -> None:
+    assert all(spec.update_columns for spec in LOAD_SPECS)


### PR DESCRIPTION
## Summary

- Add a PostgreSQL warehouse loader for local parquet pipeline outputs with idempotent upserts and dry-run counts.
- Add source-to-warehouse consistency checks and a walkthrough for reconciling MongoDB-style source records, pipeline outputs, and PostgreSQL tables.
- Align MongoDB demo source documents with the pipeline demo fixture.
- Add disabled-by-default Terraform scaffolding for RDS PostgreSQL, Aurora PostgreSQL, and Amazon DocumentDB.
- Add managed database documentation with cost-aware opt-in guidance.

## Validation

- `make lint`
- `make test` - 42 passed
- `make clean-generated && make run-demo && make load-postgres-dry-run`
- `git diff --check`

Docker and Terraform are not installed in the local shell used for this change, so container startup and `terraform validate` were not run here.