### PR TITLE
Add engineering delivery readiness workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,145 @@
+# Agent Operating Guide
+
+Use this file as durable project guidance for coding agents working in this
+repository.
+
+## Project Purpose
+
+This is a portfolio-grade data engineering platform focused on pipeline
+reliability:
+
+1. Ingest market-like source events and external signals.
+2. Validate, normalise, and deduplicate records.
+3. Write raw and curated partitioned parquet outputs.
+4. Load curated outputs into PostgreSQL-style warehouse tables.
+5. Reconcile source, raw, curated, and warehouse counts.
+6. Document AWS deployment and managed database paths without deploying by
+   default.
+
+Prioritise clear engineering evidence over broad feature sprawl.
+
+## Default Commands
+
+Use these commands for normal validation:
+
+```bash
+make lint
+make test
+make readiness-check
+```
+
+Expected test suite result:
+
+```text
+42 passed
+```
+
+When Docker is available, validate the local source-to-warehouse loop:
+
+```bash
+make local-db-up
+make consistency-demo
+make local-db-down
+```
+
+When Terraform is available, validate infrastructure changes:
+
+```bash
+terraform -chdir=infra/terraform fmt -check -diff
+terraform -chdir=infra/terraform init -backend=false
+terraform -chdir=infra/terraform validate
+```
+
+If Docker or Terraform is unavailable, state that clearly in the final summary
+and run the closest local validation that does not require those tools.
+
+## Engineering Rules
+
+1. Prefer small, defensible changes with tests.
+2. Keep generated local outputs out of git.
+3. Do not commit `data/`, `.demo/`, caches, virtual environments, or local
+   database volumes.
+4. Keep AWS resources disabled by default unless the user explicitly asks to
+   deploy.
+5. Do not run `terraform apply`, cloud deploy workflows, or destructive cloud
+   commands without explicit user confirmation.
+6. Do not add streaming/Kinesis features unless specifically requested; the
+   stronger interview story is Airbyte-style ELT, PostgreSQL, MongoDB/DocumentDB
+   mapping, S3/Lambda, data quality, and backfills.
+7. When adding a new feature, update the relevant walkthrough or preparation
+   doc if it changes how the project should be explained.
+
+## Git Workflow
+
+Unless the user asks only for analysis:
+
+1. Inspect `git status --short --branch` before editing.
+2. Preserve unrelated user changes.
+3. Use a neutral branch name when asked to create a branch.
+4. Stage only files that belong to the task.
+5. Use neutral commit and pull request wording.
+6. Run checks before pushing.
+
+Do not mention internal tool names in commit messages or pull request titles
+unless the user explicitly asks for that.
+
+## Validation Expectations
+
+For Python or pipeline changes:
+
+```bash
+make lint
+make test
+```
+
+For demo-path changes:
+
+```bash
+make readiness-check
+```
+
+For PostgreSQL/MongoDB local-playground changes:
+
+```bash
+.venv/bin/python -c "import yaml; yaml.safe_load(open('docker-compose.yml', encoding='utf-8'))"
+make lint
+make test
+```
+
+Also run Docker-based checks if Docker is available.
+
+For Terraform changes, run Terraform format and validate if Terraform is
+available. Keep optional managed databases behind explicit `create_*` flags that
+default to `false`.
+
+## Documentation Style
+
+Docs should be interview-useful:
+
+1. Explain the engineering decision.
+2. State the trade-off.
+3. Point to concrete files or commands.
+4. Avoid overclaiming production use of tools that are only scaffolded or
+   locally demonstrated.
+
+Preferred wording for tool gaps:
+
+```text
+The repo demonstrates the engineering pattern around the tool: source landing,
+validation, deduplication, idempotent loading, data quality, and backfill
+behaviour. It does not claim production ownership of every managed service.
+```
+
+## Risk Guardrails
+
+High-risk changes require extra care:
+
+1. Terraform/cloud resources.
+2. Database schemas and load logic.
+3. Deployment workflows.
+4. Data quality thresholds.
+5. Backfill and locking behaviour.
+6. Authentication, secrets, IAM, and network access.
+
+For these, include tests or a concrete validation note. If a tool is unavailable
+locally, say what was not run.

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ PIP ?= $(PYTHON) -m pip
 
 LOCAL_POSTGRES_DSN ?= postgresql://risk_user:risk_password@localhost:5433/risk_platform
 
-.PHONY: setup lint test format benchmark-io docker-build k8s-render-dev k8s-render-prod clean-generated local-db-up local-db-down local-db-wait local-db-logs postgres-shell mongo-shell run-demo load-postgres-demo load-postgres-dry-run check-postgres-consistency consistency-demo
+.PHONY: setup lint test format benchmark-io docker-build k8s-render-dev k8s-render-prod clean-generated readiness-check local-db-up local-db-down local-db-wait local-db-logs postgres-shell mongo-shell run-demo load-postgres-demo load-postgres-dry-run check-postgres-consistency consistency-demo
 
 setup:
 	python3 -m venv .venv
@@ -33,6 +33,8 @@ k8s-render-prod:
 
 clean-generated:
 	rm -rf data .demo .benchmarks .pytest_cache .mypy_cache .ruff_cache
+
+readiness-check: lint test clean-generated run-demo load-postgres-dry-run
 
 local-db-up:
 	docker compose up -d postgres mongo

--- a/README.md
+++ b/README.md
@@ -55,12 +55,7 @@ For a fuller local walkthrough with duplicates, a late event, and curated
 metrics:
 
 ```bash
-make clean-generated
-.venv/bin/python -m src.orchestration.run_pipeline \
-  --input tests/fixtures/demo_events.json \
-  --late-seconds 60 \
-  --vol-window 2 \
-  --summary-json .demo/pipeline-summary.json
+make readiness-check
 ```
 
 Include landed external risk signals to enrich the risk summary:
@@ -87,6 +82,7 @@ See `docs/architecture.md` for the end-to-end design.
 
 Additional preparation notes:
 
+0. `AGENTS.md` for durable project instructions used by coding agents
 1. `docs/demo-script.md` for a short technical walkthrough
 2. `docs/preparation-plan.md` for interview preparation
 3. `docs/interview-stories.md` for interview story rehearsal
@@ -98,6 +94,8 @@ Additional preparation notes:
 9. `docs/aws-managed-databases.md` for disabled-by-default RDS/Aurora/DocumentDB IaC
 10. `docs/lambda-s3-orchestration.md` for AWS orchestration mapping
 11. `sql/postgres_schema.sql` and `sql/ops_queries.sql` for PostgreSQL examples
+12. `docs/agentic-workflows.md` for larger delegated development workflows
+13. `docs/engineering-delivery-workflow.md` for the engineer-owned delivery model
 
 ## Local Database Playground
 

--- a/docs/agentic-workflows.md
+++ b/docs/agentic-workflows.md
@@ -1,0 +1,199 @@
+# Agentic Workflow Guide
+
+This guide explains how to use coding agents effectively in this repository.
+The aim is to delegate larger tasks while keeping engineering control through
+branching, tests, review, and clear acceptance criteria.
+
+## Autonomy Levels
+
+Use the smallest autonomy level that fits the task.
+
+| Level | Use When | Agent Can Do | Human Must Do |
+| --- | --- | --- | --- |
+| 0: Advice | You are deciding direction | Explain options, risks, and next steps | Choose the path |
+| 1: Local Change | Scope is clear and low-risk | Edit files and run tests locally | Review final diff |
+| 2: Branch And PR | Work is multi-file but bounded | Branch, commit, push, open PR | Review PR before merge unless explicitly delegated |
+| 3: PR Follow-Through | PR has CI/review feedback | Inspect failures, patch, rerun checks | Approve risky changes |
+| 4: Cloud/Infra | AWS, Terraform, deploys, secrets | Prepare scaffolding and plans | Approve apply/deploy/secret changes |
+
+For this repo, default to Level 1 or 2. Use Level 4 only for disabled-by-default
+infrastructure scaffolding unless explicitly deploying.
+
+## Good Task Shape
+
+Strong prompts include:
+
+1. Objective.
+2. Scope boundaries.
+3. Files or areas to inspect first.
+4. Acceptance criteria.
+5. Validation commands.
+6. Git expectations.
+7. What not to do.
+
+Template:
+
+```text
+Objective:
+Implement <specific outcome>.
+
+Scope:
+Touch only <directories/files>.
+
+Acceptance criteria:
+- <observable behaviour>
+- <tests/docs updated>
+- <commands pass>
+
+Validation:
+Run <commands>.
+
+Git:
+Create a neutral branch, commit, push, open PR, wait for checks, merge if green.
+
+Do not:
+- <risky or out-of-scope action>
+```
+
+## Ready-To-Use Prompts
+
+### Multi-File Feature
+
+```text
+Implement a source-to-warehouse consistency improvement.
+
+Scope:
+- src/warehouse/
+- sql/
+- docs/
+- tests/
+
+Acceptance criteria:
+- Existing pipeline demo still writes 6 raw events and 9 curated records.
+- Loader dry-run prints counts for raw, returns, volatility, risk, and quality.
+- Reconciliation SQL has pass/fail output.
+- Tests cover batch collection and upsert SQL generation.
+
+Validation:
+- make lint
+- make test
+- make readiness-check
+
+Do not deploy AWS resources or run terraform apply.
+```
+
+### Refactor
+
+```text
+Refactor the pipeline module to reduce duplication without changing behaviour.
+
+Acceptance criteria:
+- Public CLI arguments remain the same.
+- Demo output counts remain the same.
+- Tests pass.
+- No unrelated formatting churn.
+
+Validation:
+- make lint
+- make test
+- make readiness-check
+```
+
+### Test Gap
+
+```text
+Find one meaningful missing test around data quality, storage idempotency, or
+warehouse loading, then implement the smallest focused test.
+
+Acceptance criteria:
+- Test fails for a plausible regression.
+- No production logic changes unless needed.
+- Test name explains the behaviour.
+
+Validation:
+- make test
+```
+
+### Pull Request Review
+
+```text
+Review this branch for correctness risks, missing tests, and overclaiming in
+documentation. Prioritise findings by severity with file references. Do not
+make edits unless asked.
+```
+
+### CI Fix
+
+```text
+Inspect the failing CI check, identify the root cause, implement the smallest
+fix, rerun the relevant local check, commit, push, and report the result.
+```
+
+### Infrastructure Scaffold
+
+```text
+Add disabled-by-default Terraform scaffolding for <resource>.
+
+Requirements:
+- Creation flag defaults to false.
+- No public access by default.
+- Use private subnet and security group variables.
+- Include cost and teardown notes in docs.
+- Do not run terraform apply.
+
+Validation:
+- terraform fmt/validate if available
+- make test
+```
+
+## Review Checklist
+
+Before accepting agent-authored changes, check:
+
+1. Does the change solve the stated problem?
+2. Are unrelated files untouched?
+3. Are generated files excluded?
+4. Do tests cover the risky behaviour?
+5. Did validation actually run?
+6. Are unavailable checks clearly disclosed?
+7. Are docs accurate and not overstated?
+8. Are cloud resources disabled by default?
+9. Are secrets absent?
+10. Is the diff small enough to review confidently?
+
+## What To Delegate
+
+Good candidates:
+
+1. Adding focused tests.
+2. Writing runbooks and walkthroughs.
+3. Implementing small loaders or adapters.
+4. Refactoring with stable behaviour.
+5. Creating disabled-by-default infrastructure scaffolds.
+6. Debugging CI failures.
+7. Drafting PR descriptions and validation summaries.
+
+Poor candidates without close review:
+
+1. IAM permissions.
+2. Secrets and credential handling.
+3. Production deploys.
+4. Destructive migrations.
+5. Broad rewrites before requirements are clear.
+6. Business-critical logic without tests.
+
+## Human Review Model
+
+Do not treat agent output as automatically correct. Treat it as a fast junior or
+mid-level implementation draft that still needs engineering ownership.
+
+For low-risk documentation or tests, review can be quick. For data loading,
+schema, infrastructure, auth, or deployment work, review the diff carefully,
+run checks, and reason through failure modes before merge.
+
+The practical target is not "no human checks code". The target is:
+
+```text
+humans spend less time typing boilerplate
+and more time reviewing design, risk, tests, and production impact
+```

--- a/docs/engineering-delivery-workflow.md
+++ b/docs/engineering-delivery-workflow.md
@@ -1,0 +1,117 @@
+# Engineering Delivery Workflow
+
+Use this note to explain how larger repo changes are prepared, reviewed, and
+validated.
+
+## Interview Position
+
+The value is not that implementation work becomes unchecked. The value is that
+routine implementation can move faster while the engineer stays responsible for
+the important work:
+
+1. Defining the objective and acceptance criteria.
+2. Choosing the smallest useful scope.
+3. Reviewing the design and diff.
+4. Running validation before merge.
+5. Keeping generated data, secrets, and cloud deploys out of accidental commits.
+6. Deciding when a change is safe enough to merge or deploy.
+
+In this repo, that model is visible through small modules, focused tests,
+repeatable demo commands, local database walkthroughs, and disabled-by-default
+AWS infrastructure.
+
+## What Can Be Delegated
+
+Good delegated tasks in this codebase:
+
+1. Add a focused test around validation, deduplication, storage, or loading.
+2. Extend a walkthrough with commands and expected output.
+3. Implement a small loader or adapter with tests.
+4. Refactor a module while preserving public CLI behaviour.
+5. Prepare disabled-by-default infrastructure scaffolding.
+6. Investigate a failed check and propose the smallest fix.
+
+Poor delegated tasks without close review:
+
+1. IAM and secret handling.
+2. Production deploys.
+3. Terraform apply or cloud resource creation.
+4. Destructive database migrations.
+5. Broad rewrites before the target behaviour is pinned down.
+6. Business-critical risk logic without tests and manual review.
+
+## Standard Task Brief
+
+```text
+Objective:
+<What outcome should exist after the change?>
+
+Scope:
+<Which files or areas are in bounds?>
+
+Acceptance criteria:
+<What must be true in the repo?>
+
+Validation:
+<Which commands must run?>
+
+Git workflow:
+<Branch, commit, PR, merge expectations>
+
+Do not:
+<Anything destructive, costly, or out of scope>
+```
+
+## Validation Ladder
+
+Use the smallest validation set that matches the risk.
+
+| Change Type | Validation |
+| --- | --- |
+| Docs only | `git diff --check` |
+| Python logic | `make lint && make test` |
+| Demo path | `make readiness-check` |
+| PostgreSQL loader | `make clean-generated && make run-demo && make load-postgres-dry-run` |
+| Local database walkthrough | `make local-db-up && make consistency-demo && make local-db-down` |
+| Terraform scaffold | `terraform -chdir=infra/terraform fmt -check -diff && terraform -chdir=infra/terraform init -backend=false && terraform -chdir=infra/terraform validate` |
+
+If Docker or Terraform is not installed locally, state that clearly and run the
+nearest available check.
+
+## Monitoring Evidence
+
+The repo has lightweight monitoring signals that are useful in a demo:
+
+1. Pipeline summary output from `make run-demo`.
+2. Late-event and duplicate-rate status in `.demo/pipeline-summary.json`.
+3. Volatility status and value-at-risk output in the pipeline summary.
+4. PostgreSQL consistency checks in `sql/consistency_checks.sql`.
+5. Operational inspection queries in `sql/ops_queries.sql`.
+6. Local source-to-warehouse reconciliation in `docs/data-consistency-walkthrough.md`.
+
+In a managed AWS version, the same model would become CloudWatch metrics,
+pipeline failure alarms, RDS/Aurora query checks, DocumentDB collection counts,
+and S3 partition freshness checks. The current repo prepares that path without
+creating billable resources by default.
+
+## Review Questions
+
+Before accepting a change, ask:
+
+1. Does the diff solve the stated objective?
+2. Are unrelated files untouched?
+3. Are generated outputs excluded?
+4. Are tests targeted at the risky behaviour?
+5. Did the validation commands actually run?
+6. Are unavailable checks disclosed?
+7. Are cloud resources still disabled by default?
+8. Are secrets absent?
+9. Is the explanation accurate without overstating production usage?
+
+## Short Talk Track
+
+I use delegated implementation for bounded tasks, but I keep engineering
+ownership. My job is to frame the problem, constrain scope, review the diff,
+run validation, and make the merge or deployment decision. This repo shows that
+model through repeatable tests, demo commands, source-to-warehouse consistency
+checks, and infrastructure that is prepared but not deployed by accident.


### PR DESCRIPTION
## Summary
- add durable project guidance for repository delivery work
- add a delegated engineering workflow note for interview preparation
- add `make readiness-check` for lint, tests, demo execution, and warehouse dry-run validation
- link the new workflow material from the README

## Validation
- `make readiness-check`
- `git diff --check`

## Notes
- AWS deployment remains disabled-by-default and was not run.
- The local readiness check generated ignored demo output only.