### PR TITLE
Add platform lineage and readiness checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,7 @@ jobs:
           python-version: "3.11"
 
       - run: python -m pip install -e '.[dev]'
+      - run: PYTHON=python make quality-check
       - run: PYTHON=python make readiness-check
 
   infrastructure-validation:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,7 @@ Use these commands for normal validation:
 
 ```bash
 make lint
+make type-check
 make test
 make security-check
 make readiness-check
@@ -32,7 +33,7 @@ make readiness-check
 Expected test suite result:
 
 ```text
-42 passed
+54 passed
 ```
 
 When Docker is available, validate the local source-to-warehouse loop:
@@ -108,8 +109,7 @@ make overnight-sandbox
 For Python or pipeline changes:
 
 ```bash
-make lint
-make test
+make quality-check
 make security-check
 ```
 

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ PIP ?= $(PYTHON) -m pip
 
 LOCAL_POSTGRES_DSN ?= postgresql://risk_user:risk_password@localhost:5433/risk_platform
 
-.PHONY: setup lint test format benchmark-io docker-build k8s-render-dev k8s-render-prod k8s-check terraform-check infrastructure-check iteration-check clean-generated security-check readiness-check sandbox-once overnight-sandbox local-db-up local-db-down local-db-wait local-db-logs postgres-shell mongo-shell run-demo load-postgres-demo load-postgres-dry-run check-postgres-consistency consistency-demo
+.PHONY: setup lint type-check test format benchmark-io docker-build k8s-render-dev k8s-render-prod k8s-check terraform-check infrastructure-check quality-check iteration-check clean-generated security-check readiness-check sandbox-once overnight-sandbox local-db-up local-db-down local-db-wait local-db-logs postgres-shell mongo-shell run-demo load-postgres-demo load-postgres-dry-run check-postgres-consistency consistency-demo
 
 setup:
 	python3 -m venv .venv
@@ -12,6 +12,9 @@ setup:
 
 lint:
 	$(PYTHON) -m ruff check .
+
+type-check:
+	$(PYTHON) -m mypy --package src
 
 format:
 	$(PYTHON) -m ruff check . --fix
@@ -42,7 +45,9 @@ terraform-check:
 
 infrastructure-check: k8s-check terraform-check
 
-iteration-check: security-check infrastructure-check readiness-check
+quality-check: lint type-check test
+
+iteration-check: security-check infrastructure-check quality-check clean-generated run-demo load-postgres-dry-run
 
 clean-generated:
 	rm -rf data .demo .benchmarks .pytest_cache .mypy_cache .ruff_cache
@@ -50,7 +55,7 @@ clean-generated:
 security-check:
 	$(PYTHON) scripts/security_check.py
 
-readiness-check: lint test clean-generated run-demo load-postgres-dry-run
+readiness-check: quality-check clean-generated run-demo load-postgres-dry-run
 
 sandbox-once:
 	PYTHONUNBUFFERED=1 $(PYTHON) scripts/overnight_sandbox.py --cycles 1 --sleep-seconds 0
@@ -84,7 +89,8 @@ run-demo:
 		--input tests/fixtures/demo_events.json \
 		--late-seconds 60 \
 		--vol-window 2 \
-		--summary-json .demo/pipeline-summary.json
+		--summary-json .demo/pipeline-summary.json \
+		--lineage-json .demo/lineage.json
 
 load-postgres-demo:
 	$(PYTHON) -m src.warehouse.postgres_loader --dsn "$(LOCAL_POSTGRES_DSN)"

--- a/README.md
+++ b/README.md
@@ -59,6 +59,10 @@ metrics:
 make readiness-check
 ```
 
+The demo writes `.demo/pipeline-summary.json` and `.demo/lineage.json`.
+The lineage manifest traces source inventory, transformations, raw and curated
+outputs, data quality checks, and the reporting view dependency.
+
 For a concise interview walkthrough, use the five-minute path in
 `docs/demo-script.md`.
 
@@ -97,7 +101,7 @@ Additional preparation notes:
 8. `docs/data-consistency-walkthrough.md` for source-to-warehouse reconciliation
 9. `docs/aws-managed-databases.md` for disabled-by-default RDS/Aurora/DocumentDB IaC
 10. `docs/lambda-s3-orchestration.md` for AWS orchestration mapping
-11. `sql/postgres_schema.sql` and `sql/ops_queries.sql` for PostgreSQL examples
+11. `sql/postgres_schema.sql` and `sql/ops_queries.sql` for PostgreSQL warehouse and reporting examples
 12. `docs/agentic-workflows.md` for larger delegated development workflows
 13. `docs/engineering-delivery-workflow.md` for the engineer-owned delivery model
 14. `docs/agent-roles.md` for splitting repo work across bounded roles
@@ -121,6 +125,15 @@ make local-db-down
 
 See `docs/postgres-mongodb-walkthrough.md` for inspection commands and
 `docs/data-consistency-walkthrough.md` for the full reconciliation flow.
+
+The PostgreSQL seed also includes a small finance reporting layer:
+
+```text
+symbol_dimension_history -> current_symbol_dimension -> finance_risk_semantic_model
+```
+
+That demonstrates SCD Type 2 history, current dimension serving, and a
+dashboard-ready view over the latest risk and data quality outputs.
 
 ## Performance Benchmark
 
@@ -146,6 +159,7 @@ Run the full local readiness path before a demo or pull request:
 
 ```bash
 make security-check
+make quality-check
 make readiness-check
 ```
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -22,6 +22,7 @@ The design emphasizes:
 | Keep raw data replayable | `src/storage/s3_writer.py`, `tests/integration/test_s3_writer.py` |
 | Make backfills deterministic | `src/orchestration/backfill.py`, `src/orchestration/locks.py`, `tests/integration/test_backfill.py` |
 | Serve stable warehouse outputs | `src/warehouse/postgres_loader.py`, `sql/postgres_schema.sql`, `sql/ops_queries.sql` |
+| Trace source-to-report lineage | `src/orchestration/lineage.py`, `.demo/lineage.json`, `tests/unit/test_lineage.py` |
 | Reconcile source to warehouse | `sql/consistency_checks.sql`, `docs/data-consistency-walkthrough.md` |
 | Validate infrastructure without deploying | `Makefile`, `deploy/kubernetes/`, `infra/terraform/` |
 

--- a/docs/data-consistency-walkthrough.md
+++ b/docs/data-consistency-walkthrough.md
@@ -13,6 +13,7 @@ MongoDB-style source documents
   -> raw parquet output
   -> curated parquet output
   -> PostgreSQL warehouse tables
+  -> lineage manifest
   -> reconciliation checks
 ```
 
@@ -29,6 +30,8 @@ The expected demo counts are:
 | `volatility_5m` rows | 2 |
 | `risk_summary` rows | 2 |
 | Data quality rows | 1 |
+| Current symbol dimension rows | 2 |
+| Finance reporting rows | 2 |
 
 ## Start Local Databases
 
@@ -59,6 +62,10 @@ Curated records written: 9
 Late rate: 16.67% (status: critical)
 Duplicate rate: 14.29% (status: critical)
 ```
+
+The demo also writes `.demo/lineage.json`. This manifest records source
+inventory, authoritative keys, raw and curated output locations,
+transformation steps, quality statuses, and the reporting view dependency.
 
 ## Dry-Run The PostgreSQL Loader
 
@@ -97,6 +104,17 @@ risk_platform.risk_summary
 risk_platform.external_signal_summary
 ```
 
+The local PostgreSQL seed also creates a finance reporting shape:
+
+```text
+risk_platform.symbol_dimension_history
+risk_platform.current_symbol_dimension
+risk_platform.finance_risk_semantic_model
+```
+
+This gives a small SCD Type 2 dimension history and a dashboard-friendly
+reporting view over the latest risk and data quality outputs.
+
 The local connection string is:
 
 ```text
@@ -124,6 +142,8 @@ The checks compare:
 5. Raw events to data quality deduped count.
 6. Curated table row counts to expected demo counts.
 7. Latest late and duplicate statuses to expected critical statuses.
+8. Current symbol dimension rows to expected demo symbol count.
+9. Finance reporting rows to latest risk summary symbols.
 
 Every row should return `status = pass`.
 
@@ -142,6 +162,13 @@ clean-generated
 run-demo
 load-postgres-demo
 check-postgres-consistency
+```
+
+`run-demo` writes:
+
+```text
+.demo/pipeline-summary.json
+.demo/lineage.json
 ```
 
 ## Inspect MongoDB Source Shape
@@ -202,7 +229,56 @@ SELECT 'volatility_5m', COUNT(*) FROM risk_platform.volatility_5m
 UNION ALL
 SELECT 'risk_summary', COUNT(*) FROM risk_platform.risk_summary
 UNION ALL
-SELECT 'data_quality_metrics', COUNT(*) FROM risk_platform.data_quality_metrics;
+SELECT 'data_quality_metrics', COUNT(*) FROM risk_platform.data_quality_metrics
+UNION ALL
+SELECT 'current_symbol_dimension', COUNT(*) FROM risk_platform.current_symbol_dimension
+UNION ALL
+SELECT 'finance_risk_semantic_model', COUNT(*) FROM risk_platform.finance_risk_semantic_model;
+```
+
+Current reporting dimension:
+
+```sql
+SELECT
+    symbol,
+    source,
+    asset_class,
+    reporting_currency,
+    sector,
+    effective_from
+FROM risk_platform.current_symbol_dimension
+ORDER BY symbol, source;
+```
+
+Finance reporting view:
+
+```sql
+SELECT
+    symbol,
+    asset_class,
+    reporting_currency,
+    sector,
+    metric_ts,
+    volatility_status,
+    late_status,
+    duplicate_status
+FROM risk_platform.finance_risk_semantic_model
+ORDER BY symbol;
+```
+
+Lineage manifest:
+
+```bash
+.venv/bin/python -m json.tool .demo/lineage.json
+```
+
+Key sections to inspect:
+
+```text
+source_inventory
+layers
+transformations
+quality_checks
 ```
 
 ## Interview Explanation
@@ -213,7 +289,11 @@ Use this version:
 > including one duplicate business event and one late event. The pipeline
 > deduplicates to 6 raw events, produces 9 curated records, loads those into
 > PostgreSQL with idempotent upserts, and the consistency SQL checks that source
-> counts, raw counts, curated counts, and data quality metrics agree.
+> counts, raw counts, curated counts, data quality metrics, and reporting rows
+> agree. I also added a small SCD Type 2 symbol dimension and a finance reporting
+> view so the warehouse shape is closer to what reporting users consume. The
+> lineage manifest gives a source-to-report explanation for how the demo output
+> was produced.
 
 The key point:
 

--- a/docs/demo-script.md
+++ b/docs/demo-script.md
@@ -26,9 +26,11 @@ Use this when the conversation is time-boxed:
 4. Show `src/orchestration/run_pipeline.py` for validation, deduplication,
    partition locking, and writes.
 5. Show `src/storage/s3_writer.py` for deterministic partitioned output.
-6. Show `sql/consistency_checks.sql` or `docs/data-consistency-walkthrough.md`
+6. Show `.demo/lineage.json` for source inventory, transformations, outputs,
+   quality checks, and the reporting view dependency.
+7. Show `sql/consistency_checks.sql` or `docs/data-consistency-walkthrough.md`
    for the source-to-warehouse reconciliation story.
-7. Close with the trade-off: the repo prioritises repeatable batch reliability
+8. Close with the trade-off: the repo prioritises repeatable batch reliability
    and local evidence over a live cloud deployment.
 
 ## Command Evidence Map
@@ -36,7 +38,7 @@ Use this when the conversation is time-boxed:
 | Command | Decision it proves |
 | --- | --- |
 | `make security-check` | Generated output, obvious secrets, deploy guardrails, Kubernetes defaults, and Terraform creation flags are checked locally. |
-| `make readiness-check` | Linting, tests, demo pipeline output, and warehouse dry-run loading work together. |
+| `make readiness-check` | Linting, type checking, tests, demo summary, lineage output, and warehouse dry-run loading work together. |
 | `make infrastructure-check` | Kubernetes overlays render and Terraform validates without applying cloud resources. |
 | `make consistency-demo` | With Docker available, source audit counts, raw records, curated rows, and warehouse checks reconcile. |
 
@@ -64,7 +66,8 @@ Use this when the conversation is time-boxed:
      --input tests/fixtures/demo_events.json \
      --late-seconds 60 \
      --vol-window 2 \
-     --summary-json .demo/pipeline-summary.json
+     --summary-json .demo/pipeline-summary.json \
+     --lineage-json .demo/lineage.json
    ```
 
    Call out the summary values: raw events written, curated records written,
@@ -75,6 +78,10 @@ Use this when the conversation is time-boxed:
    late event. With the strict demo thresholds, those rates are reported as
    critical so the walkthrough shows visible data quality evidence instead of a
    happy-path-only run.
+
+   Open `.demo/lineage.json` to show the source inventory, authoritative keys,
+   raw and curated outputs, transformation steps, quality checks, and the
+   reporting view dependency.
 
 4. Show storage reliability.
 

--- a/docs/iteration-loop.md
+++ b/docs/iteration-loop.md
@@ -44,6 +44,14 @@ make consistency-demo
 make local-db-down
 ```
 
+For Python-only changes:
+
+```bash
+make security-check
+make quality-check
+make readiness-check
+```
+
 ## Stop Conditions
 
 Stop and ask for review before continuing when:

--- a/docs/postgres-mongodb-walkthrough.md
+++ b/docs/postgres-mongodb-walkthrough.md
@@ -18,7 +18,8 @@ PostgreSQL is the warehouse-serving shape:
 1. Data is flattened into tables with clear columns.
 2. Primary keys and `ON CONFLICT` make loads idempotent.
 3. Indexes and views make common ops questions fast and repeatable.
-4. SQL consumers should not need to understand raw nested source payloads.
+4. SCD Type 2 dimensions preserve reporting history when reference data changes.
+5. SQL consumers should not need to understand raw nested source payloads.
 
 The pipeline sits between them:
 
@@ -29,7 +30,7 @@ MongoDB-style source documents
   -> validation and flattening
   -> deduplication
   -> curated PostgreSQL tables
-  -> ops queries and dashboards
+  -> reporting dimensions, ops queries, and dashboards
 ```
 
 ## Optional Local Playground
@@ -187,6 +188,51 @@ Inspect latest curated summaries:
 SELECT *
 FROM risk_platform.latest_risk_summary
 ORDER BY symbol;
+```
+
+Inspect the current reporting dimension:
+
+```sql
+SELECT
+    symbol,
+    source,
+    asset_class,
+    reporting_currency,
+    sector,
+    effective_from
+FROM risk_platform.current_symbol_dimension
+ORDER BY symbol, source;
+```
+
+Inspect the finance reporting view:
+
+```sql
+SELECT
+    symbol,
+    asset_class,
+    reporting_currency,
+    sector,
+    metric_ts,
+    volatility_status,
+    late_status,
+    duplicate_status
+FROM risk_platform.finance_risk_semantic_model
+ORDER BY symbol;
+```
+
+Review the SCD Type 2 history:
+
+```sql
+SELECT
+    symbol,
+    source,
+    sector,
+    effective_from,
+    effective_to,
+    is_current,
+    change_reason
+FROM risk_platform.symbol_dimension_history
+ORDER BY symbol, effective_from;
 ```
 
 Check warehouse freshness:

--- a/docs/security-protocols.md
+++ b/docs/security-protocols.md
@@ -9,7 +9,8 @@ Cloud deployment remains manual and approval-driven.
    unsafe deploy triggers, missing ownership rules, unsafe local database port
    bindings, risky Kubernetes defaults, and managed database creation flags.
 2. CI separates security guardrails, Python readiness, and infrastructure
-   validation into distinct jobs.
+   validation into distinct jobs. Python readiness includes linting, type
+   checking, tests, demo execution, and warehouse dry-run loading.
 3. `.gitignore` and `.dockerignore` exclude local environments, generated data,
    Terraform state, kubeconfigs, AWS credential folders, key material, and local
    sandbox logs. Terraform provider lock files remain tracked for reproducible

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,10 +19,15 @@ dev = [
   "pytest>=8.0",
   "ruff>=0.6",
   "mypy>=1.10",
+  "types-PyYAML>=6.0",
 ]
 
 [tool.ruff]
 line-length = 100
+
+[tool.mypy]
+python_version = "3.10"
+ignore_missing_imports = true
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/sql/consistency_checks.sql
+++ b/sql/consistency_checks.sql
@@ -21,7 +21,10 @@ warehouse_counts AS (
         (SELECT COUNT(*) FROM risk_platform.returns_1m) AS returns_1m,
         (SELECT COUNT(*) FROM risk_platform.volatility_5m) AS volatility_5m,
         (SELECT COUNT(*) FROM risk_platform.risk_summary) AS risk_summary,
-        (SELECT COUNT(*) FROM risk_platform.data_quality_metrics) AS data_quality_runs
+        (SELECT COUNT(*) FROM risk_platform.data_quality_metrics) AS data_quality_runs,
+        (SELECT COUNT(*) FROM risk_platform.latest_risk_summary) AS latest_risk_symbols,
+        (SELECT COUNT(*) FROM risk_platform.current_symbol_dimension) AS current_symbol_dimensions,
+        (SELECT COUNT(*) FROM risk_platform.finance_risk_semantic_model) AS finance_reporting_rows
 )
 SELECT
     'source_records_to_quality_total' AS check_name,
@@ -105,5 +108,26 @@ SELECT
         ELSE 'fail'
     END
 FROM latest_quality
+
+UNION ALL
+
+SELECT
+    'current_symbol_dimension_rows_expected',
+    '2',
+    current_symbol_dimensions::text,
+    CASE WHEN current_symbol_dimensions = 2 THEN 'pass' ELSE 'fail' END
+FROM warehouse_counts
+
+UNION ALL
+
+SELECT
+    'finance_reporting_rows_to_latest_risk_symbols',
+    latest_risk_symbols::text,
+    finance_reporting_rows::text,
+    CASE
+        WHEN finance_reporting_rows = latest_risk_symbols THEN 'pass'
+        ELSE 'fail'
+    END
+FROM warehouse_counts
 
 ORDER BY check_name;

--- a/sql/ops_queries.sql
+++ b/sql/ops_queries.sql
@@ -169,3 +169,45 @@ SET
     latest_external_signal_source = EXCLUDED.latest_external_signal_source,
     latest_external_signal_ts_event = EXCLUDED.latest_external_signal_ts_event,
     loaded_at = now();
+
+-- 8. Current reporting dimension for semantic model joins.
+SELECT
+    symbol,
+    source,
+    asset_class,
+    reporting_currency,
+    sector,
+    effective_from,
+    change_reason
+FROM risk_platform.current_symbol_dimension
+ORDER BY symbol, source;
+
+-- 9. Finance reporting view shaped for dashboard or semantic model consumption.
+SELECT
+    symbol,
+    asset_class,
+    reporting_currency,
+    sector,
+    metric_ts,
+    volatility_5m,
+    value_at_risk_95,
+    volatility_status,
+    late_status,
+    duplicate_status,
+    required_fields_status,
+    null_rate_status,
+    value_validity_status
+FROM risk_platform.finance_risk_semantic_model
+ORDER BY symbol;
+
+-- 10. Historical dimension audit trail for SCD Type 2 review.
+SELECT
+    symbol,
+    source,
+    sector,
+    effective_from,
+    effective_to,
+    is_current,
+    change_reason
+FROM risk_platform.symbol_dimension_history
+ORDER BY symbol, effective_from;

--- a/sql/postgres_demo_data.sql
+++ b/sql/postgres_demo_data.sql
@@ -45,6 +45,7 @@ TRUNCATE TABLE
     staging.market_events_raw_batch,
     staging.risk_summary_batch,
     staging.source_event_audit,
+    risk_platform.symbol_dimension_history,
     risk_platform.external_signal_summary,
     risk_platform.risk_summary,
     risk_platform.data_quality_metrics,
@@ -52,6 +53,57 @@ TRUNCATE TABLE
     risk_platform.returns_1m,
     risk_platform.market_events_raw
 RESTART IDENTITY;
+
+INSERT INTO risk_platform.symbol_dimension_history (
+    symbol,
+    source,
+    asset_class,
+    reporting_currency,
+    sector,
+    effective_from,
+    effective_to,
+    is_current,
+    change_reason,
+    record_hash
+)
+VALUES
+    (
+        'AAPL',
+        'stooq',
+        'equity',
+        'USD',
+        'technology',
+        '2024-01-01T00:00:00Z',
+        '2025-01-20T10:00:00Z',
+        false,
+        'sector_alignment',
+        'aapl-stooq-2024-technology'
+    ),
+    (
+        'AAPL',
+        'stooq',
+        'equity',
+        'USD',
+        'information_technology',
+        '2025-01-20T10:00:00Z',
+        NULL,
+        true,
+        'sector_alignment',
+        'aapl-stooq-2025-information-technology'
+    ),
+    (
+        'MSFT',
+        'stooq',
+        'equity',
+        'USD',
+        'information_technology',
+        '2025-01-01T00:00:00Z',
+        NULL,
+        true,
+        'initial_load',
+        'msft-stooq-2025-information-technology'
+    )
+ON CONFLICT (symbol, source, effective_from) DO NOTHING;
 
 INSERT INTO risk_platform.market_events_raw (
     event_id,

--- a/sql/postgres_schema.sql
+++ b/sql/postgres_schema.sql
@@ -130,6 +130,44 @@ CREATE TABLE IF NOT EXISTS risk_platform.external_signal_summary (
 CREATE INDEX IF NOT EXISTS idx_external_signal_summary_latest
     ON risk_platform.external_signal_summary (latest_ts_event DESC, name, source);
 
+CREATE TABLE IF NOT EXISTS risk_platform.symbol_dimension_history (
+    symbol_dimension_id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    symbol TEXT NOT NULL,
+    source TEXT NOT NULL,
+    asset_class TEXT NOT NULL,
+    reporting_currency CHAR(3) NOT NULL,
+    sector TEXT,
+    effective_from TIMESTAMPTZ NOT NULL,
+    effective_to TIMESTAMPTZ,
+    is_current BOOLEAN NOT NULL,
+    change_reason TEXT NOT NULL,
+    record_hash TEXT NOT NULL,
+    loaded_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    CHECK (symbol = UPPER(symbol)),
+    CHECK (reporting_currency = UPPER(reporting_currency)),
+    CHECK (record_hash <> ''),
+    CHECK (effective_to IS NULL OR effective_to > effective_from),
+    CHECK (
+        (is_current = true AND effective_to IS NULL)
+        OR (is_current = false AND effective_to IS NOT NULL)
+    )
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_symbol_dimension_history_version
+    ON risk_platform.symbol_dimension_history (symbol, source, effective_from);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_symbol_dimension_history_current
+    ON risk_platform.symbol_dimension_history (symbol, source)
+    WHERE is_current;
+
+CREATE INDEX IF NOT EXISTS idx_symbol_dimension_history_reporting
+    ON risk_platform.symbol_dimension_history (
+        asset_class,
+        reporting_currency,
+        sector,
+        effective_from DESC
+    );
+
 CREATE OR REPLACE VIEW risk_platform.latest_risk_summary AS
 SELECT DISTINCT ON (symbol)
     symbol,
@@ -166,3 +204,51 @@ SELECT
 FROM risk_platform.data_quality_metrics
 ORDER BY ts_ingest DESC
 LIMIT 1;
+
+CREATE OR REPLACE VIEW risk_platform.current_symbol_dimension AS
+SELECT
+    symbol_dimension_id,
+    symbol,
+    source,
+    asset_class,
+    reporting_currency,
+    sector,
+    effective_from,
+    change_reason,
+    record_hash
+FROM risk_platform.symbol_dimension_history
+WHERE is_current;
+
+CREATE OR REPLACE VIEW risk_platform.finance_risk_semantic_model AS
+WITH current_symbol AS (
+    SELECT DISTINCT ON (symbol)
+        symbol,
+        source,
+        asset_class,
+        reporting_currency,
+        sector,
+        effective_from
+    FROM risk_platform.current_symbol_dimension
+    ORDER BY symbol, source
+)
+SELECT
+    risk.symbol,
+    dim.asset_class,
+    dim.reporting_currency,
+    dim.sector,
+    dim.effective_from AS dimension_effective_from,
+    risk.ts_ingest AS metric_ts,
+    risk.volatility_5m,
+    risk.value_at_risk_95,
+    risk.volatility_status,
+    risk.late_rate,
+    risk.duplicate_rate,
+    risk.late_status,
+    risk.duplicate_status,
+    risk.external_signal_count,
+    quality.required_fields_status,
+    quality.null_rate_status,
+    quality.value_validity_status
+FROM risk_platform.latest_risk_summary risk
+LEFT JOIN current_symbol dim ON risk.symbol = dim.symbol
+LEFT JOIN risk_platform.latest_data_quality_status quality ON true;

--- a/src/orchestration/lineage.py
+++ b/src/orchestration/lineage.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+def _path_or_label(path: Path | None, fallback: str) -> str:
+    return str(path) if path is not None else fallback
+
+
+def _dataset_path(storage_config: dict[str, Any], *, kind: str, dataset_key: str) -> str:
+    storage = storage_config["storage"]
+    if kind == "raw":
+        return str(Path(storage["raw"]["base_path"]) / storage["raw"]["dataset"])
+
+    dataset_name = storage["curated"]["datasets"][dataset_key]
+    return str(Path(storage["curated"]["base_path"]) / dataset_name)
+
+
+def build_lineage_manifest(
+    *,
+    run_id: str,
+    input_path: Path | None,
+    signals_path: Path | None,
+    storage_config: dict[str, Any],
+    raw_dataset: str,
+    raw_payload_count: int,
+    deduped_event_count: int,
+    external_signal_count: int,
+    raw_written: int,
+    curated_writes: dict[str, int],
+    partitions: list[str],
+    quality_summary: dict[str, Any],
+) -> dict[str, Any]:
+    generated_at = datetime.now(timezone.utc).isoformat()
+    curated_outputs = [
+        {
+            "dataset": dataset_key,
+            "path": _dataset_path(storage_config, kind="curated", dataset_key=dataset_key),
+            "records_written": record_count,
+            "depends_on": [raw_dataset],
+        }
+        for dataset_key, record_count in sorted(curated_writes.items())
+    ]
+
+    return {
+        "run_id": run_id,
+        "generated_at": generated_at,
+        "source_inventory": [
+            {
+                "name": "market_events",
+                "source_type": "json_file",
+                "location": _path_or_label(input_path, "built_in_sample_events"),
+                "authoritative_key": "event_id",
+                "records_received": raw_payload_count,
+                "records_after_deduplication": deduped_event_count,
+            },
+            {
+                "name": "external_signals",
+                "source_type": "file",
+                "location": _path_or_label(signals_path, "not_provided"),
+                "authoritative_key": "signal_id",
+                "records_received": external_signal_count,
+                "records_after_deduplication": external_signal_count,
+            },
+        ],
+        "layers": [
+            {
+                "name": "raw",
+                "datasets": [
+                    {
+                        "dataset": raw_dataset,
+                        "path": _dataset_path(storage_config, kind="raw", dataset_key=raw_dataset),
+                        "records_written": raw_written,
+                        "partitions": partitions,
+                    }
+                ],
+            },
+            {
+                "name": "curated",
+                "datasets": curated_outputs,
+            },
+            {
+                "name": "reporting",
+                "datasets": [
+                    {
+                        "dataset": "risk_platform.finance_risk_semantic_model",
+                        "path": "PostgreSQL view",
+                        "depends_on": [
+                            "risk_summary",
+                            "data_quality_metrics",
+                            "symbol_dimension_history",
+                        ],
+                    }
+                ],
+            },
+        ],
+        "transformations": [
+            {
+                "name": "validate_required_fields",
+                "inputs": ["market_events"],
+                "outputs": ["validated_events"],
+            },
+            {
+                "name": "normalize_symbols",
+                "inputs": ["validated_events"],
+                "outputs": ["normalised_events"],
+            },
+            {
+                "name": "deduplicate_events",
+                "inputs": ["normalised_events"],
+                "outputs": [raw_dataset],
+                "business_key": "event_id",
+            },
+            {
+                "name": "compute_curated_metrics",
+                "inputs": [raw_dataset, "external_signals"],
+                "outputs": sorted(curated_writes),
+            },
+        ],
+        "quality_checks": quality_summary,
+    }
+
+
+def write_lineage_manifest(path: Path, manifest: dict[str, Any]) -> None:
+    import json
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as handle:
+        json.dump(manifest, handle, indent=2, sort_keys=True, default=str)

--- a/src/orchestration/run_pipeline.py
+++ b/src/orchestration/run_pipeline.py
@@ -5,6 +5,7 @@ import json
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
+from uuid import uuid4
 
 import pandas as pd
 
@@ -31,6 +32,7 @@ from ..processing.windowing import floor_time
 from ..storage.partitioning import partition_path
 from ..storage.s3_writer import write_records
 from ..storage.storage_config import load_storage_config
+from .lineage import build_lineage_manifest, write_lineage_manifest
 from .locks import acquire_partition_locks, release_partition_locks
 
 REQUIRED_FIELDS = ["event_id", "symbol", "price", "volume", "ts_event", "ts_ingest", "source"]
@@ -80,6 +82,11 @@ def _parse_args() -> argparse.Namespace:
         "--summary-json",
         type=Path,
         help="Optional path to write the pipeline run summary as JSON.",
+    )
+    parser.add_argument(
+        "--lineage-json",
+        type=Path,
+        help="Optional path to write the source-to-report lineage manifest as JSON.",
     )
     parser.add_argument(
         "--storage-config",
@@ -256,7 +263,9 @@ def run_pipeline(
     signals_path: Path | None = None,
     lock_owner: str | None = None,
     lock_stale_seconds: int | None = None,
+    lineage_json_path: Path | None = None,
 ) -> dict[str, Any]:
+    run_id = str(uuid4())
     raw_payloads = _load_input(input_path)
     external_signal_records = _load_external_signal_records(signals_path)
     storage_config = load_storage_config(storage_config_path)
@@ -488,13 +497,7 @@ def run_pipeline(
     finally:
         release_partition_locks(lock_paths)
 
-    return {
-        "raw_events": raw_written,
-        "curated_records": curated_written,
-        "curated_records_by_dataset": curated_writes,
-        "partitions": partitions,
-        "late_rate": late_rate_value,
-        "duplicate_rate": duplicate_rate,
+    quality_summary = {
         "required_fields_status": required_field_quality["status"],
         "missing_required_field_count": required_field_quality["missing_field_count"],
         "missing_required_record_count": required_field_quality["failed_record_count"],
@@ -505,15 +508,43 @@ def run_pipeline(
         "value_validity_status": value_quality["status"],
         "invalid_value_count": value_quality["invalid_field_count"],
         "invalid_value_record_count": value_quality["failed_record_count"],
+        "late_status": late_status,
+        "duplicate_status": duplicate_status,
+    }
+    if lineage_json_path is not None:
+        lineage_manifest = build_lineage_manifest(
+            run_id=run_id,
+            input_path=input_path,
+            signals_path=signals_path,
+            storage_config=storage_config,
+            raw_dataset=raw_dataset,
+            raw_payload_count=len(raw_payloads),
+            deduped_event_count=len(deduped),
+            external_signal_count=len(external_signal_records),
+            raw_written=raw_written,
+            curated_writes=curated_writes,
+            partitions=partitions,
+            quality_summary=quality_summary,
+        )
+        write_lineage_manifest(lineage_json_path, lineage_manifest)
+
+    return {
+        "pipeline_run_id": run_id,
+        "raw_events": raw_written,
+        "curated_records": curated_written,
+        "curated_records_by_dataset": curated_writes,
+        "partitions": partitions,
+        "late_rate": late_rate_value,
+        "duplicate_rate": duplicate_rate,
+        **quality_summary,
         "volatility_latest": volatility_latest,
         "value_at_risk": var_latest,
         "volatility_status": volatility_status,
-        "late_status": late_status,
-        "duplicate_status": duplicate_status,
         "external_signal_count": len(external_signal_records),
         "external_signals_latest": {
             record["name"]: record["latest_value"] for record in external_signal_summary_records
         },
+        "lineage_manifest_path": str(lineage_json_path) if lineage_json_path is not None else None,
     }
 
 
@@ -528,6 +559,7 @@ def main() -> None:
         vol_window=args.vol_window,
         storage_config_path=args.storage_config,
         lock_stale_seconds=args.lock_stale_seconds,
+        lineage_json_path=args.lineage_json,
     )
     if args.summary_json is not None:
         args.summary_json.parent.mkdir(parents=True, exist_ok=True)

--- a/src/processing/deduplicator.py
+++ b/src/processing/deduplicator.py
@@ -1,6 +1,9 @@
-def dedupe_events(events: list[dict], key: str = "event_id") -> list[dict]:
-    seen: set[str] = set()
-    output: list[dict] = []
+from typing import Any
+
+
+def dedupe_events(events: list[dict[str, Any]], key: str = "event_id") -> list[dict[str, Any]]:
+    seen: set[Any] = set()
+    output: list[dict[str, Any]] = []
     for event in events:
         event_id = event.get(key)
         if event_id in seen:

--- a/tests/integration/test_backfill.py
+++ b/tests/integration/test_backfill.py
@@ -2,41 +2,16 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 from pathlib import Path
+from typing import Any
 from uuid import UUID
-
-import yaml
 
 from src.orchestration.backfill import run_backfill
 from src.orchestration.locks import acquire_partition_locks, release_partition_locks
 from src.storage.s3_writer import write_records
+from tests.storage_config_helpers import build_storage_config, write_storage_config
 
 
-def _build_storage_config(tmp_path: Path) -> dict:
-    return {
-        "storage": {
-            "base_dir": str(tmp_path),
-            "raw": {
-                "base_path": str(tmp_path / "raw"),
-                "dataset": "market_events",
-            },
-            "curated": {
-                "base_path": str(tmp_path / "curated"),
-                "datasets": {
-                    "returns_1m": "returns_1m",
-                    "volatility_5m": "volatility_5m",
-                    "data_quality_metrics": "data_quality_metrics",
-                    "risk_summary": "risk_summary",
-                },
-            },
-            "format": "parquet",
-            "partitioning": {
-                "granularity": "hourly",
-            },
-        }
-    }
-
-
-def _seed_raw_partitions(storage_config: dict) -> None:
+def _seed_raw_partitions(storage_config: dict[str, Any]) -> None:
     records = [
         {
             "event_id": "evt-1",
@@ -97,10 +72,8 @@ def _seed_raw_partitions(storage_config: dict) -> None:
 
 
 def test_run_backfill_replays_hourly_partitions_resumes_and_can_force_rerun(tmp_path: Path) -> None:
-    storage_config = _build_storage_config(tmp_path)
-    storage_config_path = tmp_path / "storage.yaml"
-    with storage_config_path.open("w", encoding="utf-8") as handle:
-        yaml.safe_dump(storage_config, handle, sort_keys=False)
+    storage_config = build_storage_config(tmp_path, include_external_signal_summary=False)
+    storage_config_path = write_storage_config(tmp_path, include_external_signal_summary=False)
 
     _seed_raw_partitions(storage_config)
 
@@ -138,7 +111,6 @@ def test_run_backfill_replays_hourly_partitions_resumes_and_can_force_rerun(tmp_
     )
     assert second == []
 
-
     third = run_backfill(
         "2025-01-20T10:00:00Z",
         "2025-01-20T11:00:00Z",
@@ -158,10 +130,8 @@ def test_run_backfill_replays_hourly_partitions_resumes_and_can_force_rerun(tmp_
 
 
 def test_run_backfill_resumes_after_blocked_overlap(tmp_path: Path) -> None:
-    storage_config = _build_storage_config(tmp_path)
-    storage_config_path = tmp_path / "storage.yaml"
-    with storage_config_path.open("w", encoding="utf-8") as handle:
-        yaml.safe_dump(storage_config, handle, sort_keys=False)
+    storage_config = build_storage_config(tmp_path, include_external_signal_summary=False)
+    storage_config_path = write_storage_config(tmp_path, include_external_signal_summary=False)
 
     _seed_raw_partitions(storage_config)
     locked_partition = "year=2025/month=01/day=20/hour=10"

--- a/tests/integration/test_run_pipeline_curated.py
+++ b/tests/integration/test_run_pipeline_curated.py
@@ -65,6 +65,7 @@ def test_run_pipeline_cli_creates_summary_parent_directory(
         yaml.safe_dump(storage_config, handle, sort_keys=False)
 
     summary_path = tmp_path / ".demo" / "pipeline-summary.json"
+    lineage_path = tmp_path / ".demo" / "lineage.json"
     monkeypatch.setattr(
         sys,
         "argv",
@@ -80,6 +81,8 @@ def test_run_pipeline_cli_creates_summary_parent_directory(
             "2",
             "--summary-json",
             str(summary_path),
+            "--lineage-json",
+            str(lineage_path),
         ],
     )
 
@@ -94,6 +97,16 @@ def test_run_pipeline_cli_creates_summary_parent_directory(
     assert summary["required_fields_status"] == "ok"
     assert summary["late_rate"] > 0.0
     assert summary["duplicate_rate"] > 0.0
+    assert summary["lineage_manifest_path"] == str(lineage_path)
+
+    with lineage_path.open("r", encoding="utf-8") as handle:
+        lineage = json.load(handle)
+    assert lineage["run_id"] == summary["pipeline_run_id"]
+    assert lineage["source_inventory"][0]["records_received"] == 7
+    assert lineage["source_inventory"][0]["records_after_deduplication"] == 6
+    assert lineage["layers"][2]["datasets"][0]["dataset"] == (
+        "risk_platform.finance_risk_semantic_model"
+    )
 
 
 def test_run_pipeline_materializes_all_curated_datasets(tmp_path: Path) -> None:

--- a/tests/storage_config_helpers.py
+++ b/tests/storage_config_helpers.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+CURATED_DATASETS = {
+    "returns_1m": "returns_1m",
+    "volatility_5m": "volatility_5m",
+    "data_quality_metrics": "data_quality_metrics",
+    "risk_summary": "risk_summary",
+    "external_signal_summary": "external_signal_summary",
+}
+
+
+def build_storage_config(
+    tmp_path: Path,
+    *,
+    include_external_signal_summary: bool = True,
+) -> dict[str, Any]:
+    curated_datasets = dict(CURATED_DATASETS)
+    if not include_external_signal_summary:
+        curated_datasets.pop("external_signal_summary")
+
+    return {
+        "storage": {
+            "base_dir": str(tmp_path),
+            "raw": {
+                "base_path": str(tmp_path / "raw"),
+                "dataset": "market_events",
+            },
+            "curated": {
+                "base_path": str(tmp_path / "curated"),
+                "datasets": curated_datasets,
+            },
+            "format": "parquet",
+            "partitioning": {
+                "granularity": "hourly",
+            },
+        }
+    }
+
+
+def write_storage_config(
+    tmp_path: Path,
+    *,
+    include_external_signal_summary: bool = True,
+) -> Path:
+    storage_config_path = tmp_path / "storage.yaml"
+    storage_config = build_storage_config(
+        tmp_path,
+        include_external_signal_summary=include_external_signal_summary,
+    )
+    with storage_config_path.open("w", encoding="utf-8") as handle:
+        yaml.safe_dump(storage_config, handle, sort_keys=False)
+    return storage_config_path

--- a/tests/unit/test_docker_compose_contract.py
+++ b/tests/unit/test_docker_compose_contract.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+def _load_compose() -> dict[str, Any]:
+    with Path("docker-compose.yml").open("r", encoding="utf-8") as handle:
+        return yaml.safe_load(handle)
+
+
+def test_local_database_services_are_present() -> None:
+    compose = _load_compose()
+
+    assert {"postgres", "mongo"} <= set(compose["services"])
+
+
+def test_local_database_ports_are_bound_to_loopback_only() -> None:
+    services = _load_compose()["services"]
+
+    assert services["postgres"]["ports"] == ["127.0.0.1:5433:5432"]
+    assert services["mongo"]["ports"] == ["127.0.0.1:27018:27017"]
+
+
+def test_local_database_seed_mounts_are_read_only() -> None:
+    services = _load_compose()["services"]
+
+    assert services["postgres"]["volumes"] == [
+        "./sql/postgres_schema.sql:/docker-entrypoint-initdb.d/01_schema.sql:ro",
+        "./sql/postgres_demo_data.sql:/docker-entrypoint-initdb.d/02_demo_data.sql:ro",
+    ]
+    assert services["mongo"]["volumes"] == ["./mongo/init:/docker-entrypoint-initdb.d:ro"]
+
+
+def test_local_database_services_have_healthchecks() -> None:
+    services = _load_compose()["services"]
+
+    assert "pg_isready -U risk_user -d risk_platform" in services["postgres"]["healthcheck"]["test"]
+    assert services["mongo"]["healthcheck"]["test"][0] == "CMD-SHELL"
+    assert "db.adminCommand({ ping: 1 }).ok" in services["mongo"]["healthcheck"]["test"][1]
+
+
+def test_postgres_uses_demo_only_credentials() -> None:
+    environment = _load_compose()["services"]["postgres"]["environment"]
+
+    assert environment == {
+        "POSTGRES_DB": "risk_platform",
+        "POSTGRES_USER": "risk_user",
+        "POSTGRES_PASSWORD": "risk_password",
+    }

--- a/tests/unit/test_lineage.py
+++ b/tests/unit/test_lineage.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from src.orchestration.lineage import build_lineage_manifest
+from tests.storage_config_helpers import build_storage_config
+
+
+def test_build_lineage_manifest_tracks_source_to_reporting_flow(tmp_path: Path) -> None:
+    manifest = build_lineage_manifest(
+        run_id="run-1",
+        input_path=Path("tests/fixtures/demo_events.json"),
+        signals_path=None,
+        storage_config=build_storage_config(tmp_path),
+        raw_dataset="market_events",
+        raw_payload_count=7,
+        deduped_event_count=6,
+        external_signal_count=0,
+        raw_written=6,
+        curated_writes={
+            "returns_1m": 4,
+            "volatility_5m": 2,
+            "data_quality_metrics": 1,
+            "risk_summary": 2,
+            "external_signal_summary": 0,
+        },
+        partitions=["year=2025/month=01/day=20/hour=10"],
+        quality_summary={
+            "required_fields_status": "ok",
+            "late_status": "critical",
+            "duplicate_status": "critical",
+        },
+    )
+
+    assert manifest["run_id"] == "run-1"
+    assert manifest["source_inventory"][0] == {
+        "name": "market_events",
+        "source_type": "json_file",
+        "location": "tests/fixtures/demo_events.json",
+        "authoritative_key": "event_id",
+        "records_received": 7,
+        "records_after_deduplication": 6,
+    }
+    assert manifest["layers"][0]["datasets"][0]["records_written"] == 6
+    assert manifest["layers"][2]["datasets"][0]["dataset"] == (
+        "risk_platform.finance_risk_semantic_model"
+    )
+    assert manifest["transformations"][-1]["outputs"] == [
+        "data_quality_metrics",
+        "external_signal_summary",
+        "returns_1m",
+        "risk_summary",
+        "volatility_5m",
+    ]
+    assert manifest["quality_checks"]["duplicate_status"] == "critical"

--- a/tests/unit/test_postgres_loader.py
+++ b/tests/unit/test_postgres_loader.py
@@ -3,8 +3,6 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-import yaml
-
 from src.orchestration.run_pipeline import run_pipeline
 from src.warehouse.postgres_loader import (
     LOAD_SPECS,
@@ -13,36 +11,7 @@ from src.warehouse.postgres_loader import (
     collect_load_batches,
     load_batches_to_postgres,
 )
-
-
-def _write_storage_config(tmp_path: Path) -> Path:
-    storage_config = {
-        "storage": {
-            "base_dir": str(tmp_path),
-            "raw": {
-                "base_path": str(tmp_path / "raw"),
-                "dataset": "market_events",
-            },
-            "curated": {
-                "base_path": str(tmp_path / "curated"),
-                "datasets": {
-                    "returns_1m": "returns_1m",
-                    "volatility_5m": "volatility_5m",
-                    "data_quality_metrics": "data_quality_metrics",
-                    "risk_summary": "risk_summary",
-                    "external_signal_summary": "external_signal_summary",
-                },
-            },
-            "format": "parquet",
-            "partitioning": {
-                "granularity": "hourly",
-            },
-        }
-    }
-    storage_config_path = tmp_path / "storage.yaml"
-    with storage_config_path.open("w", encoding="utf-8") as handle:
-        yaml.safe_dump(storage_config, handle, sort_keys=False)
-    return storage_config_path
+from tests.storage_config_helpers import write_storage_config
 
 
 def _write_demo_input(tmp_path: Path) -> Path:
@@ -56,7 +25,7 @@ def _write_demo_input(tmp_path: Path) -> Path:
 
 
 def test_collect_load_batches_matches_demo_pipeline_outputs(tmp_path: Path) -> None:
-    storage_config_path = _write_storage_config(tmp_path)
+    storage_config_path = write_storage_config(tmp_path)
     input_path = _write_demo_input(tmp_path)
 
     run_pipeline(
@@ -83,7 +52,7 @@ def test_collect_load_batches_matches_demo_pipeline_outputs(tmp_path: Path) -> N
 
 
 def test_load_batches_to_postgres_dry_run_returns_counts(tmp_path: Path) -> None:
-    storage_config_path = _write_storage_config(tmp_path)
+    storage_config_path = write_storage_config(tmp_path)
     input_path = _write_demo_input(tmp_path)
     run_pipeline(
         input_path=input_path,

--- a/tests/unit/test_reporting_sql_contract.py
+++ b/tests/unit/test_reporting_sql_contract.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def _read_sql(path: str) -> str:
+    return Path(path).read_text(encoding="utf-8")
+
+
+def test_postgres_schema_exposes_finance_reporting_contract() -> None:
+    schema_sql = _read_sql("sql/postgres_schema.sql")
+
+    assert "CREATE TABLE IF NOT EXISTS risk_platform.symbol_dimension_history" in schema_sql
+    assert "CREATE OR REPLACE VIEW risk_platform.current_symbol_dimension" in schema_sql
+    assert "CREATE OR REPLACE VIEW risk_platform.finance_risk_semantic_model" in schema_sql
+    assert "idx_symbol_dimension_history_current" in schema_sql
+    assert "WHERE is_current" in schema_sql
+
+
+def test_demo_data_seeds_scd_type_2_symbol_history() -> None:
+    demo_sql = _read_sql("sql/postgres_demo_data.sql")
+
+    assert "risk_platform.symbol_dimension_history" in demo_sql
+    assert "'AAPL'" in demo_sql
+    assert "'MSFT'" in demo_sql
+    assert "'2025-01-20T10:00:00Z'" in demo_sql
+    assert "'sector_alignment'" in demo_sql
+
+
+def test_consistency_checks_cover_reporting_view_shape() -> None:
+    consistency_sql = _read_sql("sql/consistency_checks.sql")
+
+    assert "current_symbol_dimension_rows_expected" in consistency_sql
+    assert "finance_reporting_rows_to_latest_risk_symbols" in consistency_sql
+    assert "risk_platform.finance_risk_semantic_model" in consistency_sql


### PR DESCRIPTION
## Summary
- add a source-to-report lineage manifest for demo pipeline runs
- add finance reporting warehouse objects, SCD Type 2 symbol history, and related SQL checks
- strengthen quality/readiness validation with type checking, Compose contract tests, and SQL reporting contract tests

## Validation
- make quality-check
- make iteration-check
- git diff --check
