### PR TITLE
Add point-in-time symbol dimension lookup

### DIFF
--- a/scripts/seed_reference_data.py
+++ b/scripts/seed_reference_data.py
@@ -158,6 +158,35 @@ def validate_symbol_dimension_rows(rows: list[SymbolDimensionRow]) -> None:
                 raise ValueError(f"Overlapping effective intervals for {symbol}/{source}")
 
 
+def find_symbol_dimension_row_as_of(
+    rows: list[SymbolDimensionRow],
+    *,
+    symbol: str,
+    source: str,
+    as_of: datetime,
+) -> SymbolDimensionRow | None:
+    """Return the symbol version valid at ``as_of``, using half-open intervals."""
+    validate_symbol_dimension_rows(rows)
+    canonical_symbol = symbol.strip().upper()
+    canonical_source = source.strip().lower()
+    effective_at = _parse_effective_timestamp(as_of)
+
+    matches = [
+        row
+        for row in rows
+        if row.symbol == canonical_symbol
+        and row.source == canonical_source
+        and row.effective_from <= effective_at
+        and (row.effective_to is None or effective_at < row.effective_to)
+    ]
+    if len(matches) > 1:
+        raise ValueError(
+            f"Multiple symbol dimension rows match "
+            f"{canonical_symbol}/{canonical_source} at {_format_timestamp(effective_at)}"
+        )
+    return matches[0] if matches else None
+
+
 def build_record_hash(version: SymbolVersion) -> str:
     payload = {
         "asset_class": version.asset_class,

--- a/tests/unit/test_seed_reference_data.py
+++ b/tests/unit/test_seed_reference_data.py
@@ -11,6 +11,7 @@ from scripts.seed_reference_data import (
     build_record_hash,
     build_symbol_dimension_rows,
     build_symbol_dimension_upsert_sql,
+    find_symbol_dimension_row_as_of,
     format_symbol_dimension_sql,
     load_symbol_versions,
     parse_symbol_versions,
@@ -103,6 +104,46 @@ def test_build_symbol_dimension_rows_marks_one_current_row_per_symbol_source() -
         ("EURUSD", "stooq"): 1,
         ("MSFT", "stooq"): 1,
     }
+
+
+@pytest.mark.parametrize(
+    ("as_of", "expected_sector"),
+    [
+        (datetime(2025, 1, 20, 9, 59, 59, tzinfo=timezone.utc), "technology"),
+        (
+            datetime(2025, 1, 20, 10, 0, tzinfo=timezone.utc),
+            "information_technology",
+        ),
+    ],
+)
+def test_find_symbol_dimension_row_as_of_uses_half_open_intervals(
+    as_of: datetime,
+    expected_sector: str,
+) -> None:
+    rows = build_symbol_dimension_rows(parse_symbol_versions(_sample_config()))
+
+    row = find_symbol_dimension_row_as_of(
+        rows,
+        symbol=" aapl ",
+        source="STOOQ",
+        as_of=as_of,
+    )
+
+    assert row is not None
+    assert row.sector == expected_sector
+
+
+def test_find_symbol_dimension_row_as_of_returns_none_outside_history() -> None:
+    rows = build_symbol_dimension_rows(parse_symbol_versions(_sample_config()))
+
+    row = find_symbol_dimension_row_as_of(
+        rows,
+        symbol="AAPL",
+        source="stooq",
+        as_of=datetime(2023, 12, 31, 23, 59, 59, tzinfo=timezone.utc),
+    )
+
+    assert row is None
 
 
 def test_duplicate_effective_dates_are_rejected() -> None:


### PR DESCRIPTION
## Summary

- add a point-in-time lookup for SCD Type 2 symbol dimension rows
- normalize symbol and source keys and use half-open effective intervals
- cover the version boundary and dates outside known history

## Validation

- `make quality-check` — 66 tests passed
- `make security-check` — passed
- `git diff --check` — passed