### PR TITLE
Validate pipeline window options

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,7 @@ make readiness-check
 Expected test suite result:
 
 ```text
-54 passed
+All collected tests pass.
 ```
 
 When Docker is available, validate the local source-to-warehouse loop:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,9 @@ dev = [
 [tool.ruff]
 line-length = 100
 
+[tool.ruff.lint]
+select = ["E4", "E7", "E9", "F"]
+
 [tool.mypy]
 python_version = "3.10"
 ignore_missing_imports = true

--- a/src/orchestration/run_pipeline.py
+++ b/src/orchestration/run_pipeline.py
@@ -42,6 +42,16 @@ VALUE_RULES = {
 }
 
 
+def _positive_int(value: str) -> int:
+    try:
+        parsed = int(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("must be an integer greater than zero") from exc
+    if parsed <= 0:
+        raise argparse.ArgumentTypeError("must be greater than zero")
+    return parsed
+
+
 def _parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Run the local end-to-end risk pipeline demo.")
     parser.add_argument(
@@ -68,15 +78,15 @@ def _parse_args() -> argparse.Namespace:
     )
     parser.add_argument(
         "--window-minutes",
-        type=int,
+        type=_positive_int,
         default=5,
-        help="Window size in minutes for aggregation.",
+        help="Window size in minutes for aggregation. Must be greater than zero.",
     )
     parser.add_argument(
         "--vol-window",
-        type=int,
+        type=_positive_int,
         default=5,
-        help="Rolling window length for volatility.",
+        help="Rolling window length for volatility. Must be greater than zero.",
     )
     parser.add_argument(
         "--summary-json",
@@ -177,6 +187,15 @@ def _validate_and_normalize(payload: dict[str, Any]) -> dict[str, Any]:
     return event.model_dump()
 
 
+def _validate_window_options(window_minutes: int, vol_window: int) -> None:
+    for name, value in (
+        ("window_minutes", window_minutes),
+        ("vol_window", vol_window),
+    ):
+        if value <= 0:
+            raise ValueError(f"{name} must be greater than zero")
+
+
 def _evaluate_threshold(value: float, warn: float | None, critical: float | None) -> str:
     if critical is not None and value >= critical:
         return "critical"
@@ -265,6 +284,8 @@ def run_pipeline(
     lock_stale_seconds: int | None = None,
     lineage_json_path: Path | None = None,
 ) -> dict[str, Any]:
+    _validate_window_options(window_minutes, vol_window)
+
     run_id = str(uuid4())
     raw_payloads = _load_input(input_path)
     external_signal_records = _load_external_signal_records(signals_path)

--- a/tests/unit/test_pipeline_options.py
+++ b/tests/unit/test_pipeline_options.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+from src.orchestration.run_pipeline import main as run_pipeline_main
+from src.orchestration.run_pipeline import run_pipeline
+
+
+@pytest.mark.parametrize(
+    ("option", "value"),
+    [
+        ("--window-minutes", "0"),
+        ("--window-minutes", "-1"),
+        ("--vol-window", "0"),
+        ("--vol-window", "-1"),
+    ],
+)
+def test_cli_rejects_non_positive_window_options(
+    option: str,
+    value: str,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setattr(sys, "argv", ["run_pipeline", option, value])
+
+    with pytest.raises(SystemExit) as exc_info:
+        run_pipeline_main()
+
+    assert exc_info.value.code == 2
+    assert f"argument {option}: must be greater than zero" in capsys.readouterr().err
+
+
+@pytest.mark.parametrize(
+    ("window_minutes", "vol_window", "expected_message"),
+    [
+        (0, 5, "window_minutes must be greater than zero"),
+        (5, 0, "vol_window must be greater than zero"),
+    ],
+)
+def test_run_pipeline_rejects_non_positive_windows_before_loading_input(
+    tmp_path: Path,
+    window_minutes: int,
+    vol_window: int,
+    expected_message: str,
+) -> None:
+    with pytest.raises(ValueError, match=expected_message):
+        run_pipeline(
+            input_path=tmp_path / "input-is-not-loaded.json",
+            thresholds_path=tmp_path / "thresholds-are-not-loaded.yaml",
+            late_seconds=60,
+            window_minutes=window_minutes,
+            vol_window=vol_window,
+            storage_config_path=tmp_path / "storage-is-not-loaded.yaml",
+        )


### PR DESCRIPTION
## Summary

- reject zero and negative aggregation and volatility window values at the CLI boundary
- protect direct `run_pipeline()` callers before any input or configuration files are loaded
- add focused regression coverage and remove the stale fixed test-count expectation
- make the existing Ruff lint policy explicit so CI remains stable across tool releases

## Why

A zero aggregation window reached the windowing calculation and raised a division-by-zero traceback. A zero volatility window could silently produce no volatility rows. Failing early gives users a clear configuration error and keeps invalid runs from entering pipeline processing.

CI subsequently installed Ruff 0.16.2 while the local environment used 0.15.2. Because the lint rule selection was implicit, the newer release surfaced 26 unrelated findings in existing files. The explicit `E4`, `E7`, `E9`, and `F` selection preserves the repository's established policy without broad unrelated rewrites.

## Validation

- Ruff 0.16.2: passed
- `make quality-check` — 72 tests passed, lint and type checking passed
- `make security-check` — passed
- `make readiness-check` — demo pipeline and warehouse dry-run passed
- `git diff --check` — passed