### PR TITLE
Validate pipeline input event objects

### DIFF
--- a/src/orchestration/run_pipeline.py
+++ b/src/orchestration/run_pipeline.py
@@ -168,7 +168,7 @@ def _load_input(path: Path | None) -> list[dict[str, Any]]:
         return _sample_events()
     with path.open("r", encoding="utf-8") as handle:
         data = json.load(handle)
-    if not isinstance(data, list):
+    if not isinstance(data, list) or any(not isinstance(record, dict) for record in data):
         raise ValueError("Input JSON must be a list of event objects.")
     return data
 

--- a/tests/unit/test_pipeline_input.py
+++ b/tests/unit/test_pipeline_input.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from src.orchestration.run_pipeline import _load_input, run_pipeline
+
+
+def _write_payload(tmp_path: Path, payload: Any) -> Path:
+    input_path = tmp_path / "events.json"
+    input_path.write_text(json.dumps(payload), encoding="utf-8")
+    return input_path
+
+
+def test_load_input_accepts_a_list_of_event_objects(tmp_path: Path) -> None:
+    payload = [{"event_id": "evt-1"}, {"event_id": "evt-2"}]
+
+    assert _load_input(_write_payload(tmp_path, payload)) == payload
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"event_id": "evt-1"},
+        [42],
+        ["evt-1"],
+        [[]],
+        [None],
+        [{"event_id": "evt-1"}, 42],
+    ],
+)
+def test_run_pipeline_rejects_input_that_is_not_a_list_of_event_objects(
+    tmp_path: Path,
+    payload: Any,
+) -> None:
+    input_path = _write_payload(tmp_path, payload)
+
+    with pytest.raises(ValueError, match="Input JSON must be a list of event objects"):
+        run_pipeline(
+            input_path=input_path,
+            thresholds_path=tmp_path / "thresholds-are-not-loaded.yaml",
+            late_seconds=60,
+            window_minutes=5,
+            vol_window=2,
+            storage_config_path=tmp_path / "storage-is-not-loaded.yaml",
+        )


### PR DESCRIPTION
## Summary

- require every item in an input JSON list to be an event object
- reject malformed top-level and mixed record shapes before configuration or storage processing
- add focused coverage for valid object lists plus number, string, list, `null`, mixed, and non-list inputs

## Why

The loader previously checked only that the top-level JSON value was a list. A non-object item could pass loading and fail later inside data-quality processing with an opaque `TypeError`. Validating the complete input shape at the boundary gives users the existing clear contract error and prevents invalid records from entering pipeline processing.

## Impact

Valid event-object lists behave unchanged. Malformed input now fails earlier with `Input JSON must be a list of event objects.` No storage, schema, warehouse, or cloud contracts change.

## Validation

- focused input tests — 7 passed
- `make quality-check` — 79 tests passed, lint and type checking passed
- `make security-check` — passed
- `make readiness-check` — demo pipeline and warehouse dry-run passed
- `git diff --check` — passed