### PR TITLE
Expose pipeline event flow

### DIFF
--- a/docs/demo-script.md
+++ b/docs/demo-script.md
@@ -21,8 +21,9 @@ Use this when the conversation is time-boxed:
 1. State the contract: source events become validated raw parquet, curated risk
    datasets, and PostgreSQL-style serving tables.
 2. Run `make readiness-check`.
-3. Point to the summary values: 7 source records become 6 raw events, 9 curated
-   records, 1 duplicate, and 1 late event.
+3. Point to the event flow: 7 input records become 6 records after
+   deduplication, including 1 duplicate and 1 late event. Then distinguish that
+   processing evidence from the 6 raw and 9 curated records physically written.
 4. Show `src/orchestration/run_pipeline.py` for validation, deduplication,
    partition locking, and writes.
 5. Show `src/storage/s3_writer.py` for deterministic partitioned output.
@@ -70,9 +71,14 @@ Use this when the conversation is time-boxed:
      --lineage-json .demo/lineage.json
    ```
 
-   Call out the summary values: raw events written, curated records written,
-   duplicate rate, late rate, data quality status, affected partitions, and
-   latest risk metrics.
+   Call out the event flow separately from the write counts: the demo processes
+   7 input events, keeps 6 after deduplication, and writes 6 raw plus 9 curated
+   records. Duplicate rate, late rate, data quality status, affected partitions,
+   and latest risk metrics remain visible alongside those counts.
+
+   Run the same command again to demonstrate idempotency. The event flow remains
+   7 input events to 6 after deduplication, while the raw and curated write counts
+   become zero because the deterministic output files already exist.
 
    The demo fixture intentionally includes one duplicate business event and one
    late event. With the strict demo thresholds, those rates are reported as

--- a/src/orchestration/run_pipeline.py
+++ b/src/orchestration/run_pipeline.py
@@ -551,6 +551,10 @@ def run_pipeline(
 
     return {
         "pipeline_run_id": run_id,
+        "input_events": total_events,
+        "deduped_events": len(deduped),
+        "duplicate_events": total_events - len(deduped),
+        "late_events": late_count,
         "raw_events": raw_written,
         "curated_records": curated_written,
         "curated_records_by_dataset": curated_writes,
@@ -588,6 +592,12 @@ def main() -> None:
             json.dump(summary, handle, indent=2, sort_keys=True, default=str)
 
     print("Pipeline run summary")
+    print(
+        f"Event flow: {summary['input_events']} input -> "
+        f"{summary['deduped_events']} after deduplication "
+        f"(duplicate events: {summary['duplicate_events']}, "
+        f"late events: {summary['late_events']})"
+    )
     print(f"Raw events written: {summary['raw_events']}")
     print(f"Curated records written: {summary['curated_records']}")
     print(f"Partitions: {summary['partitions']}")

--- a/tests/integration/test_run_pipeline_curated.py
+++ b/tests/integration/test_run_pipeline_curated.py
@@ -90,8 +90,16 @@ def test_run_pipeline_cli_creates_summary_parent_directory(
 
     captured = capsys.readouterr()
     assert "Pipeline run summary" in captured.out
+    assert (
+        "Event flow: 7 input -> 6 after deduplication "
+        "(duplicate events: 1, late events: 1)" in captured.out
+    )
     with summary_path.open("r", encoding="utf-8") as handle:
         summary = json.load(handle)
+    assert summary["input_events"] == 7
+    assert summary["deduped_events"] == 6
+    assert summary["duplicate_events"] == 1
+    assert summary["late_events"] == 1
     assert summary["raw_events"] == 6
     assert summary["curated_records"] == 9
     assert summary["required_fields_status"] == "ok"
@@ -107,6 +115,22 @@ def test_run_pipeline_cli_creates_summary_parent_directory(
     assert lineage["layers"][2]["datasets"][0]["dataset"] == (
         "risk_platform.finance_risk_semantic_model"
     )
+
+    run_pipeline_main()
+
+    replay_output = capsys.readouterr().out
+    assert (
+        "Event flow: 7 input -> 6 after deduplication "
+        "(duplicate events: 1, late events: 1)" in replay_output
+    )
+    with summary_path.open("r", encoding="utf-8") as handle:
+        replay_summary = json.load(handle)
+    assert replay_summary["input_events"] == 7
+    assert replay_summary["deduped_events"] == 6
+    assert replay_summary["duplicate_events"] == 1
+    assert replay_summary["late_events"] == 1
+    assert replay_summary["raw_events"] == 0
+    assert replay_summary["curated_records"] == 0
 
 
 def test_run_pipeline_materializes_all_curated_datasets(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- add input, post-deduplication, duplicate, and late-event counts to the pipeline summary
- print the processing flow separately from physical raw and curated write counts
- verify that an idempotent replay preserves the event flow while reporting zero new writes
- update the demo walkthrough to explain the processing-versus-writing distinction

## Why

The existing terminal summary showed only records physically written. On a correct idempotent replay those counts become zero, which could be misread as the pipeline processing no input. The new event-flow line makes processing evidence explicit without changing storage behavior.

## Impact

The JSON summary gains four additive fields: `input_events`, `deduped_events`, `duplicate_events`, and `late_events`. The CLI gains one event-flow line. Existing write-count fields and pipeline behavior remain unchanged.

## Validation

- focused first-run and replay integration test — passed
- `make quality-check` — 79 tests passed, lint and type checking passed
- `make security-check` — passed
- `make readiness-check` — demo pipeline and warehouse dry-run passed
- `git diff --check` — passed