### PR TITLE
Define controlled change acceptance policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,6 +75,9 @@ and run the closest local validation that does not require those tools.
    controls.
 11. Use `docs/iteration-loop.md` and `docs/iteration-backlog.md` for continued
    repo iterations.
+12. Treat agent reviews and generated acceptance packages as evidence, not
+    approval. The acceptance decision must remain pending until the engineer
+    understands and explicitly accepts the final diff.
 
 ## Git Workflow
 

--- a/docs/agent-roles.md
+++ b/docs/agent-roles.md
@@ -16,6 +16,7 @@ engineer owns scope, review, merge, deployment, and production-risk decisions.
 | Kubernetes And Delivery Engineer | Container, CI, Kubernetes overlays, deploy workflow hygiene | `Dockerfile`, `.github/workflows/`, `deploy/kubernetes/`, `deploy/README.md` | Apply to clusters, trigger deploy workflows, weaken pod security, or change prod without dev parity | `make security-check && make infrastructure-check` |
 | Quality Reviewer | Tests, linting, generated-data hygiene | `tests/`, `Makefile`, CI checks | Rewrite production logic except for the smallest necessary fix | `make security-check && make readiness-check` |
 | Security Reviewer | Secrets, generated files, cloud guardrails, deploy triggers | Security docs, checks, CI guardrails | Approve risky changes without the lead engineer | `make security-check` |
+| Production Challenger | Failure, retry, concurrency, rollback, operational, and cost assumptions | None during the review pass | Edit the candidate change or present hardening ideas as proven defects | Read-only findings with file references |
 | Demo Narrator | Interview walkthroughs and expected outputs | `README.md`, `docs/`, demo fixtures if needed | Overclaim production usage of scaffolded services | `make readiness-check` when demo behaviour changes |
 
 ## Coordination Rules
@@ -27,6 +28,11 @@ engineer owns scope, review, merge, deployment, and production-risk decisions.
 5. Keep cloud deploys, Terraform apply, branch merges, and destructive database
    actions human-approved.
 6. Require validation evidence in the final handoff.
+7. A role performing an independent review is read-only for that pass. Send
+   accepted fixes back to the assigned writer and re-run affected evidence.
+8. Treat reviewer findings as evidence rather than approval. The delivery lead
+   triages and assembles evidence; the human engineer alone accepts, merges, or
+   authorises deployment.
 
 ## Overnight Use
 

--- a/docs/agentic-workflows.md
+++ b/docs/agentic-workflows.md
@@ -11,9 +11,9 @@ Use the smallest autonomy level that fits the task.
 | Level | Use When | Agent Can Do | Human Must Do |
 | --- | --- | --- | --- |
 | 0: Advice | You are deciding direction | Explain options, risks, and next steps | Choose the path |
-| 1: Local Change | Scope is clear and low-risk | Edit files and run tests locally | Review final diff |
-| 2: Branch And PR | Work is multi-file but bounded | Branch, commit, push, open PR | Review PR before merge unless explicitly delegated |
-| 3: PR Follow-Through | PR has CI/review feedback | Inspect failures, patch, rerun checks | Approve risky changes |
+| 1: Local Change | Scope is clear and low-risk | Edit files and run tests locally | Review and accept the final diff |
+| 2: Branch And PR | Work is multi-file but bounded | Branch, commit, push, open PR | Accept the change before merge |
+| 3: PR Follow-Through | PR has CI/review feedback | Inspect failures, patch, rerun checks | Accept the final revision before merge |
 | 4: Cloud/Infra | AWS, Terraform, deploys, secrets | Prepare scaffolding and plans | Approve apply/deploy/secret changes |
 
 For this repo, default to Level 1 or 2. Use Level 4 only for disabled-by-default
@@ -49,7 +49,8 @@ Validation:
 Run <commands>.
 
 Git:
-Create a neutral branch, commit, push, open PR, wait for checks, merge if green.
+Create a neutral branch, commit, push, open a PR, wait for checks, and stop for
+human acceptance before merge.
 
 Do not:
 - <risky or out-of-scope action>
@@ -124,6 +125,37 @@ documentation. Prioritise findings by severity with file references. Do not
 make edits unless asked.
 ```
 
+### Independent Correctness Review
+
+```text
+Do not modify files. Review this change against its task brief. Prioritise
+correctness, maintainability, observability, performance, security,
+testability, unnecessary complexity, and missing tests. Cite files and explain
+the failure each finding could cause. Say explicitly when no finding is proven.
+```
+
+### Production Failure Challenge
+
+```text
+Do not modify files. Assume this passed its current tests. What can still fail
+in production? Challenge input boundaries, partial failure, retries,
+idempotency, concurrency, data volume, permissions, network dependencies,
+rollout, rollback, monitoring, and cost. Separate demonstrated defects from
+questions or optional hardening.
+```
+
+### Morning Package Synthesis
+
+```text
+Do not modify files. Use the local acceptance package, task brief, reviewer
+findings, and final diff to prepare a human review summary. Explain the change,
+architecture and important data/control paths, state and side effects,
+assumptions, failure and recovery behaviour, security and permissions,
+operational/performance/cost implications, test evidence, and unresolved
+questions. Rank no more than ten concrete file locations I should inspect.
+Separate recorded evidence from inference and leave the decision pending.
+```
+
 ### CI Fix
 
 ```text
@@ -161,54 +193,15 @@ For continued improvement work, use `docs/iteration-loop.md` and pick one item
 from `docs/iteration-backlog.md`. Keep each iteration to one coherent change
 set and stop after validation for review.
 
-## Review Checklist
+For the full implement, independent-review, production-challenge,
+automated-gate, and human-acceptance sequence, use
+`docs/engineering-delivery-workflow.md`. Run `make morning-review` after the
+checks to create an ignored local evidence package; the package supports human
+review and never approves a change.
 
-Before accepting agent-authored changes, check:
+## Acceptance Policy
 
-1. Does the change solve the stated problem?
-2. Are unrelated files untouched?
-3. Are generated files excluded?
-4. Do tests cover the risky behaviour?
-5. Did validation actually run?
-6. Are unavailable checks clearly disclosed?
-7. Are docs accurate and not overstated?
-8. Are cloud resources disabled by default?
-9. Are secrets absent?
-10. Is the diff small enough to review confidently?
-
-## What To Delegate
-
-Good candidates:
-
-1. Adding focused tests.
-2. Writing runbooks and walkthroughs.
-3. Implementing small loaders or adapters.
-4. Refactoring with stable behaviour.
-5. Creating disabled-by-default infrastructure scaffolds.
-6. Debugging CI failures.
-7. Drafting PR descriptions and validation summaries.
-
-Poor candidates without close review:
-
-1. IAM permissions.
-2. Secrets and credential handling.
-3. Production deploys.
-4. Destructive migrations.
-5. Broad rewrites before requirements are clear.
-6. Business-critical logic without tests.
-
-## Human Review Model
-
-Do not treat agent output as automatically correct. Treat it as a fast junior or
-mid-level implementation draft that still needs engineering ownership.
-
-For low-risk documentation or tests, review can be quick. For data loading,
-schema, infrastructure, auth, or deployment work, review the diff carefully,
-run checks, and reason through failure modes before merge.
-
-The practical target is not "no human checks code". The target is:
-
-```text
-humans spend less time typing boilerplate
-and more time reviewing design, risk, tests, and production impact
-```
+Use `docs/engineering-delivery-workflow.md` as the single source of truth for
+delegation boundaries, evidence freshness, risk review, and human acceptance.
+This guide supplies prompts and autonomy mechanics; it does not weaken or
+replace that policy.

--- a/docs/engineering-delivery-workflow.md
+++ b/docs/engineering-delivery-workflow.md
@@ -52,6 +52,9 @@ Scope:
 Acceptance criteria:
 <What must be true in the repo?>
 
+Risk and failure behaviour:
+<State, side effects, recovery, permissions, and cost constraints>
+
 Validation:
 <Which commands must run?>
 
@@ -62,14 +65,50 @@ Do not:
 <Anything destructive, costly, or out of scope>
 ```
 
+## Controlled Agent Loop
+
+Optimise for the amount of code the lead engineer can safely accept, not the
+number of agent passes. Prefer one coherent change of roughly 200 to 500
+non-generated changed lines. This is a review heuristic rather than a quality
+target: split sooner when a change crosses contracts, schemas, IAM, deployment,
+or unrelated modules, and require an explicit reason for a larger diff.
+
+Use this sequence for agent-authored logic and other material changes:
+
+1. The delivery lead drafts the task brief and records the starting branch and
+   status. The human engineer confirms the brief before one writer receives a
+   bounded scope.
+2. The writer implements the smallest change that meets the acceptance criteria
+   and reports assumptions and checks actually run.
+3. A separate read-only reviewer checks correctness, maintainability,
+   observability, performance, security, testability, unnecessary complexity,
+   and missing tests.
+4. Another read-only pass assumes the tests pass and challenges production
+   failure modes: invalid inputs, partial failure, retries, idempotency,
+   concurrency, volume, permissions, dependencies, rollout, rollback,
+   monitoring, and cost.
+5. The delivery lead separates demonstrated defects from questions and optional
+   hardening, then assigns accepted fixes to the writer.
+6. The relevant automated gates run and the lead verifies their evidence.
+7. `make morning-review` creates an ignored local evidence package for the final
+   human review.
+
+Reviewers do not approve their own changes, and repeated agreement between
+agents is not an acceptance signal. The delivery lead triages and assembles
+evidence; the human engineer alone accepts the final diff, merges, or authorises
+deployment. Use the prompts in
+`docs/agentic-workflows.md` and the role boundaries in `docs/agent-roles.md`.
+Any fix invalidates review or validation evidence affected by that fix; repeat
+the relevant pass before acceptance.
+
 ## Validation Ladder
 
 Use the smallest validation set that matches the risk.
 
 | Change Type | Validation |
 | --- | --- |
-| Docs only | `git diff --check` |
-| Python logic | `make security-check && make lint && make test` |
+| Docs only | `make security-check && git diff --check` |
+| Python logic | `make security-check && make quality-check` |
 | Demo path | `make readiness-check` |
 | PostgreSQL loader | `make clean-generated && make run-demo && make load-postgres-dry-run` |
 | Local database walkthrough | `make local-db-up && make consistency-demo && make local-db-down` |
@@ -78,6 +117,28 @@ Use the smallest validation set that matches the risk.
 
 If Docker or Terraform is not installed locally, state that clearly and run the
 nearest available check.
+
+## Morning Acceptance Package
+
+After review and validation, run:
+
+```bash
+make morning-review
+```
+
+The command writes a Markdown report and machine-readable JSON evidence under
+ignored `.sandbox/review-packages/`. It records the current Git state,
+changed-file risk flags, the latest overnight summary when present, up to ten
+files to inspect first, and the human acceptance questions. Automated evidence
+is kept separate from reviewer assertions and the human decision remains
+pending. Use `make morning-review REVIEW_BASE_REF=main` when the local `main`
+branch, rather than the default `origin/main`, is the intended comparison base;
+the command never fetches.
+
+The command deliberately does not include a full diff, run validation, approve
+the change, commit, push, merge, or deploy. Overnight evidence is historical
+unless it can be tied to the reviewed Git state, so its timestamp and limits
+must be considered before relying on it.
 
 ## Monitoring Evidence
 
@@ -99,6 +160,11 @@ For unattended local validation, use `docs/overnight-sandbox.md`. The sandbox
 runs readiness and security checks repeatedly, writes logs under `.sandbox/`,
 and does not push, merge, deploy, or create cloud resources.
 
+During an active controlled session, late-night agent work is best used for
+candidate code, focused tests, research, documentation, and independent review
+that can be inspected later. After the session ends, this repository's
+unattended mode remains validation-only; it does not continue modifying code.
+
 For continued improvement, use `docs/iteration-loop.md` and
 `docs/iteration-backlog.md`. The queue keeps work small enough to review.
 
@@ -107,14 +173,17 @@ For continued improvement, use `docs/iteration-loop.md` and
 Before accepting a change, ask:
 
 1. Does the diff solve the stated objective?
-2. Are unrelated files untouched?
-3. Are generated outputs excluded?
-4. Are tests targeted at the risky behaviour?
-5. Did the validation commands actually run?
-6. Are unavailable checks disclosed?
-7. Are cloud resources still disabled by default?
-8. Are secrets absent?
-9. Is the explanation accurate without overstating production usage?
+2. Can I explain the important control and data paths?
+3. Do I understand state, side effects, idempotency, and failure recovery?
+4. Are unrelated files untouched and generated outputs excluded?
+5. Are permissions, secrets, and network exposure appropriate?
+6. Are operational, performance, and cost implications understood?
+7. Are tests targeted at the risky behaviour?
+8. Did the reported validation commands actually run for the state reviewed?
+9. Are unavailable or stale checks disclosed?
+10. Are cloud resources still disabled by default?
+11. Is the explanation accurate without overstating production usage?
+12. Can I defend the change without relying on an agent's approval?
 
 ## Short Talk Track
 


### PR DESCRIPTION
## What changed

- Establish the bounded implement → independent correctness review → production challenge → automated gates → human acceptance sequence.
- Make reviewer passes read-only and require affected evidence to be repeated after fixes.
- Clarify that the delivery role assembles evidence while the human engineer alone accepts, merges, or authorizes deployment.
- Align validation guidance and reusable prompts with that authority boundary.

## Why

Multiple agreeing agents are not an acceptance signal. The repository needs one canonical policy for evidence freshness, review separation, risk escalation, and final human accountability.

## arc42 boundary

This PR is the governance contract and cross-cutting quality-policy slice. It depends on the executable evidence subsystem in the base branch but does not change pipeline, storage, database, cloud, or deployment behavior.

## Validation

- `make security-check`
- `make morning-review REVIEW_BASE_REF=agent/add-local-change-acceptance-package`
- `git diff --check agent/add-local-change-acceptance-package...HEAD`

## PR stack

This is 2 of 3 and targets `agent/add-local-change-acceptance-package`. Merge with a merge commit after PR 1; if PR 1 is squash-merged, rebase and revalidate this branch before retargeting it to `main`. Human acceptance remains pending.
