### PR TITLE
Consolidate change acceptance and arc42 documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,6 +75,9 @@ and run the closest local validation that does not require those tools.
    controls.
 11. Use `docs/iteration-loop.md` and `docs/iteration-backlog.md` for continued
    repo iterations.
+12. Treat agent reviews and generated acceptance packages as evidence, not
+    approval. The acceptance decision must remain pending until the engineer
+    understands and explicitly accepts the final diff.
 
 ## Git Workflow
 

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Additional preparation notes:
 10. `docs/lambda-s3-orchestration.md` for AWS orchestration mapping
 11. `sql/postgres_schema.sql` and `sql/ops_queries.sql` for PostgreSQL warehouse and reporting examples
 12. `docs/agentic-workflows.md` for larger delegated development workflows
-13. `docs/engineering-delivery-workflow.md` for the engineer-owned delivery model
+13. `docs/engineering-delivery-workflow.md` for the controlled agent loop and human acceptance model
 14. `docs/agent-roles.md` for splitting repo work across bounded roles
 15. `docs/overnight-sandbox.md` for safe unattended validation runs
 16. `docs/security-protocols.md` for local and cloud safety controls
@@ -178,9 +178,12 @@ For a bounded improvement iteration:
 
 ```bash
 make iteration-check
+make morning-review
 ```
 
-See `docs/iteration-loop.md` and `docs/iteration-backlog.md`.
+The morning review is written under ignored `.sandbox/review-packages/` and is
+evidence for human inspection, not an approval. See `docs/iteration-loop.md`,
+`docs/iteration-backlog.md`, and `docs/engineering-delivery-workflow.md`.
 
 ## Deployment
 

--- a/docs/agent-roles.md
+++ b/docs/agent-roles.md
@@ -16,6 +16,7 @@ engineer owns scope, review, merge, deployment, and production-risk decisions.
 | Kubernetes And Delivery Engineer | Container, CI, Kubernetes overlays, deploy workflow hygiene | `Dockerfile`, `.github/workflows/`, `deploy/kubernetes/`, `deploy/README.md` | Apply to clusters, trigger deploy workflows, weaken pod security, or change prod without dev parity | `make security-check && make infrastructure-check` |
 | Quality Reviewer | Tests, linting, generated-data hygiene | `tests/`, `Makefile`, CI checks | Rewrite production logic except for the smallest necessary fix | `make security-check && make readiness-check` |
 | Security Reviewer | Secrets, generated files, cloud guardrails, deploy triggers | Security docs, checks, CI guardrails | Approve risky changes without the lead engineer | `make security-check` |
+| Production Challenger | Failure, retry, concurrency, rollback, operational, and cost assumptions | None during the review pass | Edit the candidate change or present hardening ideas as proven defects | Read-only findings with file references |
 | Demo Narrator | Interview walkthroughs and expected outputs | `README.md`, `docs/`, demo fixtures if needed | Overclaim production usage of scaffolded services | `make readiness-check` when demo behaviour changes |
 
 ## Coordination Rules
@@ -27,6 +28,11 @@ engineer owns scope, review, merge, deployment, and production-risk decisions.
 5. Keep cloud deploys, Terraform apply, branch merges, and destructive database
    actions human-approved.
 6. Require validation evidence in the final handoff.
+7. A role performing an independent review is read-only for that pass. Send
+   accepted fixes back to the assigned writer and re-run affected evidence.
+8. Treat reviewer findings as evidence rather than approval. The delivery lead
+   triages and assembles evidence; the human engineer alone accepts, merges, or
+   authorises deployment.
 
 ## Overnight Use
 

--- a/docs/agentic-workflows.md
+++ b/docs/agentic-workflows.md
@@ -11,9 +11,9 @@ Use the smallest autonomy level that fits the task.
 | Level | Use When | Agent Can Do | Human Must Do |
 | --- | --- | --- | --- |
 | 0: Advice | You are deciding direction | Explain options, risks, and next steps | Choose the path |
-| 1: Local Change | Scope is clear and low-risk | Edit files and run tests locally | Review final diff |
-| 2: Branch And PR | Work is multi-file but bounded | Branch, commit, push, open PR | Review PR before merge unless explicitly delegated |
-| 3: PR Follow-Through | PR has CI/review feedback | Inspect failures, patch, rerun checks | Approve risky changes |
+| 1: Local Change | Scope is clear and low-risk | Edit files and run tests locally | Review and accept the final diff |
+| 2: Branch And PR | Work is multi-file but bounded | Branch, commit, push, open PR | Accept the change before merge |
+| 3: PR Follow-Through | PR has CI/review feedback | Inspect failures, patch, rerun checks | Accept the final revision before merge |
 | 4: Cloud/Infra | AWS, Terraform, deploys, secrets | Prepare scaffolding and plans | Approve apply/deploy/secret changes |
 
 For this repo, default to Level 1 or 2. Use Level 4 only for disabled-by-default
@@ -49,7 +49,8 @@ Validation:
 Run <commands>.
 
 Git:
-Create a neutral branch, commit, push, open PR, wait for checks, merge if green.
+Create a neutral branch, commit, push, open a PR, wait for checks, and stop for
+human acceptance before merge.
 
 Do not:
 - <risky or out-of-scope action>
@@ -124,6 +125,37 @@ documentation. Prioritise findings by severity with file references. Do not
 make edits unless asked.
 ```
 
+### Independent Correctness Review
+
+```text
+Do not modify files. Review this change against its task brief. Prioritise
+correctness, maintainability, observability, performance, security,
+testability, unnecessary complexity, and missing tests. Cite files and explain
+the failure each finding could cause. Say explicitly when no finding is proven.
+```
+
+### Production Failure Challenge
+
+```text
+Do not modify files. Assume this passed its current tests. What can still fail
+in production? Challenge input boundaries, partial failure, retries,
+idempotency, concurrency, data volume, permissions, network dependencies,
+rollout, rollback, monitoring, and cost. Separate demonstrated defects from
+questions or optional hardening.
+```
+
+### Morning Package Synthesis
+
+```text
+Do not modify files. Use the local acceptance package, task brief, reviewer
+findings, and final diff to prepare a human review summary. Explain the change,
+architecture and important data/control paths, state and side effects,
+assumptions, failure and recovery behaviour, security and permissions,
+operational/performance/cost implications, test evidence, and unresolved
+questions. Rank no more than ten concrete file locations I should inspect.
+Separate recorded evidence from inference and leave the decision pending.
+```
+
 ### CI Fix
 
 ```text
@@ -161,54 +193,15 @@ For continued improvement work, use `docs/iteration-loop.md` and pick one item
 from `docs/iteration-backlog.md`. Keep each iteration to one coherent change
 set and stop after validation for review.
 
-## Review Checklist
+For the full implement, independent-review, production-challenge,
+automated-gate, and human-acceptance sequence, use
+`docs/engineering-delivery-workflow.md`. Run `make morning-review` after the
+checks to create an ignored local evidence package; the package supports human
+review and never approves a change.
 
-Before accepting agent-authored changes, check:
+## Acceptance Policy
 
-1. Does the change solve the stated problem?
-2. Are unrelated files untouched?
-3. Are generated files excluded?
-4. Do tests cover the risky behaviour?
-5. Did validation actually run?
-6. Are unavailable checks clearly disclosed?
-7. Are docs accurate and not overstated?
-8. Are cloud resources disabled by default?
-9. Are secrets absent?
-10. Is the diff small enough to review confidently?
-
-## What To Delegate
-
-Good candidates:
-
-1. Adding focused tests.
-2. Writing runbooks and walkthroughs.
-3. Implementing small loaders or adapters.
-4. Refactoring with stable behaviour.
-5. Creating disabled-by-default infrastructure scaffolds.
-6. Debugging CI failures.
-7. Drafting PR descriptions and validation summaries.
-
-Poor candidates without close review:
-
-1. IAM permissions.
-2. Secrets and credential handling.
-3. Production deploys.
-4. Destructive migrations.
-5. Broad rewrites before requirements are clear.
-6. Business-critical logic without tests.
-
-## Human Review Model
-
-Do not treat agent output as automatically correct. Treat it as a fast junior or
-mid-level implementation draft that still needs engineering ownership.
-
-For low-risk documentation or tests, review can be quick. For data loading,
-schema, infrastructure, auth, or deployment work, review the diff carefully,
-run checks, and reason through failure modes before merge.
-
-The practical target is not "no human checks code". The target is:
-
-```text
-humans spend less time typing boilerplate
-and more time reviewing design, risk, tests, and production impact
-```
+Use `docs/engineering-delivery-workflow.md` as the single source of truth for
+delegation boundaries, evidence freshness, risk review, and human acceptance.
+This guide supplies prompts and autonomy mechanics; it does not weaken or
+replace that policy.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,20 +1,296 @@
 # Architecture
 
-The platform is organized into four layers:
+This document follows the twelve-section arc42 structure. It describes the
+implemented local platform, the disabled-by-default deployment scaffold, and
+the boundaries used to keep changes reviewable.
 
-1. Ingestion: market data and external risk signals
-2. Raw storage: immutable, partitioned event storage
-3. Processing: validation, deduplication, normalization, and windowing
-4. Analytics: returns, volatility, external signal summaries, data quality, and risk summaries
+## 1. Introduction And Goals
+
+The platform demonstrates a reliable market-risk data path:
+
+1. Ingest market-like events and optional external signals.
+2. Validate, normalise, and deduplicate them.
+3. Retain replayable raw parquet and derived curated parquet.
+4. Load stable PostgreSQL-style warehouse tables.
+5. Reconcile source, raw, curated, and warehouse evidence.
+6. Show a guarded AWS/Kubernetes deployment shape without deploying by default.
+
+The primary stakeholders are the engineer operating and extending the repo, a
+reviewer assessing engineering evidence, and downstream consumers of the
+warehouse views.
+
+The leading quality goals are:
+
+| Priority | Quality goal | Concrete evidence |
+| --- | --- | --- |
+| 1 | Deterministic replay and recovery | Content-addressed parquet writes, partition locks, and resumable backfills |
+| 2 | Explicit data contracts and quality | Pydantic ingestion schemas, field/range checks, late and duplicate metrics |
+| 3 | Traceable source-to-serving behaviour | Run summaries, lineage manifests, and reconciliation SQL |
+| 4 | Safe local and cloud operation | Local-first commands, manual deployment, disabled optional databases, and security checks |
+| 5 | Reviewable evolution | Bounded modules, targeted tests, independent review, and human acceptance |
 
 The design emphasizes:
 
-1. Reproducibility and deterministic backfills
-2. Explicit trade-offs between cost and latency
-3. Strong schema validation at ingestion
-4. Measurable storage and query performance improvements
+1. Reproducibility and deterministic backfills.
+2. Explicit trade-offs between cost and latency.
+3. Strong schema validation at ingestion.
+4. Measurable storage and query performance improvements.
 
-## Evidence Map
+## 2. Architecture Constraints
+
+1. Python 3.10 or newer is the implementation language.
+2. The demonstrated runtime is batch or micro-batch, not a production streaming
+   service.
+3. Local parquet paths model an S3-style raw and curated layout; the writer is
+   not an AWS S3 client.
+4. PostgreSQL is the demonstrated warehouse contract; MongoDB represents a
+   source-system document shape.
+5. Cloud resources and managed databases stay disabled unless explicitly
+   requested. Deployment is manually dispatched.
+6. Generated data, local state, caches, and evidence stay outside Git.
+7. Tests and local evidence must substantiate claims; scaffolded services are
+   not described as production-owned.
+8. Kinesis or another streaming expansion is outside the default architecture.
+
+## 3. Context And Scope
+
+### Business Context
+
+```text
+Market-event files ----+
+                       |
+External signals ------+--> Financial risk data platform
+                                  |        |         |
+                                  v        v         v
+                             raw parquet  curated  warehouse views
+                                  |        |         |
+                                  +--------+---------+
+                                           |
+                                           v
+                                  engineer / reviewer
+```
+
+The platform owns validation, normalisation, deduplication, analytical
+derivation, local storage layout, warehouse loading, and reconciliation. Source
+provider operation, production alert delivery, persistent cloud data storage,
+and live cloud ownership remain outside the demonstrated boundary.
+
+### Technical Context
+
+| Neighbour | Interface | Direction | Contract |
+| --- | --- | --- | --- |
+| Market-event source | JSON records | Inbound | `MarketEvent` schema and stable `event_id` |
+| External-signal source | CSV, JSON, JSONL, or NDJSON | Inbound | Signal ID, name, value, event/ingest timestamps, and source |
+| Local filesystem | Partitioned parquet in an S3-style layout | Outbound and replay | Storage paths from `config/storage.yaml` |
+| PostgreSQL | SQL and Psycopg | Outbound | Tables and views in `sql/` |
+| MongoDB demo | Seeded documents | Playground only | Documents in `mongo/init/`; not connected to the pipeline |
+| Operator | Make targets and Python CLIs | Bidirectional | Run output, quality status, lineage, and review evidence |
+| GitHub Actions | CI and manual deploy workflows | Outbound control | Validation on change; deployment only by explicit dispatch |
+
+## 4. Solution Strategy
+
+The four data-transformation layers are:
+
+1. Ingestion: market data and external risk signals.
+2. Raw storage: immutable, partitioned event storage.
+3. Processing: validation, deduplication, normalization, and windowing.
+4. Analytics: returns, volatility, external signal summaries, data quality, and risk summaries.
+
+Orchestration, warehouse serving, deployment, and engineering controls support
+these layers; they do not redefine the transformation flow.
+
+The solution uses a layered Python pipeline coordinated by one orchestration
+entry point. It validates source contracts before transformation, separates
+pure processing and analytics from I/O, writes replayable partitioned parquet,
+and loads warehouse tables with stable conflict keys. Deterministic filenames,
+partition locks, and resume checkpoints make retries and backfills explainable.
+
+Configuration is externalised in YAML. Local Docker services provide database
+evidence. The image, Kubernetes manifests, ECR/IAM Terraform, optional managed
+database resources, and manual deployment workflow demonstrate only the
+intended deployment shape. Repository controls and review-package tooling form
+a separate engineering-control plane; they never enter the data runtime.
+
+## 5. Building Block View
+
+### Level 1: System Building Blocks
+
+```text
+                         +-----------------------+
+                         | Orchestration         |
+                         | live run / backfill   |
+                         +-----------+-----------+
+                                     |
+        +-------------+--------------+---------------+-------------+
+        |             |              |               |             |
+        v             v              v               v             v
+   Ingestion      Processing      Analytics       Storage       Warehouse
+        \             |              /               |             /
+         +------------+-------------+----------------+------------+
+                                      |
+                                Common foundation
+
+   Deployment plane                    Engineering-control plane
+   Docker / Kubernetes / Terraform     checks / tests / review evidence / docs
+```
+
+| Block ID | Responsibility | Owned paths | May depend on |
+| --- | --- | --- | --- |
+| `ingestion` | Source adapters and inbound schemas | `src/ingestion/` | `common` and the processing symbol normaliser |
+| `processing` | Validation, normalisation, deduplication, and windowing | `src/processing/` | `common` |
+| `analytics` | Returns, volatility, risk metrics, and data-quality calculations | `src/analytics/`, `config/risk_thresholds.yaml` | `common` |
+| `storage` | Partition layout, storage configuration, and idempotent local parquet writes | `src/storage/`, `config/storage.yaml` | `common` |
+| `orchestration` | Pipeline sequencing, locks, backfills, lineage, and placeholder Glue/replay entry points | `src/orchestration/`, `scripts/replay_historical_as_live.py` | ingestion, processing, analytics, storage, common |
+| `warehouse` | PostgreSQL loading, reference data, schemas, views, checks, and operational queries | `src/warehouse/`, `sql/`, `scripts/seed_reference_data.py`, `config/symbols.yaml` | storage configuration plus raw and curated dataset contracts |
+| `common` | Shared configuration, time, logging, and exceptions | `src/common/` | no data-plane block |
+| `source-systems` | Local PostgreSQL/MongoDB fixtures and source-document mapping | `docker-compose.yml`, `mongo/`, relevant walkthroughs | warehouse and ingestion contracts |
+| `benchmarking` | CSV-versus-partitioned-parquet measurement | `src/benchmarks/`, `docs/performance-benchmark.md` | storage contracts |
+| `deployment` | Image, manual deploy workflow, Kubernetes, and Terraform | `Dockerfile`, `.github/workflows/deploy.yml`, `deploy/`, `infra/` | published runtime and config contracts |
+| `engineering-controls` | CI, ownership, validation, repository security, agent workflow, and local review evidence | `.github/workflows/ci.yml`, `.github/CODEOWNERS`, `Makefile`, control scripts and tests, `AGENTS.md`, workflow docs | all blocks as evidence subjects, never as runtime dependencies |
+
+Tests belong to the block whose behaviour they prove. Configuration and
+documentation accompany a block only when the same change alters that block's
+contract or operating instructions. `Makefile` is a shared command surface:
+classify a target change by the block it executes rather than automatically as
+an engineering-control change.
+
+### Change Modularity Rules
+
+Use the level-1 blocks above to define branches and pull requests:
+
+1. Name one primary block in every task brief and PR description.
+2. Keep one branch and PR to one behavioural outcome in that block, plus its
+   tests and directly affected documentation.
+3. A vertical slice may cross blocks only when its acceptance criterion requires
+   an end-to-end contract change. List each interface crossed and keep unrelated
+   refactoring out.
+4. Treat schemas, warehouse keys, quality thresholds, locks, security, and
+   deployment as explicit contract boundaries. Split them from ordinary feature
+   work unless they are the stated objective.
+5. Keep data-plane changes separate from deployment-plane changes. A runtime
+   change may include its image/config compatibility update, but infrastructure
+   provisioning belongs in a separate high-risk PR.
+6. Keep engineering-control changes separate from pipeline behaviour. Controls
+   can inspect the data plane but must not become a runtime dependency.
+7. If a proposed diff has two plausible primary blocks or cannot be explained
+   with one runtime scenario, split it before implementation.
+8. Use `agent/<block>-<outcome>` for automated branches and record the base SHA.
+   A branch never writes directly to `main`.
+
+The normal 200–500 non-generated changed-line budget remains a review heuristic,
+not a target. A larger atomic contract plus its tests may stay together when a
+split would create an invalid or unverified intermediate state; record that
+rationale explicitly.
+
+| Primary block | Minimum validation |
+| --- | --- |
+| ingestion, processing, analytics, storage, orchestration, common, or benchmarking | `make security-check && make quality-check && make readiness-check` |
+| warehouse | `make security-check && make quality-check && make readiness-check`; add Docker reconciliation when available |
+| source-systems | Compose YAML parse, lint, tests, and relevant Docker checks when available |
+| deployment | `make security-check && make infrastructure-check` |
+| Python engineering-controls | Focused tests, `make security-check`, `make quality-check`, and `git diff --check` |
+| Documentation-only controls | `make security-check && git diff --check` |
+
+## 6. Runtime View
+
+### Normal Pipeline Run
+
+```text
+load inputs
+  -> validate and normalise
+  -> deduplicate
+  -> calculate returns, volatility, quality, and risk summaries
+  -> acquire affected partition locks
+  -> write raw and curated parquet
+  -> release locks
+  -> emit run summary and optional lineage
+
+separate operator step
+  -> optionally load PostgreSQL with idempotent upserts
+```
+
+Invalid required fields or values stop curated publication. Late and duplicate
+records remain visible in quality evidence rather than being silently ignored.
+The individual parquet dataset writes are idempotent but are not one
+multi-dataset transaction.
+
+### Backfill
+
+The backfill runner reads raw hourly partitions, starts after the last successful
+checkpoint when resuming, obtains the same partition locks as a live run, and
+invokes the normal pipeline. An overlap blocks the run; a successful partition
+updates local resume state. See `docs/failure-scenarios.md`.
+
+### Change Acceptance
+
+```text
+bounded implementation
+  -> independent correctness review
+  -> production-failure challenge
+  -> automated validation
+  -> ignored local evidence package
+  -> human acceptance decision
+```
+
+This control flow does not run in the container or touch pipeline data.
+
+## 7. Deployment View
+
+| Environment | Nodes and stores | Purpose |
+| --- | --- | --- |
+| Developer workstation | Python virtual environment, local filesystem parquet, optional Docker PostgreSQL/MongoDB | Primary implemented and tested path |
+| GitHub Actions | Ephemeral runners | Security, Python, and infrastructure validation; manual deployment workflow |
+| Container runtime | Non-root Python image | Runs `src.orchestration.run_pipeline` with packaged config and SQL |
+| Kubernetes scaffold | CronJob, ConfigMaps, service account, network policy, dev/prod overlays | Packaging and security shape; data is currently an `emptyDir`, not persistent storage |
+| AWS scaffold | ECR and GitHub OIDC IAM; false-by-default RDS, Aurora, and DocumentDB | Managed deployment examples; S3 and Glue files are placeholders and no EKS cluster is provisioned |
+
+The deploy workflow is `workflow_dispatch` only and expects a pre-existing EKS
+cluster. It can build, validate, and apply Kubernetes resources after explicit
+invocation. When configured and authorised, it pushes an image tagged with the
+commit SHA and workflow attempt to ECR, injects that same image into the selected
+dev or prod overlay, then server-side dry-runs, diffs, and applies the same
+rendered manifest. Normal validation never deploys or runs `terraform apply`.
+
+## 8. Cross-Cutting Concepts
+
+| Concept | Approach | Evidence |
+| --- | --- | --- |
+| Data contracts | Pydantic at ingestion; explicit dataset grain and keys | `src/ingestion/schemas.py`, `docs/data-model.md` |
+| Time | Event and ingest time remain distinct; loaders normalise to UTC, but direct schema input can currently remain timezone-naive | `src/common/time.py`, `src/ingestion/market_data_loader.py`, `src/processing/windowing.py` |
+| Idempotency | Stable event/table keys and content-addressed parquet filenames | `src/storage/s3_writer.py`, `src/warehouse/postgres_loader.py` |
+| Concurrency | Partition locks prevent live/backfill overlap | `src/orchestration/locks.py` |
+| Recovery | Replayable raw data, resume checkpoints, and deterministic reruns | `src/orchestration/backfill.py` |
+| Configuration | YAML config loaded through shared helpers and mounted into deployments | `config/`, `src/common/config.py` |
+| Observability | Structured run summaries, lineage, quality metrics, and ops SQL | `src/orchestration/lineage.py`, `sql/ops_queries.sql` |
+| Security | Local-only defaults, secret scanning, CODEOWNERS, restricted pod defaults, and manual deploy | `scripts/security_check.py`, `docs/security-protocols.md` |
+| Human authority | Automated output is evidence; acceptance, merge, and deploy remain human decisions | `docs/engineering-delivery-workflow.md` |
+
+## 9. Architecture Decisions
+
+| Decision | Consequence and trade-off | Evidence |
+| --- | --- | --- |
+| Batch/micro-batch before streaming | Lower operational complexity at the cost of latency | `docs/tradeoffs.md` |
+| Retry/replay-tolerant local processing with idempotent outputs | Repeated local inputs are safe; no message-delivery or acknowledgement semantics are implemented | Storage and warehouse tests |
+| Replayable local parquet before curated publication | Backfills are explainable; local files are not a transactional lakehouse or S3 integration | `src/storage/s3_writer.py` |
+| One orchestrator over small functional blocks | End-to-end flow is easy to follow; the coordinator requires disciplined boundaries | `src/orchestration/run_pipeline.py` |
+| PostgreSQL serving contract | Familiar upserts and reconciliation; not a distributed analytical warehouse | `src/warehouse/postgres_loader.py`, `sql/` |
+| Coarse partition locks | Simple overlap protection; not a distributed lock service | `src/orchestration/locks.py` |
+| Manual, disabled-by-default cloud paths | Prevents surprise cost or mutation; live deployment requires explicit setup | `infra/terraform/variables.tf`, `.github/workflows/deploy.yml` |
+| arc42 blocks define change modules | PRs align to runtime ownership; deliberate vertical slices must describe crossed interfaces | This document |
+
+## 10. Quality Requirements
+
+| ID | Scenario | Required response | Evidence |
+| --- | --- | --- | --- |
+| Q1 | The same source batch is replayed | Do not create duplicate parquet files or warehouse facts | S3 writer and loader tests |
+| Q2 | An event arrives late or duplicated | Complete valid processing and expose the condition in quality metrics | Data-quality tests and demo output |
+| Q3 | A required field or numeric range is invalid | Fail before curated publication with explainable validation detail | Ingestion and pipeline tests |
+| Q4 | A backfill is interrupted or overlaps a live partition | Resume after the last success or stop on the active lock | Backfill and lock tests |
+| Q5 | Default infrastructure validation runs | Validate without deploying or creating optional managed databases | Security and infrastructure checks |
+| Q6 | An agent-authored change is reviewed | Keep automated evidence distinct and the final decision pending | Morning-review tests and workflow docs |
+| Q7 | A proposed change spans unrelated blocks | Split it or record the end-to-end contract and cohesion rationale | Change modularity rules above |
+
+### Evidence Map
 
 | Architecture decision | Local evidence |
 | --- | --- |
@@ -26,13 +302,41 @@ The design emphasizes:
 | Reconcile source to warehouse | `sql/consistency_checks.sql`, `docs/data-consistency-walkthrough.md` |
 | Validate infrastructure without deploying | `Makefile`, `deploy/kubernetes/`, `infra/terraform/` |
 
-## Deployment Model
+## 11. Risks And Technical Debt
 
-The deploy scaffold packages the pipeline as a Docker image and runs it as a
-Kubernetes CronJob. GitHub Actions builds and pushes immutable images to ECR,
-then applies the matching Kustomize overlay for the selected environment.
+1. Locks and backfill checkpoints are local files, not distributed coordination.
+2. Parquet writes are idempotent files, not atomic multi-table transactions or
+   AWS S3 writes.
+3. The Kubernetes CronJob uses ephemeral `emptyDir` storage; it is not a durable
+   cloud data path.
+4. Terraform contains S3, Glue, and Kinesis placeholders and does not provision
+   the EKS cluster expected by the deploy workflow.
+5. `config/environments.yaml` is not consumed by the current runtime.
+6. Direct `MarketEvent` validation does not currently require timezone-aware
+   timestamps even though UTC is the intended convention.
+7. Some analytical names imply fixed time windows while the current calculations
+   can be observation-count based; `docs/data-model.md` records the distinction.
+8. `data_quality_metrics` uses the latest ingest timestamp as a run key rather
+   than a dedicated pipeline-run identifier.
+9. Historical dimension intervals are checked by tooling but not fully excluded
+   by a database constraint.
+10. Production alert delivery, dashboards, capacity tests, and live cloud
+   operation are not implemented claims.
+11. The orchestration coordinator is intentionally direct; extract additional
+    services only when a second runtime or independently evolving contract makes
+    the boundary valuable.
+12. `infra/diagrams/architecture.png` is currently a placeholder rather than
+    architectural evidence.
 
-For this portfolio repo, cloud resources stay disabled and deployment remains
-manual by default. The repository demonstrates the engineering pattern around
-packaging, validation, deploy guardrails, data quality, and backfill behaviour;
-it does not claim production ownership of every managed service.
+## 12. Glossary
+
+| Term | Meaning in this repository |
+| --- | --- |
+| Raw | Validated, normalised, deduplicated event-level parquet retained for replay; not the untouched provider payload |
+| Curated | Derived analytical parquet datasets such as returns, volatility, quality, and risk summaries |
+| Warehouse | PostgreSQL tables and views used for stable serving and reconciliation |
+| Event time | When the source event occurred (`ts_event`) |
+| Ingest time | When the platform received the event (`ts_ingest`) |
+| Backfill | Deterministic replay of historical raw partitions through the normal pipeline |
+| Engineering-control plane | Repository checks, tests, review evidence, and delivery policy outside the data runtime |
+| Human acceptance | The engineer's explicit decision after understanding the diff and its evidence; never an automated status |

--- a/docs/engineering-delivery-workflow.md
+++ b/docs/engineering-delivery-workflow.md
@@ -52,6 +52,9 @@ Scope:
 Acceptance criteria:
 <What must be true in the repo?>
 
+Risk and failure behaviour:
+<State, side effects, recovery, permissions, and cost constraints>
+
 Validation:
 <Which commands must run?>
 
@@ -62,14 +65,50 @@ Do not:
 <Anything destructive, costly, or out of scope>
 ```
 
+## Controlled Agent Loop
+
+Optimise for the amount of code the lead engineer can safely accept, not the
+number of agent passes. Prefer one coherent change of roughly 200 to 500
+non-generated changed lines. This is a review heuristic rather than a quality
+target: split sooner when a change crosses contracts, schemas, IAM, deployment,
+or unrelated modules, and require an explicit reason for a larger diff.
+
+Use this sequence for agent-authored logic and other material changes:
+
+1. The delivery lead drafts the task brief and records the starting branch and
+   status. The human engineer confirms the brief before one writer receives a
+   bounded scope.
+2. The writer implements the smallest change that meets the acceptance criteria
+   and reports assumptions and checks actually run.
+3. A separate read-only reviewer checks correctness, maintainability,
+   observability, performance, security, testability, unnecessary complexity,
+   and missing tests.
+4. Another read-only pass assumes the tests pass and challenges production
+   failure modes: invalid inputs, partial failure, retries, idempotency,
+   concurrency, volume, permissions, dependencies, rollout, rollback,
+   monitoring, and cost.
+5. The delivery lead separates demonstrated defects from questions and optional
+   hardening, then assigns accepted fixes to the writer.
+6. The relevant automated gates run and the lead verifies their evidence.
+7. `make morning-review` creates an ignored local evidence package for the final
+   human review.
+
+Reviewers do not approve their own changes, and repeated agreement between
+agents is not an acceptance signal. The delivery lead triages and assembles
+evidence; the human engineer alone accepts the final diff, merges, or authorises
+deployment. Use the prompts in
+`docs/agentic-workflows.md` and the role boundaries in `docs/agent-roles.md`.
+Any fix invalidates review or validation evidence affected by that fix; repeat
+the relevant pass before acceptance.
+
 ## Validation Ladder
 
 Use the smallest validation set that matches the risk.
 
 | Change Type | Validation |
 | --- | --- |
-| Docs only | `git diff --check` |
-| Python logic | `make security-check && make lint && make test` |
+| Docs only | `make security-check && git diff --check` |
+| Python logic | `make security-check && make quality-check` |
 | Demo path | `make readiness-check` |
 | PostgreSQL loader | `make clean-generated && make run-demo && make load-postgres-dry-run` |
 | Local database walkthrough | `make local-db-up && make consistency-demo && make local-db-down` |
@@ -78,6 +117,28 @@ Use the smallest validation set that matches the risk.
 
 If Docker or Terraform is not installed locally, state that clearly and run the
 nearest available check.
+
+## Morning Acceptance Package
+
+After review and validation, run:
+
+```bash
+make morning-review
+```
+
+The command writes a Markdown report and machine-readable JSON evidence under
+ignored `.sandbox/review-packages/`. It records the current Git state,
+changed-file risk flags, the latest overnight summary when present, up to ten
+files to inspect first, and the human acceptance questions. Automated evidence
+is kept separate from reviewer assertions and the human decision remains
+pending. Use `make morning-review REVIEW_BASE_REF=main` when the local `main`
+branch, rather than the default `origin/main`, is the intended comparison base;
+the command never fetches.
+
+The command deliberately does not include a full diff, run validation, approve
+the change, commit, push, merge, or deploy. Overnight evidence is historical
+unless it can be tied to the reviewed Git state, so its timestamp and limits
+must be considered before relying on it.
 
 ## Monitoring Evidence
 
@@ -99,6 +160,11 @@ For unattended local validation, use `docs/overnight-sandbox.md`. The sandbox
 runs readiness and security checks repeatedly, writes logs under `.sandbox/`,
 and does not push, merge, deploy, or create cloud resources.
 
+During an active controlled session, late-night agent work is best used for
+candidate code, focused tests, research, documentation, and independent review
+that can be inspected later. After the session ends, this repository's
+unattended mode remains validation-only; it does not continue modifying code.
+
 For continued improvement, use `docs/iteration-loop.md` and
 `docs/iteration-backlog.md`. The queue keeps work small enough to review.
 
@@ -107,14 +173,17 @@ For continued improvement, use `docs/iteration-loop.md` and
 Before accepting a change, ask:
 
 1. Does the diff solve the stated objective?
-2. Are unrelated files untouched?
-3. Are generated outputs excluded?
-4. Are tests targeted at the risky behaviour?
-5. Did the validation commands actually run?
-6. Are unavailable checks disclosed?
-7. Are cloud resources still disabled by default?
-8. Are secrets absent?
-9. Is the explanation accurate without overstating production usage?
+2. Can I explain the important control and data paths?
+3. Do I understand state, side effects, idempotency, and failure recovery?
+4. Are unrelated files untouched and generated outputs excluded?
+5. Are permissions, secrets, and network exposure appropriate?
+6. Are operational, performance, and cost implications understood?
+7. Are tests targeted at the risky behaviour?
+8. Did the reported validation commands actually run for the state reviewed?
+9. Are unavailable or stale checks disclosed?
+10. Are cloud resources still disabled by default?
+11. Is the explanation accurate without overstating production usage?
+12. Can I defend the change without relying on an agent's approval?
 
 ## Short Talk Track
 

--- a/docs/iteration-backlog.md
+++ b/docs/iteration-backlog.md
@@ -219,3 +219,40 @@ Why it matters:
 
 It makes the repository look closer to a real team workflow and improves
 reviewability.
+
+## 8. Agent Change Acceptance Package
+
+Status: validated
+
+Scope:
+
+1. `scripts/morning_review.py`
+2. `tests/unit/test_morning_review.py`
+3. `Makefile`
+4. Engineering delivery, agent, iteration, and overnight workflow documentation
+
+Acceptance criteria:
+
+1. Document one bounded implementation, independent correctness review,
+   production challenge, automated gate, and human acceptance sequence.
+2. Generate an ignored local review package from Git state and the latest
+   overnight summary without running checks or changing tracked files.
+3. Highlight sensitive paths and rank up to ten files for human inspection.
+4. Keep automated evidence distinct from reviewer assertions and human
+   decisions.
+5. Cover missing Git base data and missing or malformed overnight evidence.
+
+Validation:
+
+```bash
+make security-check
+make quality-check
+make readiness-check
+make morning-review
+git diff --check
+```
+
+Why it matters:
+
+It turns high agent throughput into a reviewable engineering handoff while
+keeping acceptance, merge, and deployment decisions with the engineer.

--- a/docs/iteration-loop.md
+++ b/docs/iteration-loop.md
@@ -11,14 +11,27 @@ gate and review the diff before starting another item.
 ## Loop
 
 1. Pick one item from `docs/iteration-backlog.md`.
-2. Confirm the scope and forbidden actions.
-3. Create a neutral branch if the change will be published.
-4. Make the smallest change that satisfies the acceptance criteria.
-5. Run the validation gate.
-6. Review the diff for unrelated changes, generated files, secrets, and
-   overclaiming.
-7. Open a pull request only after validation passes.
-8. Merge only after checks pass and the diff is understood.
+2. Confirm the objective, acceptance criteria, scope, risk, and forbidden
+   actions.
+3. Record the starting status and create a neutral branch if the change will be
+   published.
+4. Give one writer a bounded implementation scope.
+5. Run independent read-only correctness and production-failure reviews for
+   agent-authored logic or other material changes.
+6. Triage findings, have the assigned writer make only accepted fixes, and
+   repeat any affected read-only review.
+7. Run the validation gate.
+8. Generate the local evidence package with `make morning-review`.
+9. Review the diff for behaviour, failure modes, unrelated changes, generated
+   files, secrets, and overclaiming.
+10. Open a pull request only after validation passes.
+11. Merge only after checks pass and the human engineer understands and accepts
+    the change.
+
+Use `docs/engineering-delivery-workflow.md` for the change-budget heuristic and
+human acceptance model, and `docs/agentic-workflows.md` for the review prompts.
+A docs-only or trivial change may combine the two read-only review roles, but
+the writer must not be the sole reviewer.
 
 ## Validation Gate
 
@@ -73,7 +86,8 @@ Before publishing:
 3. Confirm `.demo/`, `.sandbox/`, `data/`, `.terraform/`, and caches are not
    staged.
 4. Confirm `make iteration-check` passed or document exactly what was not run.
-5. Use neutral branch, commit, and pull request wording.
+5. Run `make morning-review` and inspect its risk-prioritised file list.
+6. Use neutral branch, commit, and pull request wording.
 
 ## Short Prompt Template
 
@@ -90,7 +104,12 @@ Use the selected backlog item.
 Validation:
 Run make iteration-check and git diff --check.
 
+Review:
+Use a separate read-only correctness review and production-failure challenge.
+Return accepted fixes to the writer and repeat affected evidence. Then run
+make morning-review.
+
 Do not:
 Deploy AWS, run terraform apply, change secrets, delete unrelated files, or
-start a second backlog item.
+start a second backlog item. Stop for human acceptance before merge or deploy.
 ```

--- a/docs/overnight-sandbox.md
+++ b/docs/overnight-sandbox.md
@@ -96,6 +96,17 @@ Review:
 Then decide what should become a branch or pull request. Do not merge or deploy
 based only on overnight output.
 
+Generate a local acceptance package from the latest summary and current Git
+state:
+
+```bash
+make morning-review
+```
+
+The package highlights evidence and questions for review. It does not establish
+that the implementation is correct or grant approval to publish it. Use
+`docs/engineering-delivery-workflow.md` for the human acceptance gate.
+
 ## Security Protocols
 
 1. Keep cloud credentials out of the sandbox environment.


### PR DESCRIPTION
## What changed

- Carry the controlled change-acceptance policy, its operator adoption guidance, and the arc42 module-boundary documentation onto the current `main` tree.
- Preserve the already reviewed file contents from PRs #32, #33, and #34 while replacing the divergent stacked history with one clean commit.
- Keep the executable morning-review implementation from PR #31 unchanged on `main`.

## Why

PRs #32 and #34 were squash-merged into intermediate feature branches rather than `main`. Their file trees were valid, but the remaining stack diverged from `main`, which made later squash merges unsafe and confusing. This PR repairs only the Git ancestry and targets `main` directly.

## Scope

Documentation and workflow guidance only. There are no pipeline, schema, storage, infrastructure, deployment, credential, or cloud-runtime changes.

## Validation

- The previous CI run on the identical resulting tree passed.
- A fresh pull-request CI run is required after this rebase and retarget.
- The branch is exactly one commit ahead of current `main` and zero commits behind.

## Merge plan

Squash-merge this PR into `main`, then rebase PR #35 onto the resulting `main` commit without changing its file tree.