### PR TITLE
Define guarded overnight candidate workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,6 +78,10 @@ and run the closest local validation that does not require those tools.
 12. Treat agent reviews and generated acceptance packages as evidence, not
     approval. The acceptance decision must remain pending until the engineer
     understands and explicitly accepts the final diff.
+13. Use `docs/architecture.md` to name one primary arc42 building block for each
+    change. Use `docs/overnight-development.md` only for an explicitly approved
+    scheduled candidate; its publishing mode stays disabled until every listed
+    repository and credential prerequisite is verified.
 
 ## Git Workflow
 
@@ -99,6 +103,11 @@ Unattended overnight work must be validation-first. It can run local checks and
 write logs under `.sandbox/`, but it must not push, merge, deploy, run
 `terraform apply`, or use cloud credentials unless the user explicitly approves
 that exact action.
+
+`make overnight-sandbox` is always validation-only. A separately approved
+scheduled candidate follows `docs/overnight-development.md`; absent its complete
+activation evidence and implemented isolation adapters, it must stop before
+creating a branch or modifying files.
 
 Use:
 

--- a/README.md
+++ b/README.md
@@ -106,9 +106,10 @@ Additional preparation notes:
 13. `docs/engineering-delivery-workflow.md` for the controlled agent loop and human acceptance model
 14. `docs/agent-roles.md` for splitting repo work across bounded roles
 15. `docs/overnight-sandbox.md` for safe unattended validation runs
-16. `docs/security-protocols.md` for local and cloud safety controls
-17. `docs/operational-runbook.md` for local failure investigation
-18. `docs/iteration-loop.md` and `docs/iteration-backlog.md` for continued repo iterations
+16. `docs/overnight-development.md` for guarded scheduled candidate branches and draft PRs
+17. `docs/security-protocols.md` for local and cloud safety controls
+18. `docs/operational-runbook.md` for local failure investigation
+19. `docs/iteration-loop.md` and `docs/iteration-backlog.md` for continued repo iterations
 
 ## Local Database Playground
 
@@ -171,8 +172,8 @@ make overnight-sandbox
 ```
 
 The overnight sandbox writes logs under `.sandbox/`, which is ignored by git. It
-does not push, merge, deploy, run `terraform apply`, or use cloud credentials by
-default.
+never pushes, merges, deploys, or runs `terraform apply`. Its default invocation
+also refuses cloud credential environment variables.
 
 For a bounded improvement iteration:
 

--- a/docs/agent-roles.md
+++ b/docs/agent-roles.md
@@ -36,16 +36,19 @@ engineer owns scope, review, merge, deployment, and production-risk decisions.
 
 ## Overnight Use
 
-Overnight work should be validation-first. A safe overnight loop can run checks,
-produce logs, and surface failures for review in the morning.
+Overnight work is validation-only by default. A safe sandbox loop can run
+checks, produce logs, and surface failures for review in the morning.
 
 Do not leave a role unattended with permission to:
 
-1. Push to a remote branch.
+1. Push to a remote branch outside the separately activated, manifest-bound
+   exception in `docs/overnight-development.md`.
 2. Merge a pull request.
 3. Trigger deployment workflows.
 4. Run `terraform apply`.
 5. Use cloud credentials.
 6. Delete data outside generated local output paths.
 
-Use `docs/overnight-sandbox.md` for the safe local runbook.
+Use `docs/overnight-sandbox.md` for validation. The scheduled candidate runbook
+may authorize one branch and draft PR only after all protection, credential,
+scope, and evidence gates pass; it never authorizes merge or deployment.

--- a/docs/agentic-workflows.md
+++ b/docs/agentic-workflows.md
@@ -186,8 +186,10 @@ Validation:
 Use `docs/agent-roles.md` to split larger work into bounded roles. Keep write
 scopes separate and require a final lead-engineer review before merge.
 
-For overnight work, use `docs/overnight-sandbox.md`. The overnight flow is
-validation-first and must not push, merge, deploy, or run cloud commands.
+For unattended validation, use `docs/overnight-sandbox.md`; it never publishes.
+For an explicitly approved scheduled candidate, use
+`docs/overnight-development.md`. Its publishing mode remains disabled until the
+runbook's repository-protection and least-privilege credential gates are proven.
 
 For continued improvement work, use `docs/iteration-loop.md` and pick one item
 from `docs/iteration-backlog.md`. Keep each iteration to one coherent change

--- a/docs/engineering-delivery-workflow.md
+++ b/docs/engineering-delivery-workflow.md
@@ -160,10 +160,17 @@ For unattended local validation, use `docs/overnight-sandbox.md`. The sandbox
 runs readiness and security checks repeatedly, writes logs under `.sandbox/`,
 and does not push, merge, deploy, or create cloud resources.
 
-During an active controlled session, late-night agent work is best used for
-candidate code, focused tests, research, documentation, and independent review
-that can be inspected later. After the session ends, this repository's
-unattended mode remains validation-only; it does not continue modifying code.
+Scheduled candidate mode is currently disabled. Only after every activation
+gate in `docs/overnight-development.md` passes may an explicitly approved run
+prepare one arc42-bounded change. External publication is a separate capability
+and requires the same protected-branch, CI-concurrency, least-privilege
+credential, isolation, scope, and evidence gates. Even then it may open only a
+draft PR; human acceptance and merge remain outside the scheduled run.
+
+This scheduled-candidate runbook adds isolation, authorization, recurrence, and
+publication gates only. The controlled agent loop in this document remains the
+single source of truth for implementation, review, validation, and human
+acceptance.
 
 For continued improvement, use `docs/iteration-loop.md` and
 `docs/iteration-backlog.md`. The queue keeps work small enough to review.

--- a/docs/iteration-loop.md
+++ b/docs/iteration-loop.md
@@ -10,7 +10,8 @@ gate and review the diff before starting another item.
 
 ## Loop
 
-1. Pick one item from `docs/iteration-backlog.md`.
+1. Pick one item from `docs/iteration-backlog.md` and name its one primary arc42
+   building block from `docs/architecture.md`.
 2. Confirm the objective, acceptance criteria, scope, risk, and forbidden
    actions.
 3. Record the starting status and create a neutral branch if the change will be
@@ -76,6 +77,8 @@ Stop and ask for review before continuing when:
 4. The diff grows beyond one coherent change.
 5. The task would need `terraform apply`, a cloud deploy, or destructive data
    operations.
+6. The task has two primary arc42 blocks without one explicit end-to-end
+   contract and integration scenario.
 
 ## Morning Or End-Of-Run Review
 

--- a/docs/overnight-development.md
+++ b/docs/overnight-development.md
@@ -1,0 +1,508 @@
+# Overnight Candidate Development Runbook
+
+This is a separate mode from `make overnight-sandbox`. The sandbox remains a
+validation-only command. Once activated, candidate development may edit one
+isolated worktree and create incremental green commits. A separately isolated
+publisher may push those commits to one new branch and open one draft pull
+request only after every activation prerequisite below is met.
+
+Publishing status: **disabled**
+
+Publishing authorization expires: **not set**
+
+Publisher adapter path and SHA-256: **not configured**
+
+Policy verifier path and SHA-256: **not configured**
+
+Candidate isolation adapter path and SHA-256: **not configured**
+
+The current repository audit found no protection or ruleset on `main`, no CI
+concurrency policy, and only a broad personal GitHub credential. This document
+does not turn those conditions into an approved unattended publisher.
+
+These activation fields, read from a recorded commit on protected `main`, are the
+activation source of truth. A saved scheduled prompt has no activation switch.
+Enabling publication requires a human-reviewed PR that supplies an unexpired
+authorization, records protected-base paths and approved SHA-256 digests for
+implemented publisher, policy-verifier, and candidate-isolation adapters, checks
+every prerequisite below, and changes `Publishing status` to `enabled`. The
+scheduled task must continue reading the fields from the pinned base on every
+run.
+
+## Outcome And Authority
+
+One scheduled run may produce at most:
+
+1. One approved backlog item.
+2. One primary arc42 building block.
+3. One isolated worktree and new branch.
+4. One to three coherent, locally green commits.
+5. One atomic candidate-branch push per green checkpoint when the task manifest
+   allows it.
+6. One draft pull request against the recorded base.
+
+It never grants permission to push to `main`, force-push, rewrite history, mark
+a PR ready, approve or merge a PR, deploy, use cloud credentials, or accept the
+change. The morning decision remains `PENDING` for the human engineer.
+
+Local scheduled tasks require the Codex desktop app, an available local project,
+an isolated worktree, and the app and computer to remain running. Test the prompt
+interactively before making it recurrent. See the
+[official scheduled tasks guide](https://learn.chatgpt.com/docs/automations).
+
+## Architecture Boundary
+
+```text
+Human-approved task manifest
+          |
+          v
+Scheduler and single-run lease
+          |
+          v
+Credential-free isolated worktree
+  -> bounded writer
+  -> read-only correctness reviewer
+  -> read-only production challenger
+  -> validation and evidence gate
+          |
+          v
+Least-privilege publisher
+  -> create-only branch push
+  -> draft PR adapter
+          |
+          v
+Human review and acceptance
+```
+
+The change runner and candidate tests must not receive the publisher credential.
+The publisher must not execute candidate code. Publication requires an
+out-of-process boundary or equivalent isolation that injects a short-lived token
+only after validation. The current local broad credential does not satisfy this
+design.
+
+## Activation Prerequisites
+
+`docs/security-protocols.md` remains the canonical security policy. The checks
+below add unattended-publication requirements and do not replace or weaken it.
+Keep publication disabled until all of these are implemented and independently
+verified:
+
+- [ ] Protect `main` with required pull requests and required, uniquely named CI
+      checks.
+- [ ] Require human review and CODEOWNER review for protected paths, dismiss
+      stale approvals, require approval after the last push, and require
+      conversation resolution.
+- [ ] Block force pushes, branch deletion, administrator bypass, and bot bypass.
+- [ ] Add CI concurrency keyed by pull request or branch so a new checkpoint
+      cancels superseded validation for the same candidate.
+- [ ] Use a dedicated short-lived GitHub App installation token with only
+      metadata read, contents read/write, pull-request write, and checks read.
+- [ ] Deny the publisher workflow, Actions-write, deployment, environment,
+      secret, administration, package, OIDC, merge, and ruleset-bypass authority.
+- [ ] Keep the publisher token out of the writer, reviewer, test, hook, and
+      Makefile environments.
+- [ ] Run candidate edits and validation through a named isolation adapter that
+      proves a scrubbed environment, disabled hooks and credential helpers,
+      denied publisher/cloud credentials, denied candidate network, a bounded
+      filesystem, and an enforced runtime deadline.
+- [ ] Prove create-only branch publication, draft-only PR creation, token denial,
+      base movement, branch collision, and two-run race behaviour.
+- [ ] Pin every privileged adapter and its closed dependency set to protected-
+      base blobs or signed artifacts with approved SHA-256 identities.
+- [ ] Run this workflow interactively and inspect several no-op/local-only runs
+      before enabling external writes.
+
+Until every box is checked on protected `main`, the scheduled task must stop
+before creating a branch, editing, committing, pushing, or opening a PR. Local
+candidate work remains available only in a human-controlled interactive session.
+GitHub documents the relevant controls in its
+[protected branch guidance](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/about-protected-branches).
+
+## Approved Task Manifest
+
+The scheduler may select only a backlog item that links to one complete manifest
+at `docs/overnight-manifests/<manifest-id>.yaml`. The lowercase manifest ID must
+match `[a-z0-9][a-z0-9-]{7,63}` and the filename exactly. The entire Git blob
+returned by `git show <base-sha>:<manifest-path>` is the manifest byte sequence;
+hash those bytes without newline, encoding, key-order, or whitespace
+normalisation.
+
+```yaml
+schema_version: 1
+manifest_id: frdp-example-20260815
+status: approved for overnight development
+authorization_expires: "2026-08-16T07:00:00+01:00"
+comparison_ref: origin/main
+pr_base_branch: main
+arc42_primary_block: processing
+context_goal: "One stakeholder-visible outcome"
+allowed_paths:
+  - src/processing/example.py
+  - tests/unit/test_example.py
+forbidden_paths:
+  - .github/
+interfaces_crossed: []
+runtime_scenario: "Control and data flow affected"
+quality_scenario: "Stimulus and measurable response"
+acceptance_criteria:
+  - "One observable result"
+validation:
+  - make security-check
+  - make quality-check
+  - make readiness-check
+  - git diff --check
+maximum_non_generated_changed_lines: 500
+maximum_changed_files: 2
+maximum_commits: 3
+maximum_pushes: 3
+maximum_runtime_minutes: 120
+retry_policy: human-renewed-manifest-only
+risk: low
+draft_pr_publication: authorized-after-activation
+```
+
+The human engineer must commit the backlog link and manifest to protected
+`main`. A Manifest ID is immutable and single use: changing bytes under the same
+ID is an error, not a new authorization. A retry requires a new manifest ID and
+file. Missing, expired, contradictory, high-risk, or incomplete authorization is
+a successful no-op. The scheduler must not invent a replacement task.
+
+The manifest's validation commands must include the applicable minimum for its
+primary block from `docs/architecture.md`. An explicit vertical slice may cross
+blocks only when the manifest lists every interface, keeps one observable
+outcome and rollback boundary, and includes integration evidence. Unrelated
+cross-block work remains ineligible.
+
+## Arc42 Module Selection
+
+Use the building block view and modularity rules in `docs/architecture.md`.
+When several items are eligible, prefer the item with:
+
+1. One clear stakeholder outcome and primary building block.
+2. One understandable runtime scenario and rollback boundary.
+3. A measurable quality scenario with focused tests.
+4. No path overlap with an open branch or pull request.
+5. The lowest security, data, operational, performance, and cost risk.
+
+Reject a candidate that crosses unrelated blocks, exceeds its budget, or touches
+secrets, IAM/OIDC, authentication, network access, deployment, infrastructure,
+database schemas/load logic, locks/backfills, data-quality thresholds,
+dependencies, binaries, submodules, or symlinks. Those areas require a separate
+human-directed task and PR.
+
+## Isolation And Base Freshness
+
+Each run must:
+
+1. Verify and use the scheduler-supplied isolated worktree. Refuse the primary
+   checkout and do not create a nested worktree.
+2. Require a clean tracked and untracked state.
+3. In a trusted orchestration step, fetch `origin`, resolve `origin/main`, and
+   record its commit SHA. Do not execute candidate code in this step.
+4. Read `AGENTS.md`, activation policy, architecture, security policy, and the
+   selected manifest from that exact commit with `git show <base-sha>:<path>`.
+   Hash the selected manifest and reject local, uncommitted, or stale copies.
+5. Confirm no matching local/remote branch, terminal run record, or PR exists.
+6. Verify the protected-base policy names implemented policy-verifier,
+   candidate-isolation, and publisher adapter paths plus approved SHA-256
+   digests. With the current not-configured values, stop before a branch or
+   mutation; prompt text is not isolation.
+7. Acquire the repository-global lease and manifest claim described below.
+8. In the trusted process, extract those exact protected-base blobs and their
+   closed dependencies into a read-only execution directory outside the
+   candidate-writable tree. Verify every digest before execution; never execute
+   a same-named local replacement.
+9. Only then enter the configured candidate process with inherited Git hooks,
+   credential helpers, SSH agents, cloud credentials, publisher credentials,
+   and candidate network access disabled.
+10. Create a generated branch at the recorded SHA and validate its name with
+   `git check-ref-format`, for example:
+
+   ```text
+   agent/<block>-<short-outcome>-<YYYYMMDD>-<base8>
+   ```
+
+11. Never reuse raw prompt text as a ref and never create tags.
+12. Recheck the remote base and lease before every external write. If either
+   changed, stop; do not autonomously rebase or merge.
+
+Only one scheduled run may operate on this repository at a time. Independent
+review agents may work in parallel read-only, but there is one writer and one
+candidate branch.
+
+### Repository Lease And Manifest Run Record
+
+For one workstation, use a registry beneath the absolute Git common directory
+returned by `git rev-parse --path-format=absolute --git-common-dir`. Do not put
+the registry in a per-worktree `.sandbox` directory.
+
+1. Generate a run UUID and random fencing token. Atomically acquire the fixed
+   repository lease `<git-common-dir>/overnight-candidates/active` with one
+   `mkdir`, then atomically write redacted owner metadata: run UUID, process
+   identity, base SHA, selected Manifest ID and hash, start time, deadline, and
+   fencing token. If `active` already exists, perform a no-op even when it names
+   a different manifest.
+2. Derive the manifest record key as the lowercase hexadecimal SHA-256 of the
+   UTF-8 Manifest ID only. Store the separately calculated full-blob manifest
+   hash in every claim and terminal record.
+3. While holding `active` but before acquiring a manifest claim, recheck the
+   claim and terminal paths. If exactly one well-formed record exists, verify
+   its Manifest ID and blob hash and leave it untouched. A matching ID and hash
+   is a duplicate no-op; a different hash is unauthorized ID reuse. In either
+   case, recheck the owned `active` run UUID and fencing token and atomically
+   move only that lease to a unique no-op or denied history path. This is the
+   sole finalization path that does not require a manifest claim owned by the
+   current run. If both records exist, either is malformed, or the fenced lease
+   move fails, retain `active` for human recovery.
+4. When neither record exists, atomically acquire
+   `<git-common-dir>/overnight-candidates/claims/<record-key>` with one `mkdir`
+   and atomically bind the Manifest ID and hash plus the current run UUID and
+   fencing token into it. If acquisition reports an existing record, repeat the
+   pre-claim state inspection in step 3; on any other acquisition error, retain
+   `active` for human recovery.
+5. Before every phase, mutation, and external write, verify that both `active`
+   and the single manifest claim name the expected Manifest ID and hash, current
+   run UUID, and fencing token, and verify that no terminal record exists. That
+   exact owned claim is the normal running state; renew both owner timestamps
+   and continue. Any terminal record, foreign or mismatched claim, malformed
+   record, or simultaneous claim and terminal is an invariant failure: retain
+   `active` for human recovery and do not act. The deadline is the smaller of
+   the manifest runtime and its authorization expiry.
+6. Never remove a stale or malformed repository lease, claim, or terminal
+   automatically. The human engineer inspects and explicitly resolves it before
+   issuing a new manifest ID to retry.
+7. Bind the repository-lease identity and fencing token into validation evidence
+   and every publisher request. The trusted policy verifier and publisher must
+   re-read both lease records and reject an owner, token, deadline, or manifest
+   mismatch immediately before acting.
+8. Append redacted phase records inside the manifest claim after commits and
+   external writes. A push is not terminal while draft-PR creation is still
+   pending.
+9. For a normal terminal outcome (successful local completion, an ordinary
+   implementation or validation failure, or a publication outcome), first prove
+   that `active` and the claim still match the current Manifest ID and hash, run
+   UUID, and fencing token and that no terminal record exists. Then atomically
+   move the manifest claim to
+   `<git-common-dir>/overnight-candidates/terminal/<record-key>` and write the
+   final state. Then, only after rechecking the owner and fencing token,
+   atomically move `active` to a unique history path for that run. If either
+   finalization fails, leave the repository lease in place and require human
+   recovery rather than allowing a second writer. Acquisition, metadata,
+   ownership, malformed-record, and other invariant failures described above do
+   not use this normal finalization path and retain `active`.
+
+This registry coordinates scheduler worktrees sharing one Git common directory.
+A multi-host scheduler requires an external transactional lease and is outside
+this runbook.
+
+## Implementation, Review, And Green Checkpoints
+
+For the selected item:
+
+1. Record the arc42 context, block, interfaces, runtime flow, state, side
+   effects, quality scenario, recovery, permissions, and cost constraints.
+2. Implement only the allowed paths and acceptance criteria.
+3. Run an independent read-only correctness and maintainability review.
+4. Run a separate read-only production-failure challenge covering invalid
+   input, partial failure, retries, idempotency, concurrency, volume,
+   permissions, rollout, rollback, monitoring, and cost.
+5. Separate proven defects from questions and optional hardening. Return
+   accepted fixes to the writer and repeat affected review passes.
+6. Run every manifest validation command, plus:
+
+   ```bash
+   make security-check
+   git diff --check
+   ```
+
+7. For Python logic also run:
+
+   ```bash
+   make quality-check
+   make readiness-check
+   ```
+
+8. Confirm the diff stays within its allowlist and line, file, commit, and push
+   budgets. Confirm generated outputs and credentials are not staged.
+9. Stage explicit allowed paths and run `git diff --cached --check`.
+10. Commit only a coherent checkpoint whose relevant checks pass. Do not create
+    WIP or knowingly broken commits.
+
+Count the candidate budget from the staged change against the recorded base:
+
+```bash
+git diff --cached --numstat -z <base-sha>
+```
+
+Parse the NUL-delimited records and sum additions and deletions. Reject `-`
+binary counts, submodules, symlinks, or any unlisted path. After each commit,
+calculate the content-complete fingerprint without logging the patch:
+
+```bash
+git diff --binary --full-index <base-sha>...HEAD | sha256sum
+```
+
+Use pipeline-failure propagation and reject a non-zero Git or hash command; an
+empty or partial fingerprint is never evidence.
+
+A checkpoint is not green until validation is repeated against the exact commit
+tree that would be pushed:
+
+1. Record the commit and tree SHAs, then create a fresh detached validation
+   checkout at that commit through the candidate-isolation adapter.
+2. Require an empty Git status before the first command: no tracked
+   modifications, untracked paths, or conflicts. Do not copy the development
+   worktree or its ignored outputs.
+3. Run the complete manifest and arc42 validation with credentials, hooks,
+   network, and writable paths restricted by the adapter.
+4. Before and after every command, require the same commit/tree SHAs and no
+   tracked mutation. Record exact command, tool versions, timestamps, return
+   code, and redacted log hash.
+5. Destroy no user work. Retain the redacted evidence and have the trusted policy
+   verifier bind its hash to the commit/tree, manifest, base, adapter identities,
+   and diff fingerprint.
+
+Only this post-commit evidence may authorize a checkpoint push. Any later
+commit, amend, rebase, file mutation, or validation-environment change invalidates
+the binding and requires a new isolated validation pass.
+
+When incremental publication is activated and the manifest authorizes more than
+one push, repeat scope inspection, content fingerprinting, relevant validation,
+base freshness, and the create/update lease before every checkpoint push. Never
+force-push or amend a pushed commit. Prefer one final push when intermediate
+remote recovery is not required.
+
+After the final green commit, run `make morning-review` against the recorded
+base. The evidence package remains local and the decision remains `PENDING`.
+
+## Publication Gate
+
+Publication is permitted only when the activation checklist, manifest, lease,
+base, scope, reviews, validation, content fingerprint, and credential boundary
+all pass in the same run.
+
+The publisher adapter and its adversarial tests are not implemented in this
+repository, so publication remains disabled. A future adapter must accept a
+signed, schema-validated request containing the manifest/policy hashes, lease
+and fencing token, expected base/remote SHAs, branch, commit/tree SHAs, diff
+fingerprint, validation evidence hashes, exact approved adapter paths/digests,
+and draft PR metadata. It must return a redacted signed result, verify its own
+approved identity before accepting a token, and never run repository code.
+
+When that adapter is configured, the first green checkpoint lifecycle is:
+
+1. Obtain a new short-lived publisher token outside the candidate process.
+2. Recheck the lease and protected base SHA.
+3. Use an atomic compare-and-swap ref operation whose expected old object ID is
+   the all-zero absent-ref value. Reject a concurrent creation and verify the
+   resulting remote SHA.
+4. Open one draft PR against the manifest's `PR base branch`; verify base, head,
+   draft state, and CI creation or required human approval.
+5. Drop or expire the token and record the published SHA.
+
+For each manifest-authorized later checkpoint in the same run:
+
+1. Repeat review, scope, budget, validation, fingerprint, lease, and base checks.
+2. Obtain a new short-lived token and use an atomic compare-and-swap update whose
+   expected old object ID is the last published SHA.
+3. Require the new commit to be a descendant of that SHA. Reject any mismatch,
+   remote movement, or non-fast-forward update.
+4. Verify the new remote SHA and CI state, drop the token, and update the run
+   record.
+
+After the final checkpoint, the publisher performs no further mutation. It
+never force-pushes, rebases, amends a published commit, or uses a broader token.
+
+The PR body must include:
+
+- `Decision: PENDING — human acceptance required`.
+- Manifest item and authorization expiry.
+- Base, commit, and tree SHAs plus a content-complete diff fingerprint.
+- Arc42 context, block, interfaces, runtime flow, state, and side effects.
+- Quality and production-failure scenarios.
+- Security, permissions, operational, performance, and cost implications.
+- Exact changed paths, validation commands, results, and unavailable tools.
+- Reviewer findings, dispositions, unresolved questions, and up to ten morning
+  inspection paths.
+
+## Stop And Recovery Rules
+
+Stop without external writes when authorization, protection, credential
+isolation, lease, base, scope, tools, validation, or review evidence is missing
+or ambiguous. A failed gate is not permission to weaken tests or widen scope.
+
+If a push succeeds but PR creation fails, retain and report the remote branch.
+If the PR exists but CI is red, absent, or pending approval, leave it draft and
+report it. Never automatically rebase, close, delete, merge, retry with broader
+credentials, or perform destructive cleanup.
+
+Record the last durable state: run/lease ID, manifest hash, base SHA, branch,
+commit/tree SHA, changed paths, fingerprints, exact commands and return codes,
+review dispositions, push lease, PR URL/base/head, CI URLs/status, skipped
+checks, and final stop reason. Never record credential values or raw secret-like
+content.
+
+## Scheduled Task Prompt
+
+Configure the task itself to run in a dedicated scheduler worktree. This prompt
+has no mutable publication switch; it derives authority only from the pinned
+protected-base policy and manifest:
+
+```text
+Repository: /home/alexmarinos87/projects/financial-risk-data-platform
+Comparison ref: origin/main
+PR base branch: main
+
+Verify this is the scheduler-supplied isolated worktree. In a trusted
+orchestration step, fetch origin and record the origin/main SHA. Read AGENTS.md,
+docs/architecture.md, docs/overnight-development.md,
+docs/security-protocols.md, docs/engineering-delivery-workflow.md,
+docs/agent-roles.md, and docs/iteration-backlog.md from that exact commit with
+git show. Resolve the selected manifest link, read its entire Git blob from the
+same commit, and hash the exact bytes. Never select from local or uncommitted
+copies.
+
+Select exactly one unexpired backlog item whose status is exactly
+"approved for overnight development" and whose manifest is complete. If none
+exists, report a successful no-op and change nothing.
+
+Use the arc42 building block view to produce a bounded module brief. Reject
+unrelated cross-block, high-risk, overlapping, over-budget, or ambiguous work.
+An explicit vertical slice is eligible only under the runbook's interface and
+integration-evidence rule. Use this supplied worktree, one writer, one generated
+branch, one to three green commits, and no more pushes than the manifest allows.
+
+Run separate read-only correctness and production-failure reviews. Apply only
+accepted fixes and repeat affected reviews. Run all manifest checks, make
+security-check, git diff --check, and at least the arc42 minimum validation for
+the primary block.
+Stage only allowed paths. Never create a broken or WIP commit.
+
+Read `Publishing status`, its expiry, the paths and SHA-256 identities of the
+publisher, policy verifier, and candidate isolation adapter, and the activation
+checklist from the recorded protected-base runbook. With the current
+disabled/not-configured values, report a successful no-op before creating a
+branch, editing, committing, pushing, or opening a PR. Do not simulate an
+isolation or publication adapter in prompt logic.
+
+If a future protected-base version enables publication, still publish only when
+every activation prerequisite, credential boundary, task manifest, shared
+lease, scope, base-freshness, review, validation, and fingerprint check is proven
+in this run. Invoke the named policy verifier, acquire and renew the shared
+lease, enforce the manifest deadline through the named candidate-isolation
+adapter, validate a clean detached checkout of every exact committed tree, and
+atomically finalize the run record. Extract and verify the protected-base
+adapter bytes outside the candidate-writable tree; never trust same-named local
+executables. Use only the configured short-lived least-privilege publisher and
+the first/subsequent checkpoint lifecycle in the runbook. Never push to main,
+mark ready, approve, merge, deploy, dispatch workflows, use cloud credentials,
+rewrite history, delete refs, or claim acceptance.
+
+Final output must state the selected item or no-op reason, arc42 module, base and
+commit SHAs, changed paths and line budget, exact validation, review findings,
+publication/CI state, unresolved questions, and:
+"Decision remains PENDING for human acceptance."
+```
+
+The recommended first schedule is one run at 23:30 Europe/London. Review the
+first several local-only runs before considering publication activation.

--- a/docs/overnight-sandbox.md
+++ b/docs/overnight-sandbox.md
@@ -3,6 +3,10 @@
 Use this runbook for a safe unattended validation loop. The sandbox is designed
 to gather evidence overnight, not to merge code or deploy infrastructure.
 
+This command remains validation-only even when a separate scheduled candidate
+is approved. See `docs/overnight-development.md` for that distinct, fail-closed
+mode; do not extend `scripts/overnight_sandbox.py` into a publisher.
+
 ## What It Does
 
 `make overnight-sandbox` runs repeated local validation cycles for up to eight

--- a/docs/security-protocols.md
+++ b/docs/security-protocols.md
@@ -42,6 +42,11 @@ Require explicit approval before:
 5. Running destructive database operations.
 6. Publishing or merging an unattended overnight change.
 
+Approval to prepare or publish a scheduled candidate must be encoded in the
+complete, unexpired manifest described by `docs/overnight-development.md`.
+Publication approval never includes readiness, acceptance, merge, deployment,
+workflow dispatch, or cloud credentials.
+
 ## Recommended GitHub Settings
 
 Configure branch protection or repository rules for `main`:
@@ -53,11 +58,20 @@ Configure branch protection or repository rules for `main`:
 5. Require conversation resolution before merge.
 6. Protect the `prod` GitHub Environment with required reviewers.
 
+Before any unattended branch publication, also require stale-review dismissal,
+approval after the last push, no administrator or bot bypass, CI concurrency,
+and a short-lived repository-scoped publisher credential. The writer and tests
+must never receive that credential. Until those controls are independently
+verified, scheduled publishing remains disabled.
+
 ## Overnight Sandbox
 
 Use `docs/overnight-sandbox.md` for unattended validation. The sandbox can run
 checks and write logs, but it must not push, merge, deploy, use cloud
 credentials, or create cloud resources.
+
+`docs/overnight-development.md` describes a separate candidate mode. It does
+not weaken the sandbox or activate publication by itself.
 
 ## Known Boundaries
 


### PR DESCRIPTION
## What changed

- Define a manifest-bound scheduled-candidate contract for one arc42-bounded change.
- Separate candidate editing, independent review, exact-tree validation, and isolated publication responsibilities.
- Specify repository-global fencing, single-use manifest records, base freshness, bounded checkpoint commits, and atomic create/update publication semantics.
- Connect the runbook to the canonical delivery, security, iteration, and sandbox guidance.

## Why

The repository needs a fail-closed foundation before any unattended agent can edit or publish. Prompt wording alone is not an isolation, authorization, concurrency, or credential boundary.

## arc42 boundary

- **Primary block:** `engineering-controls`
- **Runtime:** protected-base policy and manifest → fenced scheduler → credential-free candidate → independent reviews → exact-tree validation → separately isolated draft-only publisher → human acceptance.
- **Interfaces:** local Git common directory for the lease/run record, GitHub only through a future least-privilege publisher, and ignored local review evidence.
- **Unchanged:** pipeline data, schemas, storage, warehouse behavior, deployment, cloud resources, and `make overnight-sandbox`.

The diff is 583 changed lines, above the normal 200–500 review heuristic. It remains one atomic authorization contract because splitting the runbook from its canonical policy cross-references would temporarily leave contradictory controls.

## Current safety state

Scheduled candidate mode and publication remain **disabled**. This PR does not add or activate a publisher, policy verifier, candidate-isolation adapter, GitHub credential, scheduled task, branch protection setting, CI concurrency setting, deployment, or cloud access.

## History repair

The branch has been rebased onto the current `main` after its prerequisite documentation stack was squash-merged. The committed file tree is identical to the previously reviewed PR tree: one commit ahead, zero behind, exactly 8 modified paths and 1 added path, +567/-16.

## Validation

- Previous CI on the identical file tree passed.
- `make security-check`
- `git diff --check`
- explicit nine-path staging and cached whitespace validation
- independent arc42/policy review: no remaining proven blocker
- independent security/concurrency review: no remaining proven blocker
- fresh pull-request CI required on the repaired ancestry before squash merge

## Merge plan

Squash-merge into `main` after the fresh CI run succeeds. PR #42 and later engineering-control PRs remain separate follow-up slices and must be rebased in order.