### PR TITLE
Add Alpha Vantage daily adapter

### DIFF
--- a/src/ingestion/alpha_vantage_client.py
+++ b/src/ingestion/alpha_vantage_client.py
@@ -1,0 +1,380 @@
+"""Hardened Alpha Vantage daily adapter for the provider-neutral event contract.
+
+The standard-library timeout limits socket operations. A monotonic guard is
+checked between streamed reads, but Python's synchronous DNS resolution cannot
+be forcibly cancelled; callers should therefore treat it as a bounded local
+adapter rather than a hard real-time deadline.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import re
+import time
+from collections.abc import Callable, Mapping
+from datetime import date, datetime, time as datetime_time, timezone
+from decimal import Decimal, InvalidOperation
+from http.client import HTTPException
+from typing import Any
+from urllib.error import HTTPError, URLError
+from urllib.parse import urlencode, urlsplit
+from urllib.request import HTTPRedirectHandler, ProxyHandler, Request, build_opener
+
+from ..common.exceptions import IngestionError
+from ..common.time import utc_now
+from ..processing.normaliser import normalize_symbol
+from .schemas import MarketEvent
+
+API_HOST = "www.alphavantage.co"
+API_URL = f"https://{API_HOST}/query"
+DAILY_SERIES_KEY = "Time Series (Daily)"
+DEFAULT_MAX_RESPONSE_BYTES = 2_000_000
+DEFAULT_TIMEOUT_SECONDS = 10.0
+DEFAULT_MAX_RETRIES = 2
+MAX_COMPACT_RECORDS = 100
+MAX_SIGNED_64_BIT = 9_223_372_036_854_775_807
+RETRYABLE_HTTP_STATUSES = frozenset({408, 429, 500, 502, 503, 504})
+SYMBOL_PATTERN = re.compile(r"^[A-Z0-9][A-Z0-9._-]{0,31}$")
+INPUT_SYMBOL_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,31}$")
+CALENDAR_DATE_PATTERN = re.compile(r"^[0-9]{4}-[0-9]{2}-[0-9]{2}$")
+
+HttpTransport = Callable[[str, float, int], bytes]
+Sleep = Callable[[float], None]
+
+
+def _canonical_symbol(symbol: str) -> str:
+    if not isinstance(symbol, str):
+        raise IngestionError("Alpha Vantage symbol must be text")
+    stripped = symbol.strip()
+    if INPUT_SYMBOL_PATTERN.fullmatch(stripped) is None:
+        raise IngestionError("Alpha Vantage symbol contains unsupported characters")
+    canonical = normalize_symbol(stripped)
+    if SYMBOL_PATTERN.fullmatch(canonical) is None:
+        raise IngestionError("Alpha Vantage symbol contains unsupported characters")
+    return canonical
+
+
+def _aware_utc(value: datetime, *, field_name: str) -> datetime:
+    if value.tzinfo is None or value.utcoffset() is None:
+        raise IngestionError(f"{field_name} must include a timezone")
+    return value.astimezone(timezone.utc)
+
+
+def _validate_selection(
+    *,
+    start_date: date | None,
+    end_date: date | None,
+    max_records: int,
+) -> None:
+    if start_date is not None and end_date is not None and start_date > end_date:
+        raise IngestionError("start_date must be on or before end_date")
+    if isinstance(max_records, bool) or not 1 <= max_records <= MAX_COMPACT_RECORDS:
+        raise IngestionError(f"max_records must be between 1 and {MAX_COMPACT_RECORDS}")
+
+
+def _parse_price(value: Any, *, field_name: str) -> float:
+    parsed: float | None = None
+    try:
+        parsed = float(Decimal(str(value)))
+    except (InvalidOperation, TypeError, ValueError, OverflowError):
+        pass
+    if parsed is None:
+        raise IngestionError(f"Alpha Vantage {field_name} must be numeric")
+    if not math.isfinite(parsed) or parsed <= 0:
+        raise IngestionError(
+            f"Alpha Vantage {field_name} must be finite and greater than zero"
+        )
+    return parsed
+
+
+def _parse_volume(value: Any) -> int:
+    parsed: Decimal | None = None
+    try:
+        parsed = Decimal(str(value))
+    except (InvalidOperation, TypeError, ValueError):
+        pass
+    if parsed is None:
+        raise IngestionError("Alpha Vantage volume must be numeric")
+    if (
+        not parsed.is_finite()
+        or parsed < 0
+        or parsed > MAX_SIGNED_64_BIT
+        or parsed != parsed.to_integral_value()
+    ):
+        raise IngestionError("Alpha Vantage volume must be a non-negative whole number")
+    return int(parsed)
+
+
+def _event_id(symbol: str, event_date: date) -> str:
+    identity = f"alpha_vantage|TIME_SERIES_DAILY|{symbol}|{event_date.isoformat()}"
+    digest = hashlib.sha256(identity.encode("utf-8")).hexdigest()[:20]
+    return f"av-daily-{digest}"
+
+
+def _provider_error(payload: Mapping[str, Any]) -> str | None:
+    if "Error Message" in payload:
+        return "Alpha Vantage rejected the request"
+    if "Note" in payload:
+        return "Alpha Vantage rate limit was reached"
+    if "Information" in payload:
+        return "Alpha Vantage returned a service information response"
+    return None
+
+
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise ValueError("duplicate JSON key")
+        result[key] = value
+    return result
+
+
+def parse_alpha_vantage_daily_response(
+    payload_bytes: bytes,
+    *,
+    symbol: str,
+    ingested_at: datetime,
+    start_date: date | None = None,
+    end_date: date | None = None,
+    max_records: int = MAX_COMPACT_RECORDS,
+) -> list[MarketEvent]:
+    canonical_symbol = _canonical_symbol(symbol)
+    ingest_timestamp = _aware_utc(ingested_at, field_name="ingested_at")
+    _validate_selection(
+        start_date=start_date,
+        end_date=end_date,
+        max_records=max_records,
+    )
+
+    payload: Any = None
+    payload_is_invalid = False
+    try:
+        payload = json.loads(
+            payload_bytes.decode("utf-8"),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
+    except (UnicodeDecodeError, json.JSONDecodeError, RecursionError, ValueError):
+        payload_is_invalid = True
+    if payload_is_invalid:
+        raise IngestionError("Alpha Vantage response must be valid UTF-8 JSON")
+    if not isinstance(payload, dict):
+        raise IngestionError("Alpha Vantage response must be a JSON object")
+
+    provider_error = _provider_error(payload)
+    if provider_error is not None:
+        raise IngestionError(provider_error)
+
+    metadata = payload.get("Meta Data")
+    if not isinstance(metadata, dict):
+        raise IngestionError("Alpha Vantage response is missing metadata")
+    returned_symbol = metadata.get("2. Symbol")
+    if not isinstance(returned_symbol, str) or _canonical_symbol(returned_symbol) != canonical_symbol:
+        raise IngestionError("Alpha Vantage response symbol does not match the request")
+
+    series = payload.get(DAILY_SERIES_KEY)
+    if not isinstance(series, dict) or not series:
+        raise IngestionError("Alpha Vantage response contains no daily time series")
+    if len(series) > MAX_COMPACT_RECORDS:
+        raise IngestionError("Alpha Vantage compact response contains more than 100 rows")
+
+    candidates: list[tuple[date, Mapping[str, Any]]] = []
+    for raw_date, raw_bar in series.items():
+        if not isinstance(raw_date, str) or not isinstance(raw_bar, dict):
+            raise IngestionError("Alpha Vantage daily time series has an invalid row")
+        if CALENDAR_DATE_PATTERN.fullmatch(raw_date) is None:
+            raise IngestionError("Alpha Vantage daily time series has an invalid date")
+        event_date: date | None = None
+        try:
+            event_date = date.fromisoformat(raw_date)
+        except ValueError:
+            pass
+        if event_date is None:
+            raise IngestionError("Alpha Vantage daily time series has an invalid date")
+        if start_date is not None and event_date < start_date:
+            continue
+        if end_date is not None and event_date > end_date:
+            continue
+        candidates.append((event_date, raw_bar))
+
+    selected = sorted(candidates, key=lambda item: item[0], reverse=True)[:max_records]
+    events: list[MarketEvent] = []
+    for event_date, raw_bar in sorted(selected, key=lambda item: item[0]):
+        required_bar_fields = {"1. open", "2. high", "3. low", "4. close", "5. volume"}
+        if not required_bar_fields.issubset(raw_bar):
+            raise IngestionError("Alpha Vantage daily bar is missing an OHLCV field")
+        open_price = _parse_price(raw_bar["1. open"], field_name="open price")
+        high_price = _parse_price(raw_bar["2. high"], field_name="high price")
+        low_price = _parse_price(raw_bar["3. low"], field_name="low price")
+        close_price = _parse_price(raw_bar["4. close"], field_name="close price")
+        if low_price > high_price or not (
+            low_price <= open_price <= high_price and low_price <= close_price <= high_price
+        ):
+            raise IngestionError("Alpha Vantage daily bar has inconsistent OHLC values")
+        events.append(
+            MarketEvent(
+                event_id=_event_id(canonical_symbol, event_date),
+                symbol=canonical_symbol,
+                price=close_price,
+                volume=_parse_volume(raw_bar["5. volume"]),
+                ts_event=datetime.combine(event_date, datetime_time.min, tzinfo=timezone.utc),
+                ts_ingest=ingest_timestamp,
+                source="alpha_vantage",
+            )
+        )
+
+    return events
+
+
+class _RejectRedirects(HTTPRedirectHandler):
+    def redirect_request(
+        self,
+        request: Request,
+        file_pointer: Any,
+        code: int,
+        message: str,
+        headers: Any,
+        new_url: str,
+    ) -> None:
+        return None
+
+
+_HTTP_OPENER = build_opener(ProxyHandler({}), _RejectRedirects())
+
+
+def _download(url: str, timeout_seconds: float, max_response_bytes: int) -> bytes:
+    request = Request(
+        url,
+        headers={
+            "Accept": "application/json",
+            "Accept-Encoding": "identity",
+            "User-Agent": "financial-risk-data-platform/0.1",
+        },
+    )
+    deadline = time.monotonic() + timeout_seconds
+    with _HTTP_OPENER.open(request, timeout=timeout_seconds) as response:
+        final_url = urlsplit(response.geturl())
+        if final_url.scheme != "https" or final_url.hostname != API_HOST:
+            raise IngestionError("Alpha Vantage redirected to an unexpected host")
+        content_encoding = response.headers.get("Content-Encoding", "identity").lower()
+        if content_encoding not in {"", "identity"}:
+            raise IngestionError("Alpha Vantage returned unsupported content encoding")
+        content_type = response.headers.get("Content-Type", "").split(";", maxsplit=1)[0].lower()
+        if content_type != "application/json":
+            raise IngestionError("Alpha Vantage response content type must be application/json")
+        content_length = response.headers.get("Content-Length")
+        declared_length: int | None = None
+        if content_length is not None:
+            try:
+                declared_length = int(content_length)
+            except ValueError:
+                pass
+            if declared_length is None:
+                raise IngestionError("Alpha Vantage returned an invalid content length")
+            if declared_length < 0 or declared_length > max_response_bytes:
+                raise IngestionError("Alpha Vantage response exceeded the configured size limit")
+        chunks: list[bytes] = []
+        received = 0
+        reader = getattr(response, "read1", response.read)
+        while True:
+            if time.monotonic() >= deadline:
+                raise IngestionError("Alpha Vantage response exceeded the request time limit")
+            chunk = reader(min(65_536, max_response_bytes - received + 1))
+            if not chunk:
+                break
+            chunks.append(chunk)
+            received += len(chunk)
+            if received > max_response_bytes:
+                raise IngestionError("Alpha Vantage response exceeded the configured size limit")
+        payload = b"".join(chunks)
+        if declared_length is not None and received != declared_length:
+            raise IngestionError("Alpha Vantage response did not match its content length")
+    if len(payload) > max_response_bytes:
+        raise IngestionError("Alpha Vantage response exceeded the configured size limit")
+    return payload
+
+
+def fetch_alpha_vantage_daily_events(
+    *,
+    symbol: str,
+    api_key: str,
+    ingested_at: datetime | None = None,
+    start_date: date | None = None,
+    end_date: date | None = None,
+    max_records: int = MAX_COMPACT_RECORDS,
+    timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
+    max_retries: int = DEFAULT_MAX_RETRIES,
+    max_response_bytes: int = DEFAULT_MAX_RESPONSE_BYTES,
+    transport: HttpTransport = _download,
+    sleep: Sleep = time.sleep,
+) -> list[MarketEvent]:
+    canonical_symbol = _canonical_symbol(symbol)
+    _validate_selection(
+        start_date=start_date,
+        end_date=end_date,
+        max_records=max_records,
+    )
+    if ingested_at is not None:
+        ingested_at = _aware_utc(ingested_at, field_name="ingested_at")
+    secret = api_key.strip()
+    if not secret:
+        raise IngestionError("Alpha Vantage API key is required")
+    if len(secret) > 256 or not secret.isascii() or any(
+        not 33 <= ord(character) <= 126 for character in secret
+    ):
+        raise IngestionError("Alpha Vantage API key has an invalid format")
+    if not 0 < timeout_seconds <= 60:
+        raise IngestionError("timeout_seconds must be greater than zero and at most 60")
+    if not 0 <= max_retries <= 3:
+        raise IngestionError("max_retries must be between 0 and 3")
+    if not 1 <= max_response_bytes <= 10_000_000:
+        raise IngestionError("max_response_bytes must be between 1 and 10000000")
+
+    query = urlencode(
+        {
+            "function": "TIME_SERIES_DAILY",
+            "symbol": canonical_symbol,
+            "outputsize": "compact",
+            "datatype": "json",
+            "apikey": secret,
+        }
+    )
+    url = f"{API_URL}?{query}"
+
+    payload: bytes | None = None
+    for attempt in range(max_retries + 1):
+        try:
+            payload = transport(url, timeout_seconds, max_response_bytes)
+            break
+        except HTTPError as exc:
+            retryable = exc.code in RETRYABLE_HTTP_STATUSES
+            message = f"Alpha Vantage request failed with HTTP {exc.code}"
+        except (HTTPException, URLError, TimeoutError, OSError):
+            retryable = True
+            message = "Alpha Vantage request failed due to a network error"
+
+        if not retryable or attempt == max_retries:
+            raise IngestionError(message) from None
+        sleep(0.25 * (2**attempt))
+
+    if payload is None:
+        raise IngestionError("Alpha Vantage request produced no response")
+    if len(payload) > max_response_bytes:
+        raise IngestionError("Alpha Vantage response exceeded the configured size limit")
+
+    return parse_alpha_vantage_daily_response(
+        payload,
+        symbol=canonical_symbol,
+        ingested_at=ingested_at or utc_now(),
+        start_date=start_date,
+        end_date=end_date,
+        max_records=max_records,
+    )
+
+
+__all__ = [
+    "fetch_alpha_vantage_daily_events",
+    "parse_alpha_vantage_daily_response",
+]

--- a/tests/unit/ingestion/test_alpha_vantage_client.py
+++ b/tests/unit/ingestion/test_alpha_vantage_client.py
@@ -1,0 +1,636 @@
+from __future__ import annotations
+
+import json
+import traceback
+from datetime import date, datetime, timezone
+from http.client import BadStatusLine
+from urllib.error import HTTPError
+from urllib.parse import parse_qs, urlsplit
+
+import pytest
+
+import src.ingestion.alpha_vantage_client as alpha_vantage_client
+from src.common.exceptions import IngestionError
+from src.ingestion.alpha_vantage_client import (
+    fetch_alpha_vantage_daily_events,
+    parse_alpha_vantage_daily_response,
+)
+
+
+class _FakeResponse:
+    def __init__(
+        self,
+        body: bytes,
+        *,
+        headers: dict[str, str],
+        final_url: str = "https://www.alphavantage.co/query",
+    ) -> None:
+        self._body = body
+        self._offset = 0
+        self._final_url = final_url
+        self.headers = headers
+        self.closed = False
+
+    def geturl(self) -> str:
+        return self._final_url
+
+    def read(self, size: int = -1) -> bytes:
+        if size < 0:
+            size = len(self._body) - self._offset
+        chunk = self._body[self._offset : self._offset + size]
+        self._offset += len(chunk)
+        return chunk
+
+    def read1(self, size: int = -1) -> bytes:
+        return self.read(size)
+
+    def __enter__(self) -> _FakeResponse:
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        self.closed = True
+
+
+class _FakeOpener:
+    def __init__(self, response: _FakeResponse) -> None:
+        self.response = response
+        self.request: object | None = None
+        self.timeout: float | None = None
+
+    def open(self, request: object, *, timeout: float) -> _FakeResponse:
+        self.request = request
+        self.timeout = timeout
+        return self.response
+
+
+def _response(
+    *,
+    symbol: str = "IBM",
+    first_close: str = "101.50",
+    first_volume: str = "1200",
+) -> bytes:
+    return json.dumps(
+        {
+            "Meta Data": {"2. Symbol": symbol},
+            "Time Series (Daily)": {
+                "2025-01-03": {
+                    "1. open": "100.75",
+                    "2. high": "102.00",
+                    "3. low": "100.50",
+                    "4. close": first_close,
+                    "5. volume": first_volume,
+                },
+                "2025-01-02": {
+                    "1. open": "99.75",
+                    "2. high": "101.00",
+                    "3. low": "99.50",
+                    "4. close": "100.25",
+                    "5. volume": "900",
+                },
+                "2024-12-31": {
+                    "1. open": "99.00",
+                    "2. high": "100.00",
+                    "3. low": "98.50",
+                    "4. close": "99.75",
+                    "5. volume": "800",
+                },
+            },
+        }
+    ).encode("utf-8")
+
+
+def test_parse_daily_response_builds_ordered_market_events() -> None:
+    ingested_at = datetime(2025, 1, 4, 12, 30, tzinfo=timezone.utc)
+
+    events = parse_alpha_vantage_daily_response(
+        _response(symbol="ibm"),
+        symbol="IBM",
+        ingested_at=ingested_at,
+        start_date=date(2025, 1, 1),
+    )
+
+    assert [event.ts_event for event in events] == [
+        datetime(2025, 1, 2, tzinfo=timezone.utc),
+        datetime(2025, 1, 3, tzinfo=timezone.utc),
+    ]
+    assert [event.price for event in events] == [100.25, 101.5]
+    assert [event.volume for event in events] == [900, 1200]
+    assert {event.symbol for event in events} == {"IBM"}
+    assert {event.source for event in events} == {"alpha_vantage"}
+    assert {event.ts_ingest for event in events} == {ingested_at}
+
+
+def test_event_id_tracks_logical_bar_not_mutable_values() -> None:
+    ingested_at = datetime(2025, 1, 4, tzinfo=timezone.utc)
+
+    original = parse_alpha_vantage_daily_response(
+        _response(first_close="101.50", first_volume="1200"),
+        symbol="IBM",
+        ingested_at=ingested_at,
+        start_date=date(2025, 1, 3),
+    )
+    corrected = parse_alpha_vantage_daily_response(
+        _response(first_close="102.00", first_volume="1250"),
+        symbol="IBM",
+        ingested_at=ingested_at,
+        start_date=date(2025, 1, 3),
+    )
+
+    assert original[0].event_id == corrected[0].event_id
+    assert original[0].price != corrected[0].price
+
+
+def test_parse_daily_response_limits_most_recent_rows_then_orders_them() -> None:
+    events = parse_alpha_vantage_daily_response(
+        _response(),
+        symbol="IBM",
+        ingested_at=datetime(2025, 1, 4, tzinfo=timezone.utc),
+        max_records=2,
+    )
+
+    assert [event.ts_event.date() for event in events] == [
+        date(2025, 1, 2),
+        date(2025, 1, 3),
+    ]
+
+
+def test_parse_daily_response_allows_an_empty_filtered_range() -> None:
+    events = parse_alpha_vantage_daily_response(
+        _response(),
+        symbol="IBM",
+        ingested_at=datetime(2025, 1, 4, tzinfo=timezone.utc),
+        start_date=date(2026, 1, 1),
+    )
+
+    assert events == []
+
+
+@pytest.mark.parametrize(
+    ("field", "message"),
+    [
+        ("Error Message", "rejected"),
+        ("Note", "rate limit"),
+        ("Information", "service information"),
+    ],
+)
+def test_parse_daily_response_rejects_provider_errors(field: str, message: str) -> None:
+    payload = json.dumps({field: "opaque provider detail"}).encode("utf-8")
+
+    with pytest.raises(IngestionError, match=message):
+        parse_alpha_vantage_daily_response(
+            payload,
+            symbol="IBM",
+            ingested_at=datetime(2025, 1, 4, tzinfo=timezone.utc),
+        )
+
+
+@pytest.mark.parametrize(
+    ("close", "volume", "message"),
+    [
+        ("nan", "1200", "close price"),
+        ("0", "1200", "greater than zero"),
+        ("101.50", "-1", "non-negative whole number"),
+        ("101.50", "1.5", "non-negative whole number"),
+    ],
+)
+def test_parse_daily_response_rejects_invalid_values(
+    close: str,
+    volume: str,
+    message: str,
+) -> None:
+    with pytest.raises(IngestionError, match=message):
+        parse_alpha_vantage_daily_response(
+            _response(first_close=close, first_volume=volume),
+            symbol="IBM",
+            ingested_at=datetime(2025, 1, 4, tzinfo=timezone.utc),
+            start_date=date(2025, 1, 3),
+        )
+
+
+def test_parse_daily_response_rejects_inconsistent_ohlc() -> None:
+    payload = json.loads(_response())
+    payload["Time Series (Daily)"]["2025-01-03"]["2. high"] = "100.00"
+
+    with pytest.raises(IngestionError, match="inconsistent OHLC"):
+        parse_alpha_vantage_daily_response(
+            json.dumps(payload).encode("utf-8"),
+            symbol="IBM",
+            ingested_at=datetime(2025, 1, 4, tzinfo=timezone.utc),
+            start_date=date(2025, 1, 3),
+        )
+
+
+def test_parse_daily_response_rejects_duplicate_json_keys() -> None:
+    payload = b'{"Meta Data": {}, "Meta Data": {}, "Time Series (Daily)": {}}'
+
+    with pytest.raises(IngestionError, match="valid UTF-8 JSON"):
+        parse_alpha_vantage_daily_response(
+            payload,
+            symbol="IBM",
+            ingested_at=datetime(2025, 1, 4, tzinfo=timezone.utc),
+        )
+
+
+def test_parse_daily_response_rejects_iso_week_date_key() -> None:
+    payload = json.loads(_response())
+    payload["Time Series (Daily)"]["2025-W01-1"] = payload["Time Series (Daily)"].pop(
+        "2025-01-03"
+    )
+
+    with pytest.raises(IngestionError, match="invalid date"):
+        parse_alpha_vantage_daily_response(
+            json.dumps(payload).encode("utf-8"),
+            symbol="IBM",
+            ingested_at=datetime(2025, 1, 4, tzinfo=timezone.utc),
+        )
+
+
+@pytest.mark.parametrize("symbol", ["ß", "ſ", "ı", "ﬀ"])
+def test_symbol_validation_rejects_unicode_casefold_aliases(symbol: str) -> None:
+    with pytest.raises(IngestionError, match="unsupported characters"):
+        fetch_alpha_vantage_daily_events(
+            symbol=symbol,
+            api_key="test-secret",
+            transport=lambda url, timeout, maximum: _response(),
+        )
+
+
+def test_fetch_builds_bounded_request_without_logging_key() -> None:
+    calls: list[tuple[str, float, int]] = []
+    ingested_at = datetime(2025, 1, 4, tzinfo=timezone.utc)
+
+    def transport(url: str, timeout_seconds: float, max_bytes: int) -> bytes:
+        calls.append((url, timeout_seconds, max_bytes))
+        return _response()
+
+    events = fetch_alpha_vantage_daily_events(
+        symbol="ibm",
+        api_key="test-secret",
+        ingested_at=ingested_at,
+        max_records=1,
+        timeout_seconds=4.0,
+        max_response_bytes=4096,
+        transport=transport,
+    )
+
+    query = parse_qs(urlsplit(calls[0][0]).query)
+    assert urlsplit(calls[0][0]).scheme == "https"
+    assert urlsplit(calls[0][0]).hostname == "www.alphavantage.co"
+    assert query == {
+        "function": ["TIME_SERIES_DAILY"],
+        "symbol": ["IBM"],
+        "outputsize": ["compact"],
+        "datatype": ["json"],
+        "apikey": ["test-secret"],
+    }
+    assert calls[0][1:] == (4.0, 4096)
+    assert len(events) == 1
+
+
+def test_fetch_retries_retryable_http_errors() -> None:
+    attempts = 0
+    delays: list[float] = []
+
+    def transport(url: str, timeout_seconds: float, max_bytes: int) -> bytes:
+        nonlocal attempts
+        attempts += 1
+        if attempts < 3:
+            raise HTTPError(url, 503, "unavailable", hdrs=None, fp=None)
+        return _response()
+
+    events = fetch_alpha_vantage_daily_events(
+        symbol="IBM",
+        api_key="test-secret",
+        ingested_at=datetime(2025, 1, 4, tzinfo=timezone.utc),
+        transport=transport,
+        sleep=delays.append,
+    )
+
+    assert len(events) == 3
+    assert attempts == 3
+    assert delays == [0.25, 0.5]
+
+
+def test_fetch_redacts_key_when_non_retryable_request_fails() -> None:
+    def transport(url: str, timeout_seconds: float, max_bytes: int) -> bytes:
+        raise HTTPError(url, 403, "forbidden", hdrs=None, fp=None)
+
+    with pytest.raises(IngestionError) as error:
+        fetch_alpha_vantage_daily_events(
+            symbol="IBM",
+            api_key="do-not-expose",
+            transport=transport,
+        )
+
+    assert "HTTP 403" in str(error.value)
+    assert "do-not-expose" not in str(error.value)
+    assert "do-not-expose" not in repr(error.value)
+    assert "https://" not in str(error.value)
+    rendered = "".join(
+        traceback.format_exception(type(error.value), error.value, error.value.__traceback__)
+    )
+    assert "do-not-expose" not in rendered
+
+
+def test_fetch_sanitizes_low_level_http_protocol_errors() -> None:
+    def transport(url: str, timeout_seconds: float, max_bytes: int) -> bytes:
+        raise BadStatusLine(f"bad response for {url}")
+
+    with pytest.raises(IngestionError) as error:
+        fetch_alpha_vantage_daily_events(
+            symbol="IBM",
+            api_key="sentinel-secret",
+            max_retries=0,
+            transport=transport,
+        )
+
+    rendered = "".join(
+        traceback.format_exception(type(error.value), error.value, error.value.__traceback__)
+    )
+    assert "sentinel-secret" not in str(error.value)
+    assert "sentinel-secret" not in repr(error.value)
+    assert "sentinel-secret" not in rendered
+    assert error.value.__context__ is None
+
+
+def test_fetch_rejects_oversized_injected_response() -> None:
+    with pytest.raises(IngestionError, match="size limit"):
+        fetch_alpha_vantage_daily_events(
+            symbol="IBM",
+            api_key="test-secret",
+            max_response_bytes=8,
+            transport=lambda url, timeout, maximum: b"x" * 9,
+        )
+
+
+def test_default_transport_streams_json_with_fixed_network_policy(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    payload = _response()
+    response = _FakeResponse(
+        payload,
+        headers={
+            "Content-Type": "application/json; charset=utf-8",
+            "Content-Encoding": "identity",
+            "Content-Length": str(len(payload)),
+        },
+    )
+    opener = _FakeOpener(response)
+    monkeypatch.setattr(alpha_vantage_client, "_HTTP_OPENER", opener)
+
+    events = fetch_alpha_vantage_daily_events(
+        symbol="IBM",
+        api_key="sentinel-secret",
+        ingested_at=datetime(2025, 1, 4, tzinfo=timezone.utc),
+        timeout_seconds=3.0,
+    )
+
+    assert len(events) == 3
+    assert opener.timeout == 3.0
+    assert response.closed is True
+    request = opener.request
+    assert request is not None
+    assert request.get_header("Accept-encoding") == "identity"  # type: ignore[attr-defined]
+
+
+@pytest.mark.parametrize(
+    ("headers", "message"),
+    [
+        ({"Content-Type": "text/html"}, "content type"),
+        (
+            {
+                "Content-Type": "application/json",
+                "Content-Encoding": "gzip",
+            },
+            "content encoding",
+        ),
+        (
+            {
+                "Content-Type": "application/json",
+                "Content-Length": "9000000",
+            },
+            "size limit",
+        ),
+        (
+            {
+                "Content-Type": "application/json",
+                "Content-Length": "999",
+            },
+            "content length",
+        ),
+    ],
+)
+def test_default_transport_rejects_unsafe_response_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+    headers: dict[str, str],
+    message: str,
+) -> None:
+    response = _FakeResponse(_response(), headers=headers)
+    monkeypatch.setattr(alpha_vantage_client, "_HTTP_OPENER", _FakeOpener(response))
+
+    with pytest.raises(IngestionError, match=message):
+        fetch_alpha_vantage_daily_events(
+            symbol="IBM",
+            api_key="sentinel-secret",
+            max_response_bytes=4096,
+        )
+
+    assert response.closed is True
+
+
+def test_invalid_content_length_does_not_leak_reflected_value(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    response = _FakeResponse(
+        _response(),
+        headers={
+            "Content-Type": "application/json",
+            "Content-Length": "sentinel-secret",
+        },
+    )
+    monkeypatch.setattr(alpha_vantage_client, "_HTTP_OPENER", _FakeOpener(response))
+
+    with pytest.raises(IngestionError) as error:
+        fetch_alpha_vantage_daily_events(
+            symbol="IBM",
+            api_key="test-secret",
+            max_retries=0,
+        )
+
+    rendered = "".join(
+        traceback.format_exception(type(error.value), error.value, error.value.__traceback__)
+    )
+    assert "sentinel-secret" not in str(error.value)
+    assert "sentinel-secret" not in repr(error.value)
+    assert "sentinel-secret" not in rendered
+    assert error.value.__context__ is None
+
+
+def test_default_transport_enforces_streamed_monotonic_guard(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    payload = _response()
+    response = _FakeResponse(
+        payload,
+        headers={
+            "Content-Type": "application/json",
+            "Content-Length": str(len(payload)),
+        },
+    )
+    monkeypatch.setattr(alpha_vantage_client, "_HTTP_OPENER", _FakeOpener(response))
+    clock = iter([0.0, 4.0])
+    monkeypatch.setattr(alpha_vantage_client.time, "monotonic", lambda: next(clock))
+
+    with pytest.raises(IngestionError, match="time limit"):
+        fetch_alpha_vantage_daily_events(
+            symbol="IBM",
+            api_key="test-secret",
+            timeout_seconds=3.0,
+            max_retries=0,
+        )
+
+    assert response.closed is True
+
+
+def test_default_opener_disables_proxy_environment_and_redirects() -> None:
+    proxy_handlers = [
+        handler
+        for handler in alpha_vantage_client._HTTP_OPENER.handlers
+        if isinstance(handler, alpha_vantage_client.ProxyHandler)
+    ]
+    redirect_handlers = [
+        handler
+        for handler in alpha_vantage_client._HTTP_OPENER.handlers
+        if isinstance(handler, alpha_vantage_client._RejectRedirects)
+    ]
+
+    # ProxyHandler({}) removes the environment-backed default and registers no
+    # proxy protocol handlers, so none remains in the built opener.
+    assert proxy_handlers == []
+    assert len(redirect_handlers) == 1
+    assert (
+        redirect_handlers[0].redirect_request(
+            alpha_vantage_client.Request("https://www.alphavantage.co/query"),
+            None,
+            302,
+            "redirect",
+            {},
+            "https://example.com/steal",
+        )
+        is None
+    )
+
+
+def test_fetch_rejects_invalid_key_before_transport() -> None:
+    called = False
+
+    def transport(url: str, timeout_seconds: float, max_bytes: int) -> bytes:
+        nonlocal called
+        called = True
+        return _response()
+
+    with pytest.raises(IngestionError, match="invalid format"):
+        fetch_alpha_vantage_daily_events(
+            symbol="IBM",
+            api_key="secret with spaces",
+            transport=transport,
+        )
+
+    assert called is False
+
+
+@pytest.mark.parametrize(
+    "options",
+    [
+        {"max_records": 0},
+        {
+            "start_date": date(2025, 1, 2),
+            "end_date": date(2025, 1, 1),
+        },
+        {"ingested_at": datetime(2025, 1, 4)},
+    ],
+)
+def test_fetch_rejects_invalid_local_options_before_transport(
+    options: dict[str, object],
+) -> None:
+    called = False
+
+    def transport(url: str, timeout_seconds: float, max_bytes: int) -> bytes:
+        nonlocal called
+        called = True
+        return _response()
+
+    with pytest.raises(IngestionError):
+        fetch_alpha_vantage_daily_events(
+            symbol="IBM",
+            api_key="test-secret",
+            transport=transport,
+            **options,  # type: ignore[arg-type]
+        )
+
+    assert called is False
+
+
+@pytest.mark.parametrize("api_key", ["", "   ", "secret\x00value"])
+def test_fetch_rejects_missing_or_control_character_key_before_transport(api_key: str) -> None:
+    called = False
+
+    def transport(url: str, timeout_seconds: float, max_bytes: int) -> bytes:
+        nonlocal called
+        called = True
+        return _response()
+
+    with pytest.raises(IngestionError):
+        fetch_alpha_vantage_daily_events(
+            symbol="IBM",
+            api_key=api_key,
+            transport=transport,
+        )
+
+    assert called is False
+
+
+def test_parse_rejects_boolean_record_limit_and_volume_overflow() -> None:
+    with pytest.raises(IngestionError, match="max_records"):
+        parse_alpha_vantage_daily_response(
+            _response(),
+            symbol="IBM",
+            ingested_at=datetime(2025, 1, 4, tzinfo=timezone.utc),
+            max_records=True,
+        )
+
+    with pytest.raises(IngestionError, match="non-negative whole number"):
+        parse_alpha_vantage_daily_response(
+            _response(first_volume="9223372036854775808"),
+            symbol="IBM",
+            ingested_at=datetime(2025, 1, 4, tzinfo=timezone.utc),
+            start_date=date(2025, 1, 3),
+        )
+
+
+def test_parse_rejects_naive_ingest_timestamp_and_symbol_mismatch() -> None:
+    with pytest.raises(IngestionError, match="timezone"):
+        parse_alpha_vantage_daily_response(
+            _response(),
+            symbol="IBM",
+            ingested_at=datetime(2025, 1, 4),
+        )
+
+    with pytest.raises(IngestionError, match="does not match"):
+        parse_alpha_vantage_daily_response(
+            _response(symbol="MSFT"),
+            symbol="IBM",
+            ingested_at=datetime(2025, 1, 4, tzinfo=timezone.utc),
+        )
+
+
+def test_parse_sanitizes_pathologically_nested_json() -> None:
+    nested = b"[" * 1_200 + b"0" + b"]" * 1_200
+    payload = b'{"ignored":' + nested + b"}"
+
+    with pytest.raises(IngestionError, match="valid UTF-8 JSON"):
+        parse_alpha_vantage_daily_response(
+            payload,
+            symbol="IBM",
+            ingested_at=datetime(2025, 1, 4, tzinfo=timezone.utc),
+        )


### PR DESCRIPTION
## Arc42 module

Primary building block: `ingestion`.

This PR adds a pure Alpha Vantage `TIME_SERIES_DAILY` client/parser. It deliberately stops at the existing provider-neutral `MarketEvent` contract: it does not write raw data, alter orchestration, add credentials, schedule polling, or change deployment.

## Context and scope

The current deployed command can fall back to fixed sample events when no input is supplied. This change establishes the source-adapter foundation without connecting that fallback-prone path yet.

Existing interfaces crossed:

- `src.common.exceptions.IngestionError` for a sanitized adapter failure contract
- `src.processing.normaliser.normalize_symbol` for the existing symbol convention
- `src.ingestion.schemas.MarketEvent` for provider-neutral output

## Building blocks

- Fixed-host HTTPS downloader with ambient proxies disabled, redirects rejected, response metadata checks, streamed size limits, socket timeout plus a monotonic read guard, and bounded retry classes.
- Strict Alpha Vantage compact-daily parser with duplicate-key/deep-JSON rejection, exact ASCII symbol/date validation, provider-symbol matching, and full OHLCV validation.
- Stable logical event IDs derived from provider, function, symbol, and trading date.
- One injected UTC ingest timestamp per batch; the provider's daily date is anchored to UTC midnight as a deterministic convention, not represented as market close time.
- Close price maps to the current `MarketEvent.price`; open/high/low are validated but not retained by the existing event schema.

Runtime sequence:

`caller -> validate local options -> fixed Alpha Vantage request -> validate transport envelope -> validate full payload -> ordered MarketEvent batch`

## Cross-cutting safeguards

- The API key is required as a function input for now and is never logged or included in public errors.
- Provider-reflected URLs, payload values, and low-level exception contexts are suppressed at the error boundary.
- Invalid local options fail before transport, preserving provider request quota.
- CI tests use injected transports and fake responses; no live HTTP call is made.
- Successful downstream storage and idempotency claims remain outside this PR.

## History repair

The original branch was stacked on `agent/document-arc42-modules`, whose documentation changes have since been merged into `main`. The adapter was rebuilt on current `main` without carrying obsolete stack history.

Current head: `f7389f950fb6f60da7904e07baaf4c962384c9d0`

- one commit ahead of `main`
- zero commits behind
- exactly two added paths
- `src/ingestion/alpha_vantage_client.py`: 380 lines
- `tests/unit/ingestion/test_alpha_vantage_client.py`: 636 lines

The two file blobs are unchanged from the previously reviewed adapter branch.

## Fresh validation

GitHub Actions run `32192118344` (`ci` run 157) passed on the repaired head:

- Security guardrails: passed
- Python readiness: passed
  - dependency installation
  - `make quality-check`
  - `make readiness-check`
- Infrastructure validation: passed
  - `make infrastructure-check`

The earlier adapter-head run also passed all three jobs.

## Cohesion rationale

The 1,016-line diff exceeds the normal 200–500-line review heuristic because the 380-line security-boundary implementation and its 636-line adversarial test matrix form one atomic adapter contract. Splitting them would leave either unverified transport behavior or tests without their implementation.

## Deferred modules

- `storage`: define event-key-aware replay and provider-correction behavior before polling can claim raw idempotency
- `orchestration`: add explicit file, sample, and API source selection with no implicit sample fallback
- `deployment`: secret wiring, controlled egress, durable storage, and a quota-safe schedule

## Human gate

This PR remains draft. Acceptance, merge, and deployment remain **PENDING** until the engineer has reviewed and explicitly accepted the final two-file diff.