### PR TITLE
Enforce raw event identity

### DIFF
--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -82,9 +82,34 @@ The project uses stable keys to make re-runs safe:
 | `risk_summary` | Re-loading the same `(symbol, ts_ingest)` updates the serving summary. |
 | `external_signal_summary` | Re-loading the same `(name, source, latest_signal_id)` updates that latest-signal row. |
 
-The parquet writer also uses a deterministic content hash for batch filenames.
-That prevents the same batch content from being written repeatedly to the same
-partition.
+Raw parquet uses `event_id` as the global logical key, matching processing and
+the warehouse. Before publication, the local writer inventories existing raw
+parquet under a dataset-wide lock. It compares `source`, `symbol`, `price`,
+`volume` and UTC `ts_event`, while treating `ts_ingest` as arrival metadata:
+
+1. The same fact with a later `ts_ingest` is a replay. It writes nothing and
+   preserves the first accepted timestamp and partition.
+2. Changed persisted business data under the same key is a correction conflict.
+   The whole write call stops before publishing any new rows.
+3. Existing duplicate keys or unreadable/incompatible raw files block further
+   publication until an operator repairs or migrates the local dataset.
+
+Inventory requires the seven named columns and compatible physical Parquet
+types: strings for IDs/source, double-precision price, integer volume, and
+DuckDB microsecond timestamp event/ingest columns. Microsecond-aligned legacy
+nanosecond columns are accepted because Python's existing input contract cannot
+carry finer precision; compatible timezone-naive timestamps are interpreted as
+UTC. Integer, decimal or single-precision physical price columns, coarse or
+submicrosecond timestamps, and string-encoded numeric or timestamp columns fail
+closed rather than being lossily coerced. UTF-8 field/call/dataset bounds are
+checked before publication and before inventory rows enter Python. Local safety
+caps also apply prospectively to the Parquet count, filesystem entries,
+physical bytes and rows that the next inventory can read. The dataset lock
+waits for at most five seconds.
+
+Curated parquet continues to use deterministic content hashes for batch
+filenames. All final parquet files are staged and published with atomic
+no-overwrite creation on the local filesystem.
 
 ## Curated Outputs
 
@@ -113,6 +138,18 @@ partition.
 5. `external_signal_summary` stores latest signal rows with `latest_signal_id`
    in the key. That is useful for retaining a small history of latest
    observations, but it is not a strict current-state table.
+6. Raw correction detection covers the persisted `MarketEvent` fields. A
+   provider-only change to open, high or low is not visible because the current
+   validated raw contract retains close as `price` and does not land the full
+   provider response.
+7. Raw inventory and locking are deliberately local and linear. A larger or
+   distributed implementation would use a table format, manifest or key index
+   with transactional coordination rather than scanning parquet under POSIX
+   `flock`.
+8. Raw first-seen identity is enforced for local parquet publication. The
+   PostgreSQL raw loader still has its existing `ON CONFLICT DO UPDATE`
+   contract; changing warehouse correction policy requires a separate
+   warehouse-owned change and migration decision.
 
 ## External Signal Summary
 

--- a/docs/failure-scenarios.md
+++ b/docs/failure-scenarios.md
@@ -44,8 +44,10 @@ Current behaviour:
 1. Records are validated before deduplication.
 2. The pipeline deduplicates by `event_id`.
 3. Duplicate count and duplicate rate are emitted as data quality metrics.
-4. Stable storage file names keep replayed writes from creating duplicate
-   parquet files.
+4. Under a local dataset lock, raw storage inventories the global `event_id`
+   keys before publication.
+5. A previously stored business fact is skipped even when the replay has a
+   later `ts_ingest`; the first accepted raw timestamp remains authoritative.
 
 Trade-off:
 
@@ -60,6 +62,42 @@ src/processing/deduplicator.py
 src/storage/s3_writer.py
 tests/integration/test_s3_writer.py
 tests/unit/test_data_quality.py
+```
+
+## Source Correction Under An Existing Event ID
+
+Scenario:
+
+A provider reuses an `event_id` but changes `source`, `symbol`, `price`,
+`volume`, or `ts_event`.
+
+Current behaviour:
+
+1. The raw writer validates the full incoming call and inventories existing raw
+   parquet while holding its dataset-wide local lock.
+2. It excludes only `ts_ingest` from business equality.
+3. A changed persisted field raises a sanitized `RawEventConflictError` before
+   any new row from that call is published.
+4. The first accepted parquet row is never overwritten and no automatic winner
+   or quarantine version is selected.
+5. If a process stops after atomic publication but before private staging-link
+   cleanup, the next raw write validates and removes that recognised staging
+   link under the dataset lock before inventorying the final file.
+
+Trade-off:
+
+This is a conservative first-seen policy. It prevents two active facts and
+forces an explicit correction decision, but it is not a versioned correction
+journal. The local lock waits for at most five seconds and inventory has bounded
+file, byte and row limits. Open/high/low-only provider changes are outside this
+check because the current raw event schema validates those Alpha Vantage values
+but retains only close as `price`.
+
+Evidence:
+
+```text
+src/storage/raw_event_writer.py
+tests/integration/test_s3_writer.py
 ```
 
 ## Schema Or Value Drift
@@ -158,8 +196,8 @@ Current behaviour:
 1. Resume state is written after each successful partition.
 2. A normal rerun skips already successful windows.
 3. A forced rerun can replay the window range again.
-4. Deterministic writes mean a forced rerun does not duplicate existing raw or
-   curated files.
+4. Raw `event_id` inventory and curated content hashes mean a forced rerun does
+   not duplicate existing facts or curated files.
 
 Trade-off:
 

--- a/src/common/exceptions.py
+++ b/src/common/exceptions.py
@@ -10,5 +10,9 @@ class StorageError(Exception):
     pass
 
 
+class RawEventConflictError(StorageError):
+    pass
+
+
 class OverlapError(Exception):
     pass

--- a/src/orchestration/backfill.py
+++ b/src/orchestration/backfill.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 from datetime import datetime, timedelta, timezone
+from decimal import Decimal
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import Any
@@ -18,7 +19,26 @@ _HOURLY_WINDOW_ALIASES = {"hourly", "hour", "1h"}
 _DEFAULT_THRESHOLDS_PATH = Path("config/risk_thresholds.yaml")
 _DEFAULT_STORAGE_CONFIG_PATH = Path("config/storage.yaml")
 _REPLAY_COLUMNS = ["event_id", "symbol", "price", "volume", "ts_event", "ts_ingest", "source"]
+_REPLAY_TIMESTAMP_COLUMNS = {"ts_event", "ts_ingest"}
 _RESUME_STATE_PATH = Path(".orchestration_state/backfill_resume.json")
+_UTC_EPOCH = datetime(1970, 1, 1, tzinfo=timezone.utc)
+
+
+def _json_replay_value(value: Any) -> Any:
+    if isinstance(value, datetime):
+        return value.isoformat()
+    if isinstance(value, Decimal):
+        return float(value)
+    return value
+
+
+def _timestamp_from_epoch_microseconds(value: Any) -> datetime:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise ValueError("Raw backfill timestamp is not an epoch-microsecond integer")
+    try:
+        return _UTC_EPOCH + timedelta(microseconds=value)
+    except (OverflowError, TypeError, ValueError):
+        raise ValueError("Raw backfill timestamp is outside the supported range") from None
 
 
 def _normalize_window(window: str) -> str:
@@ -51,15 +71,32 @@ def _load_partition_records(partition_dir: Path) -> list[dict[str, Any]]:
 
     escaped_paths = [str(path).replace("'", "''") for path in parquet_files]
     quoted_paths = ", ".join(f"'{path}'" for path in escaped_paths)
-    select_list = ", ".join(_REPLAY_COLUMNS)
+    select_list = ", ".join(
+        f"epoch_us({column}) AS {column}"
+        if column in _REPLAY_TIMESTAMP_COLUMNS
+        else column
+        for column in _REPLAY_COLUMNS
+    )
     with duckdb.connect() as conn:
-        df = conn.execute(
+        cursor = conn.execute(
             "SELECT "
             f"{select_list} "
             f"FROM read_parquet([{quoted_paths}], union_by_name=true) "
             "ORDER BY ts_ingest, event_id"
-        ).df()
-    return json.loads(df.to_json(orient="records", date_format="iso"))
+        )
+        rows = cursor.fetchall()
+        columns = [description[0] for description in cursor.description]
+    return [
+        {
+            column: _json_replay_value(
+                _timestamp_from_epoch_microseconds(value)
+                if column in _REPLAY_TIMESTAMP_COLUMNS
+                else value
+            )
+            for column, value in zip(columns, row, strict=True)
+        }
+        for row in rows
+    ]
 
 
 def _load_resume_state(path: Path) -> dict[str, Any]:

--- a/src/storage/parquet_io.py
+++ b/src/storage/parquet_io.py
@@ -51,7 +51,12 @@ def _fsync_directory(path: Path) -> None:
         os.close(directory_fd)
 
 
-def create_parquet_file(records: list[dict[str, Any]], target_path: Path) -> bool:
+def create_parquet_file(
+    records: list[dict[str, Any]],
+    target_path: Path,
+    *,
+    maximum_bytes: int | None = None,
+) -> bool:
     """Publish without replacement; an fsync error may leave a valid final link."""
 
     target_path.parent.mkdir(parents=True, exist_ok=True)
@@ -93,6 +98,9 @@ def create_parquet_file(records: list[dict[str, Any]], target_path: Path) -> boo
             stored_count = int(count_row[0])
         if stored_columns != list(frame.columns) or stored_count != len(records):
             raise StorageError("Staged parquet output failed validation")
+        staged_bytes = temporary_path.stat().st_size
+        if maximum_bytes is not None and staged_bytes > maximum_bytes:
+            raise StorageError("Staged parquet output exceeds its publication byte limit")
         temporary_path.chmod(0o600)
         with temporary_path.open("rb") as handle:
             os.fsync(handle.fileno())

--- a/src/storage/raw_event_writer.py
+++ b/src/storage/raw_event_writer.py
@@ -1,0 +1,1018 @@
+from __future__ import annotations
+
+import fcntl
+import hashlib
+import json
+import math
+import os
+import re
+import stat
+import time
+from collections.abc import Iterator
+from contextlib import contextmanager
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from decimal import Decimal, InvalidOperation
+from pathlib import Path
+from typing import Any
+
+import duckdb
+
+from ..common.exceptions import RawEventConflictError, StorageError
+from .parquet_io import batch_file_name, create_parquet_file
+from .partitioning import partition_path
+
+RAW_EVENT_FIELDS = (
+    "event_id",
+    "symbol",
+    "price",
+    "volume",
+    "ts_event",
+    "ts_ingest",
+    "source",
+)
+BUSINESS_FIELDS = (
+    "event_id",
+    "symbol",
+    "price",
+    "volume",
+    "ts_event",
+    "source",
+)
+MAX_SIGNED_64_BIT = 9_223_372_036_854_775_807
+LOCK_FILE_NAME = ".raw-write.lock"
+LOCK_TIMEOUT_SECONDS = 5.0
+MAX_INVENTORY_FILES = 10_000
+MAX_INVENTORY_ENTRIES = 60_000
+MAX_STAGING_DIRECTORIES = 100
+MAX_INVENTORY_BYTES = 2_000_000_000
+MAX_FILE_BYTES = 250_000_000
+MAX_ROWS_PER_FILE = 100_000
+MAX_INVENTORY_ROWS = 1_000_000
+MAX_INPUT_RECORDS = 100_000
+MAX_TEXT_FIELD_BYTES = 65_536
+MAX_SCALAR_TEXT_BYTES = 4_096
+MAX_INPUT_TEXT_BYTES = 16_000_000
+MAX_INVENTORY_TEXT_BYTES = 512_000_000
+BATCH_FILE_PATTERN = re.compile(r"^batch_[0-9a-f]{16}\.parquet$")
+PARTITION_PATTERN = re.compile(
+    r"^year=([0-9]{1,4})/month=([0-9]{2})/day=([0-9]{2})/hour=([0-9]{2})$"
+)
+STAGING_DIRECTORY_PREFIX = ".parquet-stage-"
+STAGING_PAYLOAD_NAME = "payload.tmp"
+UTC_EPOCH = datetime(1970, 1, 1, tzinfo=timezone.utc)
+
+_STRING_FIELDS = {"event_id", "symbol", "source"}
+_INTEGER_TYPES = {
+    "TINYINT",
+    "SMALLINT",
+    "INTEGER",
+    "BIGINT",
+    "HUGEINT",
+    "UTINYINT",
+    "USMALLINT",
+    "UINTEGER",
+    "UBIGINT",
+    "UHUGEINT",
+}
+
+
+@dataclass(frozen=True)
+class _PreparedRawEvent:
+    record: dict[str, Any]
+    key_digest: str
+    business_fingerprint: str
+    text_bytes: int
+    input_text_bytes: int
+
+
+@dataclass(frozen=True)
+class _RawInventory:
+    events: dict[str, _PreparedRawEvent]
+    file_count: int
+    entry_count: int
+    total_bytes: int
+    total_text_bytes: int
+    row_count: int
+
+
+def _text(value: Any, *, field_name: str) -> str:
+    if not isinstance(value, str):
+        raise StorageError(f"Raw event {field_name} must be a string")
+    if len(value) > MAX_TEXT_FIELD_BYTES:
+        raise StorageError(f"Raw event {field_name} exceeds the local UTF-8 byte limit")
+    utf8_compatible = True
+    encoded: bytes | None = None
+    try:
+        encoded = value.encode("utf-8")
+    except UnicodeEncodeError:
+        utf8_compatible = False
+    if not utf8_compatible:
+        raise StorageError(f"Raw event {field_name} must contain valid UTF-8 text")
+    assert encoded is not None
+    if len(encoded) > MAX_TEXT_FIELD_BYTES:
+        raise StorageError(f"Raw event {field_name} exceeds the local UTF-8 byte limit")
+    return value
+
+
+def _bounded_scalar_text(value: str, *, field_name: str) -> None:
+    if len(value) > MAX_SCALAR_TEXT_BYTES:
+        raise StorageError(f"Raw event {field_name} exceeds the local scalar byte limit")
+    encoded: bytes | None = None
+    try:
+        encoded = value.encode("utf-8")
+    except UnicodeEncodeError:
+        pass
+    if encoded is None or len(encoded) > MAX_SCALAR_TEXT_BYTES:
+        raise StorageError(f"Raw event {field_name} exceeds the local scalar byte limit")
+
+
+def _utc_datetime(value: Any, *, field_name: str) -> datetime:
+    parsed: datetime | None = None
+    if isinstance(value, datetime):
+        parsed = value
+    elif isinstance(value, str):
+        _bounded_scalar_text(value, field_name=field_name)
+        try:
+            parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        except (OverflowError, ValueError):
+            pass
+    if parsed is None:
+        raise StorageError(f"Raw event {field_name} must be an ISO-8601 datetime")
+
+    offset_known: bool | None = None
+    try:
+        offset_known = parsed.tzinfo is not None and parsed.utcoffset() is not None
+    except Exception:
+        pass
+    if offset_known is None:
+        raise StorageError(f"Raw event {field_name} has an invalid timezone")
+    if not offset_known:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    converted: datetime | None = None
+    try:
+        converted = parsed.astimezone(timezone.utc)
+    except Exception:
+        pass
+    if converted is None:
+        raise StorageError(f"Raw event {field_name} is outside the supported UTC range")
+    return converted
+
+
+def _datetime_from_epoch_microseconds(value: Any, *, field_name: str) -> datetime:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise StorageError(f"Existing raw parquet {field_name} is not a timestamp")
+    converted: datetime | None = None
+    try:
+        converted = UTC_EPOCH + timedelta(microseconds=value)
+    except (OverflowError, TypeError, ValueError):
+        pass
+    if converted is None:
+        raise StorageError(f"Existing raw parquet {field_name} is outside the supported range")
+    return converted
+
+
+def _price(value: Any) -> float:
+    if isinstance(value, bool):
+        raise StorageError("Raw market event price must not be a boolean")
+    if not isinstance(value, (Decimal, float, int, str)):
+        raise StorageError("Raw market event price must be numeric")
+    if isinstance(value, str):
+        _bounded_scalar_text(value, field_name="price")
+    parsed: float | None = None
+    try:
+        parsed = float(value)
+    except (OverflowError, TypeError, ValueError):
+        pass
+    if parsed is None or not math.isfinite(parsed) or parsed <= 0:
+        raise StorageError("Raw market event price must be finite and greater than zero")
+    return parsed
+
+
+def _volume(value: Any) -> int:
+    if isinstance(value, bool):
+        raise StorageError("Raw market event volume must not be a boolean")
+    if not isinstance(value, (Decimal, float, int, str)):
+        raise StorageError("Raw market event volume must be an integer")
+    if isinstance(value, str):
+        _bounded_scalar_text(value, field_name="volume")
+    parsed: int | None = value if isinstance(value, int) else None
+    if parsed is None:
+        candidate: Decimal | None = None
+        try:
+            candidate = Decimal(str(value))
+        except (InvalidOperation, TypeError, ValueError):
+            pass
+        if (
+            candidate is not None
+            and candidate.is_finite()
+            and Decimal(0) <= candidate <= Decimal(MAX_SIGNED_64_BIT)
+        ):
+            integral = candidate.to_integral_value()
+            if candidate == integral:
+                parsed = int(integral)
+    if parsed is None or parsed < 0 or parsed > MAX_SIGNED_64_BIT:
+        raise StorageError(
+            "Raw market event volume must fit a non-negative signed 64-bit integer"
+        )
+    return parsed
+
+
+def _canonical_record(record: dict[str, Any]) -> dict[str, Any]:
+    if set(record) != set(RAW_EVENT_FIELDS):
+        raise StorageError("Raw market event must contain exactly the seven contract fields")
+
+    return {
+        "event_id": _text(record["event_id"], field_name="event_id"),
+        "symbol": _text(record["symbol"], field_name="symbol"),
+        "price": _price(record["price"]),
+        "volume": _volume(record["volume"]),
+        "ts_event": _utc_datetime(record["ts_event"], field_name="ts_event"),
+        "ts_ingest": _utc_datetime(record["ts_ingest"], field_name="ts_ingest"),
+        "source": _text(record["source"], field_name="source"),
+    }
+
+
+def _business_fingerprint(record: dict[str, Any]) -> str:
+    business_record = {
+        field: (
+            record[field].isoformat()
+            if isinstance(record[field], datetime)
+            else record[field]
+        )
+        for field in BUSINESS_FIELDS
+    }
+    payload = json.dumps(
+        business_record,
+        allow_nan=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def _prepare_record(record: dict[str, Any]) -> _PreparedRawEvent:
+    canonical = _canonical_record(record)
+    key_digest = hashlib.sha256(canonical["event_id"].encode("utf-8")).hexdigest()
+    return _PreparedRawEvent(
+        record=canonical,
+        key_digest=key_digest,
+        business_fingerprint=_business_fingerprint(canonical),
+        text_bytes=sum(
+            len(canonical[field].encode("utf-8")) for field in _STRING_FIELDS
+        ),
+        input_text_bytes=sum(
+            len(value.encode("utf-8"))
+            for value in record.values()
+            if isinstance(value, str)
+        ),
+    )
+
+
+def _conflict(message: str, key_digest: str) -> RawEventConflictError:
+    return RawEventConflictError(f"{message} for raw event key {key_digest[:12]}")
+
+
+def _prepare_incoming(records: list[dict[str, Any]]) -> dict[str, _PreparedRawEvent]:
+    if len(records) > MAX_INPUT_RECORDS:
+        raise StorageError("Raw input exceeds the supported local record limit")
+    prepared: dict[str, _PreparedRawEvent] = {}
+    prepared_text_bytes = 0
+    for record in records:
+        candidate = _prepare_record(record)
+        prepared_text_bytes += candidate.input_text_bytes
+        if prepared_text_bytes > MAX_INPUT_TEXT_BYTES:
+            raise StorageError("Raw input exceeds the local UTF-8 byte limit")
+        event_id = candidate.record["event_id"]
+        current = prepared.get(event_id)
+        if current is None:
+            prepared[event_id] = candidate
+            continue
+        if current.business_fingerprint != candidate.business_fingerprint:
+            raise _conflict("Incoming batch contains conflicting versions", candidate.key_digest)
+        if candidate.record["ts_ingest"] < current.record["ts_ingest"]:
+            prepared[event_id] = candidate
+    return prepared
+
+
+def _validate_partition(partition: str) -> None:
+    match = PARTITION_PATTERN.fullmatch(partition)
+    if match is None:
+        raise StorageError("Raw parquet file is outside the hourly partition layout")
+    year, month, day, hour = (int(value) for value in match.groups())
+    valid = True
+    try:
+        datetime(year, month, day, hour, tzinfo=timezone.utc)
+    except ValueError:
+        valid = False
+    if not valid:
+        raise StorageError("Raw parquet file has an invalid hourly partition")
+
+
+def _metadata(path: Path, *, message: str) -> os.stat_result:
+    metadata: os.stat_result | None = None
+    try:
+        metadata = path.lstat()
+    except OSError:
+        pass
+    if metadata is None:
+        raise StorageError(message)
+    return metadata
+
+
+def _resolved(path: Path, *, strict: bool, message: str) -> Path:
+    resolved: Path | None = None
+    try:
+        resolved = path.resolve(strict=strict)
+    except (OSError, RuntimeError, ValueError):
+        pass
+    if resolved is None:
+        raise StorageError(message)
+    return resolved
+
+
+def _is_beneath(candidate: Path, parent: Path, *, allow_equal: bool = False) -> bool:
+    relative: Path | None = None
+    try:
+        relative = candidate.relative_to(parent)
+    except ValueError:
+        pass
+    if relative is None:
+        return False
+    return allow_equal or relative != Path(".")
+
+
+def _filesystem_owner_is_current(metadata: os.stat_result) -> bool:
+    return not hasattr(os, "getuid") or metadata.st_uid == os.getuid()
+
+
+def _lexical_absolute(path: Path, *, message: str) -> Path:
+    absolute: Path | None = None
+    try:
+        absolute = Path(os.path.abspath(path))
+    except (OSError, ValueError):
+        pass
+    if absolute is None:
+        raise StorageError(message)
+    return absolute
+
+
+def _assert_no_symlink_components(
+    candidate: Path,
+    parent: Path,
+    *,
+    allow_equal: bool = False,
+) -> None:
+    candidate_absolute = _lexical_absolute(
+        candidate,
+        message="Raw path could not be normalised",
+    )
+    parent_absolute = _lexical_absolute(
+        parent,
+        message="Raw path boundary could not be normalised",
+    )
+    if not _is_beneath(candidate_absolute, parent_absolute, allow_equal=allow_equal):
+        raise StorageError("Raw path escaped its configured lexical boundary")
+    relative = candidate_absolute.relative_to(parent_absolute)
+    current = parent_absolute
+    for part in relative.parts:
+        current /= part
+        metadata: os.stat_result | None = None
+        metadata_failed = False
+        try:
+            metadata = current.lstat()
+        except FileNotFoundError:
+            break
+        except OSError:
+            metadata_failed = True
+        if metadata_failed:
+            raise StorageError("Raw path metadata is unreadable")
+        assert metadata is not None
+        if stat.S_ISLNK(metadata.st_mode):
+            raise StorageError("Raw path must not contain symbolic links")
+
+
+def _remove_recoverable_staging_directory(path: Path) -> None:
+    directory_metadata = _metadata(
+        path,
+        message="Raw parquet staging metadata is unreadable",
+    )
+    if (
+        not stat.S_ISDIR(directory_metadata.st_mode)
+        or stat.S_IMODE(directory_metadata.st_mode) != 0o700
+        or not _filesystem_owner_is_current(directory_metadata)
+    ):
+        raise StorageError("Raw parquet staging directory has an unsafe owner or type")
+
+    entries: list[os.DirEntry[str]] | None = None
+    try:
+        with os.scandir(path) as iterator:
+            entries = list(iterator)
+    except OSError:
+        pass
+    if entries is None:
+        raise StorageError("Raw parquet staging directory is unreadable")
+    if len(entries) > 1 or (entries and entries[0].name != STAGING_PAYLOAD_NAME):
+        raise StorageError("Raw parquet staging directory contains unmanaged content")
+
+    if entries:
+        payload = path / STAGING_PAYLOAD_NAME
+        payload_metadata = _metadata(
+            payload,
+            message="Raw parquet staging payload metadata is unreadable",
+        )
+        if (
+            not stat.S_ISREG(payload_metadata.st_mode)
+            or payload_metadata.st_nlink not in {1, 2}
+            or not _filesystem_owner_is_current(payload_metadata)
+        ):
+            raise StorageError("Raw parquet staging payload has an unsafe owner or type")
+
+        if payload_metadata.st_nlink == 2:
+            matching_finals = 0
+            siblings: list[os.DirEntry[str]] | None = None
+            try:
+                with os.scandir(path.parent) as iterator:
+                    siblings = list(iterator)
+            except OSError:
+                pass
+            if siblings is None:
+                raise StorageError("Raw parquet staging parent is unreadable")
+            for sibling in siblings:
+                if BATCH_FILE_PATTERN.fullmatch(sibling.name) is None:
+                    continue
+                final_metadata = _metadata(
+                    path.parent / sibling.name,
+                    message="Raw parquet recovery target metadata is unreadable",
+                )
+                if (
+                    stat.S_ISREG(final_metadata.st_mode)
+                    and final_metadata.st_dev == payload_metadata.st_dev
+                    and final_metadata.st_ino == payload_metadata.st_ino
+                    and final_metadata.st_nlink == 2
+                    and stat.S_IMODE(final_metadata.st_mode) == 0o600
+                    and _filesystem_owner_is_current(final_metadata)
+                ):
+                    matching_finals += 1
+            if matching_finals != 1:
+                raise StorageError("Raw parquet staging link has no unique managed final file")
+
+        removed_payload = False
+        try:
+            payload.unlink()
+            removed_payload = True
+        except OSError:
+            pass
+        if not removed_payload:
+            raise StorageError("Raw parquet staging payload could not be recovered")
+
+    removed_directory = False
+    try:
+        path.rmdir()
+        removed_directory = True
+    except OSError:
+        pass
+    if not removed_directory:
+        raise StorageError("Raw parquet staging directory could not be recovered")
+
+
+def _recover_private_staging(root: Path) -> None:
+    walk_failed = False
+    entry_count = 0
+    staging_count = 0
+
+    def record_walk_error(error: OSError) -> None:
+        nonlocal walk_failed
+        walk_failed = True
+
+    for current_root, directory_names, file_names in os.walk(
+        root,
+        topdown=True,
+        followlinks=False,
+        onerror=record_walk_error,
+    ):
+        staging_names = [
+            name for name in directory_names if name.startswith(STAGING_DIRECTORY_PREFIX)
+        ]
+        staging_count += len(staging_names)
+        if staging_count > MAX_STAGING_DIRECTORIES:
+            raise StorageError("Raw dataset exceeds the private staging recovery limit")
+        entry_count += len(directory_names) - len(staging_names) + len(file_names)
+        if entry_count > MAX_INVENTORY_ENTRIES:
+            raise StorageError("Raw dataset exceeds the supported local entry count")
+        current = Path(current_root)
+        directory_names[:] = [name for name in directory_names if name not in staging_names]
+        for name in staging_names:
+            _remove_recoverable_staging_directory(current / name)
+    if walk_failed:
+        raise StorageError("Raw parquet staging inventory cannot be traversed")
+
+
+def _compatible_physical_type(
+    field_name: str,
+    physical_type: str,
+    parquet_converted_type: str | None,
+) -> bool:
+    normalized = physical_type.upper()
+    if field_name in _STRING_FIELDS:
+        return normalized == "VARCHAR"
+    if field_name == "price":
+        return normalized == "DOUBLE"
+    if field_name == "volume":
+        return normalized in _INTEGER_TYPES
+    if field_name in {"ts_event", "ts_ingest"}:
+        return (
+            normalized in {"TIMESTAMP", "TIMESTAMP WITH TIME ZONE"}
+            and parquet_converted_type == "TIMESTAMP_MICROS"
+        ) or (
+            normalized == "TIMESTAMP_NS" and parquet_converted_type is None
+        )
+    return False
+
+
+def _assert_safe_tree(root: Path) -> tuple[list[Path], int, int]:
+    parquet_files: list[Path] = []
+    inventory_bytes = 0
+    entry_count = 0
+
+    walk_failed = False
+
+    def record_walk_error(error: OSError) -> None:
+        nonlocal walk_failed
+        walk_failed = True
+
+    for current_root, directory_names, file_names in os.walk(
+        root,
+        followlinks=False,
+        onerror=record_walk_error,
+    ):
+        entry_count += len(directory_names) + len(file_names)
+        if entry_count > MAX_INVENTORY_ENTRIES:
+            raise StorageError("Raw dataset exceeds the supported local entry count")
+        current = Path(current_root)
+        for name in [*directory_names, *file_names]:
+            candidate = current / name
+            metadata = _metadata(
+                candidate,
+                message="Raw parquet inventory metadata is unreadable",
+            )
+            if stat.S_ISLNK(metadata.st_mode):
+                raise StorageError("Raw dataset must not contain symbolic links")
+        for name in file_names:
+            if Path(name).suffix != ".parquet":
+                continue
+            candidate = current / name
+            metadata = _metadata(
+                candidate,
+                message="Raw parquet inventory metadata is unreadable",
+            )
+            if not stat.S_ISREG(metadata.st_mode) or metadata.st_nlink != 1:
+                raise StorageError("Raw parquet inventory must contain regular unlinked files")
+            if metadata.st_size > MAX_FILE_BYTES:
+                raise StorageError("Raw parquet file exceeds the supported local byte limit")
+            if BATCH_FILE_PATTERN.fullmatch(name) is None:
+                raise StorageError("Raw parquet inventory contains an unmanaged filename")
+            relative_partition = candidate.parent.relative_to(root).as_posix()
+            _validate_partition(relative_partition)
+            inventory_bytes += metadata.st_size
+            parquet_files.append(candidate)
+    if walk_failed:
+        raise StorageError("Raw parquet inventory cannot be traversed")
+    if len(parquet_files) > MAX_INVENTORY_FILES:
+        raise StorageError("Raw parquet inventory exceeds the supported local file count")
+    if inventory_bytes > MAX_INVENTORY_BYTES:
+        raise StorageError("Raw parquet inventory exceeds the supported local byte limit")
+    return sorted(parquet_files), inventory_bytes, entry_count
+
+
+def _read_inventory(root: Path) -> _RawInventory:
+    parquet_files, inventory_bytes, entry_count = _assert_safe_tree(root)
+    if not parquet_files:
+        return _RawInventory(
+            events={},
+            file_count=0,
+            entry_count=entry_count,
+            total_bytes=0,
+            total_text_bytes=0,
+            row_count=0,
+        )
+
+    inventory: dict[str, _PreparedRawEvent] = {}
+    inventory_rows = 0
+    inventory_text_bytes = 0
+    for path in parquet_files:
+        rows: list[tuple[Any, ...]] | None = None
+        schema: dict[str, str] | None = None
+        parquet_converted_types: dict[str, str | None] | None = None
+        try:
+            with duckdb.connect() as connection:
+                schema_rows = connection.execute(
+                    "DESCRIBE SELECT * FROM read_parquet(?, hive_partitioning=false)",
+                    [str(path)],
+                ).fetchall()
+                schema = {str(row[0]): str(row[1]) for row in schema_rows}
+                parquet_rows = connection.execute(
+                    "SELECT name, converted_type FROM parquet_schema(?) "
+                    "WHERE name <> 'duckdb_schema'",
+                    [str(path)],
+                ).fetchall()
+                parquet_converted_types = {
+                    str(row[0]): None if row[1] is None else str(row[1])
+                    for row in parquet_rows
+                }
+        except (duckdb.Error, OSError):
+            pass
+        if schema is None or parquet_converted_types is None:
+            raise StorageError("Existing raw parquet inventory is unreadable")
+        if set(schema) != set(RAW_EVENT_FIELDS) or len(schema) != len(RAW_EVENT_FIELDS):
+            raise StorageError("Existing raw parquet file has an incompatible schema")
+        if set(parquet_converted_types) != set(RAW_EVENT_FIELDS):
+            raise StorageError("Existing raw parquet file has incompatible physical metadata")
+        if any(
+            not _compatible_physical_type(
+                field_name,
+                schema[field_name],
+                parquet_converted_types[field_name],
+            )
+            for field_name in RAW_EVENT_FIELDS
+        ):
+            raise StorageError("Existing raw parquet file has incompatible physical types")
+
+        nanosecond_fields = [
+            field_name
+            for field_name in ("ts_event", "ts_ingest")
+            if schema[field_name].upper() == "TIMESTAMP_NS"
+        ]
+        if nanosecond_fields:
+            precision_row: tuple[Any, ...] | None = None
+            precision_select = ", ".join(
+                "COALESCE(SUM(CASE WHEN epoch_ns(\""
+                f"{field_name}"
+                "\") % 1000 <> 0 THEN 1 ELSE 0 END), 0)"
+                for field_name in nanosecond_fields
+            )
+            try:
+                with duckdb.connect() as connection:
+                    precision_row = connection.execute(
+                        f"SELECT {precision_select} "
+                        "FROM read_parquet(?, hive_partitioning=false)",
+                        [str(path)],
+                    ).fetchone()
+            except (duckdb.Error, OSError):
+                pass
+            if precision_row is None:
+                raise StorageError("Existing raw parquet inventory is unreadable")
+            if any(int(value) > 0 for value in precision_row):
+                raise StorageError("Existing raw parquet timestamps exceed microsecond precision")
+
+        metrics: tuple[Any, ...] | None = None
+        try:
+            with duckdb.connect() as connection:
+                metrics = connection.execute(
+                    "SELECT COUNT(*), "
+                    "COALESCE(MAX(octet_length(encode(event_id))), 0), "
+                    "COALESCE(MAX(octet_length(encode(symbol))), 0), "
+                    "COALESCE(MAX(octet_length(encode(source))), 0), "
+                    "COALESCE(SUM(COALESCE(octet_length(encode(event_id)), 0) + "
+                    "COALESCE(octet_length(encode(symbol)), 0) + "
+                    "COALESCE(octet_length(encode(source)), 0)), 0) "
+                    "FROM read_parquet(?, hive_partitioning=false)",
+                    [str(path)],
+                ).fetchone()
+        except (duckdb.Error, OSError):
+            pass
+        if metrics is None:
+            raise StorageError("Existing raw parquet inventory is unreadable")
+        row_count = int(metrics[0])
+        maximum_text_bytes = max(int(value) for value in metrics[1:4])
+        file_text_bytes = int(metrics[4])
+        if row_count == 0:
+            raise StorageError("Existing raw parquet file must not be empty")
+        if row_count > MAX_ROWS_PER_FILE:
+            raise StorageError("Existing raw parquet file exceeds the supported row limit")
+        if maximum_text_bytes > MAX_TEXT_FIELD_BYTES:
+            raise StorageError("Existing raw parquet text exceeds the local field byte limit")
+        inventory_rows += row_count
+        if inventory_rows > MAX_INVENTORY_ROWS:
+            raise StorageError("Raw parquet inventory exceeds the supported local row limit")
+        inventory_text_bytes += file_text_bytes
+        if inventory_text_bytes > MAX_INVENTORY_TEXT_BYTES:
+            raise StorageError("Raw parquet inventory exceeds the local UTF-8 byte limit")
+
+        try:
+            with duckdb.connect() as connection:
+                select_list = ", ".join(
+                    f'epoch_us("{field}") AS "{field}"'
+                    if field in {"ts_event", "ts_ingest"}
+                    else f'"{field}"'
+                    for field in RAW_EVENT_FIELDS
+                )
+                rows = connection.execute(
+                    f"SELECT {select_list} "
+                    "FROM read_parquet(?, hive_partitioning=false)",
+                    [str(path)],
+                ).fetchall()
+        except (duckdb.Error, OSError):
+            pass
+        if rows is None or len(rows) != row_count:
+            raise StorageError("Existing raw parquet file could not be read completely")
+
+        relative_partition = path.parent.relative_to(root).as_posix()
+        for row in rows:
+            stored_record = dict(zip(RAW_EVENT_FIELDS, row, strict=True))
+            for timestamp_field in ("ts_event", "ts_ingest"):
+                stored_record[timestamp_field] = _datetime_from_epoch_microseconds(
+                    stored_record[timestamp_field],
+                    field_name=timestamp_field,
+                )
+            candidate = _prepare_record(stored_record)
+            if partition_path(candidate.record["ts_ingest"]) != relative_partition:
+                raise StorageError("Raw parquet record does not match its ingest-hour partition")
+            event_id = candidate.record["event_id"]
+            current = inventory.get(event_id)
+            if current is None:
+                inventory[event_id] = candidate
+                continue
+            if current.business_fingerprint != candidate.business_fingerprint:
+                raise _conflict(
+                    "Existing raw dataset contains conflicting versions",
+                    candidate.key_digest,
+                )
+            raise StorageError(
+                "Existing raw dataset contains duplicate records for key "
+                f"{candidate.key_digest[:12]}"
+            )
+    return _RawInventory(
+        events=inventory,
+        file_count=len(parquet_files),
+        entry_count=entry_count,
+        total_bytes=inventory_bytes,
+        total_text_bytes=inventory_text_bytes,
+        row_count=inventory_rows,
+    )
+
+
+@contextmanager
+def _dataset_lock(root: Path) -> Iterator[None]:
+    lock_path = root / LOCK_FILE_NAME
+    lock_is_symlink = False
+    try:
+        lock_is_symlink = lock_path.is_symlink()
+    except OSError:
+        pass
+    if lock_is_symlink:
+        raise StorageError("Raw dataset lock must not be a symbolic link")
+    flags = os.O_CREAT | os.O_RDWR
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+
+    descriptor: int | None = None
+    open_failed = False
+    try:
+        descriptor = os.open(lock_path, flags, 0o600)
+        metadata = os.fstat(descriptor)
+        if (
+            not stat.S_ISREG(metadata.st_mode)
+            or metadata.st_nlink != 1
+            or not _filesystem_owner_is_current(metadata)
+        ):
+            raise OSError("unsafe lock file")
+        os.fchmod(descriptor, 0o600)
+    except OSError:
+        open_failed = True
+    if open_failed:
+        if descriptor is not None:
+            try:
+                os.close(descriptor)
+            except OSError:
+                pass
+        raise StorageError("Unable to open the raw dataset lock")
+    assert descriptor is not None
+
+    acquired = False
+    deadline = time.monotonic() + LOCK_TIMEOUT_SECONDS
+    try:
+        while not acquired:
+            blocked = False
+            acquire_failed = False
+            try:
+                fcntl.flock(descriptor, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                acquired = True
+            except BlockingIOError:
+                blocked = True
+            except OSError:
+                acquire_failed = True
+            if acquire_failed:
+                raise StorageError("Unable to acquire the raw dataset lock")
+            if blocked:
+                if time.monotonic() >= deadline:
+                    raise StorageError("Timed out waiting for the raw dataset lock")
+                time.sleep(0.05)
+        yield
+    finally:
+        if acquired:
+            fcntl.flock(descriptor, fcntl.LOCK_UN)
+        os.close(descriptor)
+
+
+def _ensure_partition_directory(root: Path, partition: str) -> Path:
+    target = root / partition
+    created = True
+    try:
+        target.mkdir(parents=True, exist_ok=True)
+    except OSError:
+        created = False
+    if not created:
+        raise StorageError("Raw partition directory could not be created")
+    current = root
+    for part in Path(partition).parts:
+        current /= part
+        metadata = _metadata(
+            current,
+            message="Raw partition path metadata is unreadable",
+        )
+        if stat.S_ISLNK(metadata.st_mode) or not stat.S_ISDIR(metadata.st_mode):
+            raise StorageError("Raw partition path must contain only regular directories")
+        resolved = _resolved(
+            current,
+            strict=True,
+            message="Raw partition path could not be resolved",
+        )
+        if not _is_beneath(resolved, root):
+            raise StorageError("Raw partition path escaped the configured dataset")
+    return target
+
+
+def _path_exists(path: Path) -> bool:
+    exists: bool | None = None
+    try:
+        path.lstat()
+        exists = True
+    except FileNotFoundError:
+        exists = False
+    except OSError:
+        pass
+    if exists is None:
+        raise StorageError("Raw parquet target metadata is unreadable")
+    return exists
+
+
+def _publish_raw_batch(
+    batch: list[dict[str, Any]],
+    target: Path,
+    *,
+    maximum_bytes: int,
+) -> bool:
+    published: bool | None = None
+    try:
+        published = create_parquet_file(
+            batch,
+            target,
+            maximum_bytes=maximum_bytes,
+        )
+    except StorageError:
+        pass
+    if published is None:
+        raise StorageError("Unable to publish raw parquet output")
+    return published
+
+
+def write_raw_event_records(
+    records: list[dict[str, Any]],
+    *,
+    dataset_path: Path,
+    raw_base_path: Path,
+    storage_base_dir: Path,
+    file_format: str,
+) -> int:
+    if file_format != "parquet":
+        raise StorageError(f"Unsupported storage format '{file_format}'")
+    incoming = _prepare_incoming(records)
+    if not incoming:
+        return 0
+
+    configured_root = _resolved(
+        storage_base_dir,
+        strict=False,
+        message="storage.base_dir could not be resolved",
+    )
+    configured_raw_base = _resolved(
+        raw_base_path,
+        strict=False,
+        message="Raw base path could not be resolved",
+    )
+    candidate_root = _resolved(
+        dataset_path,
+        strict=False,
+        message="Raw dataset path could not be resolved",
+    )
+    if not _is_beneath(configured_raw_base, configured_root, allow_equal=True):
+        raise StorageError("Raw base path must remain beneath storage.base_dir")
+    if not _is_beneath(candidate_root, configured_raw_base):
+        raise StorageError("Raw dataset must remain beneath its configured raw base path")
+    _assert_no_symlink_components(
+        raw_base_path,
+        storage_base_dir,
+        allow_equal=True,
+    )
+    _assert_no_symlink_components(dataset_path, raw_base_path)
+
+    dataset_is_symlink = False
+    raw_base_is_symlink = False
+    try:
+        dataset_is_symlink = dataset_path.is_symlink()
+        raw_base_is_symlink = raw_base_path.is_symlink()
+    except OSError:
+        pass
+    if dataset_is_symlink or raw_base_is_symlink:
+        raise StorageError("Raw dataset path must not be a symbolic link")
+
+    created = True
+    try:
+        dataset_path.mkdir(parents=True, exist_ok=True)
+    except OSError:
+        created = False
+    if not created:
+        raise StorageError("Raw dataset path could not be created")
+    _assert_no_symlink_components(
+        raw_base_path,
+        storage_base_dir,
+        allow_equal=True,
+    )
+    _assert_no_symlink_components(dataset_path, raw_base_path)
+    root = _resolved(
+        dataset_path,
+        strict=True,
+        message="Raw dataset path could not be resolved after creation",
+    )
+    actual_raw_base = _resolved(
+        raw_base_path,
+        strict=True,
+        message="Raw base path could not be resolved after creation",
+    )
+    if not _is_beneath(actual_raw_base, configured_root, allow_equal=True):
+        raise StorageError("Raw base path escaped storage.base_dir during creation")
+    if not _is_beneath(root, actual_raw_base):
+        raise StorageError("Raw dataset escaped its configured raw base during creation")
+
+    with _dataset_lock(root):
+        _recover_private_staging(root)
+        inventory = _read_inventory(root)
+        unseen: list[_PreparedRawEvent] = []
+        for event_id in sorted(incoming):
+            candidate = incoming[event_id]
+            current = inventory.events.get(event_id)
+            if current is None:
+                unseen.append(candidate)
+                continue
+            if current.business_fingerprint != candidate.business_fingerprint:
+                raise _conflict("Incoming event conflicts with the immutable first version", candidate.key_digest)
+
+        if inventory.row_count + len(unseen) > MAX_INVENTORY_ROWS:
+            raise StorageError("Raw parquet publication would exceed the local row limit")
+        if (
+            inventory.total_text_bytes
+            + sum(candidate.text_bytes for candidate in unseen)
+            > MAX_INVENTORY_TEXT_BYTES
+        ):
+            raise StorageError("Raw parquet publication would exceed the local UTF-8 byte limit")
+
+        partitioned: dict[str, list[dict[str, Any]]] = {}
+        for candidate in unseen:
+            partition = partition_path(candidate.record["ts_ingest"])
+            partitioned.setdefault(partition, []).append(candidate.record)
+        if inventory.file_count + len(partitioned) > MAX_INVENTORY_FILES:
+            raise StorageError("Raw parquet publication would exceed the local file limit")
+        if inventory.entry_count + (5 * len(partitioned)) > MAX_INVENTORY_ENTRIES:
+            raise StorageError("Raw parquet publication would exceed the local entry limit")
+
+        publication_plan: list[tuple[list[dict[str, Any]], Path]] = []
+        for partition in sorted(partitioned):
+            batch = sorted(partitioned[partition], key=lambda record: record["event_id"])
+            target_directory = _ensure_partition_directory(root, partition)
+            target = target_directory / batch_file_name(batch, file_format)
+            if _path_exists(target):
+                raise StorageError("Raw parquet target already exists unexpectedly")
+            publication_plan.append((batch, target))
+
+        written = 0
+        remaining_bytes = MAX_INVENTORY_BYTES - inventory.total_bytes
+        for batch, target in publication_plan:
+            publication_byte_limit = min(MAX_FILE_BYTES, remaining_bytes)
+            if publication_byte_limit <= 0:
+                raise StorageError("Raw parquet publication would exceed the local byte limit")
+            if not _publish_raw_batch(
+                batch,
+                target,
+                maximum_bytes=publication_byte_limit,
+            ):
+                raise StorageError("Raw parquet target appeared during publication")
+            remaining_bytes -= _metadata(
+                target,
+                message="Published raw parquet metadata is unreadable",
+            ).st_size
+            written += len(batch)
+        return written
+
+
+__all__ = ["write_raw_event_records"]

--- a/src/storage/s3_writer.py
+++ b/src/storage/s3_writer.py
@@ -7,7 +7,20 @@ from typing import Any
 from ..common.exceptions import StorageError
 from .parquet_io import batch_file_name, create_parquet_file
 from .partitioning import partition_path
+from .raw_event_writer import write_raw_event_records
 from .storage_config import load_storage_config, validate_storage_config
+
+
+def _validate_dataset_segment(value: Any) -> str:
+    if (
+        not isinstance(value, str)
+        or value in {"", ".", ".."}
+        or "/" in value
+        or "\\" in value
+        or any(ord(character) < 32 for character in value)
+    ):
+        raise StorageError("Configured raw dataset must be one safe path segment")
+    return value
 
 
 def _resolve_dataset_name(
@@ -18,7 +31,7 @@ def _resolve_dataset_name(
 ) -> tuple[str, Path]:
     if kind == "raw":
         raw = storage["raw"]
-        dataset_name = raw["dataset"]
+        dataset_name = _validate_dataset_segment(raw["dataset"])
         if dataset is not None and dataset != dataset_name:
             raise StorageError(f"Raw dataset must be '{dataset_name}', got '{dataset}'")
         base_path = Path(raw["base_path"])
@@ -84,6 +97,15 @@ def write_records(
 
     dataset_name, base_path = _resolve_dataset_name(storage, kind=kind, dataset=dataset)
     dataset_path = base_path / dataset_name
+
+    if kind == "raw":
+        return write_raw_event_records(
+            records,
+            dataset_path=dataset_path,
+            raw_base_path=base_path,
+            storage_base_dir=Path(storage["base_dir"]),
+            file_format=file_format,
+        )
 
     partitioned_batches: dict[str | None, list[dict[str, Any]]] = {}
     for record in records:

--- a/tests/integration/test_backfill.py
+++ b/tests/integration/test_backfill.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
+import sys
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 from uuid import UUID
 
-from src.orchestration.backfill import run_backfill
+import pytest
+
+from src.orchestration.backfill import _load_partition_records, run_backfill
 from src.orchestration.locks import acquire_partition_locks, release_partition_locks
 from src.storage.s3_writer import write_records
 from tests.storage_config_helpers import build_storage_config, write_storage_config
@@ -184,3 +187,63 @@ def test_run_backfill_resumes_after_blocked_overlap(tmp_path: Path) -> None:
         vol_window=2,
     )
     assert third == []
+
+
+def test_backfill_preserves_raw_identity_precision(tmp_path: Path) -> None:
+    storage_config = build_storage_config(tmp_path, include_external_signal_summary=False)
+    storage_config_path = write_storage_config(
+        tmp_path,
+        include_external_signal_summary=False,
+    )
+    precise_event = {
+        "event_id": "precise-event",
+        "symbol": "AAPL",
+        "price": 100.1234567890123,
+        "volume": 10,
+        "ts_event": datetime(
+            2025,
+            1,
+            20,
+            10,
+            1,
+            2,
+            123456,
+            tzinfo=timezone.utc,
+        ),
+        "ts_ingest": datetime(2025, 1, 20, 10, 2, tzinfo=timezone.utc),
+        "source": "stooq",
+    }
+    assert write_records([precise_event], kind="raw", storage_config=storage_config) == 1
+
+    result = run_backfill(
+        "2025-01-20T10:00:00Z",
+        "2025-01-20T10:00:00Z",
+        "hourly",
+        storage_config_path=storage_config_path,
+        thresholds_path=Path("config/risk_thresholds.yaml"),
+        vol_window=2,
+    )
+
+    assert len(result) == 1
+    assert result[0]["status"] == "success"
+    assert result[0]["records_replayed"] == 1
+    assert result[0]["raw_events"] == 0
+
+
+def test_backfill_partition_read_does_not_require_pytz(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    storage_config = build_storage_config(tmp_path, include_external_signal_summary=False)
+    _seed_raw_partitions(storage_config)
+    partition_dir = (
+        Path(storage_config["storage"]["raw"]["base_path"])
+        / storage_config["storage"]["raw"]["dataset"]
+        / "year=2025/month=01/day=20/hour=10"
+    )
+
+    monkeypatch.setitem(sys.modules, "pytz", None)
+
+    records = _load_partition_records(partition_dir)
+    assert len(records) == 3
+    assert records[0]["ts_event"].endswith("+00:00")

--- a/tests/integration/test_s3_writer.py
+++ b/tests/integration/test_s3_writer.py
@@ -1,10 +1,21 @@
 from __future__ import annotations
 
-from datetime import datetime, timezone
+import json
+import os
+import sys
+import traceback
+from concurrent.futures import ThreadPoolExecutor
+from datetime import datetime, timedelta, timezone, tzinfo
 from pathlib import Path
+from threading import Barrier
 
 import duckdb
+import pytest
 
+import src.storage.raw_event_writer as raw_event_writer
+from src.common.exceptions import RawEventConflictError, StorageError
+from src.ingestion.alpha_vantage_client import parse_alpha_vantage_daily_response
+from src.storage.parquet_io import create_parquet_file
 from src.storage.partitioning import partition_path
 from src.storage.s3_writer import write_records
 
@@ -38,6 +49,60 @@ def _parquet_row_count(path: Path) -> int:
     escaped = str(path).replace("'", "''")
     with duckdb.connect() as conn:
         return int(conn.execute(f"SELECT COUNT(*) FROM read_parquet('{escaped}')").fetchone()[0])
+
+
+def _event(
+    event_id: str = "evt-1",
+    *,
+    symbol: str = "AAPL",
+    price: float = 100.0,
+    volume: int = 10,
+    ts_event: datetime | None = None,
+    ts_ingest: datetime | None = None,
+    source: str = "stooq",
+) -> dict:
+    return {
+        "event_id": event_id,
+        "symbol": symbol,
+        "price": price,
+        "volume": volume,
+        "ts_event": ts_event or datetime(2025, 1, 20, 10, 0, tzinfo=timezone.utc),
+        "ts_ingest": ts_ingest or datetime(2025, 1, 20, 10, 1, tzinfo=timezone.utc),
+        "source": source,
+    }
+
+
+class _FailsOnSecondOffset(tzinfo):
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def utcoffset(self, value: datetime | None) -> timedelta:
+        self.calls += 1
+        if self.calls > 1:
+            raise RuntimeError("sentinel-secret-timezone")
+        return timedelta(0)
+
+    def dst(self, value: datetime | None) -> timedelta:
+        return timedelta(0)
+
+
+def _raw_records(tmp_path: Path) -> list[dict]:
+    files = sorted((tmp_path / "raw" / "market_events").rglob("*.parquet"))
+    if not files:
+        return []
+    with duckdb.connect() as connection:
+        frame = connection.execute(
+            "SELECT * FROM read_parquet(?, union_by_name=true, hive_partitioning=false)",
+            [[str(path) for path in files]],
+        ).df()
+    return frame.to_dict("records")
+
+
+def _write_legacy_batch(tmp_path: Path, records: list[dict], *, digest: str) -> Path:
+    partition = partition_path(records[0]["ts_ingest"])
+    target = tmp_path / "raw" / "market_events" / partition / f"batch_{digest}.parquet"
+    assert create_parquet_file(records, target) is True
+    return target
 
 
 def test_write_records_raw_partitioned_and_idempotent(tmp_path: Path) -> None:
@@ -78,6 +143,20 @@ def test_write_records_raw_partitioned_and_idempotent(tmp_path: Path) -> None:
     assert len(list(dataset_dir.glob("*.parquet"))) == 1
 
 
+def test_raw_inventory_does_not_require_pytz(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config = _build_storage_config(tmp_path)
+    first = _event()
+    assert write_records([first], kind="raw", storage_config=config) == 1
+
+    monkeypatch.setitem(sys.modules, "pytz", None)
+
+    replay = _event(ts_ingest=first["ts_ingest"] + timedelta(hours=1))
+    assert write_records([replay], kind="raw", storage_config=config) == 0
+
+
 def test_write_records_curated_without_ts_ingest(tmp_path: Path) -> None:
     config = _build_storage_config(tmp_path)
     records = [{"late_rate": 0.2, "duplicate_rate": 0.1}]
@@ -94,3 +173,642 @@ def test_write_records_curated_without_ts_ingest(tmp_path: Path) -> None:
     parquet_files = list(dataset_dir.glob("*.parquet"))
     assert len(parquet_files) == 1
     assert _parquet_row_count(parquet_files[0]) == 1
+
+
+def test_raw_replay_ignores_later_ingest_time_and_preserves_first_seen(tmp_path: Path) -> None:
+    config = _build_storage_config(tmp_path)
+    first = _event()
+    replay = _event(ts_ingest=datetime(2025, 1, 21, 11, 0, tzinfo=timezone.utc))
+
+    assert write_records([first], kind="raw", storage_config=config) == 1
+    assert write_records([replay], kind="raw", storage_config=config) == 0
+
+    rows = _raw_records(tmp_path)
+    assert len(rows) == 1
+    assert rows[0]["event_id"] == "evt-1"
+    assert rows[0]["ts_ingest"].to_pydatetime() == first["ts_ingest"]
+    assert len(list((tmp_path / "raw" / "market_events").rglob("*.parquet"))) == 1
+
+
+@pytest.mark.parametrize(
+    "updates",
+    [
+        {"symbol": "MSFT"},
+        {"price": 101.0},
+        {"volume": 11},
+        {"ts_event": datetime(2025, 1, 20, 10, 5, tzinfo=timezone.utc)},
+        {"source": "alpha_vantage"},
+    ],
+)
+def test_raw_correction_conflicts_without_overwriting(
+    tmp_path: Path,
+    updates: dict,
+) -> None:
+    config = _build_storage_config(tmp_path)
+    original = _event()
+    assert write_records([original], kind="raw", storage_config=config) == 1
+
+    corrected = _event(ts_ingest=datetime(2025, 1, 21, 11, 0, tzinfo=timezone.utc))
+    corrected.update(updates)
+    with pytest.raises(RawEventConflictError, match="immutable first version"):
+        write_records([corrected], kind="raw", storage_config=config)
+
+    rows = _raw_records(tmp_path)
+    assert len(rows) == 1
+    assert rows[0]["symbol"] == "AAPL"
+    assert rows[0]["price"] == 100.0
+    assert rows[0]["volume"] == 10
+    assert rows[0]["source"] == "stooq"
+
+
+def test_raw_conflict_preflights_entire_batch_before_publication(tmp_path: Path) -> None:
+    config = _build_storage_config(tmp_path)
+    assert write_records([_event()], kind="raw", storage_config=config) == 1
+    new_event = _event("evt-2", symbol="MSFT")
+    correction = _event(price=101.0)
+
+    with pytest.raises(RawEventConflictError):
+        write_records([new_event, correction], kind="raw", storage_config=config)
+
+    assert {row["event_id"] for row in _raw_records(tmp_path)} == {"evt-1"}
+
+
+def test_raw_incoming_duplicate_collapses_to_earliest_ingest_time(tmp_path: Path) -> None:
+    config = _build_storage_config(tmp_path)
+    later = _event(ts_ingest=datetime(2025, 1, 21, 11, 0, tzinfo=timezone.utc))
+    earlier = _event(ts_ingest=datetime(2025, 1, 20, 9, 0, tzinfo=timezone.utc))
+
+    assert write_records([later, earlier], kind="raw", storage_config=config) == 1
+
+    rows = _raw_records(tmp_path)
+    assert len(rows) == 1
+    assert rows[0]["ts_ingest"].to_pydatetime() == earlier["ts_ingest"]
+
+
+def test_raw_incoming_correction_fails_before_creating_dataset(tmp_path: Path) -> None:
+    config = _build_storage_config(tmp_path)
+    with pytest.raises(RawEventConflictError, match="Incoming batch"):
+        write_records(
+            [_event(), _event(price=101.0)],
+            kind="raw",
+            storage_config=config,
+        )
+
+    assert not (tmp_path / "raw" / "market_events").exists()
+
+
+def test_concurrent_identical_raw_writers_land_one_fact(tmp_path: Path) -> None:
+    config = _build_storage_config(tmp_path)
+    barrier = Barrier(2)
+
+    def publish() -> int:
+        barrier.wait()
+        return write_records([_event()], kind="raw", storage_config=config)
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        results = [future.result() for future in [executor.submit(publish), executor.submit(publish)]]
+
+    assert sorted(results) == [0, 1]
+    assert len(_raw_records(tmp_path)) == 1
+
+
+def test_concurrent_correction_never_overwrites_winner(tmp_path: Path) -> None:
+    config = _build_storage_config(tmp_path)
+    barrier = Barrier(2)
+
+    def publish(record: dict) -> int | str:
+        barrier.wait()
+        try:
+            return write_records([record], kind="raw", storage_config=config)
+        except RawEventConflictError:
+            return "conflict"
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        futures = [executor.submit(publish, _event()), executor.submit(publish, _event(price=101.0))]
+        results = [future.result() for future in futures]
+
+    assert sorted(str(result) for result in results) == ["1", "conflict"]
+    rows = _raw_records(tmp_path)
+    assert len(rows) == 1
+    assert rows[0]["price"] in {100.0, 101.0}
+
+
+def test_legacy_raw_batch_participates_in_identity_checks(tmp_path: Path) -> None:
+    config = _build_storage_config(tmp_path)
+    _write_legacy_batch(tmp_path, [_event()], digest="0" * 16)
+
+    replay = _event(ts_ingest=datetime(2025, 1, 21, 11, 0, tzinfo=timezone.utc))
+    assert write_records([replay], kind="raw", storage_config=config) == 0
+    with pytest.raises(RawEventConflictError):
+        write_records([_event(price=101.0)], kind="raw", storage_config=config)
+
+
+def test_duplicate_legacy_keys_block_new_publication(tmp_path: Path) -> None:
+    config = _build_storage_config(tmp_path)
+    first = _event()
+    second = _event(ts_ingest=datetime(2025, 1, 21, 11, 0, tzinfo=timezone.utc))
+    _write_legacy_batch(tmp_path, [first], digest="0" * 16)
+    _write_legacy_batch(tmp_path, [second], digest="1" * 16)
+
+    with pytest.raises(StorageError, match="duplicate records"):
+        write_records([_event("evt-2")], kind="raw", storage_config=config)
+
+    assert {row["event_id"] for row in _raw_records(tmp_path)} == {"evt-1"}
+
+
+@pytest.mark.parametrize(
+    "invalid_record",
+    [
+        {**_event(), "unexpected": "value"},
+        {key: value for key, value in _event().items() if key != "source"},
+        _event(price=float("nan")),
+        _event(price=True),
+        _event(price="1" * 4_097),
+        _event(volume=-1),
+        _event(volume=True),
+        _event(volume=1.5),
+        _event(volume="1e1000000"),
+        _event(volume=9_223_372_036_854_775_808),
+        _event(event_id=123),
+        _event(event_id="x" * 65_537),
+        _event(ts_event="not-a-timestamp"),
+        _event(ts_event="1" * 4_097),
+    ],
+)
+def test_raw_contract_rejects_unsafe_or_ambiguous_records(
+    tmp_path: Path,
+    invalid_record: dict,
+) -> None:
+    with pytest.raises(StorageError):
+        write_records(
+            [invalid_record],
+            kind="raw",
+            storage_config=_build_storage_config(tmp_path),
+        )
+
+    assert not list(tmp_path.rglob("*.parquet"))
+
+
+def test_raw_contract_preserves_existing_text_timestamp_and_integer_compatibility(
+    tmp_path: Path,
+) -> None:
+    config = _build_storage_config(tmp_path)
+    event = _event(
+        event_id="vendor event/événement 1",
+        symbol="BRK/B",
+        volume=9_007_199_254_740_993,
+        ts_event=datetime(999, 1, 20, 10, 0),
+        ts_ingest=datetime(999, 1, 20, 10, 1),
+        source="vendor feed",
+    )
+
+    assert write_records([event], kind="raw", storage_config=config) == 1
+    assert write_records([event], kind="raw", storage_config=config) == 0
+
+    files = list((tmp_path / "raw" / "market_events").rglob("*.parquet"))
+    with duckdb.connect() as connection:
+        row = connection.execute(
+            "SELECT event_id, symbol, volume, source FROM read_parquet(?)",
+            [[str(path) for path in files]],
+        ).fetchone()
+    assert row == (
+        event["event_id"],
+        "BRK/B",
+        9_007_199_254_740_993,
+        "vendor feed",
+    )
+
+
+def test_raw_contract_sanitizes_stateful_timezone_failures(tmp_path: Path) -> None:
+    broken_time = datetime(2025, 1, 20, 10, tzinfo=_FailsOnSecondOffset())
+
+    with pytest.raises(StorageError) as captured:
+        write_records(
+            [_event(ts_event=broken_time)],
+            kind="raw",
+            storage_config=_build_storage_config(tmp_path),
+        )
+
+    assert captured.value.__context__ is None
+    assert "sentinel-secret" not in "".join(traceback.format_exception(captured.value))
+    assert not list(tmp_path.rglob("*.parquet"))
+
+
+def test_raw_inventory_accepts_microsecond_aligned_legacy_timestamp_ns(
+    tmp_path: Path,
+) -> None:
+    config = _build_storage_config(tmp_path)
+    event = _event(
+        ts_event=datetime(2025, 1, 20, 10, 0, 0, 123456),
+        ts_ingest=datetime(2025, 1, 20, 10, 1, 0, 654321),
+    )
+
+    _write_legacy_batch(tmp_path, [event], digest="0" * 16)
+    assert write_records([event], kind="raw", storage_config=config) == 0
+
+
+def test_raw_dataset_rejects_base_escape_and_partition_symlink(tmp_path: Path) -> None:
+    config = _build_storage_config(tmp_path)
+    config["storage"]["raw"]["base_path"] = str(tmp_path.parent / "outside-raw")
+    with pytest.raises(StorageError, match="storage.base_dir"):
+        write_records([_event()], kind="raw", storage_config=config)
+
+    config = _build_storage_config(tmp_path)
+    dataset = tmp_path / "raw" / "market_events"
+    dataset.mkdir(parents=True)
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (dataset / "year=2025").symlink_to(outside, target_is_directory=True)
+    with pytest.raises(StorageError, match="symbolic links"):
+        write_records([_event()], kind="raw", storage_config=config)
+    assert not list(outside.rglob("*.parquet"))
+
+
+def test_raw_dataset_rejects_dataset_traversal_and_redacts_filesystem_errors(
+    tmp_path: Path,
+) -> None:
+    config = _build_storage_config(tmp_path)
+    config["storage"]["raw"]["dataset"] = ".."
+    with pytest.raises(StorageError, match="safe path segment"):
+        write_records([_event()], kind="raw", storage_config=config)
+    assert not list(tmp_path.glob("year=*"))
+
+    sentinel = tmp_path / "sentinel-secret-raw-base"
+    sentinel.write_text("not a directory", encoding="utf-8")
+    config = _build_storage_config(tmp_path)
+    config["storage"]["raw"]["base_path"] = str(sentinel)
+    with pytest.raises(StorageError) as captured:
+        write_records([_event()], kind="raw", storage_config=config)
+
+    error = captured.value
+    rendered = "".join(traceback.format_exception(error))
+    assert error.__context__ is None
+    assert str(sentinel) not in str(error)
+    assert str(sentinel) not in rendered
+
+
+@pytest.mark.parametrize("path_field", ["base_dir", "raw_base_path"])
+def test_raw_dataset_redacts_embedded_nul_paths(
+    tmp_path: Path,
+    path_field: str,
+) -> None:
+    config = _build_storage_config(tmp_path)
+    if path_field == "base_dir":
+        config["storage"]["base_dir"] = "bad\0sentinel-secret"
+    else:
+        config["storage"]["raw"]["base_path"] = "bad\0sentinel-secret"
+
+    with pytest.raises(StorageError) as captured:
+        write_records([_event()], kind="raw", storage_config=config)
+
+    assert captured.value.__context__ is None
+    assert "sentinel-secret" not in "".join(traceback.format_exception(captured.value))
+
+
+def test_raw_dataset_rejects_symlinked_path_components_before_creation(
+    tmp_path: Path,
+) -> None:
+    real = tmp_path / "real"
+    real.mkdir()
+    alias = tmp_path / "alias"
+    alias.symlink_to(real, target_is_directory=True)
+    config = _build_storage_config(tmp_path)
+    config["storage"]["raw"]["base_path"] = str(alias / "raw")
+
+    with pytest.raises(StorageError, match="must not contain symbolic links"):
+        write_records([_event()], kind="raw", storage_config=config)
+
+    assert not (real / "raw").exists()
+
+
+@pytest.mark.parametrize("lock_kind", ["directory", "fifo"])
+def test_raw_dataset_lock_rejects_non_regular_files_without_path_context(
+    tmp_path: Path,
+    lock_kind: str,
+) -> None:
+    dataset = tmp_path / "raw" / "market_events"
+    dataset.mkdir(parents=True)
+    lock_path = dataset / ".raw-write.lock"
+    if lock_kind == "directory":
+        lock_path.mkdir()
+    else:
+        os.mkfifo(lock_path)
+
+    with pytest.raises(StorageError, match="Unable to open") as captured:
+        write_records(
+            [_event()],
+            kind="raw",
+            storage_config=_build_storage_config(tmp_path),
+        )
+
+    assert captured.value.__context__ is None
+    assert str(tmp_path) not in "".join(traceback.format_exception(captured.value))
+
+
+def test_raw_dataset_lock_rejects_hardlink_without_mutating_its_target(
+    tmp_path: Path,
+) -> None:
+    dataset = tmp_path / "raw" / "market_events"
+    dataset.mkdir(parents=True)
+    sentinel = tmp_path / "sentinel.txt"
+    sentinel.write_text("unchanged", encoding="utf-8")
+    sentinel.chmod(0o644)
+    os.link(sentinel, dataset / ".raw-write.lock")
+
+    with pytest.raises(StorageError, match="Unable to open"):
+        write_records(
+            [_event()],
+            kind="raw",
+            storage_config=_build_storage_config(tmp_path),
+        )
+
+    assert sentinel.read_text(encoding="utf-8") == "unchanged"
+    assert sentinel.stat().st_mode & 0o777 == 0o644
+    assert not list(tmp_path.rglob("*.parquet"))
+
+
+def test_raw_retry_recovers_private_staging_link_after_publication_crash(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config = _build_storage_config(tmp_path)
+    event = _event()
+    assert write_records([event], kind="raw", storage_config=config) == 1
+    final = next((tmp_path / "raw" / "market_events").rglob("*.parquet"))
+    staging = final.parent / ".parquet-stage-interrupted"
+    staging.mkdir(mode=0o700)
+    os.link(final, staging / "payload.tmp")
+    assert final.stat().st_nlink == 2
+    monkeypatch.setattr(raw_event_writer, "MAX_INVENTORY_ENTRIES", 6)
+
+    replay = _event(ts_ingest=datetime(2025, 1, 21, 11, tzinfo=timezone.utc))
+    assert write_records([replay], kind="raw", storage_config=config) == 0
+
+    assert final.stat().st_nlink == 1
+    assert not staging.exists()
+
+
+def test_raw_inventory_rejects_incompatible_physical_types(tmp_path: Path) -> None:
+    config = _build_storage_config(tmp_path)
+    string_record = {key: str(value) for key, value in _event().items()}
+    partition = partition_path(_event()["ts_ingest"])
+    target = (
+        tmp_path
+        / "raw"
+        / "market_events"
+        / partition
+        / f"batch_{'0' * 16}.parquet"
+    )
+    assert create_parquet_file([string_record], target) is True
+
+    with pytest.raises(StorageError, match="incompatible physical types"):
+        write_records([_event("evt-2")], kind="raw", storage_config=config)
+
+    assert len(list((tmp_path / "raw" / "market_events").rglob("*.parquet"))) == 1
+
+
+@pytest.mark.parametrize(
+    "price_sql",
+    [
+        "100.1::FLOAT",
+        "1.0000000000000000001::DECIMAL(20, 19)",
+        "9007199254740993::BIGINT",
+    ],
+)
+def test_raw_inventory_rejects_noncanonical_price_storage(
+    tmp_path: Path,
+    price_sql: str,
+) -> None:
+    config = _build_storage_config(tmp_path)
+    partition = partition_path(_event()["ts_ingest"])
+    target = (
+        tmp_path
+        / "raw"
+        / "market_events"
+        / partition
+        / f"batch_{'0' * 16}.parquet"
+    )
+    target.parent.mkdir(parents=True)
+    with duckdb.connect() as connection:
+        connection.execute(
+            "COPY (SELECT "
+            "'evt-1'::VARCHAR AS event_id, 'AAPL'::VARCHAR AS symbol, "
+            f"{price_sql} AS price, 10::BIGINT AS volume, "
+            "TIMESTAMPTZ '2025-01-20 10:00:00+00' AS ts_event, "
+            "TIMESTAMPTZ '2025-01-20 10:01:00+00' AS ts_ingest, "
+            "'stooq'::VARCHAR AS source) TO ? (FORMAT PARQUET)",
+            [str(target)],
+        )
+
+    with pytest.raises(StorageError, match="incompatible physical types"):
+        write_records([_event()], kind="raw", storage_config=config)
+
+
+def test_raw_inventory_rejects_coarse_timestamp_storage(tmp_path: Path) -> None:
+    config = _build_storage_config(tmp_path)
+    partition = partition_path(_event()["ts_ingest"])
+    target = (
+        tmp_path
+        / "raw"
+        / "market_events"
+        / partition
+        / f"batch_{'0' * 16}.parquet"
+    )
+    target.parent.mkdir(parents=True)
+    with duckdb.connect() as connection:
+        connection.execute(
+            "COPY (SELECT "
+            "'evt-1'::VARCHAR AS event_id, 'AAPL'::VARCHAR AS symbol, "
+            "100.0::DOUBLE AS price, 10::BIGINT AS volume, "
+            "CAST(TIMESTAMP '2025-01-20 10:00:00.123456' AS TIMESTAMP_MS) "
+            "AS ts_event, TIMESTAMP '2025-01-20 10:01:00' AS ts_ingest, "
+            "'stooq'::VARCHAR AS source) TO ? (FORMAT PARQUET)",
+            [str(target)],
+        )
+
+    with pytest.raises(StorageError, match="incompatible physical types"):
+        write_records([_event()], kind="raw", storage_config=config)
+
+
+def test_raw_inventory_rejects_submicrosecond_legacy_timestamps(
+    tmp_path: Path,
+) -> None:
+    config = _build_storage_config(tmp_path)
+    partition = partition_path(_event()["ts_ingest"])
+    target = (
+        tmp_path
+        / "raw"
+        / "market_events"
+        / partition
+        / f"batch_{'0' * 16}.parquet"
+    )
+    target.parent.mkdir(parents=True)
+    with duckdb.connect() as connection:
+        connection.execute(
+            "COPY (SELECT "
+            "'evt-1'::VARCHAR AS event_id, 'AAPL'::VARCHAR AS symbol, "
+            "100.0::DOUBLE AS price, 10::BIGINT AS volume, "
+            "CAST('2025-01-20 10:00:00.123456789' AS TIMESTAMP_NS) AS ts_event, "
+            "CAST('2025-01-20 10:01:00' AS TIMESTAMP_NS) AS ts_ingest, "
+            "'stooq'::VARCHAR AS source) TO ? (FORMAT PARQUET)",
+            [str(target)],
+        )
+
+    with pytest.raises(StorageError, match="microsecond precision"):
+        write_records([_event()], kind="raw", storage_config=config)
+
+
+def test_raw_text_caps_count_duplicates_and_utf8_bytes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(raw_event_writer, "MAX_INPUT_TEXT_BYTES", 20)
+    with pytest.raises(StorageError, match="UTF-8 byte limit"):
+        write_records(
+            [_event(), _event()],
+            kind="raw",
+            storage_config=_build_storage_config(tmp_path),
+        )
+    assert not list(tmp_path.rglob("*.parquet"))
+
+    monkeypatch.setattr(raw_event_writer, "MAX_INPUT_TEXT_BYTES", 16_000_000)
+    config = _build_storage_config(tmp_path)
+    assert write_records([_event(event_id="é")], kind="raw", storage_config=config) == 1
+    monkeypatch.setattr(raw_event_writer, "MAX_TEXT_FIELD_BYTES", 1)
+    with pytest.raises(StorageError, match="text exceeds"):
+        write_records(
+            [_event(event_id="a", symbol="A", source="s")],
+            kind="raw",
+            storage_config=config,
+        )
+
+
+def test_raw_publication_enforces_prospective_inventory_caps(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config = _build_storage_config(tmp_path)
+    assert write_records([_event()], kind="raw", storage_config=config) == 1
+    existing = next((tmp_path / "raw" / "market_events").rglob("*.parquet"))
+
+    monkeypatch.setattr(raw_event_writer, "MAX_INVENTORY_FILES", 1)
+    with pytest.raises(StorageError, match="file limit"):
+        write_records(
+            [
+                _event(
+                    "evt-2",
+                    ts_ingest=datetime(2025, 1, 21, 11, tzinfo=timezone.utc),
+                )
+            ],
+            kind="raw",
+            storage_config=config,
+        )
+    assert list((tmp_path / "raw" / "market_events").rglob("*.parquet")) == [
+        existing
+    ]
+
+    monkeypatch.setattr(raw_event_writer, "MAX_INVENTORY_FILES", 10_000)
+    monkeypatch.setattr(raw_event_writer, "MAX_INVENTORY_ENTRIES", 6)
+    with pytest.raises(StorageError, match="entry limit"):
+        write_records([_event("evt-entry")], kind="raw", storage_config=config)
+
+    monkeypatch.setattr(raw_event_writer, "MAX_INVENTORY_ENTRIES", 60_000)
+    monkeypatch.setattr(raw_event_writer, "MAX_INVENTORY_ROWS", 1)
+    with pytest.raises(StorageError, match="row limit"):
+        write_records([_event("evt-3")], kind="raw", storage_config=config)
+
+    monkeypatch.setattr(raw_event_writer, "MAX_INVENTORY_ROWS", 1_000_000)
+    monkeypatch.setattr(raw_event_writer, "MAX_INVENTORY_TEXT_BYTES", 14)
+    with pytest.raises(StorageError, match="UTF-8 byte limit"):
+        write_records([_event("evt-4")], kind="raw", storage_config=config)
+
+    monkeypatch.setattr(raw_event_writer, "MAX_INVENTORY_TEXT_BYTES", 512_000_000)
+    monkeypatch.setattr(raw_event_writer, "MAX_INVENTORY_BYTES", existing.stat().st_size)
+    with pytest.raises(StorageError, match="byte limit"):
+        write_records([_event("evt-5")], kind="raw", storage_config=config)
+
+    assert list((tmp_path / "raw" / "market_events").rglob("*.parquet")) == [
+        existing
+    ]
+
+
+def test_raw_publication_rejects_oversized_staged_file_before_link(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(raw_event_writer, "MAX_FILE_BYTES", 1)
+
+    with pytest.raises(StorageError, match="Unable to publish raw parquet"):
+        write_records(
+            [_event()],
+            kind="raw",
+            storage_config=_build_storage_config(tmp_path),
+        )
+
+    assert not list(tmp_path.rglob("*.parquet"))
+
+
+def test_corrupt_or_mispartitioned_raw_inventory_fails_closed(tmp_path: Path) -> None:
+    config = _build_storage_config(tmp_path)
+    partition = partition_path(_event()["ts_ingest"])
+    corrupt = tmp_path / "raw" / "market_events" / partition / f"batch_{'0' * 16}.parquet"
+    corrupt.parent.mkdir(parents=True)
+    corrupt.write_bytes(b"not parquet")
+    with pytest.raises(StorageError, match="unreadable"):
+        write_records([_event("evt-2")], kind="raw", storage_config=config)
+
+    corrupt.unlink()
+    misplaced = _event(ts_ingest=datetime(2025, 1, 21, 11, 0, tzinfo=timezone.utc))
+    _write_legacy_batch(tmp_path, [misplaced], digest="1" * 16)
+    actual = next((tmp_path / "raw" / "market_events").rglob(f"batch_{'1' * 16}.parquet"))
+    wrong_directory = tmp_path / "raw" / "market_events" / partition
+    wrong_directory.mkdir(parents=True, exist_ok=True)
+    wrong = wrong_directory / actual.name
+    actual.replace(wrong)
+    with pytest.raises(StorageError, match="ingest-hour partition"):
+        write_records([_event("evt-2")], kind="raw", storage_config=config)
+
+
+def test_alpha_vantage_bar_repoll_and_correction_use_raw_identity_contract(
+    tmp_path: Path,
+) -> None:
+    def payload(close: str, volume: str) -> bytes:
+        return json.dumps(
+            {
+                "Meta Data": {"2. Symbol": "IBM"},
+                "Time Series (Daily)": {
+                    "2025-01-03": {
+                        "1. open": "100.00",
+                        "2. high": "103.00",
+                        "3. low": "99.00",
+                        "4. close": close,
+                        "5. volume": volume,
+                    }
+                },
+            }
+        ).encode("utf-8")
+
+    first = parse_alpha_vantage_daily_response(
+        payload("101.00", "1200"),
+        symbol="IBM",
+        ingested_at=datetime(2025, 1, 4, tzinfo=timezone.utc),
+    )[0].model_dump()
+    replay = parse_alpha_vantage_daily_response(
+        payload("101.00", "1200"),
+        symbol="IBM",
+        ingested_at=datetime(2025, 1, 5, tzinfo=timezone.utc),
+    )[0].model_dump()
+    correction = parse_alpha_vantage_daily_response(
+        payload("102.00", "1250"),
+        symbol="IBM",
+        ingested_at=datetime(2025, 1, 6, tzinfo=timezone.utc),
+    )[0].model_dump()
+    config = _build_storage_config(tmp_path)
+
+    assert first["event_id"] == replay["event_id"] == correction["event_id"]
+    assert write_records([first], kind="raw", storage_config=config) == 1
+    assert write_records([replay], kind="raw", storage_config=config) == 0
+    with pytest.raises(RawEventConflictError):
+        write_records([correction], kind="raw", storage_config=config)
+
+    assert len(_raw_records(tmp_path)) == 1

--- a/tests/unit/storage/test_parquet_io.py
+++ b/tests/unit/storage/test_parquet_io.py
@@ -54,6 +54,18 @@ def test_create_parquet_file_never_overwrites_existing_target(tmp_path: Path) ->
     assert target.read_bytes() == original
 
 
+def test_create_parquet_file_enforces_byte_limit_before_publication(
+    tmp_path: Path,
+) -> None:
+    target = tmp_path / "dataset" / "batch.parquet"
+
+    with pytest.raises(StorageError, match="byte limit"):
+        create_parquet_file([{"value": "payload"}], target, maximum_bytes=1)
+
+    assert not target.exists()
+    assert not list(target.parent.glob(".parquet-stage-*"))
+
+
 def test_concurrent_publishers_create_one_complete_file(tmp_path: Path) -> None:
     target = tmp_path / "dataset" / "batch.parquet"
     barrier = Barrier(2)


### PR DESCRIPTION
## Context

Primary arc42 building block: `storage`.

This change enforces one global `event_id` identity at the local raw Parquet boundary. It deliberately crosses one orchestration interface only to preserve backfill timestamp and numeric precision.

## Building blocks and runtime

- A storage-owned canonical raw-event contract.
- A bounded, locked inventory of existing managed raw Parquet files.
- Replay detection that ignores only `ts_ingest` and preserves the first accepted row and partition.
- Conflict detection that rejects changed facts under an existing `event_id` before unrelated publication.
- No-overwrite Parquet publication with private staging and crash-state recovery.
- A precision-preserving backfill adapter.

## Safety and semantics

- Raw identity is global `event_id`, consistent with processing, lineage, and warehouse keys.
- Paths, symlinks, lock files, physical schemas, row/file/byte/entry counts, and UTF-8 text are checked fail-closed.
- Errors are sanitized so configured paths and provider data are not copied into public exception context.
- Existing compatible legacy timestamps are interpreted consistently; lossy physical representations are rejected.
- Raw inventory and backfill read timestamps as UTC epoch microseconds, avoiding DuckDB's incidental `pytz` conversion dependency while preserving exact microsecond instants.
- This remains a single-host, operator-owned local Parquet boundary. It is not an S3 or distributed-lock claim.
- Multi-partition calls are not transactions; a valid prefix can remain after a later partition fails, and replay converges the remainder.
- PostgreSQL `ON CONFLICT DO UPDATE` behavior is unchanged and remains a separate warehouse-policy decision.

## History repair

The original two-commit branch was stacked on the pre-squash #37 history. Its final reviewed code, tests, data-model documentation, and failure semantics were rebuilt as one commit on current `main`.

Current head: `8c75cdae83bad92d36a5993ef0604db5b9b12378`

- one commit ahead of `main`
- zero commits behind
- ten changed paths
- 1,972 additions and 15 deletions

The rebuild includes the original follow-up that replaces implicit timezone conversion with exact UTC epoch-microsecond handling.

## Conflict resolution

The original branch also modified `docs/architecture.md`, but that path has since received a much larger controls-oriented architecture update on `main`. Replacing it with the old branch blob would have reverted newer documentation.

The repaired branch therefore preserves current `docs/architecture.md` unchanged. Raw identity, replay, correction-conflict, locking, precision, and local-boundary semantics remain fully documented in:

- `docs/data-model.md`
- `docs/failure-scenarios.md`

A focused architecture-document alignment can be handled separately without coupling it to this storage merge.

## Fresh validation

GitHub Actions run `32193004558` (`ci` run 161) passed on the repaired head:

- Security guardrails: passed
- Python readiness: passed
  - dependency installation
  - `make quality-check`
  - `make readiness-check`
- Infrastructure validation: passed
  - `make infrastructure-check`

No unresolved review threads or requested changes were present.

## Cohesion rationale

The roughly 2,000 changed lines exceed the normal 200–500-line heuristic because the contract, inventory, locking, recovery, publication, compatibility adapter, and adversarial evidence must land together. Splitting them further would leave an unused or unsafe intermediate storage contract.

## Merge boundary

Following the instruction to process and squash the dependency stack, this PR is ready to merge as one storage commit. It does not deploy, create cloud resources, or change the PostgreSQL correction policy.