### PR TITLE
Validate raw destinations before source I/O

### DIFF
--- a/src/storage/raw_event_writer.py
+++ b/src/storage/raw_event_writer.py
@@ -877,20 +877,15 @@ def _publish_raw_batch(
     return published
 
 
-def write_raw_event_records(
-    records: list[dict[str, Any]],
+def _validated_raw_destination(
     *,
     dataset_path: Path,
     raw_base_path: Path,
     storage_base_dir: Path,
     file_format: str,
-) -> int:
+) -> tuple[Path, Path, Path]:
     if file_format != "parquet":
         raise StorageError(f"Unsupported storage format '{file_format}'")
-    incoming = _prepare_incoming(records)
-    if not incoming:
-        return 0
-
     configured_root = _resolved(
         storage_base_dir,
         strict=False,
@@ -910,6 +905,26 @@ def write_raw_event_records(
         raise StorageError("Raw base path must remain beneath storage.base_dir")
     if not _is_beneath(candidate_root, configured_raw_base):
         raise StorageError("Raw dataset must remain beneath its configured raw base path")
+
+    for path, label in (
+        (storage_base_dir, "storage.base_dir"),
+        (raw_base_path, "Raw base path"),
+        (dataset_path, "Raw dataset path"),
+    ):
+        metadata: os.stat_result | None = None
+        metadata_failed = False
+        try:
+            metadata = path.lstat()
+        except FileNotFoundError:
+            continue
+        except OSError:
+            metadata_failed = True
+        if metadata_failed:
+            raise StorageError(f"{label} metadata is unreadable")
+        assert metadata is not None
+        if stat.S_ISLNK(metadata.st_mode) or not stat.S_ISDIR(metadata.st_mode):
+            raise StorageError(f"{label} must be a regular directory")
+
     _assert_no_symlink_components(
         raw_base_path,
         storage_base_dir,
@@ -926,6 +941,43 @@ def write_raw_event_records(
         pass
     if dataset_is_symlink or raw_base_is_symlink:
         raise StorageError("Raw dataset path must not be a symbolic link")
+    return configured_root, configured_raw_base, candidate_root
+
+
+def validate_raw_event_destination(
+    *,
+    dataset_path: Path,
+    raw_base_path: Path,
+    storage_base_dir: Path,
+    file_format: str,
+) -> None:
+    """Validate the non-mutating raw destination boundary before source I/O."""
+
+    _validated_raw_destination(
+        dataset_path=dataset_path,
+        raw_base_path=raw_base_path,
+        storage_base_dir=storage_base_dir,
+        file_format=file_format,
+    )
+
+
+def write_raw_event_records(
+    records: list[dict[str, Any]],
+    *,
+    dataset_path: Path,
+    raw_base_path: Path,
+    storage_base_dir: Path,
+    file_format: str,
+) -> int:
+    configured_root, _, _ = _validated_raw_destination(
+        dataset_path=dataset_path,
+        raw_base_path=raw_base_path,
+        storage_base_dir=storage_base_dir,
+        file_format=file_format,
+    )
+    incoming = _prepare_incoming(records)
+    if not incoming:
+        return 0
 
     created = True
     try:
@@ -1015,4 +1067,4 @@ def write_raw_event_records(
         return written
 
 
-__all__ = ["write_raw_event_records"]
+__all__ = ["validate_raw_event_destination", "write_raw_event_records"]

--- a/src/storage/s3_writer.py
+++ b/src/storage/s3_writer.py
@@ -7,7 +7,7 @@ from typing import Any
 from ..common.exceptions import StorageError
 from .parquet_io import batch_file_name, create_parquet_file
 from .partitioning import partition_path
-from .raw_event_writer import write_raw_event_records
+from .raw_event_writer import validate_raw_event_destination, write_raw_event_records
 from .storage_config import load_storage_config, validate_storage_config
 
 
@@ -66,6 +66,22 @@ def _parse_ingest_timestamp(value: Any) -> datetime | None:
     if ts.tzinfo is None:
         ts = ts.replace(tzinfo=timezone.utc)
     return ts
+
+
+def validate_raw_storage_destination(storage_config: dict[str, Any]) -> str:
+    """Validate the configured raw path without creating files or directories."""
+
+    validate_storage_config(storage_config)
+    storage = storage_config["storage"]
+    file_format = storage["format"].lower()
+    dataset_name, base_path = _resolve_dataset_name(storage, kind="raw", dataset=None)
+    validate_raw_event_destination(
+        dataset_path=base_path / dataset_name,
+        raw_base_path=base_path,
+        storage_base_dir=Path(storage["base_dir"]),
+        file_format=file_format,
+    )
+    return dataset_name
 
 
 def write_records(

--- a/tests/integration/test_s3_writer.py
+++ b/tests/integration/test_s3_writer.py
@@ -17,7 +17,7 @@ from src.common.exceptions import RawEventConflictError, StorageError
 from src.ingestion.alpha_vantage_client import parse_alpha_vantage_daily_response
 from src.storage.parquet_io import create_parquet_file
 from src.storage.partitioning import partition_path
-from src.storage.s3_writer import write_records
+from src.storage.s3_writer import validate_raw_storage_destination, write_records
 
 
 def _build_storage_config(tmp_path: Path) -> dict:
@@ -445,6 +445,33 @@ def test_raw_dataset_rejects_dataset_traversal_and_redacts_filesystem_errors(
     assert error.__context__ is None
     assert str(sentinel) not in str(error)
     assert str(sentinel) not in rendered
+
+
+def test_raw_destination_preflight_is_non_mutating_and_rejects_non_directories(
+    tmp_path: Path,
+) -> None:
+    config = _build_storage_config(tmp_path)
+
+    assert validate_raw_storage_destination(config) == "market_events"
+    assert list(tmp_path.iterdir()) == []
+
+    dataset = tmp_path / "raw" / "market_events"
+    dataset.parent.mkdir(parents=True)
+    dataset.write_text("not a directory", encoding="utf-8")
+
+    with pytest.raises(StorageError, match="must be a regular directory"):
+        validate_raw_storage_destination(config)
+
+
+def test_raw_writer_validates_destination_before_empty_input_return(tmp_path: Path) -> None:
+    with pytest.raises(StorageError, match="Unsupported storage format"):
+        raw_event_writer.write_raw_event_records(
+            [],
+            dataset_path=tmp_path / "raw" / "market_events",
+            raw_base_path=tmp_path / "raw",
+            storage_base_dir=tmp_path,
+            file_format="csv",
+        )
 
 
 @pytest.mark.parametrize("path_field", ["base_dir", "raw_base_path"])


### PR DESCRIPTION
## Context

Primary arc42 building block: `storage`.

This change exposes the existing raw-path safety checks as a non-mutating storage boundary so callers can validate local configuration before spending source I/O.

## Building block and runtime

- Validate format, base path, raw path, and dataset shape without creating output.
- Reject existing non-directory targets before a provider request.
- Repeat the same validation inside the raw writer before publication.
- Ensure empty input cannot bypass the low-level writer's format validation.

No ingestion, cloud, deployment, schema, or warehouse behavior is added.

## History repair

The original branch was stacked on #38 before that PR was squash-merged. The exact three-file preflight change was rebuilt on current `main` without carrying obsolete stack commits.

Current head: `3c1057bdeb9e194117f3c2378f66a61ad342d1ea`

- one commit ahead of `main`
- zero commits behind
- three changed paths
- 105 additions and 10 deletions

The current `main` blobs for all three paths exactly matched the original #39 base before reconstruction.

## Fresh validation

GitHub Actions run `32193293151` (`ci` run 163) passed on the repaired head:

- Security guardrails: passed
- Python readiness: passed
  - dependency installation
  - `make quality-check`
  - `make readiness-check`
- Infrastructure validation: passed
  - `make infrastructure-check`

No unresolved review threads or requested changes were present.

## Merge boundary

Following the instruction to process and squash the dependency stack, this PR is ready to merge as one storage commit. It does not perform provider I/O, deploy infrastructure, or authorize the later orchestration changes automatically.