### PR TITLE
Exclude daily observations from minute backfills

### DIFF
--- a/src/ingestion/alpha_vantage_client.py
+++ b/src/ingestion/alpha_vantage_client.py
@@ -39,6 +39,7 @@ RETRYABLE_HTTP_STATUSES = frozenset({408, 429, 500, 502, 503, 504})
 SYMBOL_PATTERN = re.compile(r"^[A-Z0-9][A-Z0-9._-]{0,31}$")
 INPUT_SYMBOL_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,31}$")
 CALENDAR_DATE_PATTERN = re.compile(r"^[0-9]{4}-[0-9]{2}-[0-9]{2}$")
+ALPHA_VANTAGE_DAILY_EVENT_PREFIX = "av-daily-"
 
 HttpTransport = Callable[[str, float, int], bytes]
 Sleep = Callable[[float], None]
@@ -107,10 +108,15 @@ def _parse_volume(value: Any) -> int:
     return int(parsed)
 
 
-def _event_id(symbol: str, event_date: date) -> str:
-    identity = f"alpha_vantage|TIME_SERIES_DAILY|{symbol}|{event_date.isoformat()}"
+def alpha_vantage_daily_event_id(symbol: str, event_date: date) -> str:
+    if type(event_date) is not date:
+        raise IngestionError("Alpha Vantage event identity requires a calendar date")
+    canonical_symbol = _canonical_symbol(symbol)
+    identity = (
+        f"alpha_vantage|TIME_SERIES_DAILY|{canonical_symbol}|{event_date.isoformat()}"
+    )
     digest = hashlib.sha256(identity.encode("utf-8")).hexdigest()[:20]
-    return f"av-daily-{digest}"
+    return f"{ALPHA_VANTAGE_DAILY_EVENT_PREFIX}{digest}"
 
 
 def _provider_error(payload: Mapping[str, Any]) -> str | None:
@@ -215,7 +221,7 @@ def parse_alpha_vantage_daily_response(
             raise IngestionError("Alpha Vantage daily bar has inconsistent OHLC values")
         events.append(
             MarketEvent(
-                event_id=_event_id(canonical_symbol, event_date),
+                event_id=alpha_vantage_daily_event_id(canonical_symbol, event_date),
                 symbol=canonical_symbol,
                 price=close_price,
                 volume=_parse_volume(raw_bar["5. volume"]),
@@ -375,6 +381,8 @@ def fetch_alpha_vantage_daily_events(
 
 
 __all__ = [
+    "ALPHA_VANTAGE_DAILY_EVENT_PREFIX",
+    "alpha_vantage_daily_event_id",
     "fetch_alpha_vantage_daily_events",
     "parse_alpha_vantage_daily_response",
 ]

--- a/src/orchestration/backfill.py
+++ b/src/orchestration/backfill.py
@@ -11,6 +11,7 @@ from uuid import uuid4
 import duckdb
 
 from ..common.exceptions import OverlapError
+from ..ingestion.alpha_vantage_client import ALPHA_VANTAGE_DAILY_EVENT_PREFIX
 from ..storage.partitioning import partition_path
 from ..storage.storage_config import load_storage_config
 from .run_pipeline import run_pipeline
@@ -39,6 +40,12 @@ def _timestamp_from_epoch_microseconds(value: Any) -> datetime:
         return _UTC_EPOCH + timedelta(microseconds=value)
     except (OverflowError, TypeError, ValueError):
         raise ValueError("Raw backfill timestamp is outside the supported range") from None
+
+
+def _minute_analytics_eligible(record: dict[str, Any]) -> bool:
+    return record.get("source") != "alpha_vantage" and not str(
+        record.get("event_id", "")
+    ).startswith(ALPHA_VANTAGE_DAILY_EVENT_PREFIX)
 
 
 def _normalize_window(window: str) -> str:
@@ -86,7 +93,7 @@ def _load_partition_records(partition_dir: Path) -> list[dict[str, Any]]:
         )
         rows = cursor.fetchall()
         columns = [description[0] for description in cursor.description]
-    return [
+    records = [
         {
             column: _json_replay_value(
                 _timestamp_from_epoch_microseconds(value)
@@ -97,6 +104,7 @@ def _load_partition_records(partition_dir: Path) -> list[dict[str, Any]]:
         }
         for row in rows
     ]
+    return [record for record in records if _minute_analytics_eligible(record)]
 
 
 def _load_resume_state(path: Path) -> dict[str, Any]:

--- a/tests/integration/test_backfill.py
+++ b/tests/integration/test_backfill.py
@@ -1,13 +1,14 @@
 from __future__ import annotations
 
 import sys
-from datetime import datetime, timezone
+from datetime import date, datetime, timezone
 from pathlib import Path
 from typing import Any
 from uuid import UUID
 
 import pytest
 
+from src.ingestion.alpha_vantage_client import alpha_vantage_daily_event_id
 from src.orchestration.backfill import _load_partition_records, run_backfill
 from src.orchestration.locks import acquire_partition_locks, release_partition_locks
 from src.storage.s3_writer import write_records
@@ -247,3 +248,54 @@ def test_backfill_partition_read_does_not_require_pytz(
     records = _load_partition_records(partition_dir)
     assert len(records) == 3
     assert records[0]["ts_event"].endswith("+00:00")
+
+
+def test_backfill_excludes_alpha_vantage_daily_events_from_minute_analytics(
+    tmp_path: Path,
+) -> None:
+    storage_config = build_storage_config(tmp_path, include_external_signal_summary=False)
+    storage_config_path = write_storage_config(
+        tmp_path,
+        include_external_signal_summary=False,
+    )
+    common = {
+        "symbol": "IBM",
+        "price": 101.5,
+        "volume": 1_200,
+        "ts_ingest": datetime(2025, 2, 2, 12, 30, tzinfo=timezone.utc),
+    }
+    events = [
+        {
+            **common,
+            "event_id": alpha_vantage_daily_event_id("IBM", date(2025, 1, 3)),
+            "ts_event": datetime(2025, 1, 3, tzinfo=timezone.utc),
+            "source": "alpha_vantage",
+        },
+        {
+            **common,
+            "event_id": "future-alpha-identity",
+            "ts_event": datetime(2025, 1, 4, tzinfo=timezone.utc),
+            "source": "alpha_vantage",
+        },
+        {
+            **common,
+            "event_id": "av-daily-legacy-marker",
+            "ts_event": datetime(2025, 1, 5, tzinfo=timezone.utc),
+            "source": "legacy-provider",
+        },
+    ]
+    assert write_records(events, kind="raw", storage_config=storage_config) == 3
+
+    result = run_backfill(
+        "2025-02-02T12:00:00Z",
+        "2025-02-02T12:00:00Z",
+        "hourly",
+        storage_config_path=storage_config_path,
+        thresholds_path=Path("config/risk_thresholds.yaml"),
+        resume=False,
+    )
+
+    assert len(result) == 1
+    assert result[0]["status"] == "skipped_no_records"
+    assert result[0]["records_replayed"] == 0
+    assert not (tmp_path / "curated").exists()

--- a/tests/unit/ingestion/test_alpha_vantage_client.py
+++ b/tests/unit/ingestion/test_alpha_vantage_client.py
@@ -12,6 +12,7 @@ import pytest
 import src.ingestion.alpha_vantage_client as alpha_vantage_client
 from src.common.exceptions import IngestionError
 from src.ingestion.alpha_vantage_client import (
+    alpha_vantage_daily_event_id,
     fetch_alpha_vantage_daily_events,
     parse_alpha_vantage_daily_response,
 )
@@ -137,7 +138,20 @@ def test_event_id_tracks_logical_bar_not_mutable_values() -> None:
     )
 
     assert original[0].event_id == corrected[0].event_id
+    assert original[0].event_id == "av-daily-696a6d4963466a26937a"
     assert original[0].price != corrected[0].price
+
+
+def test_daily_event_identity_is_pinned_to_canonical_symbol_and_calendar_date() -> None:
+    expected = "av-daily-696a6d4963466a26937a"
+
+    assert alpha_vantage_daily_event_id("IBM", date(2025, 1, 3)) == expected
+    assert alpha_vantage_daily_event_id("ibm", date(2025, 1, 3)) == expected
+    with pytest.raises(IngestionError, match="requires a calendar date"):
+        alpha_vantage_daily_event_id(
+            "IBM",
+            datetime(2025, 1, 3, tzinfo=timezone.utc),  # type: ignore[arg-type]
+        )
 
 
 def test_parse_daily_response_limits_most_recent_rows_then_orders_them() -> None:


### PR DESCRIPTION
## Context

Primary arc42 building block: `orchestration` (`Backfill`), with a narrow stable-identity interface to `ingestion`.

## Building block and runtime

- Pin the Alpha Vantage daily event identity contract.
- Exclude both Alpha Vantage source rows and `av-daily-` identities before minute-labelled replay analytics.
- Report an all-excluded partition as `skipped_no_records`.
- Fail closed for a future Alpha Vantage intraday feed until cadence is explicit.

This prevents daily bars from entering minute-return, five-minute-volatility, and lateness outputs. It adds no provider request, CLI, deployment, or warehouse behavior.

## History repair

The original branch was stacked on #39 before that PR was squash-merged. Its four behavioural paths were rebuilt on current `main` without carrying obsolete stack commits.

Current head: `b3f92fc7932fe794a4a805924b18a1c0f31aec2d`

- one commit ahead of `main`
- zero commits behind
- four changed paths
- 88 additions and 6 deletions

## Conflict resolution

The original branch also modified `docs/architecture.md`, but that path has since received a much larger controls-oriented architecture update on `main`. Replacing it with the old branch blob would revert newer documentation.

The repaired branch therefore preserves current `docs/architecture.md` unchanged. The cadence and exclusion behavior remains covered by code, this PR description, and focused ingestion/backfill tests. A focused architecture alignment can be handled separately.

## Fresh validation

GitHub Actions run `32193502720` (`ci` run 165) passed on the repaired head:

- Security guardrails: passed
- Python readiness: passed
  - dependency installation
  - `make quality-check`
  - `make readiness-check`
- Infrastructure validation: passed
  - `make infrastructure-check`

No unresolved review threads or requested changes were present.

## Merge boundary

Following the instruction to process and squash the dependency stack, this PR is ready to merge as one orchestration commit. It does not request the provider, deploy infrastructure, or authorize #41 automatically.