### PR TITLE
Harden CI publication controls

### DIFF
--- a/.github/overnight-publication-policy.json
+++ b/.github/overnight-publication-policy.json
@@ -1,0 +1,21 @@
+{
+  "schema_version": 1,
+  "publication_status": "disabled",
+  "authorization_expires": null,
+  "protected_base": {"repository": "alexmarinos87/financial-risk-data-platform", "branch": "main"},
+  "required_status_checks": [
+    "Security guardrails",
+    "Python readiness",
+    "Infrastructure validation"
+  ],
+  "adapters": {
+    "candidate_isolation": {"path": null, "sha256": null},
+    "policy_verifier": {"path": null, "sha256": null},
+    "publisher": {"path": null, "sha256": null}
+  },
+  "scheduled_run_capabilities": {
+    "create_local_branch": false, "edit_worktree": false,
+    "create_commit": false, "create_remote_branch": false,
+    "update_remote_branch": false, "open_draft_pull_request": false
+  }
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,14 @@
 name: ci
 
-on:
+"on":
   push:
+    branches:
+      - main
   pull_request:
+
+concurrency:
+  group: ci-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 permissions:
   contents: read
@@ -12,9 +18,11 @@ jobs:
     name: Security guardrails
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          persist-credentials: false
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.11"
 
@@ -26,9 +34,11 @@ jobs:
     env:
       PYTHONPATH: .
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          persist-credentials: false
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.11"
 
@@ -40,11 +50,13 @@ jobs:
     name: Infrastructure validation
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          persist-credentials: false
 
-      - uses: azure/setup-kubectl@v4
+      - uses: azure/setup-kubectl@776406bce94f63e41d621b960d78ee25c8b76ede # v4.0.1
 
-      - uses: hashicorp/setup-terraform@v3
+      - uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
         with:
           terraform_wrapper: false
 

--- a/docs/overnight-development.md
+++ b/docs/overnight-development.md
@@ -6,28 +6,26 @@ isolated worktree and create incremental green commits. A separately isolated
 publisher may push those commits to one new branch and open one draft pull
 request only after every activation prerequisite below is met.
 
-Publishing status: **disabled**
+Machine policy: `.github/overnight-publication-policy.json`
 
-Publishing authorization expires: **not set**
+Schema version 1 publication status: **disabled only**
 
-Publisher adapter path and SHA-256: **not configured**
+The machine policy, read as an exact Git blob from a recorded commit on
+protected `main`, is the activation source of truth. This prose and a saved
+scheduled prompt have no activation switch. The dependency-free security check
+rejects malformed, ambiguous, configured, or enabled schema-version-1 policy;
+it does not act as the future privileged activation verifier.
 
-Policy verifier path and SHA-256: **not configured**
+The current repository audit found no protection or ruleset on `main` and only
+a broad personal GitHub credential. CI now defines bounded triggers,
+concurrency, read-only permissions, and immutable action revisions, but those
+repository-file controls do not create an approved unattended publisher.
 
-Candidate isolation adapter path and SHA-256: **not configured**
-
-The current repository audit found no protection or ruleset on `main`, no CI
-concurrency policy, and only a broad personal GitHub credential. This document
-does not turn those conditions into an approved unattended publisher.
-
-These activation fields, read from a recorded commit on protected `main`, are the
-activation source of truth. A saved scheduled prompt has no activation switch.
-Enabling publication requires a human-reviewed PR that supplies an unexpired
-authorization, records protected-base paths and approved SHA-256 digests for
-implemented publisher, policy-verifier, and candidate-isolation adapters, checks
-every prerequisite below, and changes `Publishing status` to `enabled`. The
-scheduled task must continue reading the fields from the pinned base on every
-run.
+Enabling publication requires a later human-reviewed policy schema and trusted
+verifier that supply an unexpired authorization and approved identities for
+implemented publisher, policy-verifier, and candidate-isolation adapters. Every
+prerequisite below must also be independently verified. The scheduled task must
+continue reading and hashing the policy from the pinned base on every run.
 
 ## Outcome And Authority
 
@@ -93,8 +91,9 @@ verified:
       stale approvals, require approval after the last push, and require
       conversation resolution.
 - [ ] Block force pushes, branch deletion, administrator bypass, and bot bypass.
-- [ ] Add CI concurrency keyed by pull request or branch so a new checkpoint
-      cancels superseded validation for the same candidate.
+- [ ] Independently verify the repository CI concurrency keyed by pull request
+      or branch so a new checkpoint cancels superseded validation for the same
+      candidate. This is not the overnight writer lease.
 - [ ] Use a dedicated short-lived GitHub App installation token with only
       metadata read, contents read/write, pull-request write, and checks read.
 - [ ] Deny the publisher workflow, Actions-write, deployment, environment,
@@ -199,9 +198,10 @@ Each run must:
 2. Require a clean tracked and untracked state.
 3. In a trusted orchestration step, fetch `origin`, resolve `origin/main`, and
    record its commit SHA. Do not execute candidate code in this step.
-4. Read `AGENTS.md`, activation policy, architecture, security policy, and the
-   selected manifest from that exact commit with `git show <base-sha>:<path>`.
-   Hash the selected manifest and reject local, uncommitted, or stale copies.
+4. Read `AGENTS.md`, `.github/overnight-publication-policy.json`, architecture,
+   security policy, and the selected manifest from that exact commit with
+   `git show <base-sha>:<path>`. Hash the machine policy and selected manifest;
+   reject local, uncommitted, or stale copies.
 5. Confirm no matching local/remote branch, terminal run record, or PR exists.
 6. Verify the protected-base policy names implemented policy-verifier,
    candidate-isolation, and publisher adapter paths plus approved SHA-256
@@ -458,9 +458,10 @@ orchestration step, fetch origin and record the origin/main SHA. Read AGENTS.md,
 docs/architecture.md, docs/overnight-development.md,
 docs/security-protocols.md, docs/engineering-delivery-workflow.md,
 docs/agent-roles.md, and docs/iteration-backlog.md from that exact commit with
-git show. Resolve the selected manifest link, read its entire Git blob from the
-same commit, and hash the exact bytes. Never select from local or uncommitted
-copies.
+git show. Also read `.github/overnight-publication-policy.json` from that exact
+commit and hash its complete Git blob. Resolve the selected manifest link, read
+its entire Git blob from the same commit, and hash the exact bytes. Never select
+from local or uncommitted copies.
 
 Select exactly one unexpired backlog item whose status is exactly
 "approved for overnight development" and whose manifest is complete. If none
@@ -478,12 +479,12 @@ security-check, git diff --check, and at least the arc42 minimum validation for
 the primary block.
 Stage only allowed paths. Never create a broken or WIP commit.
 
-Read `Publishing status`, its expiry, the paths and SHA-256 identities of the
-publisher, policy verifier, and candidate isolation adapter, and the activation
-checklist from the recorded protected-base runbook. With the current
-disabled/not-configured values, report a successful no-op before creating a
-branch, editing, committing, pushing, or opening a PR. Do not simulate an
-isolation or publication adapter in prompt logic.
+Strictly validate the recorded protected-base machine policy. Schema version 1
+authorizes only a disabled state with no expiry, configured adapters, or
+scheduled mutation capabilities. Report a successful no-op before creating a
+branch, editing, committing, pushing, or opening a PR. Do not infer authority
+from this runbook or simulate an isolation or publication adapter in prompt
+logic.
 
 If a future protected-base version enables publication, still publish only when
 every activation prerequisite, credential boundary, task manifest, shared

--- a/docs/security-protocols.md
+++ b/docs/security-protocols.md
@@ -8,7 +8,10 @@ Cloud deployment remains manual and approval-driven.
 1. `make security-check` scans for obvious committed secrets, generated output,
    unsafe deploy triggers, missing ownership rules, unsafe local database port
    bindings, risky Kubernetes defaults, and managed database creation flags.
-2. CI separates security guardrails, Python readiness, and infrastructure
+2. CI runs for pull requests and pushes to `main`, cancels superseded
+   runs for the same pull request or branch, keeps repository permissions
+   read-only, and pins its external actions to reviewed commit SHAs. It
+   separates security guardrails, Python readiness, and infrastructure
    validation into distinct jobs. Python readiness includes linting, type
    checking, tests, demo execution, and warehouse dry-run loading.
 3. `.gitignore` and `.dockerignore` exclude local environments, generated data,
@@ -73,9 +76,19 @@ credentials, or create cloud resources.
 `docs/overnight-development.md` describes a separate candidate mode. It does
 not weaken the sandbox or activate publication by itself.
 
+`.github/overnight-publication-policy.json` is the machine-readable publication
+policy. Schema version 1 is deliberately disabled-only: `make security-check`
+rejects attempted activation, configured adapters, mutation capabilities,
+ambiguous JSON, and CI contract regressions. That candidate-tree check is not a
+trusted activation verifier. A future scheduler must load and verify approved
+policy and verifier bytes from the pinned protected-base commit before any
+branch creation or worktree mutation.
+
 ## Known Boundaries
 
 The current local security check is intentionally lightweight. It is useful for
 this repo, but it is not a substitute for organization-wide secret scanning,
 SAST, dependency scanning, image scanning, cloud policy checks, or production
-security review.
+security review. Immutable-action enforcement in this iteration covers
+`.github/workflows/ci.yml`; the privileged manual deployment workflow remains a
+separate deployment-control review.

--- a/scripts/overnight_publication_policy.py
+++ b/scripts/overnight_publication_policy.py
@@ -1,0 +1,198 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+
+POLICY_PATH = Path(".github/overnight-publication-policy.json")
+CI_PATH = Path(".github/workflows/ci.yml")
+MAX_POLICY_BYTES = 16 * 1024
+MAX_CI_BYTES = 128 * 1024
+
+REQUIRED_STATUS_CHECKS = ("Security guardrails", "Python readiness", "Infrastructure validation")
+
+EXPECTED_POLICY: dict[str, Any] = {
+    "schema_version": 1,
+    "publication_status": "disabled",
+    "authorization_expires": None,
+    "protected_base": {"repository": "alexmarinos87/financial-risk-data-platform", "branch": "main"},
+    "required_status_checks": list(REQUIRED_STATUS_CHECKS),
+    "adapters": {
+        "candidate_isolation": {"path": None, "sha256": None},
+        "policy_verifier": {"path": None, "sha256": None},
+        "publisher": {"path": None, "sha256": None},
+    },
+    "scheduled_run_capabilities": {
+        "create_local_branch": False, "edit_worktree": False,
+        "create_commit": False, "create_remote_branch": False,
+        "update_remote_branch": False, "open_draft_pull_request": False,
+    },
+}
+
+EXPECTED_TOP_LEVEL_BLOCKS = {
+    "name": "name: ci",
+    "on": """\
+"on":
+  push:
+    branches:
+      - main
+  pull_request:""",
+    "concurrency": """\
+concurrency:
+  group: ci-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true""",
+    "permissions": """\
+permissions:
+  contents: read""",
+}
+EXPECTED_TOP_LEVEL_KEYS = ("name", "on", "concurrency", "permissions", "jobs")
+EXPECTED_CI_SHA256 = "09359624d59e624b9697e9b24799046d47b4555c70ba4da994002c36135d13fe"
+EXPECTED_JOBS_SHA256 = "38cfb5469cb446dd6633badd5c1d19f9a1e0e6e448ecd729167318091268ef32"
+
+ALLOWED_ACTIONS = {
+    "actions/checkout": "11d5960a326750d5838078e36cf38b85af677262",
+    "actions/setup-python": "a26af69be951a213d495a4c3e4e4022e16d87065",
+    "azure/setup-kubectl": "776406bce94f63e41d621b960d78ee25c8b76ede",
+    "hashicorp/setup-terraform": "b9cd54a3c349d3f38e8881555d616ced269862dd",
+}
+
+
+class _DuplicateKeyError(ValueError):
+    pass
+
+
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise _DuplicateKeyError
+        result[key] = value
+    return result
+
+
+def _reject_nonstandard_constant(_value: str) -> None:
+    raise ValueError
+
+
+def _read_control_file(path: Path, maximum_bytes: int, label: str) -> tuple[str | None, list[str]]:
+    try:
+        if path.is_symlink() or not path.is_file():
+            return None, [f"{label} must be a regular non-symlink file"]
+        if path.stat().st_size > maximum_bytes:
+            return None, [f"{label} exceeds its size limit"]
+        data = path.read_bytes()
+        if len(data) > maximum_bytes:
+            return None, [f"{label} exceeds its size limit"]
+        return data.decode("utf-8"), []
+    except (OSError, UnicodeError, ValueError):
+        return None, [f"{label} could not be read safely"]
+
+
+def _matches_exact_types(actual: Any, expected: Any) -> bool:
+    if type(actual) is not type(expected):
+        return False
+    if isinstance(expected, dict):
+        return actual.keys() == expected.keys() and all(
+            _matches_exact_types(actual[key], value) for key, value in expected.items()
+        )
+    if isinstance(expected, list):
+        return len(actual) == len(expected) and all(
+            _matches_exact_types(item, expected[index]) for index, item in enumerate(actual)
+        )
+    return actual == expected
+
+
+def validate_disabled_policy_text(text: str) -> list[str]:
+    try:
+        policy = json.loads(
+            text,
+            object_pairs_hook=_reject_duplicate_keys,
+            parse_constant=_reject_nonstandard_constant,
+        )
+    except (json.JSONDecodeError, _DuplicateKeyError, ValueError, TypeError):
+        return ["overnight publication policy is not strict JSON"]
+
+    if not _matches_exact_types(policy, EXPECTED_POLICY):
+        return ["overnight publication policy must match disabled schema version 1"]
+    return []
+
+
+def _top_level_blocks(text: str) -> tuple[dict[str, str], bool]:
+    lines = text.splitlines()
+    starts: list[tuple[int, str]] = []
+    pattern = re.compile(r'^(?:"(?P<quoted>[^"]+)"|(?P<plain>[A-Za-z][A-Za-z0-9_-]*)):(?:\s.*)?$')
+    for index, line in enumerate(lines):
+        match = pattern.fullmatch(line)
+        if match:
+            starts.append((index, match.group("quoted") or match.group("plain")))
+
+    blocks: dict[str, str] = {}
+    duplicate = False
+    for position, (start, name) in enumerate(starts):
+        end = starts[position + 1][0] if position + 1 < len(starts) else len(lines)
+        if name in blocks:
+            duplicate = True
+        blocks[name] = "\n".join(lines[start:end]).rstrip()
+    return blocks, duplicate
+
+
+def validate_ci_text(text: str) -> list[str]:
+    failures: list[str] = []
+    if hashlib.sha256(text.encode()).hexdigest() != EXPECTED_CI_SHA256:
+        failures.append("CI workflow bytes do not match the reviewed contract")
+    blocks, duplicate = _top_level_blocks(text)
+    if duplicate:
+        failures.append("CI workflow has duplicate top-level keys")
+    if tuple(blocks) != EXPECTED_TOP_LEVEL_KEYS:
+        failures.append("CI workflow top-level keys are not exact")
+    for name, expected in EXPECTED_TOP_LEVEL_BLOCKS.items():
+        if blocks.get(name) != expected:
+            failures.append(f"CI workflow {name} contract is not exact")
+
+    jobs = blocks.get("jobs", "")
+    if hashlib.sha256(jobs.encode()).hexdigest() != EXPECTED_JOBS_SHA256:
+        failures.append("CI workflow job contract is not exact")
+    job_names = re.findall(r"(?m)^    name: (.+)$", jobs)
+    if tuple(job_names) != REQUIRED_STATUS_CHECKS or len(set(job_names)) != len(job_names):
+        failures.append("CI workflow required status-check names are not exact and unique")
+
+    action_pattern = re.compile(r"(?m)^\s*- uses:\s+([^#\s]+)(?:\s+#.*)?$")
+    action_matches = list(action_pattern.finditer(text))
+    if len(action_matches) != text.count("uses:"):
+        failures.append("CI workflow contains an unparseable action reference")
+    for match in action_matches:
+        reference = match.group(1)
+        if "@" not in reference:
+            failures.append("CI workflow action reference is missing an immutable revision")
+            continue
+        action, revision = reference.rsplit("@", maxsplit=1)
+        if not re.fullmatch(r"[0-9a-f]{40}", revision):
+            failures.append("CI workflow action reference is not a full commit SHA")
+        if ALLOWED_ACTIONS.get(action) != revision:
+            failures.append("CI workflow action is not on the approved immutable allowlist")
+
+        if action == "actions/checkout":
+            next_step = re.search(r"(?m)^      - ", text[match.end() :])
+            end = match.end() + next_step.start() if next_step else len(text)
+            step = text[match.end() : end]
+            if "\n        with:\n          persist-credentials: false" not in step:
+                failures.append("CI checkout must disable persisted credentials")
+
+    return failures
+
+
+def validate_repository_controls(root: Path) -> list[str]:
+    policy_text, failures = _read_control_file(
+        root / POLICY_PATH, MAX_POLICY_BYTES, "overnight publication policy"
+    )
+    if policy_text is not None:
+        failures.extend(validate_disabled_policy_text(policy_text))
+
+    ci_text, ci_failures = _read_control_file(root / CI_PATH, MAX_CI_BYTES, "CI workflow")
+    failures.extend(ci_failures)
+    if ci_text is not None:
+        failures.extend(validate_ci_text(ci_text))
+    return failures

--- a/scripts/security_check.py
+++ b/scripts/security_check.py
@@ -5,6 +5,8 @@ import subprocess
 import sys
 from pathlib import Path
 
+from overnight_publication_policy import validate_repository_controls
+
 
 ROOT = Path(__file__).resolve().parents[1]
 
@@ -208,6 +210,7 @@ def main() -> int:
     check_kubernetes_defaults(failures)
     check_kubernetes_config_copies(failures)
     check_terraform_flags(failures)
+    failures.extend(validate_repository_controls(ROOT))
 
     if failures:
         print("Security check failed:")
@@ -224,6 +227,7 @@ def main() -> int:
     print("- base Kubernetes defaults avoid token mounting and deny egress")
     print("- Kubernetes deploy config copies match repo config")
     print("- optional managed database creation flags default to false")
+    print("- CI contract is valid and overnight publication policy is disabled")
     return 0
 
 

--- a/tests/unit/test_overnight_publication_policy.py
+++ b/tests/unit/test_overnight_publication_policy.py
@@ -1,0 +1,164 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts.overnight_publication_policy import (
+    CI_PATH,
+    EXPECTED_POLICY,
+    MAX_POLICY_BYTES,
+    POLICY_PATH,
+    validate_ci_text,
+    validate_disabled_policy_text,
+    validate_repository_controls,
+)
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def _policy_text(policy: object = EXPECTED_POLICY) -> str:
+    return json.dumps(policy)
+
+
+def _changed_policy(*path: str, value: object) -> dict[str, object]:
+    policy = json.loads(_policy_text())
+    target = policy
+    for key in path[:-1]:
+        target = target[key]
+    target[path[-1]] = value
+    return policy
+
+
+def _copy_controls(tmp_path: Path) -> None:
+    for relative_path in (POLICY_PATH, CI_PATH):
+        destination = tmp_path / relative_path
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        destination.write_bytes((ROOT / relative_path).read_bytes())
+
+
+def test_repository_controls_accept_canonical_disabled_state() -> None:
+    assert validate_repository_controls(ROOT) == []
+
+
+@pytest.mark.parametrize(
+    ("path", "value"),
+    [
+        (("publication_status",), "enabled"),
+        (("publication_status",), "DISABLED"),
+        (("publication_status",), None),
+        (("publication_status",), False),
+        (("authorization_expires",), "2026-08-16T07:00:00Z"),
+        (("schema_version",), True),
+        (("scheduled_run_capabilities", "create_commit"), 0),
+        (("scheduled_run_capabilities", "create_commit"), 0.0),
+        (("adapters", "candidate_isolation", "path"), "scripts/isolate.py"),
+        (("adapters", "candidate_isolation", "sha256"), "0" * 64),
+        (("adapters", "policy_verifier", "path"), "scripts/verify.py"),
+        (("adapters", "policy_verifier", "sha256"), "0" * 64),
+        (("adapters", "publisher", "path"), "scripts/publisher.py"),
+        (("adapters", "publisher", "sha256"), "0" * 64),
+        (("scheduled_run_capabilities", "create_local_branch"), True),
+        (("scheduled_run_capabilities", "edit_worktree"), True),
+        (("scheduled_run_capabilities", "create_commit"), True),
+        (("scheduled_run_capabilities", "create_remote_branch"), True),
+        (("scheduled_run_capabilities", "update_remote_branch"), True),
+        (("scheduled_run_capabilities", "open_draft_pull_request"), True),
+    ],
+)
+def test_disabled_policy_rejects_activation_data(path: tuple[str, ...], value: object) -> None:
+    assert validate_disabled_policy_text(_policy_text(_changed_policy(*path, value=value)))
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "",
+        "not json",
+        "[]",
+        '{"publication_status":"disabled","publication_status":"disabled"}',
+        '{"schema_version": NaN}',
+    ],
+)
+def test_disabled_policy_rejects_malformed_or_wrong_shaped_json(text: str) -> None:
+    assert validate_disabled_policy_text(text)
+
+
+def test_disabled_policy_rejects_unknown_and_missing_fields() -> None:
+    unknown = json.loads(_policy_text())
+    unknown["override"] = False
+    missing = json.loads(_policy_text())
+    del missing["authorization_expires"]
+
+    assert validate_disabled_policy_text(_policy_text(unknown))
+    assert validate_disabled_policy_text(_policy_text(missing))
+
+
+def test_repository_controls_reject_missing_symlinked_and_oversized_policy(
+    tmp_path: Path,
+) -> None:
+    _copy_controls(tmp_path)
+    policy_path = tmp_path / POLICY_PATH
+
+    policy_path.unlink()
+    assert validate_repository_controls(tmp_path)
+
+    policy_path.symlink_to(ROOT / POLICY_PATH)
+    assert validate_repository_controls(tmp_path)
+
+    policy_path.unlink()
+    policy_path.write_text(" " * (MAX_POLICY_BYTES + 1), encoding="utf-8")
+    assert validate_repository_controls(tmp_path)
+
+    policy_path.write_bytes((ROOT / POLICY_PATH).read_bytes())
+    ci_path = tmp_path / CI_PATH
+    ci_path.write_bytes(ci_path.read_bytes().replace(b"\n", b"\r\n"))
+    assert validate_repository_controls(tmp_path)
+
+
+@pytest.mark.parametrize(
+    ("old", "new"),
+    [
+        ("      - main", "      - '*'"),
+        ("  pull_request:", "  pull_request_target:"),
+        ("  cancel-in-progress: true", "  cancel-in-progress: false"),
+        ("@11d5960a326750d5838078e36cf38b85af677262", "@v4"),
+        (
+            "@11d5960a326750d5838078e36cf38b85af677262",
+            "@${{ github.event.after }}",
+        ),
+        (
+            "actions/checkout@11d5960a326750d5838078e36cf38b85af677262",
+            "example/checkout@11d5960a326750d5838078e36cf38b85af677262",
+        ),
+        ("          persist-credentials: false", "          persist-credentials: true"),
+        ("  contents: read", "  contents: write"),
+        ("    name: Python readiness", "    name: Security guardrails"),
+        (
+            "      - run: PYTHON=python make security-check",
+            "      - run: true",
+        ),
+        (
+            "      - run: PYTHON=python make security-check",
+            "      - run: PYTHON=python make security-check\n        continue-on-error: true",
+        ),
+        (
+            "    runs-on: ubuntu-latest",
+            "    permissions: contents: write\n    runs-on: ubuntu-latest",
+        ),
+        (
+            "      - run: PYTHON=python make readiness-check",
+            "      - if: false\n      - run: PYTHON=python make readiness-check",
+        ),
+        ('"on":', '"on":\n"o\\u006e":\n  pull_request_target:'),
+        ("permissions:", 'permissions:\n"per\\u006dissions": write-all'),
+        ("      - uses:", '      - "uses":'),
+    ],
+)
+def test_ci_contract_rejects_security_regressions(old: str, new: str) -> None:
+    canonical = (ROOT / CI_PATH).read_text(encoding="utf-8")
+    assert old in canonical
+
+    assert validate_ci_text(canonical.replace(old, new, 1))


### PR DESCRIPTION
## Context

This PR is the first machine-enforced engineering-controls prerequisite for guarded overnight work. It does not activate scheduled mutation or publication.

## Changes

- Run CI for pull requests and pushes to `main`, with per-PR/ref concurrency and stale-run cancellation.
- Pin every CI action to a reviewed full commit SHA and disable persisted checkout credentials.
- Add a strict, dependency-free machine policy whose schema v1 accepts only the disabled state.
- Make `make security-check` fail closed on malformed, ambiguous, configured, or enabled policy and on any byte change to the reviewed CI contract.
- Add mutation tests for JSON type confusion, duplicate/non-standard JSON, symlink/size cases, triggers, permissions, skipped checks, mutable/unapproved actions, encoded YAML keys, and checkout credentials.
- Update the overnight and security runbooks to make the protected-base machine policy authoritative.

## Safety boundary

Publication remains disabled: authorization expiry and all adapter identities are null; all six local/remote mutation capabilities are exact Boolean `false`; no scheduler, publisher, credential broker, lease, or isolation adapter is added. Markdown and candidate-tree checks are explicitly non-authoritative.

Branch protection, a second trusted reviewer, the least-privilege GitHub App/broker, protected-base verifier, lease/fencing, candidate isolation, deploy-workflow pinning, publication, merge, and deployment are out of scope.

## History repair

The previously reviewed tree was rebased unchanged onto current `main` after PR #35 was squash-merged. The branch is exactly one commit ahead and zero behind. Scope remains 455 additions and 42 deletions across 7 files.

## Evidence

- `make security-check`: passed
- `make quality-check`: passed; 138 tests
- `make readiness-check`: passed
- `make infrastructure-check`: passed; Kubernetes render plus Terraform fmt/init/validate
- focused policy/CI tests: 44 passed
- strict YAML parse: expected triggers, concurrency, and read-only permissions
- `git diff --check`: passed
- fresh detached-checkout validation: passed with clean state before and after
- independent correctness and adversarial reviews found no remaining blocker
- fresh pull-request CI required on the repaired ancestry before squash merge

## Merge plan

Squash-merge into `main` after the fresh CI run succeeds. Later engineering-control PRs remain separate slices and must be rebased in order.