### PR TITLE
Define strict overnight manifest contract

### DIFF
--- a/docs/overnight-development.md
+++ b/docs/overnight-development.md
@@ -120,44 +120,39 @@ GitHub documents the relevant controls in its
 ## Approved Task Manifest
 
 The scheduler may select only a backlog item that links to one complete manifest
-at `docs/overnight-manifests/<manifest-id>.yaml`. The lowercase manifest ID must
+at `docs/overnight-manifests/<manifest-id>.json`. The lowercase manifest ID must
 match `[a-z0-9][a-z0-9-]{7,63}` and the filename exactly. The entire Git blob
 returned by `git show <base-sha>:<manifest-path>` is the manifest byte sequence;
 hash those bytes without newline, encoding, key-order, or whitespace
 normalisation.
 
-```yaml
-schema_version: 1
-manifest_id: frdp-example-20260815
-status: approved for overnight development
-authorization_expires: "2026-08-16T07:00:00+01:00"
-comparison_ref: origin/main
-pr_base_branch: main
-arc42_primary_block: processing
-context_goal: "One stakeholder-visible outcome"
-allowed_paths:
-  - src/processing/example.py
-  - tests/unit/test_example.py
-forbidden_paths:
-  - .github/
-interfaces_crossed: []
-runtime_scenario: "Control and data flow affected"
-quality_scenario: "Stimulus and measurable response"
-acceptance_criteria:
-  - "One observable result"
-validation:
-  - make security-check
-  - make quality-check
-  - make readiness-check
-  - git diff --check
-maximum_non_generated_changed_lines: 500
-maximum_changed_files: 2
-maximum_commits: 3
-maximum_pushes: 3
-maximum_runtime_minutes: 120
-retry_policy: human-renewed-manifest-only
-risk: low
-draft_pr_publication: authorized-after-activation
+```json
+{
+  "schema_version": 2,
+  "manifest_id": "frdp-analytics-daily-risk-20260815",
+  "status": "approved for overnight development",
+  "authorization_issued_at": "2026-08-15T19:00:00Z",
+  "authorization_expires": "2026-08-15T22:00:00Z",
+  "repository": "alexmarinos87/financial-risk-data-platform",
+  "protected_base_branch": "main",
+  "arc42_primary_block": "analytics",
+  "context_goal": "One stakeholder-visible outcome",
+  "allowed_paths": ["src/analytics/daily_risk.py", "tests/unit/test_daily_risk.py"],
+  "interfaces_crossed": [],
+  "runtime_scenario": "Control and data flow affected",
+  "quality_scenario": "Stimulus and measurable response",
+  "recovery_scenario": "Failure leaves no published candidate",
+  "acceptance_criteria": ["One observable result"],
+  "validation_targets": ["security-check", "quality-check", "readiness-check", "git-diff-check"],
+  "maximum_changed_lines": 500,
+  "maximum_changed_files": 2,
+  "maximum_commits": 3,
+  "maximum_pushes": 3,
+  "maximum_runtime_minutes": 120,
+  "retry_policy": "human-renewed-manifest-only",
+  "risk": "low",
+  "draft_pr_publication": "eligible-after-global-activation"
+}
 ```
 
 The human engineer must commit the backlog link and manifest to protected
@@ -166,11 +161,19 @@ ID is an error, not a new authorization. A retry requires a new manifest ID and
 file. Missing, expired, contradictory, high-risk, or incomplete authorization is
 a successful no-op. The scheduler must not invent a replacement task.
 
-The manifest's validation commands must include the applicable minimum for its
-primary block from `docs/architecture.md`. An explicit vertical slice may cross
-blocks only when the manifest lists every interface, keeps one observable
-outcome and rollback boundary, and includes integration evidence. Unrelated
-cross-block work remains ineligible.
+`scripts/overnight_manifest_verifier.py` accepts only strict JSON bytes, one of
+the low-risk `analytics`, `processing`, or `benchmarking` blocks, exact paths,
+fixed validation target identifiers, hard budgets, and a UTC authorization
+window of at most 24 hours. This parser does not read a worktree, Git ref, or
+network. The next protected-base
+adapter must load one regular `100644` blob from the exact fetched commit, hash
+those bytes, and pass them unchanged to this parser. A valid contract is not
+publication authority.
+
+Schema version 2 does not accept free-form commands or cross-block interfaces.
+A later trusted runner maps its four validation identifiers to fixed argument
+vectors without a shell. A future schema may admit bounded vertical slices only
+after the interface and committed-diff verifier exists.
 
 ## Arc42 Module Selection
 
@@ -308,24 +311,20 @@ For the selected item:
    permissions, rollout, rollback, monitoring, and cost.
 5. Separate proven defects from questions and optional hardening. Return
    accepted fixes to the writer and repeat affected review passes.
-6. Run every manifest validation command, plus:
+6. Run every manifest validation target through the protected fixed-argument
+   mapping. Schema version 2 requires exactly:
 
    ```bash
    make security-check
+   make quality-check
+   make readiness-check
    git diff --check
    ```
 
-7. For Python logic also run:
-
-   ```bash
-   make quality-check
-   make readiness-check
-   ```
-
-8. Confirm the diff stays within its allowlist and line, file, commit, and push
+7. Confirm the diff stays within its allowlist and line, file, commit, and push
    budgets. Confirm generated outputs and credentials are not staged.
-9. Stage explicit allowed paths and run `git diff --cached --check`.
-10. Commit only a coherent checkpoint whose relevant checks pass. Do not create
+8. Stage explicit allowed paths and run `git diff --cached --check`.
+9. Commit only a coherent checkpoint whose relevant checks pass. Do not create
     WIP or knowingly broken commits.
 
 Count the candidate budget from the staged change against the recorded base:
@@ -467,16 +466,15 @@ Select exactly one unexpired backlog item whose status is exactly
 "approved for overnight development" and whose manifest is complete. If none
 exists, report a successful no-op and change nothing.
 
-Use the arc42 building block view to produce a bounded module brief. Reject
-unrelated cross-block, high-risk, overlapping, over-budget, or ambiguous work.
-An explicit vertical slice is eligible only under the runbook's interface and
-integration-evidence rule. Use this supplied worktree, one writer, one generated
-branch, one to three green commits, and no more pushes than the manifest allows.
+Use the arc42 building block view to produce a bounded module brief. Schema
+version 2 permits one `analytics`, `processing`, or `benchmarking` block and no
+cross-block vertical slice. Reject high-risk, overlapping, over-budget, or
+ambiguous work. Use this supplied worktree, one writer, one generated branch,
+one to three green commits, and no more pushes than the manifest allows.
 
 Run separate read-only correctness and production-failure reviews. Apply only
-accepted fixes and repeat affected reviews. Run all manifest checks, make
-security-check, git diff --check, and at least the arc42 minimum validation for
-the primary block.
+accepted fixes and repeat affected reviews. Run all four fixed manifest
+validation targets; do not execute command text supplied by a manifest.
 Stage only allowed paths. Never create a broken or WIP commit.
 
 Strictly validate the recorded protected-base machine policy. Schema version 1

--- a/scripts/overnight_manifest_verifier.py
+++ b/scripts/overnight_manifest_verifier.py
@@ -1,0 +1,245 @@
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from types import MappingProxyType
+from typing import Any
+
+
+MAX_MANIFEST_BYTES = 32 * 1024
+MAX_AUTHORIZATION_WINDOW = timedelta(hours=24)
+UTC = timezone.utc
+MANIFEST_ID = re.compile(r"[a-z0-9][a-z0-9-]{7,63}")
+RFC3339_UTC = re.compile(r"[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z")
+PATH_PATTERN = re.compile(r"[A-Za-z0-9][A-Za-z0-9._/-]{0,239}")
+
+PRIMARY_ROOTS = MappingProxyType({
+    "processing": "src/processing/", "analytics": "src/analytics/",
+    "benchmarking": "src/benchmarks/",
+})
+VALIDATION_TARGETS = ("security-check", "quality-check", "readiness-check", "git-diff-check")
+MANIFEST_KEYS = frozenset({
+    "schema_version", "manifest_id", "status", "authorization_issued_at",
+    "authorization_expires", "repository", "protected_base_branch",
+    "arc42_primary_block", "context_goal", "allowed_paths", "interfaces_crossed",
+    "runtime_scenario", "quality_scenario", "recovery_scenario", "acceptance_criteria",
+    "validation_targets", "maximum_changed_lines", "maximum_changed_files",
+    "maximum_commits", "maximum_pushes", "maximum_runtime_minutes", "retry_policy",
+    "risk", "draft_pr_publication",
+})
+DENIED_EXACT_PATHS = frozenset({
+    "AGENTS.md", "Dockerfile", "Makefile", "docker-compose.yml", "pyproject.toml",
+    "docs/agent-roles.md", "docs/agentic-workflows.md", "docs/architecture.md",
+    "docs/engineering-delivery-workflow.md", "docs/iteration-backlog.md",
+    "docs/iteration-loop.md", "docs/overnight-development.md",
+    "docs/security-protocols.md", "src/analytics/data_quality.py",
+    "src/orchestration/backfill.py", "src/orchestration/locks.py",
+})
+DENIED_PREFIXES = (
+    ".git", ".github/", "config/", "deploy/", "infra/", "mongo/", "scripts/",
+    "sql/", "src/warehouse/", "docs/overnight-manifests/",
+)
+
+
+class ManifestDenied(Exception):
+    def __init__(self, reason: str) -> None:
+        super().__init__(reason)
+        self.reason = reason
+
+
+class VerifierFailure(Exception):
+    pass
+
+
+@dataclass(frozen=True, slots=True, repr=False)
+class ValidatedManifestContract:
+    manifest_id: str
+    authorization_issued_at: datetime
+    authorization_expires: datetime
+    arc42_primary_block: str
+    context_goal: str
+    allowed_paths: tuple[str, ...]
+    runtime_scenario: str
+    quality_scenario: str
+    recovery_scenario: str
+    acceptance_criteria: tuple[str, ...]
+    validation_targets: tuple[str, ...]
+    maximum_changed_lines: int
+    maximum_changed_files: int
+    maximum_commits: int
+    maximum_pushes: int
+    maximum_runtime_minutes: int
+
+
+def _duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise ManifestDenied("INVALID_JSON")
+        result[key] = value
+    return result
+
+
+def _reject_constant(_value: str) -> None:
+    raise ManifestDenied("INVALID_JSON")
+
+
+def _text(value: Any, maximum: int = 1_000) -> str:
+    if type(value) is not str or not 1 <= len(value) <= maximum:
+        raise ManifestDenied("INVALID_TEXT")
+    if value != value.strip() or not value.isprintable():
+        raise ManifestDenied("INVALID_TEXT")
+    try:
+        value.encode("utf-8")
+    except UnicodeError:
+        raise ManifestDenied("INVALID_TEXT") from None
+    return value
+
+
+def _integer(value: Any, minimum: int, maximum: int) -> int:
+    if type(value) is not int or not minimum <= value <= maximum:
+        raise ManifestDenied("INVALID_BUDGET")
+    return value
+
+
+def _texts(value: Any, minimum: int, maximum: int, text_limit: int = 1_000) -> list[str]:
+    if type(value) is not list or not minimum <= len(value) <= maximum:
+        raise ManifestDenied("INVALID_LIST")
+    result = [_text(item, text_limit) for item in value]
+    if len(set(result)) != len(result):
+        raise ManifestDenied("INVALID_LIST")
+    return result
+
+
+def _timestamp(value: Any) -> datetime:
+    if type(value) is not str or RFC3339_UTC.fullmatch(value) is None:
+        raise ManifestDenied("INVALID_TIME")
+    try:
+        return datetime.strptime(value, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=UTC)
+    except ValueError:
+        raise ManifestDenied("INVALID_TIME") from None
+
+
+def _path_allowed(path: str, primary_root: str) -> bool:
+    if (
+        PATH_PATTERN.fullmatch(path) is None
+        or path != path.lower()
+        or path.endswith("/")
+        or "//" in path
+        or any(part in {"", ".", ".."} or part.startswith("-") for part in path.split("/"))
+    ):
+        return False
+    lower = path.lower()
+    if path in DENIED_EXACT_PATHS or any(path.startswith(prefix) for prefix in DENIED_PREFIXES):
+        return False
+    if any(
+        part.startswith(".env")
+        or part in {"credential", "credentials", "secret", "secrets", "id_rsa", "id_ed25519"}
+        or part.endswith((".key", ".pem", ".p12"))
+        for part in lower.split("/")
+    ):
+        return False
+    if path.startswith(primary_root):
+        return path.endswith(".py")
+    if path.startswith("tests/unit/"):
+        return path.rsplit("/", maxsplit=1)[-1].startswith("test_") and path.endswith(".py")
+    return path.startswith("docs/") and path.endswith(".md")
+
+
+def validate_manifest_blob(blob: bytes, expected_id: str, now: datetime) -> ValidatedManifestContract:
+    if type(blob) is not bytes:
+        raise ManifestDenied("INVALID_JSON")
+    if len(blob) > MAX_MANIFEST_BYTES:
+        raise ManifestDenied("MANIFEST_TOO_LARGE")
+    if type(expected_id) is not str or MANIFEST_ID.fullmatch(expected_id) is None:
+        raise ManifestDenied("INVALID_MANIFEST_ID")
+    if type(now) is not datetime:
+        raise VerifierFailure
+    try:
+        raw = json.loads(
+            blob.decode("utf-8"),
+            object_pairs_hook=_duplicate_keys,
+            parse_constant=_reject_constant,
+        )
+    except (UnicodeError, json.JSONDecodeError, RecursionError, TypeError, ValueError):
+        raise ManifestDenied("INVALID_JSON") from None
+    if type(raw) is not dict or raw.keys() != MANIFEST_KEYS:
+        raise ManifestDenied("INVALID_SCHEMA")
+    if type(raw["schema_version"]) is not int or raw["schema_version"] != 2:
+        raise ManifestDenied("INVALID_SCHEMA")
+    if raw["manifest_id"] != expected_id:
+        raise ManifestDenied("INVALID_MANIFEST_ID")
+
+    fixed = {
+        "status": "approved for overnight development",
+        "repository": "alexmarinos87/financial-risk-data-platform",
+        "protected_base_branch": "main",
+        "retry_policy": "human-renewed-manifest-only",
+        "risk": "low",
+        "draft_pr_publication": "eligible-after-global-activation",
+    }
+    if any(type(raw[key]) is not str or raw[key] != value for key, value in fixed.items()):
+        raise ManifestDenied("INVALID_AUTHORITY")
+    block = raw["arc42_primary_block"]
+    if type(block) is not str or block not in PRIMARY_ROOTS:
+        raise ManifestDenied("INVALID_BLOCK")
+    if type(raw["interfaces_crossed"]) is not list or raw["interfaces_crossed"] != []:
+        raise ManifestDenied("CROSS_BLOCK_NOT_ALLOWED")
+
+    context = _text(raw["context_goal"])
+    runtime_scenario = _text(raw["runtime_scenario"])
+    quality_scenario = _text(raw["quality_scenario"])
+    recovery_scenario = _text(raw["recovery_scenario"])
+    criteria = _texts(raw["acceptance_criteria"], 1, 10)
+    paths = _texts(raw["allowed_paths"], 1, 12, 240)
+    if paths != sorted(paths) or any(not _path_allowed(path, PRIMARY_ROOTS[block]) for path in paths):
+        raise ManifestDenied("INVALID_PATH")
+    if not any(path.startswith(PRIMARY_ROOTS[block]) for path in paths):
+        raise ManifestDenied("PRIMARY_BLOCK_PATH_REQUIRED")
+    if not any(path.startswith("tests/unit/") for path in paths):
+        raise ManifestDenied("TEST_PATH_REQUIRED")
+    if raw["validation_targets"] != list(VALIDATION_TARGETS) or any(
+        type(item) is not str for item in raw["validation_targets"]
+    ):
+        raise ManifestDenied("INVALID_VALIDATION_PROFILE")
+
+    lines = _integer(raw["maximum_changed_lines"], 1, 500)
+    files = _integer(raw["maximum_changed_files"], 1, min(12, len(paths)))
+    commits = _integer(raw["maximum_commits"], 1, 3)
+    pushes = _integer(raw["maximum_pushes"], 1, commits)
+    runtime = _integer(raw["maximum_runtime_minutes"], 1, 120)
+
+    try:
+        clock_is_aware = now.tzinfo is not None and now.utcoffset() is not None
+        verified_at = now.astimezone(UTC)
+    except Exception:
+        raise VerifierFailure from None
+    if not clock_is_aware:
+        raise VerifierFailure
+    issued = _timestamp(raw["authorization_issued_at"])
+    expires = _timestamp(raw["authorization_expires"])
+    if not issued <= verified_at < expires or expires - issued > MAX_AUTHORIZATION_WINDOW:
+        raise ManifestDenied("AUTHORIZATION_INACTIVE")
+    if verified_at + timedelta(minutes=runtime) > expires:
+        raise ManifestDenied("RUNTIME_EXCEEDS_AUTHORIZATION")
+
+    return ValidatedManifestContract(
+        manifest_id=expected_id,
+        authorization_issued_at=issued,
+        authorization_expires=expires,
+        arc42_primary_block=block,
+        context_goal=context,
+        allowed_paths=tuple(paths),
+        runtime_scenario=runtime_scenario,
+        quality_scenario=quality_scenario,
+        recovery_scenario=recovery_scenario,
+        acceptance_criteria=tuple(criteria),
+        validation_targets=VALIDATION_TARGETS,
+        maximum_changed_lines=lines,
+        maximum_changed_files=files,
+        maximum_commits=commits,
+        maximum_pushes=pushes,
+        maximum_runtime_minutes=runtime,
+    )

--- a/tests/unit/test_overnight_manifest_verifier.py
+++ b/tests/unit/test_overnight_manifest_verifier.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+
+import pytest
+
+from scripts.overnight_manifest_verifier import (
+    MAX_MANIFEST_BYTES,
+    ManifestDenied,
+    validate_manifest_blob,
+)
+
+
+UTC = timezone.utc
+NOW = datetime(2026, 8, 15, 20, tzinfo=UTC)
+MANIFEST_ID = "frdp-analytics-daily-risk-20260815"
+
+
+def _manifest(**changes: object) -> dict[str, object]:
+    value: dict[str, object] = {
+        "schema_version": 2,
+        "manifest_id": MANIFEST_ID,
+        "status": "approved for overnight development",
+        "authorization_issued_at": "2026-08-15T19:00:00Z",
+        "authorization_expires": "2026-08-15T22:00:00Z",
+        "repository": "alexmarinos87/financial-risk-data-platform",
+        "protected_base_branch": "main",
+        "arc42_primary_block": "analytics",
+        "context_goal": "Calculate daily risk from validated prices",
+        "allowed_paths": ["src/analytics/daily_risk.py", "tests/unit/test_daily_risk.py"],
+        "interfaces_crossed": [],
+        "runtime_scenario": "Daily prices produce one deterministic risk result",
+        "quality_scenario": "Golden vectors match within the documented tolerance",
+        "recovery_scenario": "A failed check leaves no published candidate",
+        "acceptance_criteria": ["Golden daily return vectors pass"],
+        "validation_targets": [
+            "security-check", "quality-check", "readiness-check", "git-diff-check"
+        ],
+        "maximum_changed_lines": 500,
+        "maximum_changed_files": 2,
+        "maximum_commits": 3,
+        "maximum_pushes": 3,
+        "maximum_runtime_minutes": 120,
+        "retry_policy": "human-renewed-manifest-only",
+        "risk": "low",
+        "draft_pr_publication": "eligible-after-global-activation",
+    }
+    value.update(changes)
+    return value
+
+
+def _blob(**changes: object) -> bytes:
+    return json.dumps(_manifest(**changes), separators=(",", ":")).encode()
+
+
+def _reason(blob: bytes, expected_id: str = MANIFEST_ID) -> str:
+    with pytest.raises(ManifestDenied) as raised:
+        validate_manifest_blob(blob, expected_id, NOW)
+    return raised.value.reason
+
+
+def test_valid_manifest_contract_is_evidence_not_publication_authority() -> None:
+    result = validate_manifest_blob(_blob(), MANIFEST_ID, NOW)
+    assert result.arc42_primary_block == "analytics"
+    assert result.allowed_paths == ("src/analytics/daily_risk.py", "tests/unit/test_daily_risk.py")
+    assert result.maximum_changed_lines == 500
+    assert "Calculate daily risk" not in repr(result)
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "reason"),
+    [
+        ("schema_version", True, "INVALID_SCHEMA"),
+        ("status", "enabled", "INVALID_AUTHORITY"),
+        ("arc42_primary_block", "ingestion", "INVALID_BLOCK"),
+        ("context_goal", "   ", "INVALID_TEXT"),
+        ("quality_scenario", " padded", "INVALID_TEXT"),
+        ("interfaces_crossed", ["analytics->storage"], "CROSS_BLOCK_NOT_ALLOWED"),
+        ("validation_targets", ["make deploy"], "INVALID_VALIDATION_PROFILE"),
+        ("maximum_changed_lines", True, "INVALID_BUDGET"),
+        ("maximum_changed_lines", 1.5, "INVALID_BUDGET"),
+        ("maximum_changed_lines", 501, "INVALID_BUDGET"),
+        ("maximum_changed_files", 3, "INVALID_BUDGET"),
+        ("maximum_pushes", 4, "INVALID_BUDGET"),
+        ("risk", "high", "INVALID_AUTHORITY"),
+        ("authorization_issued_at", "2026-08-15T19:00:00+00:00", "INVALID_TIME"),
+        ("authorization_expires", "2026-08-15T20:00:00Z", "AUTHORIZATION_INACTIVE"),
+        ("authorization_expires", "2026-08-16T20:00:01Z", "AUTHORIZATION_INACTIVE"),
+    ],
+)
+def test_manifest_rejects_invalid_authority_and_budgets(
+    field: str, value: object, reason: str
+) -> None:
+    assert _reason(_blob(**{field: value})) == reason
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "../src/analytics/risk.py",
+        "/src/analytics/risk.py",
+        "src\\analytics\\risk.py",
+        "src/analytics/*.py",
+        "src/processing/risk.py",
+        "src/analytics/data_quality.py",
+        "tests/integration/test_risk.py",
+        "tests/unit/risk_test.py",
+        ".github/workflows/ci.yml",
+        "docs/overnight-development.md",
+        "tests/.env",
+    ],
+)
+def test_manifest_rejects_unsafe_sensitive_and_cross_block_paths(path: str) -> None:
+    assert _reason(_blob(allowed_paths=[path], maximum_changed_files=1)) == "INVALID_PATH"
+
+
+def test_manifest_requires_exact_schema_strict_json_and_matching_id() -> None:
+    unknown = _manifest(extra=False)
+    missing = _manifest()
+    del missing["risk"]
+    duplicate = _blob().replace(b'"status":', b'"status":"duplicate","status":', 1)
+    escaped_duplicate = _blob().replace(b'"status":', b'"status":"duplicate","\\u0073tatus":', 1)
+
+    assert _reason(json.dumps(unknown).encode()) == "INVALID_SCHEMA"
+    assert _reason(json.dumps(missing).encode()) == "INVALID_SCHEMA"
+    assert _reason(duplicate) == "INVALID_JSON"
+    assert _reason(escaped_duplicate) == "INVALID_JSON"
+    assert _reason(b'{"schema_version":NaN}') == "INVALID_JSON"
+    assert _reason(b"\xff") == "INVALID_JSON"
+    assert _reason(b"[" * 1_200 + b"0" + b"]" * 1_200) == "INVALID_JSON"
+    assert _reason(_blob(), "different-valid-id") == "INVALID_MANIFEST_ID"
+    assert _reason(b"x" * (MAX_MANIFEST_BYTES + 1)) == "MANIFEST_TOO_LARGE"
+
+
+def test_manifest_requires_test_path_sorted_unique_paths_and_runtime_window() -> None:
+    assert _reason(_blob(allowed_paths=["src/analytics/risk.py"], maximum_changed_files=1)) == "TEST_PATH_REQUIRED"
+    paths = ["tests/unit/test_risk.py", "src/analytics/risk.py"]
+    assert _reason(_blob(allowed_paths=paths)) == "INVALID_PATH"
+    duplicate = ["src/analytics/risk.py", "tests/unit/test_risk.py", "tests/unit/test_risk.py"]
+    assert _reason(_blob(allowed_paths=duplicate)) == "INVALID_LIST"
+    assert _reason(_blob(maximum_runtime_minutes=121)) == "INVALID_BUDGET"
+    assert _reason(_blob(authorization_expires="2026-08-15T21:00:00Z")) == (
+        "RUNTIME_EXCEEDS_AUTHORIZATION"
+    )


### PR DESCRIPTION
## Context

This is the next `engineering-controls` slice after the hardened CI foundation. It has one outcome: deterministically admit or deny the bytes of one low-risk overnight task manifest. It does not activate scheduled mutation or publication.

## Contract

- Replace the unactivated YAML/free-form-command proposal with strict JSON schema v2.
- Accept exactly one `analytics`, `processing`, or `benchmarking` block; deny cross-block interfaces.
- Require sorted exact source paths plus a narrowly formed unit-test path.
- Hard-deny controls, data-quality controls, configuration, deployment, infrastructure, warehouse/schema, lock/backfill, credential, Git, script, and manifest paths.
- Replace command strings with four fixed validation target identifiers for a later protected argv mapping.
- Enforce exact key/type checks, duplicate/non-standard JSON rejection, 32 KiB and text/list bounds, immutable results, UTC-only authorization windows of at most 24 hours, and true-integer budgets.
- Cap changed lines at 500, files at the exact allowlist, commits at 3, pushes at commits, and runtime at 120 minutes.
- Return a validated contract, never publication authority.

## Safety boundary

The global publication policy remains byte-for-byte disabled and unconfigured. No manifest file, backlog authorization, filesystem access, Git operation, subprocess, network call, branch, commit, push, pull request, merge, or deployment authority is added.

## History repair

The reviewed three-file change was rebuilt on the latest `main` after the data-path stack was squash-merged. The authoritative runbook blob on `main` exactly matched the original branch base before reconstruction.

Current head: `22d42ae6ef5ad442f9c11842bc0111b2e066e00e`

- one commit ahead of `main`
- zero commits behind
- three changed paths
- 444 additions and 56 deletions

The final verifier, unit-test, and runbook blobs are unchanged from the reviewed #43 commit.

## Fresh validation

GitHub Actions run `32194089107` (`ci` run 170) was initially interrupted by an external/transient cancellation after security had passed. Re-running only the interrupted jobs completed successfully:

- Security guardrails: passed
- Python readiness: passed
  - dependency installation
  - `make quality-check`
  - `make readiness-check`
- Infrastructure validation: passed
  - `make infrastructure-check`

No unresolved review threads or requested changes were present.

## Merge boundary

Following the instruction to process and squash the dependency stack, this PR is ready to merge as one engineering-controls commit. It validates a manifest contract only; it does not execute manifest-selected work, mutate Git, publish a branch, open a pull request, merge, deploy, or enable unattended operation.