### PR TITLE
Bind overnight manifests to protected-base Git blobs

### DIFF
--- a/docs/overnight-development.md
+++ b/docs/overnight-development.md
@@ -165,10 +165,29 @@ a successful no-op. The scheduler must not invent a replacement task.
 the low-risk `analytics`, `processing`, or `benchmarking` blocks, exact paths,
 fixed validation target identifiers, hard budgets, and a UTC authorization
 window of at most 24 hours. This parser does not read a worktree, Git ref, or
-network. The next protected-base
-adapter must load one regular `100644` blob from the exact fetched commit, hash
-those bytes, and pass them unchanged to this parser. A valid contract is not
-publication authority.
+network. Its `verify_protected_base_manifest` adapter requires a full commit SHA
+equal to the local `origin/main` ref before and after verification, derives the
+path from the Manifest ID, and loads one size-bounded `100644` Git blob. It
+independently recomputes the repository-format Git object ID, hashes the exact
+bytes, and emits redacted evidence with
+`publication_authorized: false`.
+
+The adapter is a Linux/WSL boundary that uses `/usr/bin/git`, a symlink-free
+repository-root path, a minimal child environment, bounded output, and disabled
+Git protocols. It rejects partial/promisor repositories before object reads.
+It relies on the trusted fetch and local object store for commit/tree parsing;
+the selected blob gets the additional independent object-ID check. It never
+fetches and cannot prove that the local ref is fresh, that GitHub protects
+`main`, or that a human approved the commit. The trusted orchestrator owns those
+checks. A valid contract is not publication authority.
+
+Invoke the repository adapter with `.venv/bin/python
+scripts/overnight_manifest_verifier.py
+--repository <root> --base-sha <full-sha> --manifest-id <id>`. Exit `0` emits
+valid-but-non-authorizing evidence. Exit `2` is a controlled denial that the
+scheduler maps to a successful no-mutation outcome. Exit `1` is an operational
+verifier failure that requires investigation; neither nonzero outcome permits a
+branch, edit, commit, or external write.
 
 Schema version 2 does not accept free-form commands or cross-block interfaces.
 A later trusted runner maps its four validation identifiers to fixed argument
@@ -458,9 +477,11 @@ docs/architecture.md, docs/overnight-development.md,
 docs/security-protocols.md, docs/engineering-delivery-workflow.md,
 docs/agent-roles.md, and docs/iteration-backlog.md from that exact commit with
 git show. Also read `.github/overnight-publication-policy.json` from that exact
-commit and hash its complete Git blob. Resolve the selected manifest link, read
-its entire Git blob from the same commit, and hash the exact bytes. Never select
-from local or uncommitted copies.
+commit and hash its complete Git blob. Resolve the selected Manifest ID and run
+the protected-base manifest adapter against the recorded SHA. Require its
+redacted result to bind the exact blob and recheck local `origin/main`; never
+select from local or uncommitted copies. Independently prove the fetch and
+GitHub protection because the adapter does not.
 
 Select exactly one unexpired backlog item whose status is exactly
 "approved for overnight development" and whose manifest is complete. If none

--- a/scripts/overnight_manifest_verifier.py
+++ b/scripts/overnight_manifest_verifier.py
@@ -1,14 +1,24 @@
 from __future__ import annotations
 
+import argparse
+import hashlib
 import json
+import os
 import re
+import select
+import subprocess
+import sys
+import time
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
+from pathlib import Path
 from types import MappingProxyType
-from typing import Any
+from typing import Any, NoReturn
 
 
 MAX_MANIFEST_BYTES = 32 * 1024
+MAX_GIT_METADATA_BYTES = 4 * 1024
+GIT_TIMEOUT_SECONDS = 10.0
 MAX_AUTHORIZATION_WINDOW = timedelta(hours=24)
 UTC = timezone.utc
 MANIFEST_ID = re.compile(r"[a-z0-9][a-z0-9-]{7,63}")
@@ -41,6 +51,30 @@ DENIED_PREFIXES = (
     ".git", ".github/", "config/", "deploy/", "infra/", "mongo/", "scripts/",
     "sql/", "src/warehouse/", "docs/overnight-manifests/",
 )
+DENIAL_REASONS = frozenset({
+    "INVALID_JSON", "MANIFEST_TOO_LARGE", "INVALID_TEXT", "INVALID_BUDGET",
+    "INVALID_LIST", "INVALID_TIME", "INVALID_SCHEMA", "INVALID_MANIFEST_ID",
+    "INVALID_AUTHORITY", "INVALID_BLOCK", "CROSS_BLOCK_NOT_ALLOWED", "INVALID_PATH",
+    "PRIMARY_BLOCK_PATH_REQUIRED", "TEST_PATH_REQUIRED", "INVALID_VALIDATION_PROFILE",
+    "AUTHORIZATION_INACTIVE", "RUNTIME_EXCEEDS_AUTHORIZATION", "INVALID_BASE_SHA",
+    "BASE_NOT_CURRENT", "BASE_MOVED", "MANIFEST_BLOB_INVALID",
+})
+GIT_ENVIRONMENT = MappingProxyType({
+    "GIT_ALLOW_PROTOCOL": "",
+    "GIT_CONFIG_GLOBAL": "/dev/null",
+    "GIT_CONFIG_NOSYSTEM": "1",
+    "GIT_CONFIG_SYSTEM": "/dev/null",
+    "GIT_NO_LAZY_FETCH": "1",
+    "GIT_NO_REPLACE_OBJECTS": "1",
+    "GIT_OPTIONAL_LOCKS": "0",
+    "GIT_PROTOCOL_FROM_USER": "0",
+    "GIT_TERMINAL_PROMPT": "0",
+    "HOME": "/nonexistent",
+    "LANG": "C",
+    "LC_ALL": "C",
+    "PATH": "/usr/bin:/bin",
+    "XDG_CONFIG_HOME": "/nonexistent",
+})
 
 
 class ManifestDenied(Exception):
@@ -71,6 +105,47 @@ class ValidatedManifestContract:
     maximum_commits: int
     maximum_pushes: int
     maximum_runtime_minutes: int
+
+
+@dataclass(frozen=True, slots=True, repr=False)
+class ProtectedBaseManifest:
+    contract: ValidatedManifestContract
+    base_commit_sha: str
+    base_tree_sha: str
+    manifest_path: str
+    git_blob_oid: str
+    manifest_sha256: str
+    record_key: str
+    object_format: str
+    verified_at: datetime
+
+    def redacted_evidence(self) -> dict[str, Any]:
+        return {
+            "status": "manifest-contract-valid",
+            "publication_authorized": False,
+            "manifest_repository": "alexmarinos87/financial-risk-data-platform",
+            "declared_base_branch": "main",
+            "local_tracking_ref": "refs/remotes/origin/main",
+            "base_commit_sha": self.base_commit_sha,
+            "base_tree_sha": self.base_tree_sha,
+            "object_format": self.object_format,
+            "manifest_path": self.manifest_path,
+            "git_blob_oid": self.git_blob_oid,
+            "manifest_sha256": self.manifest_sha256,
+            "record_key": self.record_key,
+            "manifest_id": self.contract.manifest_id,
+            "arc42_primary_block": self.contract.arc42_primary_block,
+            "allowed_paths": list(self.contract.allowed_paths),
+            "maximum_changed_lines": self.contract.maximum_changed_lines,
+            "maximum_changed_files": self.contract.maximum_changed_files,
+            "maximum_commits": self.contract.maximum_commits,
+            "maximum_pushes": self.contract.maximum_pushes,
+            "maximum_runtime_minutes": self.contract.maximum_runtime_minutes,
+            "verified_at": self.verified_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
+            "authorization_expires": self.contract.authorization_expires.strftime(
+                "%Y-%m-%dT%H:%M:%SZ"
+            ),
+        }
 
 
 def _duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
@@ -243,3 +318,252 @@ def validate_manifest_blob(blob: bytes, expected_id: str, now: datetime) -> Vali
         maximum_pushes=pushes,
         maximum_runtime_minutes=runtime,
     )
+
+
+def _stop_process(process: subprocess.Popen[bytes]) -> None:
+    try:
+        process.kill()
+    except OSError:
+        pass
+    try:
+        process.wait(timeout=1)
+    except (OSError, subprocess.TimeoutExpired):
+        pass
+
+
+def _run_git(
+    repository: Path,
+    *arguments: str,
+    maximum_output_bytes: int = MAX_GIT_METADATA_BYTES,
+    allowed_returncodes: tuple[int, ...] = (0,),
+    excess_reason: str | None = None,
+) -> bytes:
+    process: subprocess.Popen[bytes] | None = None
+    try:
+        process = subprocess.Popen(
+            ["/usr/bin/git", *arguments],
+            cwd=repository,
+            env=dict(GIT_ENVIRONMENT),
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+        )
+        if process.stdout is None:
+            raise VerifierFailure
+        deadline = time.monotonic() + GIT_TIMEOUT_SECONDS
+        output = bytearray()
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise VerifierFailure
+            readable, _, _ = select.select((process.stdout,), (), (), remaining)
+            if not readable:
+                raise VerifierFailure
+            chunk = os.read(
+                process.stdout.fileno(),
+                min(8 * 1024, maximum_output_bytes + 1 - len(output)),
+            )
+            if not chunk:
+                break
+            output.extend(chunk)
+            if len(output) > maximum_output_bytes:
+                if excess_reason is not None:
+                    raise ManifestDenied(excess_reason)
+                raise VerifierFailure
+        returncode = process.wait(timeout=max(0.001, deadline - time.monotonic()))
+    except ManifestDenied:
+        if process is not None:
+            _stop_process(process)
+        raise
+    except VerifierFailure:
+        if process is not None:
+            _stop_process(process)
+        raise
+    except (OSError, ValueError, subprocess.SubprocessError):
+        if process is not None:
+            _stop_process(process)
+        raise VerifierFailure from None
+    finally:
+        if process is not None and process.stdout is not None:
+            process.stdout.close()
+    if returncode not in allowed_returncodes:
+        raise VerifierFailure
+    return bytes(output)
+
+
+def _git_object_oid(object_format: str, kind: str, content: bytes) -> str:
+    hasher = hashlib.new(object_format, usedforsecurity=False)
+    hasher.update(f"{kind} {len(content)}\0".encode("ascii"))
+    hasher.update(content)
+    return hasher.hexdigest()
+
+
+def _ascii(value: bytes) -> str:
+    try:
+        decoded = value.decode("ascii")
+    except UnicodeError:
+        raise VerifierFailure from None
+    if not decoded.endswith("\n") or "\n" in decoded[:-1]:
+        raise VerifierFailure
+    return decoded[:-1]
+
+
+def verify_protected_base_manifest(
+    repository: Path, base_sha: str, manifest_id: str, *, now: datetime | None = None
+) -> ProtectedBaseManifest:
+    if now is not None and type(now) is not datetime:
+        raise VerifierFailure
+    try:
+        if not isinstance(repository, Path):
+            raise VerifierFailure
+        absolute_repository = Path(os.path.abspath(repository))
+        if any(component.is_symlink() for component in (absolute_repository, *absolute_repository.parents)):
+            raise VerifierFailure
+        trusted_repository = absolute_repository.resolve(strict=True)
+        if trusted_repository != absolute_repository:
+            raise VerifierFailure
+    except (OSError, RuntimeError):
+        raise VerifierFailure from None
+    if not trusted_repository.is_dir():
+        raise VerifierFailure
+
+    top_level_output = _run_git(
+        trusted_repository, "rev-parse", "--path-format=absolute", "--show-toplevel"
+    )
+    if (
+        not top_level_output.endswith(b"\n")
+        or b"\n" in top_level_output[:-1]
+        or b"\0" in top_level_output
+        or Path(os.fsdecode(top_level_output[:-1])) != trusted_repository
+    ):
+        raise VerifierFailure
+    partial_clone_keys = _run_git(
+        trusted_repository,
+        "config",
+        "--name-only",
+        "--get-regexp",
+        r"^(extensions\.partialclone|remote\..*\.promisor)$",
+        allowed_returncodes=(0, 1),
+    )
+    if partial_clone_keys:
+        raise VerifierFailure
+    object_format = _ascii(_run_git(trusted_repository, "rev-parse", "--show-object-format"))
+    sha_length = {"sha1": 40, "sha256": 64}.get(object_format)
+    if sha_length is None:
+        raise VerifierFailure
+    if type(base_sha) is not str or re.fullmatch(f"[0-9a-f]{{{sha_length}}}", base_sha) is None:
+        raise ManifestDenied("INVALID_BASE_SHA")
+    if type(manifest_id) is not str or MANIFEST_ID.fullmatch(manifest_id) is None:
+        raise ManifestDenied("INVALID_MANIFEST_ID")
+
+    def current_base() -> str:
+        ref_sha = _ascii(
+            _run_git(
+                trusted_repository,
+                "rev-parse",
+                "--verify",
+                "refs/remotes/origin/main",
+            )
+        )
+        if re.fullmatch(f"[0-9a-f]{{{sha_length}}}", ref_sha) is None:
+            raise VerifierFailure
+        return ref_sha
+
+    if current_base() != base_sha:
+        raise ManifestDenied("BASE_NOT_CURRENT")
+    resolved = _ascii(
+        _run_git(
+            trusted_repository,
+            "rev-parse",
+            "--verify",
+            f"{base_sha}^{{commit}}",
+        )
+    )
+    if resolved != base_sha:
+        raise ManifestDenied("INVALID_BASE_SHA")
+    tree_sha = _ascii(_run_git(trusted_repository, "rev-parse", f"{base_sha}^{{tree}}"))
+    if re.fullmatch(f"[0-9a-f]{{{sha_length}}}", tree_sha) is None:
+        raise VerifierFailure
+    manifest_path = f"docs/overnight-manifests/{manifest_id}.json"
+    entry = _run_git(
+        trusted_repository, "ls-tree", "-z", "--full-tree", base_sha, "--", manifest_path
+    )
+    records = [record for record in entry.split(b"\0") if record]
+    try:
+        metadata, encoded_path = records[0].split(b"\t", maxsplit=1)
+        mode, kind, blob_oid = metadata.decode("ascii").split()
+    except (IndexError, UnicodeError, ValueError):
+        raise ManifestDenied("MANIFEST_BLOB_INVALID") from None
+    if (
+        len(records) != 1
+        or mode != "100644"
+        or kind != "blob"
+        or re.fullmatch(f"[0-9a-f]{{{sha_length}}}", blob_oid) is None
+        or encoded_path != manifest_path.encode("ascii")
+    ):
+        raise ManifestDenied("MANIFEST_BLOB_INVALID")
+    size_text = _ascii(
+        _run_git(trusted_repository, "cat-file", "-s", blob_oid, maximum_output_bytes=16)
+    )
+    if len(size_text) > 10 or re.fullmatch(r"[0-9]+", size_text) is None:
+        raise VerifierFailure
+    size = int(size_text)
+    if size > MAX_MANIFEST_BYTES:
+        raise ManifestDenied("MANIFEST_TOO_LARGE")
+    blob = _run_git(
+        trusted_repository,
+        "cat-file",
+        "blob",
+        blob_oid,
+        maximum_output_bytes=MAX_MANIFEST_BYTES,
+        excess_reason="MANIFEST_TOO_LARGE",
+    )
+    if len(blob) != size:
+        raise VerifierFailure
+    if _git_object_oid(object_format, "blob", blob) != blob_oid:
+        raise VerifierFailure
+    verified_at = datetime.now(UTC) if now is None else now
+    contract = validate_manifest_blob(blob, manifest_id, verified_at)
+    if current_base() != base_sha:
+        raise ManifestDenied("BASE_MOVED")
+    return ProtectedBaseManifest(
+        contract=contract,
+        base_commit_sha=base_sha,
+        base_tree_sha=tree_sha,
+        manifest_path=manifest_path,
+        git_blob_oid=blob_oid,
+        manifest_sha256=hashlib.sha256(blob).hexdigest(),
+        record_key=hashlib.sha256(manifest_id.encode("ascii")).hexdigest(),
+        object_format=object_format,
+        verified_at=verified_at.astimezone(UTC),
+    )
+
+
+class _SafeArgumentParser(argparse.ArgumentParser):
+    def error(self, _message: str) -> NoReturn:
+        raise VerifierFailure
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = _SafeArgumentParser(description="Verify one current origin/main manifest")
+    parser.add_argument("--repository", required=True, type=Path)
+    parser.add_argument("--base-sha", required=True)
+    parser.add_argument("--manifest-id", required=True)
+    try:
+        arguments = parser.parse_args(argv)
+        binding = verify_protected_base_manifest(
+            arguments.repository, arguments.base_sha, arguments.manifest_id
+        )
+    except ManifestDenied as error:
+        reason = error.reason if error.reason in DENIAL_REASONS else "MANIFEST_DENIED"
+        print(json.dumps({"status": "denied", "reason": reason}), file=sys.stderr)
+        return 2
+    except Exception:
+        print('{"status":"error","reason":"VERIFIER_FAILURE"}', file=sys.stderr)
+        return 1
+    print(json.dumps(binding.redacted_evidence(), sort_keys=True, separators=(",", ":")))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/test_overnight_manifest_verifier.py
+++ b/tests/unit/test_overnight_manifest_verifier.py
@@ -1,14 +1,22 @@
 from __future__ import annotations
 
+import hashlib
 import json
-from datetime import datetime, timezone
+import subprocess
+import zlib
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
 
 import pytest
 
 from scripts.overnight_manifest_verifier import (
     MAX_MANIFEST_BYTES,
     ManifestDenied,
+    VerifierFailure,
+    main,
     validate_manifest_blob,
+    verify_protected_base_manifest,
 )
 
 
@@ -143,3 +151,252 @@ def test_manifest_requires_test_path_sorted_unique_paths_and_runtime_window() ->
     assert _reason(_blob(authorization_expires="2026-08-15T21:00:00Z")) == (
         "RUNTIME_EXCEEDS_AUTHORIZATION"
     )
+
+
+def _git(repository: Path, *arguments: str) -> str:
+    result = subprocess.run(
+        ["/usr/bin/git", *arguments], cwd=repository, check=True, text=True,
+        stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+    )
+    return result.stdout.strip()
+
+
+def _repository(tmp_path: Path, content: bytes | None = None, *, executable: bool = False) -> tuple[Path, str]:
+    repository = tmp_path / "repo"
+    repository.mkdir()
+    _git(repository, "init", "-q", "-b", "main")
+    _git(repository, "config", "user.email", "tests@example.invalid")
+    _git(repository, "config", "user.name", "Tests")
+    path = repository / "docs" / "overnight-manifests" / f"{MANIFEST_ID}.json"
+    path.parent.mkdir(parents=True)
+    path.write_bytes(content if content is not None else _blob())
+    if executable:
+        path.chmod(0o755)
+    _git(repository, "add", path.relative_to(repository).as_posix())
+    _git(repository, "commit", "-q", "-m", "Add manifest")
+    base = _git(repository, "rev-parse", "HEAD")
+    _git(repository, "update-ref", "refs/remotes/origin/main", base)
+    return repository, base
+
+
+def test_git_binding_uses_exact_blob_without_mutating_worktree_or_trusting_git_env(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repository, base = _repository(tmp_path)
+    path = repository / "docs" / "overnight-manifests" / f"{MANIFEST_ID}.json"
+    path.write_text("dirty worktree content", encoding="utf-8")
+    status_before = _git(repository, "status", "--porcelain=v1", "-uall")
+    from scripts import overnight_manifest_verifier as verifier
+
+    original_popen = verifier.subprocess.Popen
+    child_environments: list[dict[str, str]] = []
+
+    def recording_popen(*args: Any, **kwargs: Any) -> subprocess.Popen[bytes]:
+        if "env" in kwargs:
+            child_environments.append(dict(kwargs["env"]))
+        return original_popen(*args, **kwargs)
+
+    monkeypatch.setattr(verifier.subprocess, "Popen", recording_popen)
+    for key in ("GIT_DIR", "LD_PRELOAD", "AWS_SECRET_ACCESS_KEY", "GH_TOKEN", "SSH_AUTH_SOCK"):
+        monkeypatch.setenv(key, "sentinel-secret-invalid")
+
+    binding = verify_protected_base_manifest(repository, base, MANIFEST_ID, now=NOW)
+
+    evidence = binding.redacted_evidence()
+    assert evidence["publication_authorized"] is False
+    assert evidence["object_format"] == "sha1"
+    assert evidence["manifest_sha256"] == hashlib.sha256(_blob()).hexdigest()
+    assert "Calculate daily risk" not in json.dumps(evidence)
+    assert child_environments
+    assert all(
+        not {"GIT_DIR", "LD_PRELOAD", "AWS_SECRET_ACCESS_KEY", "GH_TOKEN", "SSH_AUTH_SOCK"}
+        & environment.keys()
+        for environment in child_environments
+    )
+    assert all(environment["GIT_ALLOW_PROTOCOL"] == "" for environment in child_environments)
+    for key in ("GIT_DIR", "LD_PRELOAD", "AWS_SECRET_ACCESS_KEY", "GH_TOKEN", "SSH_AUTH_SOCK"):
+        monkeypatch.delenv(key)
+    assert _git(repository, "status", "--porcelain=v1", "-uall") == status_before
+
+
+@pytest.mark.parametrize(
+    ("content", "executable", "reason"),
+    [
+        (_blob(), True, "MANIFEST_BLOB_INVALID"),
+        (b"x" * (MAX_MANIFEST_BYTES + 1), False, "MANIFEST_TOO_LARGE"),
+        (b"\xff", False, "INVALID_JSON"),
+    ],
+)
+def test_git_binding_rejects_wrong_mode_oversize_and_invalid_utf8(
+    tmp_path: Path, content: bytes, executable: bool, reason: str
+) -> None:
+    repository, base = _repository(tmp_path, content, executable=executable)
+    with pytest.raises(ManifestDenied, match=reason):
+        verify_protected_base_manifest(repository, base, MANIFEST_ID, now=NOW)
+
+
+def test_git_binding_rejects_base_movement_abbreviation_and_symlink_root(
+    tmp_path: Path,
+) -> None:
+    repository, base = _repository(tmp_path)
+    other = repository / "other.txt"
+    other.write_text("move", encoding="utf-8")
+    _git(repository, "add", "other.txt")
+    _git(repository, "commit", "-q", "-m", "Move base")
+    _git(repository, "update-ref", "refs/remotes/origin/main", "HEAD")
+    with pytest.raises(ManifestDenied, match="BASE_NOT_CURRENT"):
+        verify_protected_base_manifest(repository, base, MANIFEST_ID, now=NOW)
+    with pytest.raises(ManifestDenied, match="INVALID_BASE_SHA"):
+        verify_protected_base_manifest(repository, base[:12], MANIFEST_ID, now=NOW)
+    link = tmp_path / "repo-link"
+    link.symlink_to(repository, target_is_directory=True)
+    with pytest.raises(VerifierFailure):
+        verify_protected_base_manifest(link, base, MANIFEST_ID, now=NOW)
+
+
+@pytest.mark.parametrize(
+    ("key", "value"),
+    [("extensions.partialClone", "origin"), ("remote.origin.promisor", "true")],
+)
+def test_git_binding_rejects_partial_clone_configuration_before_object_reads(
+    tmp_path: Path, key: str, value: str
+) -> None:
+    repository, base = _repository(tmp_path)
+    _git(repository, "config", key, value)
+    objects_before = sorted(
+        path.relative_to(repository) for path in (repository / ".git/objects").rglob("*")
+    )
+
+    with pytest.raises(VerifierFailure):
+        verify_protected_base_manifest(repository, base, MANIFEST_ID, now=NOW)
+
+    assert sorted(
+        path.relative_to(repository) for path in (repository / ".git/objects").rglob("*")
+    ) == objects_before
+
+
+def test_git_binding_rejects_blob_bytes_that_do_not_match_tree_oid(tmp_path: Path) -> None:
+    repository, base = _repository(tmp_path)
+    manifest_path = f"docs/overnight-manifests/{MANIFEST_ID}.json"
+    blob_oid = _git(repository, "rev-parse", f"HEAD:{manifest_path}")
+    altered = _blob().replace(b"Calculate", b"Fabricate")
+    assert len(altered) == len(_blob())
+    loose_object = repository / ".git" / "objects" / blob_oid[:2] / blob_oid[2:]
+    loose_object.chmod(0o600)
+    loose_object.write_bytes(zlib.compress(f"blob {len(altered)}\0".encode() + altered))
+
+    with pytest.raises(VerifierFailure):
+        verify_protected_base_manifest(repository, base, MANIFEST_ID, now=NOW)
+
+
+def test_git_binding_treats_broken_tracking_ref_as_operational_failure(tmp_path: Path) -> None:
+    repository, base = _repository(tmp_path)
+    tracking_ref = repository / ".git" / "refs" / "remotes" / "origin" / "main"
+    tracking_ref.write_text("not-an-object\n", encoding="ascii")
+
+    with pytest.raises(VerifierFailure):
+        verify_protected_base_manifest(repository, base, MANIFEST_ID, now=NOW)
+
+
+def test_git_reader_enforces_output_cap_and_falsey_clock_is_not_defaulted(
+    tmp_path: Path,
+) -> None:
+    repository, base = _repository(tmp_path)
+    from scripts import overnight_manifest_verifier as verifier
+
+    blob_oid = _git(
+        repository, "rev-parse", f"HEAD:docs/overnight-manifests/{MANIFEST_ID}.json"
+    )
+    with pytest.raises(ManifestDenied, match="MANIFEST_TOO_LARGE"):
+        verifier._run_git(
+            repository,
+            "cat-file",
+            "blob",
+            blob_oid,
+            maximum_output_bytes=8,
+            excess_reason="MANIFEST_TOO_LARGE",
+        )
+    with pytest.raises(VerifierFailure):
+        verify_protected_base_manifest(repository, base, MANIFEST_ID, now=False)  # type: ignore[arg-type]
+
+
+def test_git_binding_detects_remote_ref_moving_during_verification(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repository, base = _repository(tmp_path)
+    from scripts import overnight_manifest_verifier as verifier
+
+    original = verifier._run_git
+    base_reads = 0
+
+    def moving_ref(repo: Path, *arguments: str, **options: Any) -> bytes:
+        nonlocal base_reads
+        if arguments[-1:] == ("refs/remotes/origin/main",):
+            base_reads += 1
+            if base_reads == 2:
+                return ("0" * 40 + "\n").encode()
+        return original(repo, *arguments, **options)
+
+    monkeypatch.setattr(verifier, "_run_git", moving_ref)
+    with pytest.raises(ManifestDenied, match="BASE_MOVED"):
+        verify_protected_base_manifest(repository, base, MANIFEST_ID, now=NOW)
+
+
+def test_cli_denial_is_fixed_and_redacted(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    repository, _ = _repository(tmp_path)
+    result = main([
+        "--repository", str(repository), "--base-sha", "sentinel-secret",
+        "--manifest-id", MANIFEST_ID,
+    ])
+    output = capsys.readouterr()
+
+    assert result == 2
+    assert output.out == ""
+    assert json.loads(output.err) == {"status": "denied", "reason": "INVALID_BASE_SHA"}
+    assert "sentinel-secret" not in output.err
+
+
+@pytest.mark.parametrize("arguments", [[], ["--unknown", "sentinel-secret-value"]])
+def test_cli_argument_errors_are_redacted_operational_failures(
+    arguments: list[str], capsys: pytest.CaptureFixture[str]
+) -> None:
+    result = main(arguments)
+    output = capsys.readouterr()
+
+    assert result == 1
+    assert output.out == ""
+    assert json.loads(output.err) == {"status": "error", "reason": "VERIFIER_FAILURE"}
+    assert "sentinel-secret-value" not in output.err
+
+
+def test_cli_success_and_operational_failure_are_distinct(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    current = datetime.now(UTC).replace(microsecond=0)
+    repository, base = _repository(
+        tmp_path,
+        _blob(
+            authorization_issued_at=(current - timedelta(hours=1)).strftime(
+                "%Y-%m-%dT%H:%M:%SZ"
+            ),
+            authorization_expires=(current + timedelta(hours=3)).strftime(
+                "%Y-%m-%dT%H:%M:%SZ"
+            ),
+        ),
+    )
+    result = main([
+        "--repository", str(repository), "--base-sha", base, "--manifest-id", MANIFEST_ID,
+    ])
+    success = capsys.readouterr()
+    assert result == 0
+    assert json.loads(success.out)["publication_authorized"] is False
+    assert success.err == ""
+
+    _git(repository, "config", "remote.origin.promisor", "true")
+    result = main([
+        "--repository", str(repository), "--base-sha", base, "--manifest-id", MANIFEST_ID,
+    ])
+    failure = capsys.readouterr()
+    assert result == 1
+    assert failure.out == ""
+    assert json.loads(failure.err) == {"status": "error", "reason": "VERIFIER_FAILURE"}


### PR DESCRIPTION
## Context

This `engineering-controls` slice binds one strict overnight manifest to an exact protected-base Git blob. It keeps scheduled mutation and publication disabled.

## Runtime boundary

The protected-base adapter:

1. accepts an externally recorded full base SHA and Manifest ID;
2. requires the local `refs/remotes/origin/main` value to match before and after inspection;
3. derives the manifest path rather than accepting one from input;
4. loads one bounded regular `100644` Git blob;
5. independently recomputes its canonical Git object identity;
6. passes the exact bytes to the strict schema-v2 contract parser; and
7. emits redacted, explicitly non-authorizing evidence.

## Safeguards

- Fixed minimal Git child environment with credential, proxy, loader, SSH-agent, and cloud variables removed.
- Empty Git protocol allowlist and explicit partial/promisor-repository rejection.
- Fixed Git executable, no shell, bounded output, and per-command timeout.
- Symlink-free repository-root requirement.
- Corruption and tool failures remain operational failures; controlled manifest denials remain distinct.
- No fetch, edit, commit, push, pull request, merge, deployment, scheduler, publisher, or credential authority is added.

## History repair

The reviewed three-file delta was rebuilt on the squash merge of #43. Every `main` blob in this slice exactly matched #44's original parent before reconstruction.

Current head: `edb0d9ab4a2f3ab5731bb8dccb9187cf5742d61e`

- one commit ahead of `main`
- zero commits behind
- three changed paths
- 611 additions and 9 deletions

The final verifier, unit-test, and runbook blobs are unchanged from the reviewed #44 commit.

## Fresh validation

GitHub Actions run `32194395810` (`ci` run 173) passed on the repaired head:

- Security guardrails: passed
- Python readiness: passed
  - dependency installation
  - `make quality-check`
  - `make readiness-check`
- Infrastructure validation: passed
  - `make infrastructure-check`

No unresolved review threads or requested changes were present.

## Merge boundary

Following the instruction to process and squash the dependency stack, this PR is ready to merge as one engineering-controls commit. It verifies local protected-base Git objects only; it does not fetch, edit, commit, push, open a pull request, merge, deploy, schedule work, or authorize publication.