### PR TITLE
Observe committed candidate history scope

### DIFF
--- a/docs/overnight-development.md
+++ b/docs/overnight-development.md
@@ -352,16 +352,25 @@ Count the candidate budget from the staged change against the recorded base:
 git diff --cached --numstat -z <base-sha>
 ```
 
-Parse the NUL-delimited records and sum additions and deletions. Reject `-`
-binary counts, submodules, symlinks, or any unlisted path. After each commit,
-calculate the content-complete fingerprint without logging the patch:
+Parse the NUL-delimited records and sum additions and deletions. Use numstat only
+for paths, binary markers, and lines; the committed tree-snapshot gate rejects
+symlinks and gitlinks. This is a pre-commit line-budget check until the separate
+committed-line adapter exists.
 
-```bash
-git diff --binary --full-index <base-sha>...HEAD | sha256sum
-```
-
-Use pipeline-failure propagation and reject a non-zero Git or hash command; an
-empty or partial fingerprint is never evidence.
+After each commit, call `verify_committed_candidate_history` with the exact base,
+Manifest ID, and full candidate SHA. It derives the linear parent chain from
+independently rehashed commit bytes and compares every edge using in-memory,
+raw-byte path maps from independently rehashed canonical tree objects. Empty or
+malformed tree topology, unlisted paths, non-regular/non-text blobs, and file or
+commit budget overflow fail closed without logging file content. The observer
+caps each blob at 1 MiB, the unique changed-blob set at 4 MiB, and recursively
+expanded tree graphs by object, byte, entry, depth, and path limits. Its evidence
+explicitly
+leaves line budget, content fingerprint, worktree cleanliness, validation, push
+count, object-store isolation, and publication authority unverified. The trusted
+controller must establish common-object-store isolation before relying on this
+observation in a later gate; this observer does not establish that isolation. A
+candidate cannot proceed merely because this scope gate passes.
 
 A checkpoint is not green until validation is repeated against the exact commit
 tree that would be pushed:

--- a/scripts/overnight_manifest_verifier.py
+++ b/scripts/overnight_manifest_verifier.py
@@ -18,6 +18,16 @@ from typing import Any, NoReturn
 
 MAX_MANIFEST_BYTES = 32 * 1024
 MAX_GIT_METADATA_BYTES = 4 * 1024
+MAX_CANDIDATE_BLOB_BYTES = 1024 * 1024
+MAX_CANDIDATE_TOTAL_BLOB_BYTES = 4 * 1024 * 1024
+MAX_COMMIT_OBJECT_BYTES = 64 * 1024
+MAX_TREE_OBJECT_BYTES = 1024 * 1024
+MAX_TOTAL_TREE_BYTES = 16 * 1024 * 1024
+MAX_TREE_OBJECTS = 4096
+MAX_EXPANDED_TREE_ENTRIES = 100_000
+MAX_EXPANDED_TREE_PATH_BYTES = 64 * 1024 * 1024
+MAX_TREE_PATH_BYTES = 4096
+MAX_TREE_DEPTH = 128
 GIT_TIMEOUT_SECONDS = 10.0
 MAX_AUTHORIZATION_WINDOW = timedelta(hours=24)
 UTC = timezone.utc
@@ -58,9 +68,12 @@ DENIAL_REASONS = frozenset({
     "PRIMARY_BLOCK_PATH_REQUIRED", "TEST_PATH_REQUIRED", "INVALID_VALIDATION_PROFILE",
     "AUTHORIZATION_INACTIVE", "RUNTIME_EXCEEDS_AUTHORIZATION", "INVALID_BASE_SHA",
     "BASE_NOT_CURRENT", "BASE_MOVED", "MANIFEST_BLOB_INVALID",
+    "INVALID_CANDIDATE_SHA", "CANDIDATE_HISTORY_INVALID", "CANDIDATE_DIFF_INVALID",
+    "CANDIDATE_BUDGET_EXCEEDED",
 })
 GIT_ENVIRONMENT = MappingProxyType({
     "GIT_ALLOW_PROTOCOL": "",
+    "GIT_ATTR_NOSYSTEM": "1",
     "GIT_CONFIG_GLOBAL": "/dev/null",
     "GIT_CONFIG_NOSYSTEM": "1",
     "GIT_CONFIG_SYSTEM": "/dev/null",
@@ -143,6 +156,48 @@ class ProtectedBaseManifest:
             "maximum_runtime_minutes": self.contract.maximum_runtime_minutes,
             "verified_at": self.verified_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
             "authorization_expires": self.contract.authorization_expires.strftime(
+                "%Y-%m-%dT%H:%M:%SZ"
+            ),
+        }
+
+
+@dataclass(frozen=True, slots=True, repr=False)
+class CommittedCandidateHistory:
+    manifest: ProtectedBaseManifest
+    candidate_commit_sha: str
+    candidate_tree_sha: str
+    commit_shas: tuple[str, ...]
+    touched_paths: tuple[str, ...]
+    final_paths: tuple[str, ...]
+    verified_at: datetime
+
+    def redacted_evidence(self) -> dict[str, Any]:
+        return {
+            "status": "candidate-history-scope-observed",
+            "publication_authorized": False,
+            "object_store_isolation_verified": False,
+            "worktree_cleanliness_verified": False,
+            "validation_verified": False,
+            "changed_line_budget_verified": False,
+            "content_fingerprint_verified": False,
+            "push_budget_verified": False,
+            "manifest_id": self.manifest.contract.manifest_id,
+            "manifest_sha256": self.manifest.manifest_sha256,
+            "record_key": self.manifest.record_key,
+            "base_commit_sha": self.manifest.base_commit_sha,
+            "base_tree_sha": self.manifest.base_tree_sha,
+            "candidate_commit_sha": self.candidate_commit_sha,
+            "candidate_tree_sha": self.candidate_tree_sha,
+            "commit_shas": list(self.commit_shas),
+            "commit_count": len(self.commit_shas),
+            "touched_paths": list(self.touched_paths),
+            "changed_file_count": len(self.touched_paths),
+            "final_paths": list(self.final_paths),
+            "maximum_changed_lines": self.manifest.contract.maximum_changed_lines,
+            "maximum_changed_files": self.manifest.contract.maximum_changed_files,
+            "maximum_commits": self.manifest.contract.maximum_commits,
+            "verified_at": self.verified_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
+            "authorization_expires": self.manifest.contract.authorization_expires.strftime(
                 "%Y-%m-%dT%H:%M:%SZ"
             ),
         }
@@ -536,6 +591,310 @@ def verify_protected_base_manifest(
         record_key=hashlib.sha256(manifest_id.encode("ascii")).hexdigest(),
         object_format=object_format,
         verified_at=verified_at.astimezone(UTC),
+    )
+
+
+def _verified_object(
+    repository: Path, object_format: str, kind: str, oid: str, maximum_bytes: int
+) -> tuple[str, int, bytes]:
+    size_text = _ascii(
+        _run_git(repository, "cat-file", "-s", oid, maximum_output_bytes=16)
+    )
+    if len(size_text) > 10 or not size_text.isdigit():
+        raise VerifierFailure
+    size = int(size_text)
+    if size > maximum_bytes:
+        raise ManifestDenied("CANDIDATE_DIFF_INVALID")
+    content = _run_git(
+        repository,
+        "cat-file",
+        kind,
+        oid,
+        maximum_output_bytes=maximum_bytes,
+        excess_reason="CANDIDATE_DIFF_INVALID",
+    )
+    if len(content) != size or _git_object_oid(object_format, kind, content) != oid:
+        raise VerifierFailure
+    return hashlib.sha256(content).hexdigest(), size, content
+
+
+def _commit_tree_and_parents(content: bytes, sha_length: int) -> tuple[str, tuple[str, ...]]:
+    header, separator, _ = content.partition(b"\n\n")
+    headers = header.split(b"\n")
+    if not separator or not headers or not headers[0].startswith(b"tree "):
+        raise ManifestDenied("CANDIDATE_HISTORY_INVALID")
+    tree = headers[0].removeprefix(b"tree ")
+    parent_index = 1
+    parents: list[bytes] = []
+    while parent_index < len(headers) and headers[parent_index].startswith(b"parent "):
+        parents.append(headers[parent_index].removeprefix(b"parent "))
+        parent_index += 1
+    pattern = re.compile(f"[0-9a-f]{{{sha_length}}}".encode("ascii"))
+    if (
+        pattern.fullmatch(tree) is None
+        or tree == b"0" * sha_length
+        or any(line.startswith((b"tree ", b"parent ")) for line in headers[parent_index:])
+        or any(
+            pattern.fullmatch(parent) is None or parent == b"0" * sha_length
+            for parent in parents
+        )
+    ):
+        raise ManifestDenied("CANDIDATE_HISTORY_INVALID")
+    return tree.decode("ascii"), tuple(parent.decode("ascii") for parent in parents)
+
+
+def _tree_entries(content: bytes, oid_bytes: int) -> tuple[tuple[bytes, str, str], ...]:
+    if not content:
+        raise ManifestDenied("CANDIDATE_DIFF_INVALID")
+    offset = 0
+    names: set[bytes] = set()
+    previous_key: bytes | None = None
+    result: list[tuple[bytes, str, str]] = []
+    allowed_modes = {b"40000", b"100644", b"100755", b"120000", b"160000"}
+    while offset < len(content):
+        space = content.find(b" ", offset)
+        nul = content.find(b"\0", space + 1)
+        oid_end = nul + 1 + oid_bytes
+        if space <= offset or nul <= space + 1 or oid_end > len(content):
+            raise VerifierFailure
+        mode = content[offset:space]
+        name = content[space + 1:nul]
+        raw_oid = content[nul + 1:oid_end]
+        order_key = name + (b"/" if mode == b"40000" else b"\0")
+        if (
+            mode not in allowed_modes
+            or not name
+            or b"/" in name
+            or name in {b".", b".."}
+            or name.lower() == b".git"
+            or name in names
+            or raw_oid == b"\0" * oid_bytes
+            or (previous_key is not None and order_key <= previous_key)
+        ):
+            raise ManifestDenied("CANDIDATE_DIFF_INVALID")
+        names.add(name)
+        previous_key = order_key
+        result.append((name, mode.decode("ascii"), raw_oid.hex()))
+        offset = oid_end
+    return tuple(result)
+
+
+def _verified_tree_snapshots(
+    repository: Path, object_format: str, roots: tuple[str, ...]
+) -> dict[str, dict[bytes, tuple[str, str]]]:
+    oid_bytes = {"sha1": 20, "sha256": 32}.get(object_format)
+    if oid_bytes is None:
+        raise VerifierFailure
+    parsed: dict[str, tuple[tuple[bytes, str, str], ...]] = {}
+    total_bytes = 0
+    expanded_entries = 0
+    expanded_path_bytes = 0
+    snapshots: dict[str, dict[bytes, tuple[str, str]]] = {}
+
+    def entries_for(oid: str) -> tuple[tuple[bytes, str, str], ...]:
+        nonlocal total_bytes
+        if oid not in parsed:
+            if len(parsed) >= MAX_TREE_OBJECTS:
+                raise ManifestDenied("CANDIDATE_DIFF_INVALID")
+            _, size, content = _verified_object(
+                repository, object_format, "tree", oid, MAX_TREE_OBJECT_BYTES
+            )
+            total_bytes += size
+            if total_bytes > MAX_TOTAL_TREE_BYTES:
+                raise ManifestDenied("CANDIDATE_DIFF_INVALID")
+            parsed[oid] = _tree_entries(content, oid_bytes)
+        return parsed[oid]
+
+    for root in roots:
+        if root in snapshots:
+            continue
+        snapshot: dict[bytes, tuple[str, str]] = {}
+        pending: list[tuple[str, bytes, tuple[str, ...], int]] = [(root, b"", (), 0)]
+        while pending:
+            oid, prefix, ancestors, depth = pending.pop()
+            if oid in ancestors or depth > MAX_TREE_DEPTH:
+                raise ManifestDenied("CANDIDATE_DIFF_INVALID")
+            next_ancestors = (*ancestors, oid)
+            for name, mode, child_oid in reversed(entries_for(oid)):
+                full_path = prefix + name
+                expanded_entries += 1
+                expanded_path_bytes += len(full_path)
+                if (
+                    expanded_entries > MAX_EXPANDED_TREE_ENTRIES
+                    or expanded_path_bytes > MAX_EXPANDED_TREE_PATH_BYTES
+                    or len(full_path) > MAX_TREE_PATH_BYTES
+                ):
+                    raise ManifestDenied("CANDIDATE_DIFF_INVALID")
+                if mode == "40000":
+                    pending.append((child_oid, full_path + b"/", next_ancestors, depth + 1))
+                elif full_path in snapshot:
+                    raise ManifestDenied("CANDIDATE_DIFF_INVALID")
+                else:
+                    snapshot[full_path] = (mode, child_oid)
+        snapshots[root] = snapshot
+    return snapshots
+
+
+def _verified_commit_history(
+    repository: Path, binding: ProtectedBaseManifest, candidate_sha: str
+) -> tuple[tuple[str, ...], dict[str, str]]:
+    current = candidate_sha
+    reverse_commits: list[str] = []
+    trees: dict[str, str] = {}
+    while current != binding.base_commit_sha:
+        if len(reverse_commits) >= binding.contract.maximum_commits:
+            raise ManifestDenied("CANDIDATE_BUDGET_EXCEEDED")
+        _, _, content = _verified_object(
+            repository, binding.object_format, "commit", current, MAX_COMMIT_OBJECT_BYTES
+        )
+        tree, parents = _commit_tree_and_parents(content, len(binding.base_commit_sha))
+        if len(parents) != 1:
+            raise ManifestDenied("CANDIDATE_HISTORY_INVALID")
+        reverse_commits.append(current)
+        trees[current] = tree
+        current = parents[0]
+    if not reverse_commits:
+        raise ManifestDenied("CANDIDATE_HISTORY_INVALID")
+    _, _, base_content = _verified_object(
+        repository, binding.object_format, "commit", binding.base_commit_sha,
+        MAX_COMMIT_OBJECT_BYTES,
+    )
+    base_tree, _ = _commit_tree_and_parents(base_content, len(binding.base_commit_sha))
+    if base_tree != binding.base_tree_sha:
+        raise VerifierFailure
+    return tuple(reversed(reverse_commits)), trees
+
+
+def _is_lfs_pointer(content: bytes) -> bool:
+    if len(content) > 1024:
+        return False
+    lines = content.splitlines()
+    return (
+        len(lines) >= 3
+        and re.fullmatch(rb"version https://[^\s]+/spec/v1", lines[0]) is not None
+        and any(re.fullmatch(rb"oid sha256:[0-9a-f]{64}", line) for line in lines[1:])
+        and any(re.fullmatch(rb"size [0-9]+", line) for line in lines[1:])
+    )
+
+
+def _inspect_edge(
+    repository: Path,
+    old_snapshot: dict[bytes, tuple[str, str]],
+    new_snapshot: dict[bytes, tuple[str, str]],
+    binding: ProtectedBaseManifest,
+    blob_cache: dict[str, tuple[str, int]],
+) -> tuple[str, ...]:
+    allowed_paths = {path.encode("ascii"): path for path in binding.contract.allowed_paths}
+    changed_paths: list[str] = []
+    for raw_path in sorted(old_snapshot.keys() | new_snapshot.keys()):
+        old = old_snapshot.get(raw_path)
+        new = new_snapshot.get(raw_path)
+        if old == new:
+            continue
+        path = allowed_paths.get(raw_path)
+        if path is None or any(
+            endpoint is not None and endpoint[0] != "100644" for endpoint in (old, new)
+        ):
+            raise ManifestDenied("CANDIDATE_DIFF_INVALID")
+        changed_paths.append(path)
+        for endpoint in (old, new):
+            if endpoint is None or endpoint[1] in blob_cache:
+                continue
+            oid = endpoint[1]
+            digest, size, content = _verified_object(
+                repository, binding.object_format, "blob", oid, MAX_CANDIDATE_BLOB_BYTES
+            )
+            try:
+                content.decode("utf-8")
+            except UnicodeError:
+                raise ManifestDenied("CANDIDATE_DIFF_INVALID") from None
+            if b"\0" in content or _is_lfs_pointer(content):
+                raise ManifestDenied("CANDIDATE_DIFF_INVALID")
+            blob_cache[oid] = (digest, size)
+            if sum(item[1] for item in blob_cache.values()) > MAX_CANDIDATE_TOTAL_BLOB_BYTES:
+                raise ManifestDenied("CANDIDATE_DIFF_INVALID")
+    return tuple(changed_paths)
+
+
+def verify_committed_candidate_history(
+    repository: Path,
+    base_sha: str,
+    manifest_id: str,
+    candidate_sha: str,
+    *,
+    now: datetime | None = None,
+) -> CommittedCandidateHistory:
+    binding = verify_protected_base_manifest(repository, base_sha, manifest_id, now=now)
+    repository = Path(os.path.abspath(repository))
+    sha_length = len(binding.base_commit_sha)
+    if type(candidate_sha) is not str or re.fullmatch(
+        f"[0-9a-f]{{{sha_length}}}", candidate_sha
+    ) is None:
+        raise ManifestDenied("INVALID_CANDIDATE_SHA")
+    shallow = _ascii(_run_git(repository, "rev-parse", "--is-shallow-repository"))
+    if shallow != "false":
+        raise VerifierFailure
+    grafts_path = Path(_ascii(_run_git(
+        repository, "rev-parse", "--path-format=absolute", "--git-path", "info/grafts"
+    )))
+    if grafts_path.exists() or grafts_path.is_symlink():
+        raise VerifierFailure
+    commits, commit_trees = _verified_commit_history(repository, binding, candidate_sha)
+    candidate_tree = commit_trees[candidate_sha]
+    tree_roots = (binding.base_tree_sha, *(commit_trees[commit] for commit in commits))
+    snapshots = _verified_tree_snapshots(repository, binding.object_format, tree_roots)
+
+    touched_paths: set[str] = set()
+    blob_cache: dict[str, tuple[str, int]] = {}
+    previous_tree = binding.base_tree_sha
+    for commit in commits:
+        current_tree = commit_trees[commit]
+        changed_paths = _inspect_edge(
+            repository, snapshots[previous_tree], snapshots[current_tree], binding, blob_cache
+        )
+        if not changed_paths:
+            raise ManifestDenied("CANDIDATE_HISTORY_INVALID")
+        touched_paths.update(changed_paths)
+        if len(touched_paths) > binding.contract.maximum_changed_files:
+            raise ManifestDenied("CANDIDATE_BUDGET_EXCEEDED")
+        previous_tree = current_tree
+    final_paths = _inspect_edge(
+        repository,
+        snapshots[binding.base_tree_sha],
+        snapshots[candidate_tree],
+        binding,
+        blob_cache,
+    )
+    if not final_paths:
+        raise ManifestDenied("CANDIDATE_DIFF_INVALID")
+    closing_commits, closing_trees = _verified_commit_history(repository, binding, candidate_sha)
+    if closing_commits != commits or closing_trees != commit_trees:
+        raise VerifierFailure
+    closing_snapshots = _verified_tree_snapshots(
+        repository, binding.object_format, tree_roots
+    )
+    if closing_snapshots != snapshots:
+        raise VerifierFailure
+    try:
+        closing = verify_protected_base_manifest(repository, base_sha, manifest_id, now=now)
+    except ManifestDenied as error:
+        if error.reason == "BASE_NOT_CURRENT":
+            raise ManifestDenied("BASE_MOVED") from None
+        raise
+    if (
+        closing.base_tree_sha != binding.base_tree_sha
+        or closing.manifest_sha256 != binding.manifest_sha256
+        or closing.contract != binding.contract
+    ):
+        raise VerifierFailure
+    return CommittedCandidateHistory(
+        manifest=closing,
+        candidate_commit_sha=candidate_sha,
+        candidate_tree_sha=candidate_tree,
+        commit_shas=commits,
+        touched_paths=tuple(sorted(touched_paths)),
+        final_paths=final_paths,
+        verified_at=closing.verified_at,
     )
 
 

--- a/tests/unit/test_overnight_manifest_verifier.py
+++ b/tests/unit/test_overnight_manifest_verifier.py
@@ -16,6 +16,7 @@ from scripts.overnight_manifest_verifier import (
     VerifierFailure,
     main,
     validate_manifest_blob,
+    verify_committed_candidate_history,
     verify_protected_base_manifest,
 )
 
@@ -159,6 +160,15 @@ def _git(repository: Path, *arguments: str) -> str:
         stdout=subprocess.PIPE, stderr=subprocess.PIPE,
     )
     return result.stdout.strip()
+
+
+def _hash_object(repository: Path, kind: str, content: bytes) -> str:
+    result = subprocess.run(
+        ["/usr/bin/git", "hash-object", "--literally", "-w", "-t", kind, "--stdin"],
+        cwd=repository, check=True, input=content, stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    return result.stdout.decode("ascii").strip()
 
 
 def _repository(tmp_path: Path, content: bytes | None = None, *, executable: bool = False) -> tuple[Path, str]:
@@ -400,3 +410,212 @@ def test_cli_success_and_operational_failure_are_distinct(
     assert result == 1
     assert failure.out == ""
     assert json.loads(failure.err) == {"status": "error", "reason": "VERIFIER_FAILURE"}
+
+
+def _candidate_commit(repository: Path, path: str, content: bytes, message: str) -> str:
+    target = repository / path
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_bytes(content)
+    _git(repository, "add", "--", path)
+    _git(repository, "commit", "-q", "-m", message)
+    return _git(repository, "rev-parse", "HEAD")
+
+
+def test_committed_history_binds_every_allowed_commit_and_ignores_dirty_worktree(
+    tmp_path: Path,
+) -> None:
+    repository, base = _repository(tmp_path)
+    first = _candidate_commit(
+        repository, "src/analytics/daily_risk.py", b"VALUE = 1\n", "Source checkpoint"
+    )
+    head = _candidate_commit(
+        repository, "tests/unit/test_daily_risk.py", b"def test_value():\n    assert 1\n", "Test checkpoint"
+    )
+    (repository / "src/analytics/daily_risk.py").write_text("dirty sentinel", encoding="utf-8")
+    (repository / "sentinel-secret-untracked").write_text("not evidence", encoding="utf-8")
+
+    result = verify_committed_candidate_history(repository, base, MANIFEST_ID, head, now=NOW)
+    evidence = result.redacted_evidence()
+
+    assert result.commit_shas == (first, head)
+    assert result.touched_paths == (
+        "src/analytics/daily_risk.py", "tests/unit/test_daily_risk.py"
+    )
+    assert evidence["changed_line_budget_verified"] is False
+    assert evidence["content_fingerprint_verified"] is False
+    assert evidence["object_store_isolation_verified"] is False
+    assert evidence["publication_authorized"] is False
+    assert "sentinel" not in json.dumps(evidence)
+
+
+@pytest.mark.parametrize("grafted", [False, True])
+def test_committed_history_rejects_forbidden_path_even_when_later_removed(
+    tmp_path: Path, grafted: bool
+) -> None:
+    repository, base = _repository(tmp_path)
+    _candidate_commit(repository, "docs/forbidden.md", b"temporary\n", "Forbidden checkpoint")
+    (repository / "docs/forbidden.md").unlink()
+    _git(repository, "add", "-u", "--", "docs/forbidden.md")
+    _git(repository, "commit", "-q", "-m", "Remove forbidden path")
+    head = _candidate_commit(
+        repository, "src/analytics/daily_risk.py", b"VALUE = 1\n", "Allowed checkpoint"
+    )
+    if grafted:
+        (repository / ".git/info/grafts").write_text(f"{head} {base}\n", encoding="ascii")
+
+    expected = VerifierFailure if grafted else ManifestDenied
+    with pytest.raises(expected):
+        verify_committed_candidate_history(repository, base, MANIFEST_ID, head, now=NOW)
+
+
+@pytest.mark.parametrize("kind", ["binary", "executable", "symlink", "lfs"])
+def test_committed_history_rejects_non_regular_or_nonlocal_text(
+    tmp_path: Path, kind: str
+) -> None:
+    repository, base = _repository(tmp_path)
+    target = repository / "src/analytics/daily_risk.py"
+    target.parent.mkdir(parents=True)
+    if kind == "symlink":
+        target.symlink_to("sentinel-target")
+    else:
+        content = {
+            "binary": b"bad\0data",
+            "executable": b"VALUE = 1\n",
+            "lfs": (
+                b"version https://hawser.github.com/spec/v1\noid sha256:"
+                + b"a" * 64 + b"\nsize 1\n"
+            ),
+        }[kind]
+        target.write_bytes(content)
+        if kind == "executable":
+            target.chmod(0o755)
+    _git(repository, "add", "--", "src/analytics/daily_risk.py")
+    _git(repository, "commit", "-q", "-m", "Invalid endpoint")
+
+    with pytest.raises(ManifestDenied, match="CANDIDATE_DIFF_INVALID"):
+        verify_committed_candidate_history(
+            repository, base, MANIFEST_ID, _git(repository, "rev-parse", "HEAD"), now=NOW
+        )
+
+
+def test_committed_history_enforces_file_and_commit_budgets(tmp_path: Path) -> None:
+    paths = [
+        "src/analytics/daily_risk.py", "src/analytics/other.py",
+        "tests/unit/test_daily_risk.py",
+    ]
+    repository, base = _repository(
+        tmp_path, _blob(allowed_paths=paths, maximum_changed_files=2, maximum_commits=3)
+    )
+    for index, path in enumerate(paths):
+        head = _candidate_commit(repository, path, f"VALUE = {index}\n".encode(), f"Checkpoint {index}")
+    with pytest.raises(ManifestDenied, match="CANDIDATE_BUDGET_EXCEEDED"):
+        verify_committed_candidate_history(repository, base, MANIFEST_ID, head, now=NOW)
+
+    _candidate_commit(repository, paths[0], b"VALUE = 4\n", "Fourth checkpoint")
+    with pytest.raises(ManifestDenied, match="CANDIDATE_BUDGET_EXCEEDED"):
+        verify_committed_candidate_history(
+            repository, base, MANIFEST_ID, _git(repository, "rev-parse", "HEAD"), now=NOW
+        )
+
+
+def test_committed_history_rejects_empty_abbreviated_and_merge_tips(
+    tmp_path: Path,
+) -> None:
+    repository, base = _repository(tmp_path)
+    with pytest.raises(ManifestDenied):
+        verify_committed_candidate_history(repository, base, MANIFEST_ID, base, now=NOW)
+    with pytest.raises(ManifestDenied, match="INVALID_CANDIDATE_SHA"):
+        verify_committed_candidate_history(repository, base, MANIFEST_ID, base[:12], now=NOW)
+
+    _git(repository, "checkout", "-q", "-b", "side", base)
+    _candidate_commit(repository, "tests/unit/test_daily_risk.py", b"def test_side():\n    pass\n", "Side")
+    _git(repository, "checkout", "-q", "-b", "candidate", base)
+    _candidate_commit(repository, "src/analytics/daily_risk.py", b"VALUE = 1\n", "Candidate")
+    _git(repository, "merge", "-q", "--no-ff", "side", "-m", "Merge")
+    with pytest.raises(ManifestDenied, match="CANDIDATE_HISTORY_INVALID"):
+        verify_committed_candidate_history(
+            repository, base, MANIFEST_ID, _git(repository, "rev-parse", "HEAD"), now=NOW
+        )
+
+
+def test_committed_history_rejects_parent_header_after_author(tmp_path: Path) -> None:
+    repository, base = _repository(tmp_path)
+    normal_head = _candidate_commit(
+        repository, "src/analytics/daily_risk.py", b"VALUE = 1\n", "Allowed checkpoint"
+    )
+    tree = _git(repository, "rev-parse", f"{normal_head}^{{tree}}")
+    malformed = (
+        f"tree {tree}\nauthor Tests <tests@example.invalid> 0 +0000\n"
+        f"parent {base}\ncommitter Tests <tests@example.invalid> 0 +0000\n\nMessage\n"
+    ).encode("ascii")
+    candidate = _hash_object(repository, "commit", malformed)
+    assert _git(repository, "rev-list", "--parents", "-1", candidate) == candidate
+
+    with pytest.raises(ManifestDenied, match="CANDIDATE_HISTORY_INVALID"):
+        verify_committed_candidate_history(repository, base, MANIFEST_ID, candidate, now=NOW)
+
+
+def test_committed_history_rejects_non_lf_commit_headers(tmp_path: Path) -> None:
+    repository, base = _repository(tmp_path)
+    normal_head = _candidate_commit(
+        repository, "src/analytics/daily_risk.py", b"VALUE = 1\n", "Allowed checkpoint"
+    )
+    tree = _git(repository, "rev-parse", f"{normal_head}^{{tree}}")
+    malformed = (
+        f"tree {tree}\r\nparent {base}\nauthor Tests <tests@example.invalid> 0 +0000\n"
+        "committer Tests <tests@example.invalid> 0 +0000\n\nMessage\n"
+    ).encode("ascii")
+    candidate = _hash_object(repository, "commit", malformed)
+
+    with pytest.raises(ManifestDenied, match="CANDIDATE_HISTORY_INVALID"):
+        verify_committed_candidate_history(repository, base, MANIFEST_ID, candidate, now=NOW)
+
+
+def test_committed_history_rejects_substituted_nested_tree_bytes(tmp_path: Path) -> None:
+    repository, base = _repository(tmp_path)
+    (repository / "docs/forbidden.md").write_text("hidden\n", encoding="utf-8")
+    head = _candidate_commit(
+        repository, "src/analytics/daily_risk.py", b"VALUE = 1\n", "Mixed checkpoint"
+    )
+    _git(repository, "add", "--", "docs/forbidden.md")
+    _git(repository, "commit", "--amend", "-q", "--no-edit")
+    head = _git(repository, "rev-parse", "HEAD")
+    candidate_docs = _git(repository, "rev-parse", f"{head}:docs")
+    base_docs = subprocess.run(
+        ["/usr/bin/git", "cat-file", "tree", f"{base}:docs"], cwd=repository,
+        check=True, stdout=subprocess.PIPE,
+    ).stdout
+    loose_tree = repository / ".git/objects" / candidate_docs[:2] / candidate_docs[2:]
+    loose_tree.chmod(0o600)
+    loose_tree.write_bytes(zlib.compress(f"tree {len(base_docs)}\0".encode() + base_docs))
+
+    with pytest.raises(VerifierFailure):
+        verify_committed_candidate_history(repository, base, MANIFEST_ID, head, now=NOW)
+
+
+@pytest.mark.parametrize("malformation", ["zero-padded-directory", "hidden-empty-tree"])
+def test_committed_history_rejects_noncanonical_or_empty_tree_topology(
+    tmp_path: Path, malformation: str
+) -> None:
+    repository, base = _repository(tmp_path)
+    normal_head = _candidate_commit(
+        repository, "src/analytics/daily_risk.py", b"VALUE = 1\n", "Allowed checkpoint"
+    )
+    normal_tree = _git(repository, "rev-parse", f"{normal_head}^{{tree}}")
+    tree_bytes = subprocess.run(
+        ["/usr/bin/git", "cat-file", "tree", normal_tree], cwd=repository,
+        check=True, stdout=subprocess.PIPE,
+    ).stdout
+    if malformation == "zero-padded-directory":
+        malformed_tree = tree_bytes.replace(b"40000 src\0", b"040000 src\0", 1)
+        assert malformed_tree != tree_bytes
+    else:
+        empty_tree = _hash_object(repository, "tree", b"")
+        malformed_tree = (
+            tree_bytes + b"40000 zz-forbidden-empty\0" + bytes.fromhex(empty_tree)
+        )
+    tree_oid = _hash_object(repository, "tree", malformed_tree)
+    candidate = _git(repository, "commit-tree", tree_oid, "-p", base, "-m", "Malformed tree")
+
+    with pytest.raises(ManifestDenied, match="CANDIDATE_DIFF_INVALID"):
+        verify_committed_candidate_history(repository, base, MANIFEST_ID, candidate, now=NOW)


### PR DESCRIPTION
## Context

This `engineering-controls` slice observes the exact committed candidate history and changed-path scope after protected-base manifest binding. It does not authorize publication.

## Runtime sequence

1. Rebind the protected-base manifest.
2. Walk the candidate’s bounded one-parent history from independently rehashed commit bytes.
3. Build bounded in-memory path snapshots from independently rehashed canonical tree objects.
4. Compare every parent-to-commit edge and the final base-to-candidate state.
5. Verify exact allowlisted paths, regular text blobs, and file/commit budgets.
6. Re-read commits, trees, and the protected-base binding before returning redacted evidence.

## Safeguards

- Nonlinear history, transient forbidden paths, executable files, symlinks, gitlinks, binary/LFS content, malformed trees, hidden empty subtrees, and noncanonical ancestry fail closed.
- Blob, tree-object, expanded-entry, path, depth, and aggregate-byte limits bound local object reads.
- Candidate content is not written to logs or evidence.
- Worktree cleanliness, content line budgets, candidate isolation, push authority, and publication authority remain unverified and false.

## History repair

The reviewed three-file delta was rebuilt on the squash merge of #44. Every `main` blob in this slice exactly matched #45’s original parent before reconstruction.

Current head: `257aab3626533acaf5f1424b564270968ae50844`

- one commit ahead of `main`
- zero commits behind
- three changed paths
- 597 additions and 10 deletions

The final verifier, unit-test, and runbook blobs are unchanged from the reviewed #45 commit.

## Fresh validation

GitHub Actions run `32194581343` (`ci` run 176) passed on the repaired head:

- Security guardrails: passed
- Python readiness: passed
  - dependency installation
  - `make quality-check`
  - `make readiness-check`
- Infrastructure validation: passed
  - `make infrastructure-check`

No unresolved review threads or requested changes were present.

## Merge boundary

Following the instruction to process and squash the dependency stack, this PR is ready to merge as one engineering-controls commit. It observes bounded committed history and path scope only; it does not establish content line budgets, isolate a candidate, push, open a pull request, merge, deploy, or authorize publication.