### PR TITLE
Bind candidate history to content evidence

### DIFF
--- a/docs/overnight-development.md
+++ b/docs/overnight-development.md
@@ -353,24 +353,38 @@ git diff --cached --numstat -z <base-sha>
 ```
 
 Parse the NUL-delimited records and sum additions and deletions. Use numstat only
-for paths, binary markers, and lines; the committed tree-snapshot gate rejects
-symlinks and gitlinks. This is a pre-commit line-budget check until the separate
-committed-line adapter exists.
+as an advisory pre-commit estimate; Git attributes and diff heuristics are not
+part of the authoritative committed calculation. The committed tree-snapshot
+gate rejects symlinks and gitlinks.
 
-After each commit, call `verify_committed_candidate_history` with the exact base,
-Manifest ID, and full candidate SHA. It derives the linear parent chain from
-independently rehashed commit bytes and compares every edge using in-memory,
-raw-byte path maps from independently rehashed canonical tree objects. Empty or
-malformed tree topology, unlisted paths, non-regular/non-text blobs, and file or
-commit budget overflow fail closed without logging file content. The observer
-caps each blob at 1 MiB, the unique changed-blob set at 4 MiB, and recursively
-expanded tree graphs by object, byte, entry, depth, and path limits. Its evidence
-explicitly
-leaves line budget, content fingerprint, worktree cleanliness, validation, push
-count, object-store isolation, and publication authority unverified. The trusted
-controller must establish common-object-store isolation before relying on this
-observation in a later gate; this observer does not establish that isolation. A
-candidate cannot proceed merely because this scope gate passes.
+After each commit, call `verify_committed_candidate_content` with the exact base,
+Manifest ID, and full candidate SHA. It first runs the committed-history observer,
+which derives the linear parent chain from independently rehashed commit bytes
+and compares every edge using bounded, in-memory path maps from independently
+rehashed canonical tree objects. Empty or malformed tree topology, unlisted
+paths, non-regular/non-text blobs, and file or commit budget overflow fail closed
+without logging file content.
+
+The content adapter then uses only those captured bytes. Algorithm
+`frdp-lf-minimal-insdel-v1` counts the shortest insertion/deletion line distance
+on every parent-to-commit edge; byte LF is the only separator, a replacement
+costs one deletion plus one addition, and repeated or reverted edits count again.
+It never adds the final base-to-tip summary a second time. Equality with the
+manifest budget passes. Lines longer than 64 KiB, more than 100,000 records in
+one blob or 200,000 across the changed-blob set, and bounded-edit work above its
+fixed operation or compared-byte caps fail closed.
+
+The adapter also emits a SHA-256 fingerprint for the versioned,
+length-framed `frdp.overnight.candidate-content.v1` transcript. It binds the
+manifest hash, object format, exact commit and tree observations, every ordered
+edge/path/endpoint, derived line counts, final summary, and a deduplicated table
+of exact changed-blob bytes. It excludes the runtime verification timestamp and
+worktree state; the manifest hash still binds its human-issued authorization
+times. Evidence marks the
+changed-line budget and fingerprint verified, but leaves worktree
+cleanliness, validation, push count, object-store isolation, and publication
+authority false. The trusted controller must establish common-object-store
+isolation before relying on the observation in a later gate.
 
 A checkpoint is not green until validation is repeated against the exact commit
 tree that would be pushed:

--- a/scripts/overnight_candidate_content.py
+++ b/scripts/overnight_candidate_content.py
@@ -1,0 +1,550 @@
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from scripts.overnight_manifest_verifier import (
+    MAX_CANDIDATE_BLOB_BYTES,
+    MAX_CANDIDATE_TOTAL_BLOB_BYTES,
+    CommittedCandidateHistory,
+    CommittedHistoryEdge,
+    CommittedPathChange,
+    ManifestDenied,
+    VerifiedFileContent,
+    VerifierFailure,
+    verify_committed_candidate_history,
+)
+
+
+LINE_COUNT_ALGORITHM = "frdp-lf-minimal-insdel-v1"
+FINGERPRINT_SCHEMA = "frdp.overnight.candidate-content.v1"
+FINGERPRINT_ALGORITHM = "sha256"
+FINGERPRINT_DOMAIN = FINGERPRINT_SCHEMA.encode("ascii") + b"\0"
+REPOSITORY_ID = b"alexmarinos87/financial-risk-data-platform"
+MAX_LINE_RECORD_BYTES = 64 * 1024
+MAX_LINE_RECORDS_PER_BLOB = 100_000
+MAX_TOTAL_LINE_RECORDS = 200_000
+MAX_EDIT_WORK_UNITS = 5_000_000
+MAX_EDIT_COMPARISON_BYTES = 64 * 1024 * 1024
+
+
+@dataclass(frozen=True, slots=True, repr=False)
+class CandidateEdgeLineCount:
+    parent_commit_sha: str
+    parent_tree_sha: str
+    commit_sha: str
+    commit_tree_sha: str
+    additions: int
+    deletions: int
+
+    @property
+    def changed_lines(self) -> int:
+        return self.additions + self.deletions
+
+    def redacted_evidence(self) -> dict[str, Any]:
+        return {
+            "parent_commit_sha": self.parent_commit_sha,
+            "parent_tree_sha": self.parent_tree_sha,
+            "commit_sha": self.commit_sha,
+            "commit_tree_sha": self.commit_tree_sha,
+            "additions": self.additions,
+            "deletions": self.deletions,
+            "changed_lines": self.changed_lines,
+        }
+
+
+@dataclass(frozen=True, slots=True, repr=False)
+class CommittedCandidateContent:
+    history: CommittedCandidateHistory
+    edge_line_counts: tuple[CandidateEdgeLineCount, ...]
+    cumulative_additions: int
+    cumulative_deletions: int
+    candidate_fingerprint_sha256: str
+    fingerprinted_blob_count: int
+    fingerprinted_blob_bytes: int
+
+    @property
+    def cumulative_changed_lines(self) -> int:
+        return self.cumulative_additions + self.cumulative_deletions
+
+    def redacted_evidence(self) -> dict[str, Any]:
+        evidence = self.history.redacted_evidence()
+        evidence.update({
+            "status": "candidate-content-observed",
+            "publication_authorized": False,
+            "object_store_isolation_verified": False,
+            "worktree_cleanliness_verified": False,
+            "validation_verified": False,
+            "push_budget_verified": False,
+            "changed_line_budget_verified": True,
+            "content_fingerprint_verified": True,
+            "line_count_algorithm": LINE_COUNT_ALGORITHM,
+            "cumulative_additions": self.cumulative_additions,
+            "cumulative_deletions": self.cumulative_deletions,
+            "cumulative_changed_lines": self.cumulative_changed_lines,
+            "edge_line_counts": [item.redacted_evidence() for item in self.edge_line_counts],
+            "candidate_fingerprint_schema": FINGERPRINT_SCHEMA,
+            "candidate_fingerprint_algorithm": FINGERPRINT_ALGORITHM,
+            "candidate_fingerprint": f"sha256:{self.candidate_fingerprint_sha256}",
+            "fingerprinted_blob_count": self.fingerprinted_blob_count,
+            "fingerprinted_blob_bytes": self.fingerprinted_blob_bytes,
+        })
+        return evidence
+
+
+@dataclass(slots=True)
+class _EditWork:
+    units: int = 0
+    comparison_bytes: int = 0
+
+    def step(self) -> None:
+        self.units += 1
+        if self.units > MAX_EDIT_WORK_UNITS:
+            raise ManifestDenied("CANDIDATE_DIFF_INVALID")
+
+    def equal(self, left: bytes, right: bytes) -> bool:
+        self.step()
+        self.comparison_bytes += len(left) + len(right)
+        if self.comparison_bytes > MAX_EDIT_COMPARISON_BYTES:
+            raise ManifestDenied("CANDIDATE_DIFF_INVALID")
+        return left == right
+
+
+@dataclass(frozen=True, slots=True, repr=False)
+class _CountedChange:
+    change: CommittedPathChange
+    additions: int
+    deletions: int
+
+
+@dataclass(frozen=True, slots=True, repr=False)
+class _CountedEdge:
+    edge: CommittedHistoryEdge
+    changes: tuple[_CountedChange, ...]
+    line_count: CandidateEdgeLineCount
+
+
+class _Transcript:
+    def __init__(self) -> None:
+        self._digest = hashlib.sha256(FINGERPRINT_DOMAIN)
+
+    def field(self, tag: str, value: bytes) -> None:
+        try:
+            encoded_tag = tag.encode("ascii")
+            length = len(value).to_bytes(8, "big")
+        except (OverflowError, UnicodeError):
+            raise VerifierFailure from None
+        if not encoded_tag or len(encoded_tag) > 255:
+            raise VerifierFailure
+        self._digest.update(bytes((len(encoded_tag),)))
+        self._digest.update(encoded_tag)
+        self._digest.update(length)
+        self._digest.update(value)
+
+    def integer(self, tag: str, value: int) -> None:
+        if type(value) is not int or not 0 <= value < 2**64:
+            raise VerifierFailure
+        self.field(tag, value.to_bytes(8, "big"))
+
+    def hexdigest(self) -> str:
+        return self._digest.hexdigest()
+
+
+def _line_records(content: bytes) -> tuple[bytes, ...]:
+    records: list[bytes] = []
+    start = 0
+    while start < len(content):
+        newline = content.find(b"\n", start)
+        end = len(content) if newline < 0 else newline + 1
+        record = content[start:end]
+        if len(record) > MAX_LINE_RECORD_BYTES:
+            raise ManifestDenied("CANDIDATE_DIFF_INVALID")
+        records.append(record)
+        if len(records) > MAX_LINE_RECORDS_PER_BLOB:
+            raise ManifestDenied("CANDIDATE_DIFF_INVALID")
+        start = end
+    return tuple(records)
+
+
+def _bounded_edit_distance(
+    old: tuple[bytes, ...], new: tuple[bytes, ...], limit: int, work: _EditWork
+) -> int:
+    prefix = 0
+    while prefix < len(old) and prefix < len(new) and work.equal(old[prefix], new[prefix]):
+        prefix += 1
+    old_end = len(old)
+    new_end = len(new)
+    while (
+        old_end > prefix
+        and new_end > prefix
+        and work.equal(old[old_end - 1], new[new_end - 1])
+    ):
+        old_end -= 1
+        new_end -= 1
+    old_middle = old[prefix:old_end]
+    new_middle = new[prefix:new_end]
+    old_count = len(old_middle)
+    new_count = len(new_middle)
+    if abs(old_count - new_count) > limit:
+        raise ManifestDenied("CANDIDATE_BUDGET_EXCEEDED")
+    if not old_middle or not new_middle:
+        distance = old_count + new_count
+        if distance > limit:
+            raise ManifestDenied("CANDIDATE_BUDGET_EXCEEDED")
+        return distance
+
+    frontier = {1: 0}
+    for distance in range(limit + 1):
+        for diagonal in range(-distance, distance + 1, 2):
+            work.step()
+            if diagonal == -distance or (
+                diagonal != distance
+                and frontier.get(diagonal - 1, -1) < frontier.get(diagonal + 1, -1)
+            ):
+                x = frontier.get(diagonal + 1, 0)
+            else:
+                x = frontier.get(diagonal - 1, 0) + 1
+            y = x - diagonal
+            while (
+                x < old_count
+                and y < new_count
+                and work.equal(old_middle[x], new_middle[y])
+            ):
+                x += 1
+                y += 1
+            frontier[diagonal] = x
+            if x >= old_count and y >= new_count:
+                return distance
+    raise ManifestDenied("CANDIDATE_BUDGET_EXCEEDED")
+
+
+def _collect_blobs(history: CommittedCandidateHistory) -> tuple[VerifiedFileContent, ...]:
+    blobs: dict[str, VerifiedFileContent] = {}
+    changes = [change for edge in history.edges for change in edge.changes]
+    changes.extend(history.final_changes)
+    for change in changes:
+        for endpoint in (change.old, change.new):
+            if endpoint is None:
+                continue
+            existing = blobs.get(endpoint.git_oid)
+            if existing is not None and existing != endpoint:
+                raise VerifierFailure
+            try:
+                git_hasher = hashlib.new(
+                    history.manifest.object_format, usedforsecurity=False
+                )
+            except (TypeError, ValueError):
+                raise VerifierFailure from None
+            git_hasher.update(
+                b"blob " + str(len(endpoint.content)).encode("ascii") + b"\0"
+            )
+            git_hasher.update(endpoint.content)
+            if (
+                len(endpoint.content) > MAX_CANDIDATE_BLOB_BYTES
+                or git_hasher.hexdigest() != endpoint.git_oid
+                or hashlib.sha256(endpoint.content).hexdigest() != endpoint.sha256
+            ):
+                raise VerifierFailure
+            blobs[endpoint.git_oid] = endpoint
+    if not blobs:
+        raise VerifierFailure
+    if sum(len(blob.content) for blob in blobs.values()) > MAX_CANDIDATE_TOTAL_BLOB_BYTES:
+        raise VerifierFailure
+    return tuple(blobs[oid] for oid in sorted(blobs))
+
+
+def _is_hex(value: str, length: int) -> bool:
+    return (
+        type(value) is str
+        and len(value) == length
+        and all(character in "0123456789abcdef" for character in value)
+    )
+
+
+def _valid_endpoint(value: VerifiedFileContent | None, oid_length: int) -> bool:
+    return value is None or (
+        value.mode == "100644"
+        and _is_hex(value.git_oid, oid_length)
+        and _is_hex(value.sha256, 64)
+    )
+
+
+def _validate_history_observation(
+    history: CommittedCandidateHistory,
+    base_sha: str,
+    manifest_id: str,
+    candidate_sha: str,
+) -> None:
+    oid_length = {"sha1": 40, "sha256": 64}.get(history.manifest.object_format)
+    if oid_length is None or not (
+        len(history.commit_shas)
+        == len(history.commit_object_sha256s)
+        == len(history.edges)
+        > 0
+    ):
+        raise VerifierFailure
+    contract = history.manifest.contract
+    if (
+        history.manifest.base_commit_sha != base_sha
+        or contract.manifest_id != manifest_id
+        or history.candidate_commit_sha != candidate_sha
+        or len(history.commit_shas) > contract.maximum_commits
+        or len(set(history.commit_shas)) != len(history.commit_shas)
+        or history.manifest.base_commit_sha in history.commit_shas
+        or not _is_hex(history.base_commit_sha256, 64)
+    ):
+        raise VerifierFailure
+    previous_commit = history.manifest.base_commit_sha
+    previous_tree = history.manifest.base_tree_sha
+    touched_paths: set[str] = set()
+    base_state: dict[str, VerifiedFileContent | None] = {}
+    current_state: dict[str, VerifiedFileContent | None] = {}
+    for commit, digest, edge in zip(
+        history.commit_shas, history.commit_object_sha256s, history.edges
+    ):
+        paths = tuple(change.path for change in edge.changes)
+        if (
+            not _is_hex(commit, oid_length)
+            or not _is_hex(digest, 64)
+            or edge.parent_commit_sha != previous_commit
+            or edge.parent_tree_sha != previous_tree
+            or edge.commit_sha != commit
+            or edge.commit_sha == edge.parent_commit_sha
+            or not _is_hex(edge.commit_tree_sha, oid_length)
+            or edge.commit_tree_sha == edge.parent_tree_sha
+            or not paths
+            or paths != tuple(sorted(set(paths)))
+        ):
+            raise VerifierFailure
+        for change in edge.changes:
+            if change.path not in history.manifest.contract.allowed_paths:
+                raise VerifierFailure
+            if change.old is None and change.new is None:
+                raise VerifierFailure
+            if change.old == change.new:
+                raise VerifierFailure
+            if not all(_valid_endpoint(endpoint, oid_length) for endpoint in (change.old, change.new)):
+                raise VerifierFailure
+            if change.path in current_state:
+                if current_state[change.path] != change.old:
+                    raise VerifierFailure
+            else:
+                base_state[change.path] = change.old
+            current_state[change.path] = change.new
+        touched_paths.update(paths)
+        previous_commit = edge.commit_sha
+        previous_tree = edge.commit_tree_sha
+    expected_final = tuple(
+        CommittedPathChange(path, base_state[path], current_state[path])
+        for path in sorted(current_state)
+        if base_state[path] != current_state[path]
+    )
+    final_paths = tuple(change.path for change in history.final_changes)
+    if (
+        previous_commit != history.candidate_commit_sha
+        or previous_tree != history.candidate_tree_sha
+        or tuple(sorted(touched_paths)) != history.touched_paths
+        or len(touched_paths) > contract.maximum_changed_files
+        or not final_paths
+        or final_paths != tuple(sorted(set(final_paths)))
+        or final_paths != history.final_paths
+        or history.final_changes != expected_final
+    ):
+        raise VerifierFailure
+    tree_digests = history.tree_object_sha256s
+    tree_oids = tuple(oid for oid, _ in tree_digests)
+    if (
+        tree_digests != tuple(sorted(tree_digests))
+        or len(set(tree_oids)) != len(tree_oids)
+    ):
+        raise VerifierFailure
+    observed_tree_oids = set(tree_oids)
+    required_tree_oids = {history.manifest.base_tree_sha, history.candidate_tree_sha}
+    required_tree_oids.update(edge.parent_tree_sha for edge in history.edges)
+    required_tree_oids.update(edge.commit_tree_sha for edge in history.edges)
+    if not required_tree_oids <= observed_tree_oids:
+        raise VerifierFailure
+    if any(
+        not _is_hex(oid, oid_length) or not _is_hex(digest, 64)
+        for oid, digest in tree_digests
+    ):
+        raise VerifierFailure
+    for change in history.final_changes:
+        if change.path not in history.manifest.contract.allowed_paths:
+            raise VerifierFailure
+        if change.old is None and change.new is None:
+            raise VerifierFailure
+        if change.old == change.new:
+            raise VerifierFailure
+        if not all(_valid_endpoint(endpoint, oid_length) for endpoint in (change.old, change.new)):
+            raise VerifierFailure
+
+
+def _count_change(
+    change: CommittedPathChange,
+    lines: dict[str, tuple[bytes, ...]],
+    remaining: int,
+    work: _EditWork,
+) -> tuple[int, int]:
+    old = () if change.old is None else lines[change.old.git_oid]
+    new = () if change.new is None else lines[change.new.git_oid]
+    distance = _bounded_edit_distance(old, new, remaining, work)
+    additions_numerator = distance + len(new) - len(old)
+    deletions_numerator = distance + len(old) - len(new)
+    if additions_numerator % 2 or deletions_numerator % 2:
+        raise VerifierFailure
+    return additions_numerator // 2, deletions_numerator // 2
+
+
+def _endpoint(transcript: _Transcript, prefix: str, value: VerifiedFileContent | None) -> None:
+    transcript.field(f"{prefix}-present", b"\x00" if value is None else b"\x01")
+    if value is None:
+        return
+    transcript.field(f"{prefix}-mode", value.mode.encode("ascii"))
+    transcript.field(f"{prefix}-oid", value.git_oid.encode("ascii"))
+    transcript.field(f"{prefix}-sha256", value.sha256.encode("ascii"))
+    transcript.integer(f"{prefix}-size", len(value.content))
+
+
+def _path_change(
+    transcript: _Transcript,
+    value: CommittedPathChange,
+    additions: int | None = None,
+    deletions: int | None = None,
+) -> None:
+    transcript.field("path", value.path.encode("ascii"))
+    _endpoint(transcript, "old", value.old)
+    _endpoint(transcript, "new", value.new)
+    if additions is not None and deletions is not None:
+        transcript.integer("additions", additions)
+        transcript.integer("deletions", deletions)
+
+
+def _fingerprint(
+    history: CommittedCandidateHistory,
+    counted_edges: tuple[_CountedEdge, ...],
+    blobs: tuple[VerifiedFileContent, ...],
+    cumulative_additions: int,
+    cumulative_deletions: int,
+) -> str:
+    if not (
+        len(history.commit_shas)
+        == len(history.commit_object_sha256s)
+        == len(history.edges)
+        == len(counted_edges)
+    ):
+        raise VerifierFailure
+    transcript = _Transcript()
+    transcript.field("repository", REPOSITORY_ID)
+    transcript.field("object-format", history.manifest.object_format.encode("ascii"))
+    transcript.field("manifest-sha256", history.manifest.manifest_sha256.encode("ascii"))
+    transcript.field("line-count-algorithm", LINE_COUNT_ALGORITHM.encode("ascii"))
+    transcript.field("base-commit", history.manifest.base_commit_sha.encode("ascii"))
+    transcript.field("base-commit-sha256", history.base_commit_sha256.encode("ascii"))
+    transcript.field("base-tree", history.manifest.base_tree_sha.encode("ascii"))
+    transcript.field("candidate-commit", history.candidate_commit_sha.encode("ascii"))
+    transcript.field("candidate-tree", history.candidate_tree_sha.encode("ascii"))
+    transcript.integer("commit-count", len(history.commit_shas))
+    for commit, digest, edge in zip(
+        history.commit_shas, history.commit_object_sha256s, history.edges
+    ):
+        transcript.field("commit-oid", commit.encode("ascii"))
+        transcript.field("commit-sha256", digest.encode("ascii"))
+        transcript.field("commit-tree", edge.commit_tree_sha.encode("ascii"))
+    transcript.integer("tree-object-count", len(history.tree_object_sha256s))
+    for oid, digest in history.tree_object_sha256s:
+        transcript.field("tree-oid", oid.encode("ascii"))
+        transcript.field("tree-sha256", digest.encode("ascii"))
+    transcript.integer("edge-count", len(counted_edges))
+    for counted in counted_edges:
+        edge = counted.edge
+        transcript.field("edge-parent-commit", edge.parent_commit_sha.encode("ascii"))
+        transcript.field("edge-parent-tree", edge.parent_tree_sha.encode("ascii"))
+        transcript.field("edge-commit", edge.commit_sha.encode("ascii"))
+        transcript.field("edge-tree", edge.commit_tree_sha.encode("ascii"))
+        transcript.integer("edge-change-count", len(counted.changes))
+        for change in counted.changes:
+            _path_change(
+                transcript, change.change, change.additions, change.deletions
+            )
+    transcript.integer("final-change-count", len(history.final_changes))
+    for final_change in history.final_changes:
+        _path_change(transcript, final_change)
+    transcript.integer("blob-count", len(blobs))
+    for blob in blobs:
+        transcript.field("blob-oid", blob.git_oid.encode("ascii"))
+        transcript.integer("blob-size", len(blob.content))
+        transcript.field("blob-content", blob.content)
+    transcript.integer("cumulative-additions", cumulative_additions)
+    transcript.integer("cumulative-deletions", cumulative_deletions)
+    transcript.integer("maximum-changed-lines", history.manifest.contract.maximum_changed_lines)
+    return transcript.hexdigest()
+
+
+def verify_committed_candidate_content(
+    repository: Path,
+    base_sha: str,
+    manifest_id: str,
+    candidate_sha: str,
+    *,
+    now: datetime | None = None,
+) -> CommittedCandidateContent:
+    history = verify_committed_candidate_history(
+        repository, base_sha, manifest_id, candidate_sha, now=now
+    )
+    _validate_history_observation(history, base_sha, manifest_id, candidate_sha)
+    blobs = _collect_blobs(history)
+    line_cache: dict[str, tuple[bytes, ...]] = {}
+    total_line_records = 0
+    for blob in blobs:
+        records = _line_records(blob.content)
+        total_line_records += len(records)
+        if total_line_records > MAX_TOTAL_LINE_RECORDS:
+            raise ManifestDenied("CANDIDATE_DIFF_INVALID")
+        line_cache[blob.git_oid] = records
+
+    maximum = history.manifest.contract.maximum_changed_lines
+    cumulative_additions = 0
+    cumulative_deletions = 0
+    counted_edges: list[_CountedEdge] = []
+    work = _EditWork()
+    for edge in history.edges:
+        counted_changes: list[_CountedChange] = []
+        edge_additions = 0
+        edge_deletions = 0
+        for change in edge.changes:
+            remaining = maximum - cumulative_additions - cumulative_deletions
+            additions, deletions = _count_change(change, line_cache, remaining, work)
+            cumulative_additions += additions
+            cumulative_deletions += deletions
+            edge_additions += additions
+            edge_deletions += deletions
+            if cumulative_additions + cumulative_deletions > maximum:
+                raise ManifestDenied("CANDIDATE_BUDGET_EXCEEDED")
+            counted_changes.append(_CountedChange(change, additions, deletions))
+        line_count = CandidateEdgeLineCount(
+            edge.parent_commit_sha,
+            edge.parent_tree_sha,
+            edge.commit_sha,
+            edge.commit_tree_sha,
+            edge_additions,
+            edge_deletions,
+        )
+        counted_edges.append(_CountedEdge(edge, tuple(counted_changes), line_count))
+
+    counted = tuple(counted_edges)
+    fingerprint = _fingerprint(
+        history, counted, blobs, cumulative_additions, cumulative_deletions
+    )
+    return CommittedCandidateContent(
+        history,
+        tuple(item.line_count for item in counted),
+        cumulative_additions,
+        cumulative_deletions,
+        fingerprint,
+        len(blobs),
+        sum(len(blob.content) for blob in blobs),
+    )

--- a/scripts/overnight_manifest_verifier.py
+++ b/scripts/overnight_manifest_verifier.py
@@ -162,11 +162,40 @@ class ProtectedBaseManifest:
 
 
 @dataclass(frozen=True, slots=True, repr=False)
+class VerifiedFileContent:
+    mode: str
+    git_oid: str
+    sha256: str
+    content: bytes
+
+
+@dataclass(frozen=True, slots=True, repr=False)
+class CommittedPathChange:
+    path: str
+    old: VerifiedFileContent | None
+    new: VerifiedFileContent | None
+
+
+@dataclass(frozen=True, slots=True, repr=False)
+class CommittedHistoryEdge:
+    parent_commit_sha: str
+    parent_tree_sha: str
+    commit_sha: str
+    commit_tree_sha: str
+    changes: tuple[CommittedPathChange, ...]
+
+
+@dataclass(frozen=True, slots=True, repr=False)
 class CommittedCandidateHistory:
     manifest: ProtectedBaseManifest
     candidate_commit_sha: str
     candidate_tree_sha: str
     commit_shas: tuple[str, ...]
+    base_commit_sha256: str
+    commit_object_sha256s: tuple[str, ...]
+    tree_object_sha256s: tuple[tuple[str, str], ...]
+    edges: tuple[CommittedHistoryEdge, ...]
+    final_changes: tuple[CommittedPathChange, ...]
     touched_paths: tuple[str, ...]
     final_paths: tuple[str, ...]
     verified_at: datetime
@@ -681,11 +710,12 @@ def _tree_entries(content: bytes, oid_bytes: int) -> tuple[tuple[bytes, str, str
 
 def _verified_tree_snapshots(
     repository: Path, object_format: str, roots: tuple[str, ...]
-) -> dict[str, dict[bytes, tuple[str, str]]]:
+) -> tuple[dict[str, dict[bytes, tuple[str, str]]], tuple[tuple[str, str], ...]]:
     oid_bytes = {"sha1": 20, "sha256": 32}.get(object_format)
     if oid_bytes is None:
         raise VerifierFailure
     parsed: dict[str, tuple[tuple[bytes, str, str], ...]] = {}
+    digests: dict[str, str] = {}
     total_bytes = 0
     expanded_entries = 0
     expanded_path_bytes = 0
@@ -696,13 +726,14 @@ def _verified_tree_snapshots(
         if oid not in parsed:
             if len(parsed) >= MAX_TREE_OBJECTS:
                 raise ManifestDenied("CANDIDATE_DIFF_INVALID")
-            _, size, content = _verified_object(
+            digest, size, content = _verified_object(
                 repository, object_format, "tree", oid, MAX_TREE_OBJECT_BYTES
             )
             total_bytes += size
             if total_bytes > MAX_TOTAL_TREE_BYTES:
                 raise ManifestDenied("CANDIDATE_DIFF_INVALID")
             parsed[oid] = _tree_entries(content, oid_bytes)
+            digests[oid] = digest
         return parsed[oid]
 
     for root in roots:
@@ -732,19 +763,20 @@ def _verified_tree_snapshots(
                 else:
                     snapshot[full_path] = (mode, child_oid)
         snapshots[root] = snapshot
-    return snapshots
+    return snapshots, tuple(sorted(digests.items()))
 
 
 def _verified_commit_history(
     repository: Path, binding: ProtectedBaseManifest, candidate_sha: str
-) -> tuple[tuple[str, ...], dict[str, str]]:
+) -> tuple[tuple[str, ...], dict[str, str], dict[str, str]]:
     current = candidate_sha
     reverse_commits: list[str] = []
     trees: dict[str, str] = {}
+    digests: dict[str, str] = {}
     while current != binding.base_commit_sha:
         if len(reverse_commits) >= binding.contract.maximum_commits:
             raise ManifestDenied("CANDIDATE_BUDGET_EXCEEDED")
-        _, _, content = _verified_object(
+        digest, _, content = _verified_object(
             repository, binding.object_format, "commit", current, MAX_COMMIT_OBJECT_BYTES
         )
         tree, parents = _commit_tree_and_parents(content, len(binding.base_commit_sha))
@@ -752,17 +784,19 @@ def _verified_commit_history(
             raise ManifestDenied("CANDIDATE_HISTORY_INVALID")
         reverse_commits.append(current)
         trees[current] = tree
+        digests[current] = digest
         current = parents[0]
     if not reverse_commits:
         raise ManifestDenied("CANDIDATE_HISTORY_INVALID")
-    _, _, base_content = _verified_object(
+    base_digest, _, base_content = _verified_object(
         repository, binding.object_format, "commit", binding.base_commit_sha,
         MAX_COMMIT_OBJECT_BYTES,
     )
     base_tree, _ = _commit_tree_and_parents(base_content, len(binding.base_commit_sha))
     if base_tree != binding.base_tree_sha:
         raise VerifierFailure
-    return tuple(reversed(reverse_commits)), trees
+    digests[binding.base_commit_sha] = base_digest
+    return tuple(reversed(reverse_commits)), trees, digests
 
 
 def _is_lfs_pointer(content: bytes) -> bool:
@@ -782,10 +816,10 @@ def _inspect_edge(
     old_snapshot: dict[bytes, tuple[str, str]],
     new_snapshot: dict[bytes, tuple[str, str]],
     binding: ProtectedBaseManifest,
-    blob_cache: dict[str, tuple[str, int]],
-) -> tuple[str, ...]:
+    blob_cache: dict[str, VerifiedFileContent],
+) -> tuple[CommittedPathChange, ...]:
     allowed_paths = {path.encode("ascii"): path for path in binding.contract.allowed_paths}
-    changed_paths: list[str] = []
+    changes: list[CommittedPathChange] = []
     for raw_path in sorted(old_snapshot.keys() | new_snapshot.keys()):
         old = old_snapshot.get(raw_path)
         new = new_snapshot.get(raw_path)
@@ -796,7 +830,6 @@ def _inspect_edge(
             endpoint is not None and endpoint[0] != "100644" for endpoint in (old, new)
         ):
             raise ManifestDenied("CANDIDATE_DIFF_INVALID")
-        changed_paths.append(path)
         for endpoint in (old, new):
             if endpoint is None or endpoint[1] in blob_cache:
                 continue
@@ -810,10 +843,15 @@ def _inspect_edge(
                 raise ManifestDenied("CANDIDATE_DIFF_INVALID") from None
             if b"\0" in content or _is_lfs_pointer(content):
                 raise ManifestDenied("CANDIDATE_DIFF_INVALID")
-            blob_cache[oid] = (digest, size)
-            if sum(item[1] for item in blob_cache.values()) > MAX_CANDIDATE_TOTAL_BLOB_BYTES:
+            blob_cache[oid] = VerifiedFileContent(endpoint[0], oid, digest, content)
+            if sum(len(item.content) for item in blob_cache.values()) > MAX_CANDIDATE_TOTAL_BLOB_BYTES:
                 raise ManifestDenied("CANDIDATE_DIFF_INVALID")
-    return tuple(changed_paths)
+        changes.append(CommittedPathChange(
+            path,
+            None if old is None else blob_cache[old[1]],
+            None if new is None else blob_cache[new[1]],
+        ))
+    return tuple(changes)
 
 
 def verify_committed_candidate_history(
@@ -839,41 +877,57 @@ def verify_committed_candidate_history(
     )))
     if grafts_path.exists() or grafts_path.is_symlink():
         raise VerifierFailure
-    commits, commit_trees = _verified_commit_history(repository, binding, candidate_sha)
+    commits, commit_trees, commit_digests = _verified_commit_history(
+        repository, binding, candidate_sha
+    )
     candidate_tree = commit_trees[candidate_sha]
     tree_roots = (binding.base_tree_sha, *(commit_trees[commit] for commit in commits))
-    snapshots = _verified_tree_snapshots(repository, binding.object_format, tree_roots)
+    snapshots, tree_digests = _verified_tree_snapshots(
+        repository, binding.object_format, tree_roots
+    )
 
     touched_paths: set[str] = set()
-    blob_cache: dict[str, tuple[str, int]] = {}
+    blob_cache: dict[str, VerifiedFileContent] = {}
+    edges: list[CommittedHistoryEdge] = []
+    previous_commit = binding.base_commit_sha
     previous_tree = binding.base_tree_sha
     for commit in commits:
         current_tree = commit_trees[commit]
-        changed_paths = _inspect_edge(
+        changes = _inspect_edge(
             repository, snapshots[previous_tree], snapshots[current_tree], binding, blob_cache
         )
-        if not changed_paths:
+        if not changes:
             raise ManifestDenied("CANDIDATE_HISTORY_INVALID")
-        touched_paths.update(changed_paths)
+        edges.append(CommittedHistoryEdge(
+            previous_commit, previous_tree, commit, current_tree, changes
+        ))
+        touched_paths.update(change.path for change in changes)
         if len(touched_paths) > binding.contract.maximum_changed_files:
             raise ManifestDenied("CANDIDATE_BUDGET_EXCEEDED")
+        previous_commit = commit
         previous_tree = current_tree
-    final_paths = _inspect_edge(
+    final_changes = _inspect_edge(
         repository,
         snapshots[binding.base_tree_sha],
         snapshots[candidate_tree],
         binding,
         blob_cache,
     )
-    if not final_paths:
+    if not final_changes:
         raise ManifestDenied("CANDIDATE_DIFF_INVALID")
-    closing_commits, closing_trees = _verified_commit_history(repository, binding, candidate_sha)
-    if closing_commits != commits or closing_trees != commit_trees:
+    closing_commits, closing_trees, closing_commit_digests = _verified_commit_history(
+        repository, binding, candidate_sha
+    )
+    if (
+        closing_commits != commits
+        or closing_trees != commit_trees
+        or closing_commit_digests != commit_digests
+    ):
         raise VerifierFailure
-    closing_snapshots = _verified_tree_snapshots(
+    closing_snapshots, closing_tree_digests = _verified_tree_snapshots(
         repository, binding.object_format, tree_roots
     )
-    if closing_snapshots != snapshots:
+    if closing_snapshots != snapshots or closing_tree_digests != tree_digests:
         raise VerifierFailure
     try:
         closing = verify_protected_base_manifest(repository, base_sha, manifest_id, now=now)
@@ -892,8 +946,13 @@ def verify_committed_candidate_history(
         candidate_commit_sha=candidate_sha,
         candidate_tree_sha=candidate_tree,
         commit_shas=commits,
+        base_commit_sha256=commit_digests[binding.base_commit_sha],
+        commit_object_sha256s=tuple(commit_digests[commit] for commit in commits),
+        tree_object_sha256s=tree_digests,
+        edges=tuple(edges),
+        final_changes=final_changes,
         touched_paths=tuple(sorted(touched_paths)),
-        final_paths=final_paths,
+        final_paths=tuple(change.path for change in final_changes),
         verified_at=closing.verified_at,
     )
 

--- a/tests/unit/test_overnight_candidate_content.py
+++ b/tests/unit/test_overnight_candidate_content.py
@@ -1,0 +1,354 @@
+from __future__ import annotations
+
+import itertools
+import json
+import os
+import subprocess
+from dataclasses import replace
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from scripts import overnight_candidate_content as content
+from scripts.overnight_candidate_content import verify_committed_candidate_content
+from scripts.overnight_manifest_verifier import ManifestDenied, VerifierFailure
+
+
+UTC = timezone.utc
+NOW = datetime(2026, 8, 15, 20, tzinfo=UTC)
+MANIFEST_ID = "frdp-analytics-daily-risk-20260815"
+SOURCE_PATH = "src/analytics/daily_risk.py"
+TEST_PATH = "tests/unit/test_daily_risk.py"
+
+
+def _manifest(maximum_changed_lines: int = 20) -> bytes:
+    value = {
+        "schema_version": 2,
+        "manifest_id": MANIFEST_ID,
+        "status": "approved for overnight development",
+        "authorization_issued_at": "2026-08-15T19:00:00Z",
+        "authorization_expires": "2026-08-15T22:00:00Z",
+        "repository": "alexmarinos87/financial-risk-data-platform",
+        "protected_base_branch": "main",
+        "arc42_primary_block": "analytics",
+        "context_goal": "Calculate daily risk from validated prices",
+        "allowed_paths": [SOURCE_PATH, TEST_PATH],
+        "interfaces_crossed": [],
+        "runtime_scenario": "Daily prices produce one deterministic risk result",
+        "quality_scenario": "Golden vectors match within the documented tolerance",
+        "recovery_scenario": "A failed check leaves no published candidate",
+        "acceptance_criteria": ["Golden daily return vectors pass"],
+        "validation_targets": [
+            "security-check", "quality-check", "readiness-check", "git-diff-check"
+        ],
+        "maximum_changed_lines": maximum_changed_lines,
+        "maximum_changed_files": 2,
+        "maximum_commits": 3,
+        "maximum_pushes": 3,
+        "maximum_runtime_minutes": 120,
+        "retry_policy": "human-renewed-manifest-only",
+        "risk": "low",
+        "draft_pr_publication": "eligible-after-global-activation",
+    }
+    return json.dumps(value, separators=(",", ":")).encode()
+
+
+def _git(repository: Path, *arguments: str) -> str:
+    environment = dict(os.environ)
+    environment.update({
+        "GIT_AUTHOR_DATE": "2000-01-01T00:00:00Z",
+        "GIT_COMMITTER_DATE": "2000-01-01T00:00:00Z",
+    })
+    result = subprocess.run(
+        ["/usr/bin/git", *arguments], cwd=repository, env=environment, check=True,
+        text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+    )
+    return result.stdout.strip()
+
+
+def _repository(tmp_path: Path, maximum_changed_lines: int = 20) -> tuple[Path, str]:
+    repository = tmp_path / "repo"
+    repository.mkdir()
+    _git(repository, "init", "-q", "-b", "main")
+    _git(repository, "config", "user.email", "tests@example.invalid")
+    _git(repository, "config", "user.name", "Tests")
+    manifest = repository / "docs/overnight-manifests" / f"{MANIFEST_ID}.json"
+    manifest.parent.mkdir(parents=True)
+    manifest.write_bytes(_manifest(maximum_changed_lines))
+    _git(repository, "add", "--", manifest.relative_to(repository).as_posix())
+    _git(repository, "commit", "-q", "-m", "Add manifest")
+    base = _git(repository, "rev-parse", "HEAD")
+    _git(repository, "update-ref", "refs/remotes/origin/main", base)
+    return repository, base
+
+
+def _commit(repository: Path, path: str, value: bytes, message: str) -> str:
+    target = repository / path
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_bytes(value)
+    _git(repository, "add", "--", path)
+    _git(repository, "commit", "-q", "-m", message)
+    return _git(repository, "rev-parse", "HEAD")
+
+
+def _two_commit_candidate(repository: Path) -> str:
+    _commit(repository, SOURCE_PATH, b"alpha\nsentinel-source\n", "Add source")
+    return _commit(repository, SOURCE_PATH, b"alpha\nchanged", "Change source")
+
+
+def test_line_records_are_lf_exact_and_myers_matches_small_oracle() -> None:
+    assert content._line_records(b"") == ()
+    assert content._line_records(b"\n") == (b"\n",)
+    assert content._line_records(b"a\n") == (b"a\n",)
+    assert content._line_records(b"a") == (b"a",)
+    assert content._line_records(b"a\r\nb\xe2\x80\xa8c") == (b"a\r\n", b"b\xe2\x80\xa8c")
+
+    def oracle(old: tuple[bytes, ...], new: tuple[bytes, ...]) -> int:
+        distances = list(range(len(new) + 1))
+        for old_index, old_line in enumerate(old, 1):
+            updated = [old_index]
+            for new_index, new_line in enumerate(new, 1):
+                updated.append(
+                    distances[new_index - 1]
+                    if old_line == new_line
+                    else min(distances[new_index] + 1, updated[-1] + 1)
+                )
+            distances = updated
+        return distances[-1]
+
+    alphabet = (b"a\n", b"b\n")
+    for old_size, new_size in itertools.product(range(4), repeat=2):
+        for old in itertools.product(alphabet, repeat=old_size):
+            for new in itertools.product(alphabet, repeat=new_size):
+                assert content._bounded_edit_distance(
+                    old, new, 20, content._EditWork()
+                ) == oracle(old, new)
+
+
+def test_content_observation_counts_every_edge_once_and_redacts_source(
+    tmp_path: Path,
+) -> None:
+    repository, base = _repository(tmp_path, maximum_changed_lines=4)
+    head = _two_commit_candidate(repository)
+
+    result = verify_committed_candidate_content(repository, base, MANIFEST_ID, head, now=NOW)
+    evidence = result.redacted_evidence()
+
+    assert [(item.additions, item.deletions) for item in result.edge_line_counts] == [
+        (2, 0), (1, 1)
+    ]
+    assert (result.cumulative_additions, result.cumulative_deletions) == (3, 1)
+    assert result.cumulative_changed_lines == 4
+    assert evidence["status"] == "candidate-content-observed"
+    assert evidence["changed_line_budget_verified"] is True
+    assert evidence["content_fingerprint_verified"] is True
+    assert evidence["publication_authorized"] is False
+    assert evidence["object_store_isolation_verified"] is False
+    assert evidence["candidate_fingerprint"].startswith("sha256:")
+    assert result.candidate_fingerprint_sha256 == (
+        "68c228def5697e095e59e5730253660c1f44b38740dc79ca0baa64139766c821"
+    )
+    assert "sentinel-source" not in json.dumps(evidence)
+    assert "sentinel-source" not in repr(result)
+
+    (repository / SOURCE_PATH).write_text("dirty sentinel-source", encoding="utf-8")
+    (repository / ".gitattributes").write_text("* diff=sentinel-source\n", encoding="utf-8")
+    repeated = verify_committed_candidate_content(
+        repository, base, MANIFEST_ID, head, now=NOW
+    )
+    assert repeated.candidate_fingerprint_sha256 == result.candidate_fingerprint_sha256
+
+
+def test_content_observation_denies_one_line_over_budget(tmp_path: Path) -> None:
+    repository, base = _repository(tmp_path, maximum_changed_lines=3)
+    head = _two_commit_candidate(repository)
+
+    with pytest.raises(ManifestDenied, match="CANDIDATE_BUDGET_EXCEEDED"):
+        verify_committed_candidate_content(repository, base, MANIFEST_ID, head, now=NOW)
+
+
+def test_reverted_history_consumes_budget_and_changes_fingerprint(tmp_path: Path) -> None:
+    repository, base = _repository(tmp_path)
+    _git(repository, "checkout", "-q", "-b", "direct", base)
+    _commit(repository, SOURCE_PATH, b"alpha\n", "Add final source")
+    direct = _commit(repository, TEST_PATH, b"def test_value():\n    assert True\n", "Add test")
+    direct_result = verify_committed_candidate_content(
+        repository, base, MANIFEST_ID, direct, now=NOW
+    )
+
+    _git(repository, "checkout", "-q", "-b", "history", base)
+    _commit(repository, SOURCE_PATH, b"alpha\n", "Add source")
+    _commit(repository, SOURCE_PATH, b"temporary\n", "Temporary edit")
+    _commit(repository, SOURCE_PATH, b"alpha\n", "Restore source")
+    history = _git(repository, "rev-parse", "HEAD")
+    # Put the same final test blob into the third commit without adding a fourth commit.
+    (repository / TEST_PATH).parent.mkdir(parents=True, exist_ok=True)
+    (repository / TEST_PATH).write_bytes(b"def test_value():\n    assert True\n")
+    _git(repository, "add", "--", TEST_PATH)
+    _git(repository, "commit", "--amend", "-q", "--no-edit")
+    history = _git(repository, "rev-parse", "HEAD")
+    history_result = verify_committed_candidate_content(
+        repository, base, MANIFEST_ID, history, now=NOW
+    )
+
+    assert direct_result.history.candidate_tree_sha == history_result.history.candidate_tree_sha
+    assert direct_result.cumulative_changed_lines == 3
+    assert history_result.cumulative_changed_lines == 7
+    assert direct_result.candidate_fingerprint_sha256 != (
+        history_result.candidate_fingerprint_sha256
+    )
+    assert history_result.fingerprinted_blob_count == 3
+
+
+def test_content_observation_rejects_oversized_line_and_work(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repository, base = _repository(tmp_path)
+    head = _commit(
+        repository, SOURCE_PATH, b"x" * (content.MAX_LINE_RECORD_BYTES + 1), "Long line"
+    )
+    with pytest.raises(ManifestDenied, match="CANDIDATE_DIFF_INVALID"):
+        verify_committed_candidate_content(repository, base, MANIFEST_ID, head, now=NOW)
+
+    monkeypatch.setattr(content, "MAX_EDIT_WORK_UNITS", 1)
+    with pytest.raises(ManifestDenied, match="CANDIDATE_DIFF_INVALID"):
+        content._bounded_edit_distance(
+            (b"a\n", b"b\n"), (b"b\n", b"a\n"), 4, content._EditWork()
+        )
+
+
+def test_fingerprint_framing_is_unambiguous() -> None:
+    first = content._Transcript()
+    first.field("a", b"bc")
+    second = content._Transcript()
+    second.field("ab", b"c")
+
+    assert first.hexdigest() != second.hexdigest()
+
+
+def test_content_observation_rejects_malformed_history_capsule(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repository, base = _repository(tmp_path)
+    head = _two_commit_candidate(repository)
+    valid = verify_committed_candidate_content(
+        repository, base, MANIFEST_ID, head, now=NOW
+    ).history
+    first_edge = valid.edges[0]
+    second_edge = valid.edges[1]
+    first_commit = valid.commit_shas[0]
+    first_digest = valid.commit_object_sha256s[0]
+    conflicting_trees = tuple(sorted((
+        *valid.tree_object_sha256s,
+        (valid.tree_object_sha256s[0][0], "f" * 64),
+    )))
+    malformed = (
+        replace(
+            valid,
+            edges=valid.edges[:1],
+            commit_object_sha256s=(first_digest, "f" * 64),
+        ),
+        replace(
+            valid,
+            edges=(replace(first_edge, parent_commit_sha="0" * 40), *valid.edges[1:]),
+        ),
+        replace(
+            valid,
+            edges=(replace(first_edge, changes=()), *valid.edges[1:]),
+        ),
+        replace(
+            valid,
+            edges=(
+                first_edge,
+                replace(
+                    second_edge,
+                    changes=(replace(second_edge.changes[0], old=None),),
+                ),
+            ),
+        ),
+        replace(valid, tree_object_sha256s=conflicting_trees),
+        replace(
+            valid,
+            manifest=replace(
+                valid.manifest,
+                contract=replace(valid.manifest.contract, maximum_commits=1),
+            ),
+        ),
+        replace(
+            valid,
+            manifest=replace(
+                valid.manifest,
+                contract=replace(valid.manifest.contract, maximum_changed_files=0),
+            ),
+        ),
+        replace(
+            valid,
+            candidate_commit_sha=first_commit,
+            commit_shas=(first_commit, first_commit),
+            commit_object_sha256s=(first_digest, first_digest),
+            edges=(
+                first_edge,
+                replace(
+                    second_edge,
+                    parent_commit_sha=first_commit,
+                    commit_sha=first_commit,
+                ),
+            ),
+        ),
+    )
+    for invalid_history in malformed:
+        monkeypatch.setattr(
+            content,
+            "verify_committed_candidate_history",
+            lambda *_args, _history=invalid_history, **_kwargs: _history,
+        )
+        with pytest.raises(VerifierFailure):
+            verify_committed_candidate_content(
+                repository, base, MANIFEST_ID, head, now=NOW
+            )
+
+
+def test_content_observation_binds_requested_identifiers_and_blob_bytes(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repository, base = _repository(tmp_path)
+    head = _commit(repository, SOURCE_PATH, b"alpha\n", "Add source")
+    valid = verify_committed_candidate_content(
+        repository, base, MANIFEST_ID, head, now=NOW
+    ).history
+    monkeypatch.setattr(
+        content, "verify_committed_candidate_history", lambda *_args, **_kwargs: valid
+    )
+    for requested_base, requested_manifest, requested_head in (
+        ("f" * 40, MANIFEST_ID, head),
+        (base, "frdp-analytics-other-risk-20260815", head),
+        (base, MANIFEST_ID, "e" * 40),
+    ):
+        with pytest.raises(VerifierFailure):
+            verify_committed_candidate_content(
+                repository,
+                requested_base,
+                requested_manifest,
+                requested_head,
+                now=NOW,
+            )
+
+    original_change = valid.edges[0].changes[0]
+    assert original_change.new is not None
+    changed_endpoint = replace(original_change.new, content=b"tampered\n")
+    changed = replace(original_change, new=changed_endpoint)
+    malformed = replace(
+        valid,
+        edges=(replace(valid.edges[0], changes=(changed,)),),
+        final_changes=(changed,),
+    )
+    monkeypatch.setattr(
+        content,
+        "verify_committed_candidate_history",
+        lambda *_args, **_kwargs: malformed,
+    )
+    with pytest.raises(VerifierFailure):
+        verify_committed_candidate_content(
+            repository, base, MANIFEST_ID, head, now=NOW
+        )

--- a/tests/unit/test_overnight_manifest_verifier.py
+++ b/tests/unit/test_overnight_manifest_verifier.py
@@ -438,6 +438,11 @@ def test_committed_history_binds_every_allowed_commit_and_ignores_dirty_worktree
     evidence = result.redacted_evidence()
 
     assert result.commit_shas == (first, head)
+    assert len(result.edges) == 2
+    assert result.edges[0].changes[0].new is not None
+    assert result.edges[0].changes[0].new.content == b"VALUE = 1\n"
+    assert len(result.commit_object_sha256s) == 2
+    assert result.tree_object_sha256s
     assert result.touched_paths == (
         "src/analytics/daily_risk.py", "tests/unit/test_daily_risk.py"
     )
@@ -446,6 +451,7 @@ def test_committed_history_binds_every_allowed_commit_and_ignores_dirty_worktree
     assert evidence["object_store_isolation_verified"] is False
     assert evidence["publication_authorized"] is False
     assert "sentinel" not in json.dumps(evidence)
+    assert "VALUE = 1" not in repr(result)
 
 
 @pytest.mark.parametrize("grafted", [False, True])


### PR DESCRIPTION
## Context

This engineering-controls slice extends the committed-history scope observer with content-complete, budget-bounded evidence. It does not activate unattended publishing.

## Runtime boundary

`verify_committed_candidate_content` consumes the protected-base/history observation, validates the immutable in-memory capsule, then:

- counts cumulative additions and deletions on every parent-to-commit edge with exact LF-framed, budget-bounded comparison;
- prevents transient edits from cancelling and avoids double-counting the base-to-tip summary;
- binds ordered history, trees, paths, endpoint object IDs, exact blob bytes, and line counts into a length-framed SHA-256 fingerprint;
- returns redacted evidence only.

The content adapter does not reread Git, inspect the worktree, invoke text conversion, or execute manifest-supplied commands.

## Safeguards

- Revalidates topology, producer budgets, unique commit/tree identities, endpoint continuity, and reconstructed final state.
- Recomputes canonical Git blob IDs and SHA-256 digests and reapplies shared per-blob and aggregate byte caps.
- Bounds line size, record count, comparison bytes, and edit work.
- Keeps raw content out of `repr` and evidence.
- Explicitly leaves object-store isolation, worktree cleanliness, validation, push authority, and publication authority false.

## History repair

The original stacked ancestry was replaced with the exact reviewed candidate-content delta on current `main`. The repaired PR is one commit, five changed files, 1,028 additions and 45 deletions. The separate lease-fencing contract from PR #47 is not included and will be carried independently after this merge.

## Previous evidence

- 67 focused verifier/content tests
- 205 full tests
- Ruff and mypy
- security and readiness checks
- cached diff and whitespace checks
- three independent reviews on one frozen file-hash set

A fresh full pull-request CI run is required on the repaired head before squash merge.

## Safety boundary

The global publication policy remains disabled. This change creates no scheduler, automatic branch, push, draft PR, merge, deployment, cloud access, or publisher credential.