### PR TITLE
Require timezone-aware market event timestamps

### DIFF
--- a/src/ingestion/schemas.py
+++ b/src/ingestion/schemas.py
@@ -1,5 +1,6 @@
-from datetime import datetime
-from pydantic import BaseModel, Field
+from datetime import datetime, timezone
+
+from pydantic import AwareDatetime, BaseModel, Field, field_validator
 
 
 class MarketEvent(BaseModel):
@@ -7,6 +8,11 @@ class MarketEvent(BaseModel):
     symbol: str
     price: float
     volume: int
-    ts_event: datetime
-    ts_ingest: datetime
+    ts_event: AwareDatetime
+    ts_ingest: AwareDatetime
     source: str = Field(default="stooq")
+
+    @field_validator("ts_event", "ts_ingest")
+    @classmethod
+    def _normalise_timestamp_to_utc(cls, value: datetime) -> datetime:
+        return value.astimezone(timezone.utc)

--- a/tests/unit/ingestion/test_schemas.py
+++ b/tests/unit/ingestion/test_schemas.py
@@ -1,0 +1,67 @@
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from pydantic import ValidationError as PydanticValidationError
+
+from src.ingestion.market_data_loader import build_market_event_from_row
+from src.ingestion.schemas import MarketEvent
+
+
+def _event_payload() -> dict[str, object]:
+    return {
+        "event_id": "evt-1",
+        "symbol": "AAPL",
+        "price": 189.32,
+        "volume": 1200,
+        "ts_event": datetime(2025, 1, 20, 10, 1, tzinfo=timezone.utc),
+        "ts_ingest": datetime(2025, 1, 20, 10, 1, 3, tzinfo=timezone.utc),
+        "source": "stooq",
+    }
+
+
+@pytest.mark.parametrize("field_name", ["ts_event", "ts_ingest"])
+@pytest.mark.parametrize(
+    "naive_value",
+    [datetime(2025, 1, 20, 10, 1), "2025-01-20T10:01:00"],
+)
+def test_market_event_rejects_timezone_naive_timestamps(
+    field_name: str,
+    naive_value: datetime | str,
+) -> None:
+    payload = _event_payload()
+    payload[field_name] = naive_value
+
+    with pytest.raises(PydanticValidationError) as error:
+        MarketEvent.model_validate(payload)
+
+    assert error.value.errors()[0]["loc"] == (field_name,)
+    assert error.value.errors()[0]["type"] == "timezone_aware"
+
+
+def test_market_event_normalises_aware_offsets_to_utc() -> None:
+    offset = timezone(timedelta(hours=2))
+    payload = _event_payload()
+    payload["ts_event"] = datetime(2025, 1, 20, 12, 1, tzinfo=offset)
+    payload["ts_ingest"] = datetime(2025, 1, 20, 12, 1, 3, tzinfo=offset)
+
+    event = MarketEvent.model_validate(payload)
+
+    assert event.ts_event == datetime(2025, 1, 20, 10, 1, tzinfo=timezone.utc)
+    assert event.ts_ingest == datetime(2025, 1, 20, 10, 1, 3, tzinfo=timezone.utc)
+
+
+def test_landed_naive_timestamps_are_normalised_before_schema_validation() -> None:
+    event = build_market_event_from_row(
+        {
+            "event_id": "evt-1",
+            "symbol": "AAPL",
+            "price": 189.32,
+            "volume": 1200,
+            "ts_event": "2025-01-20T10:01:00",
+            "ts_ingest": "2025-01-20T10:01:03",
+            "source": "stooq",
+        }
+    )
+
+    assert event.ts_event == datetime(2025, 1, 20, 10, 1, tzinfo=timezone.utc)
+    assert event.ts_ingest == datetime(2025, 1, 20, 10, 1, 3, tzinfo=timezone.utc)


### PR DESCRIPTION
## 80/20 rationale

The platform’s returns, volatility, lateness, partitioning, replay, and reconciliation all depend on correct event time, but the canonical `MarketEvent` model still accepted timezone-naive datetimes. This small ingestion-contract change removes that ambiguity at the highest-leverage boundary.

## Change

- Require timezone information on both `ts_event` and `ts_ingest` with Pydantic’s `AwareDatetime` contract.
- Normalise accepted aware timestamps to UTC inside the canonical model.
- Preserve the existing landed-file compatibility rule: the market-data loader may interpret a timezone-naive source timestamp as UTC before constructing the model.

## Evidence

Focused tests cover:

- naive Python datetimes rejected for both fields;
- naive ISO-8601 strings rejected for both fields;
- non-UTC aware offsets normalised to UTC;
- landed naive source timestamps normalised by the loader before schema validation.

## Scope

Primary arc42 block: `ingestion`.

The branch is one commit ahead of `main`, zero behind, with two changed paths and 81 changed lines. It does not alter raw-storage compatibility, backfill policy, infrastructure, credentials, deployment, or live provider I/O.

## Fresh validation

GitHub Actions run `32196240679` (`ci` run 183) passed on the exact PR head:

- Security guardrails: passed
- Python readiness: passed
  - dependency installation
  - `make quality-check`
  - `make readiness-check`
- Infrastructure validation: passed
  - `make infrastructure-check`

## Merge boundary

The PR remains draft for human inspection. The change is validated but not yet accepted or merged.