### PR TITLE
Add versioned portfolio daily risk

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,8 @@ LOCK_FILE ?= requirements.lock
 LOCAL_POSTGRES_DSN ?= postgresql://risk_user:risk_password@localhost:5433/risk_platform
 REVIEW_BASE_REF ?= origin/main
 SYMBOL ?= IBM
+PORTFOLIO_ID ?= us-tech-equal
+PORTFOLIO_CONFIG ?= config/portfolios.yaml
 START_DATE ?=
 END_DATE ?=
 MAX_RECORDS ?= 100
@@ -12,7 +14,7 @@ VOL_WINDOW ?= 20
 VAR_WINDOW ?= 60
 VAR_CONFIDENCE ?= 0.95
 
-.PHONY: setup lint type-check test dependency-check format benchmark-io docker-build k8s-render-dev k8s-render-prod k8s-check terraform-check infrastructure-check quality-check iteration-check clean-generated security-check readiness-check sandbox-once overnight-sandbox morning-review daily-risk-demo daily-risk-warehouse-dry-run daily-risk-warehouse-load check-daily-risk-consistency local-db-up local-db-down local-db-wait local-db-logs postgres-shell mongo-shell run-demo load-postgres-demo load-postgres-dry-run check-postgres-consistency consistency-demo
+.PHONY: setup lint type-check test dependency-check format benchmark-io docker-build k8s-render-dev k8s-render-prod k8s-check terraform-check infrastructure-check quality-check iteration-check clean-generated security-check readiness-check sandbox-once overnight-sandbox morning-review daily-risk-demo portfolio-risk-demo daily-risk-warehouse-dry-run daily-risk-warehouse-load check-daily-risk-consistency local-db-up local-db-down local-db-wait local-db-logs postgres-shell mongo-shell run-demo load-postgres-demo load-postgres-dry-run check-postgres-consistency consistency-demo
 
 setup:
 	python3 -m venv .venv
@@ -102,6 +104,24 @@ daily-risk-demo:
 		--var-window "$(VAR_WINDOW)" \
 		--var-confidence "$(VAR_CONFIDENCE)" \
 		--summary-json .demo/daily-risk-summary.json
+
+portfolio-risk-demo:
+	@set -eu; \
+	end_date="$(END_DATE)"; \
+	if [ -z "$$end_date" ]; then \
+		end_date="$$($(PYTHON) -c 'from datetime import datetime, timedelta, timezone; print((datetime.now(timezone.utc).date() - timedelta(days=1)).isoformat())')"; \
+	fi; \
+	start_args=""; \
+	if [ -n "$(START_DATE)" ]; then start_args="--start-date $(START_DATE)"; fi; \
+	$(PYTHON) -m src.orchestration.run_portfolio_risk \
+		--portfolio-id "$(PORTFOLIO_ID)" \
+		--portfolio-config "$(PORTFOLIO_CONFIG)" \
+		$$start_args \
+		--end-date "$$end_date" \
+		--vol-window "$(VOL_WINDOW)" \
+		--var-window "$(VAR_WINDOW)" \
+		--var-confidence "$(VAR_CONFIDENCE)" \
+		--summary-json .demo/portfolio-risk-summary.json
 
 daily-risk-warehouse-dry-run:
 	$(PYTHON) -m src.warehouse.postgres_loader --dry-run

--- a/config/portfolios.yaml
+++ b/config/portfolios.yaml
@@ -1,0 +1,22 @@
+portfolios:
+  us-tech-equal:
+    description: Equal-weighted US technology equity demo
+    base_currency: USD
+    constituents:
+      - source: alpha_vantage
+        symbol: AAPL
+        weight: 0.5
+      - source: alpha_vantage
+        symbol: MSFT
+        weight: 0.5
+
+  us-tech-60-40:
+    description: Parameterised weight comparison using the same source universe
+    base_currency: USD
+    constituents:
+      - source: alpha_vantage
+        symbol: AAPL
+        weight: 0.6
+      - source: alpha_vantage
+        symbol: MSFT
+        weight: 0.4

--- a/config/storage.yaml
+++ b/config/storage.yaml
@@ -14,6 +14,8 @@ storage:
       daily_returns: "daily_returns"
       daily_volatility: "daily_volatility"
       daily_risk_summary: "daily_risk_summary"
+      portfolio_daily_returns: "portfolio_daily_returns"
+      portfolio_daily_risk_summary: "portfolio_daily_risk_summary"
   format: "parquet"
   partitioning:
     granularity: "hourly"

--- a/deploy/kubernetes/base/config/storage.yaml
+++ b/deploy/kubernetes/base/config/storage.yaml
@@ -14,6 +14,8 @@ storage:
       daily_returns: "daily_returns"
       daily_volatility: "daily_volatility"
       daily_risk_summary: "daily_risk_summary"
+      portfolio_daily_returns: "portfolio_daily_returns"
+      portfolio_daily_risk_summary: "portfolio_daily_risk_summary"
   format: "parquet"
   partitioning:
     granularity: "hourly"

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -22,6 +22,11 @@ Alpha Vantage daily closes
   -> versioned daily returns and risk analytics
   -> version-preserving PostgreSQL tables
   -> current-version and semantic views
+
+current daily-return versions
+  -> configured long-only portfolio weights
+  -> complete-date alignment
+  -> versioned portfolio returns and risk summaries
 ```
 
 The leading quality goals are:
@@ -90,7 +95,7 @@ The data plane is split into:
 
 1. **Ingestion** — source adapters and canonical schemas.
 2. **Processing** — validation, normalisation, deduplication and windowing.
-3. **Analytics** — minute metrics, daily risk and data quality.
+3. **Analytics** — minute metrics, daily risk, portfolio risk and data quality.
 4. **Storage** — bounded, idempotent raw and curated Parquet publication.
 5. **Orchestration** — sequencing, locks, backfills and summaries.
 6. **Warehouse** — PostgreSQL loading, version retention, views and checks.
@@ -186,6 +191,24 @@ The daily tables are:
 date, model version and parameter set. `daily_risk_semantic_model` joins symbol
 reference data on both `source` and `symbol`.
 
+### Portfolio daily risk
+
+```text
+current daily_returns versions
+  -> portfolio definition and weight validation
+  -> complete-date alignment across constituents
+  -> weighted portfolio returns
+  -> annualised volatility, historical VaR and drawdown
+  -> portfolio_daily_returns
+  -> portfolio_daily_risk_summary
+```
+
+The portfolio path selects the latest component calculation per source, symbol
+and event date using ingest time and calculation ID. Only dates with every
+configured constituent are emitted. Weights are positive, unique by
+source/symbol and sum to one. Component returns, contributions and calculation
+IDs remain embedded as stable JSON evidence.
+
 ### Backfill
 
 The hourly backfill runner reads immutable raw partitions, resumes after the last
@@ -215,7 +238,7 @@ deploys and never runs `terraform apply`.
 | Identity | Stable source event IDs and deterministic calculation IDs |
 | Replay | Immutable raw data and content-addressed curated files |
 | Versioning | Daily calculation versions are retained rather than overwritten |
-| Configuration | YAML for storage, thresholds, symbols and operator choices |
+| Configuration | YAML for storage, thresholds, symbols, portfolios and operator choices |
 | Data quality | Required fields, nulls, ranges, late and duplicate evidence |
 | Concurrency | Local partition locks and repository-global lease fencing |
 | Recovery | Resume checkpoints and safe reruns |
@@ -246,7 +269,8 @@ deploys and never runs `terraform apply`.
 | Q5 | Live and backfill work overlap | Block on the active partition lock |
 | Q6 | Daily history is insufficient | Emit `partial` rather than implying full readiness |
 | Q7 | A warehouse consumer asks for current daily risk | Return one row per parameterised grain |
-| Q8 | Default infrastructure checks run | Validate without deployment or resource creation |
+| Q8 | Portfolio constituent dates are incomplete | Exclude the date, report the count and fail if alignment is insufficient |
+| Q9 | Default infrastructure checks run | Validate without deployment or resource creation |
 
 ## 11. Risks And Technical Debt
 
@@ -258,12 +282,15 @@ deploys and never runs `terraform apply`.
 5. The default container command runs the minute-oriented demo, not the daily
    operator sequence.
 6. Production scheduling, alerts and dashboards are not implemented.
-7. Portfolio-level aggregation and correlation risk are not yet implemented.
-8. Exchange-specific trading calendars are not used; daily observations are
+7. Portfolio outputs are curated Parquet only; PostgreSQL portfolio serving is
+   not yet implemented.
+8. Marginal risk attribution, covariance matrices, FX conversion, short
+   positions and rebalancing schedules are not implemented.
+9. Exchange-specific trading calendars are not used; daily observations are
    consecutive available closes, not guaranteed calendar-day intervals.
-9. PostgreSQL reconciliation is an explicit local operator step rather than a CI
-   database service.
-10. Repository control documentation is extensive relative to the compact data
+10. PostgreSQL reconciliation is an explicit local operator step rather than a
+    CI database service.
+11. Repository control documentation is extensive relative to the compact data
     runtime and should not grow ahead of product evidence.
 
 ## 12. Glossary
@@ -277,4 +304,5 @@ deploys and never runs `terraform apply`.
 | Calculation ID | Deterministic identity of model version, parameters and inputs |
 | Current version | Latest ingest/calculation within a declared serving grain |
 | Partial history | Valid output without enough observations for every configured window |
+| Portfolio definition | Long-only source/symbol constituents and weights that sum to one |
 | Human acceptance | Explicit engineer decision after reviewing code and evidence |

--- a/docs/portfolio-risk.md
+++ b/docs/portfolio-risk.md
@@ -1,0 +1,157 @@
+# Portfolio Daily Risk
+
+## Outcome
+
+This increment aggregates current daily-return versions into a deterministic,
+long-only portfolio risk series:
+
+```text
+current daily-return versions
+  -> complete-date alignment
+  -> configured weighted contributions
+  -> portfolio daily return
+  -> annualised rolling volatility
+  -> historical VaR loss
+  -> maximum drawdown
+  -> versioned curated Parquet
+```
+
+The pure calculation is owned by `src/analytics/portfolio_risk.py`. The local
+runner is `src/orchestration/run_portfolio_risk.py`.
+
+## Configuration
+
+Portfolio definitions live in `config/portfolios.yaml`:
+
+```yaml
+portfolios:
+  us-tech-equal:
+    base_currency: USD
+    constituents:
+      - source: alpha_vantage
+        symbol: AAPL
+        weight: 0.5
+      - source: alpha_vantage
+        symbol: MSFT
+        weight: 0.5
+```
+
+The first contract is deliberately narrow:
+
+- two to fifty unique constituents;
+- positive, long-only weights;
+- weights must sum to one;
+- one three-letter reporting currency;
+- source and symbol form the constituent identity.
+
+The base currency is descriptive in this slice. The pipeline does not perform FX
+conversion.
+
+## Operator Flow
+
+First create daily-return history for every configured constituent using a common
+date range:
+
+```bash
+export ALPHA_VANTAGE_API_KEY='set-locally-do-not-commit'
+
+make daily-risk-demo SYMBOL=AAPL END_DATE=2026-03-31
+make daily-risk-demo SYMBOL=MSFT END_DATE=2026-03-31
+```
+
+Then calculate portfolio risk without another provider request:
+
+```bash
+make portfolio-risk-demo \
+  PORTFOLIO_ID=us-tech-equal \
+  END_DATE=2026-03-31 \
+  VOL_WINDOW=20 \
+  VAR_WINDOW=60 \
+  VAR_CONFIDENCE=0.95
+```
+
+The summary is written to `.demo/portfolio-risk-summary.json`.
+
+## Current-Version Input Selection
+
+`daily_returns` may contain more than one calculation for the same
+`(source, symbol, ts_event)` after late historical data arrives. The portfolio
+runner selects the current component row by:
+
+```text
+ts_ingest DESC
+calculation_id DESC
+```
+
+This mirrors the daily warehouse current-version tie-break while keeping the
+portfolio calculation independent of PostgreSQL.
+
+An identical duplicated row is ignored. Reusing the same `calculation_id` for
+conflicting fields fails closed because the portfolio calculation must not make a
+file-order-dependent choice.
+
+Dates are processed only when every configured constituent has a return.
+Incomplete dates are excluded and counted in the run diagnostics. The pipeline
+fails when fewer than two fully aligned dates remain.
+
+## Formula And Weighting Semantics
+
+For constituent weights `w_i` and daily returns `r_i,t`:
+
+```text
+portfolio_return_t = sum(w_i * r_i,t)
+```
+
+The persisted weighting method is:
+
+```text
+constant_weight_daily_rebalanced
+```
+
+The same target weights are therefore applied independently to every aligned
+daily return. This is equivalent to rebalancing back to the configured weights
+at each daily boundary. Transaction costs, drift between rebalances and custom
+rebalancing schedules are not modelled.
+
+The calculation records each component return, contribution, weight and
+component calculation ID as stable JSON evidence.
+
+Risk metrics are calculated from the aligned portfolio return series:
+
+- annualised sample volatility uses the configured window and `sqrt(252)`;
+- historical VaR is the positive lower-tail loss magnitude;
+- maximum drawdown is calculated from compounded portfolio wealth, including an
+  initial wealth level of one;
+- `history_status` remains `partial` until both configured windows are ready.
+
+The calculation is a transparent portfolio demonstration, not a validated
+regulatory capital model.
+
+## Dataset Grains
+
+| Dataset | One row means | Identity |
+| --- | --- | --- |
+| `portfolio_daily_returns` | One weighted, daily-rebalanced portfolio return for a portfolio and fully aligned event date. | Deterministic calculation ID from definition, weighting method and current component calculations. |
+| `portfolio_daily_risk_summary` | One portfolio return and rolling risk snapshot for a date and parameter set. | Deterministic calculation ID from definition, return history, weighting method and risk parameters. |
+
+Identical definitions, current component versions and parameters reproduce the
+same calculation IDs and content-addressed Parquet files. A component correction
+or weight change creates a distinguishable version.
+
+## Safety Bounds
+
+The local reader:
+
+- accepts only the configured `daily_returns` dataset;
+- rejects symbolic-link paths and non-regular Parquet files;
+- caps the scan at 4,096 files, 1 GB and 250,000 rows;
+- reads only rows no later than the requested end date;
+- requires exact daily-return contract fields;
+- performs no live provider request.
+
+## Current Boundary
+
+This slice writes curated portfolio Parquet only. PostgreSQL portfolio tables,
+current-version views, marginal risk attribution, covariance matrices, FX
+conversion, non-daily rebalancing schedules, transaction costs, short positions,
+leverage, scheduling, dashboards and alert delivery remain separate decisions.

--- a/src/analytics/portfolio_risk.py
+++ b/src/analytics/portfolio_risk.py
@@ -1,0 +1,574 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import re
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
+from datetime import date, datetime, time, timezone
+from pathlib import Path
+from typing import Any, TypeAlias, cast
+
+import pandas as pd
+
+from ..common.config import load_yaml
+from ..common.exceptions import ValidationError
+from .risk_metrics import value_at_risk
+
+MODEL_VERSION = "portfolio-risk-v1"
+WEIGHTING_METHOD = "constant_weight_daily_rebalanced"
+TRADING_DAYS_PER_YEAR = 252
+MAX_CONSTITUENTS = 50
+WEIGHT_TOLERANCE = 1e-9
+PORTFOLIO_ID_PATTERN = re.compile(r"^[a-z0-9][a-z0-9_-]{0,63}$")
+CURRENCY_PATTERN = re.compile(r"^[A-Z]{3}$")
+SYMBOL_PATTERN = re.compile(r"^[A-Z0-9][A-Z0-9._-]{0,31}$")
+SOURCE_PATTERN = re.compile(r"^[a-z0-9][a-z0-9._-]{0,63}$")
+
+ReturnInput: TypeAlias = Mapping[str, Any]
+
+
+@dataclass(frozen=True, slots=True)
+class PortfolioConstituent:
+    source: str
+    symbol: str
+    weight: float
+
+    @property
+    def key(self) -> str:
+        return f"{self.source}:{self.symbol}"
+
+
+@dataclass(frozen=True, slots=True)
+class PortfolioDefinition:
+    portfolio_id: str
+    base_currency: str
+    constituents: tuple[PortfolioConstituent, ...]
+
+    @property
+    def fingerprint(self) -> str:
+        payload = {
+            "base_currency": self.base_currency,
+            "constituents": [
+                {
+                    "source": constituent.source,
+                    "symbol": constituent.symbol,
+                    "weight": constituent.weight,
+                }
+                for constituent in self.constituents
+            ],
+            "portfolio_id": self.portfolio_id,
+        }
+        digest = hashlib.sha256(
+            json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+        ).hexdigest()[:24]
+        return f"portfolio-{digest}"
+
+
+@dataclass(frozen=True, slots=True)
+class PortfolioRiskOutputs:
+    returns: tuple[dict[str, Any], ...]
+    risk_summary: tuple[dict[str, Any], ...]
+    diagnostics: Mapping[str, Any]
+
+
+def _required_text(value: Any, label: str, pattern: re.Pattern[str]) -> str:
+    if not isinstance(value, str):
+        raise ValidationError(f"{label} must be text")
+    parsed = value.strip()
+    if pattern.fullmatch(parsed) is None:
+        raise ValidationError(f"{label} has an invalid format")
+    return parsed
+
+
+def _symbol(value: Any, label: str) -> str:
+    if not isinstance(value, str):
+        raise ValidationError(f"{label} must be text")
+    return _required_text(value.strip().upper(), label, SYMBOL_PATTERN)
+
+
+def _weight(value: Any) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ValidationError(
+            "portfolio weights must be finite numbers greater than zero"
+        )
+    parsed = float(value)
+    if not math.isfinite(parsed) or parsed <= 0:
+        raise ValidationError(
+            "portfolio weights must be finite numbers greater than zero"
+        )
+    return parsed
+
+
+def parse_portfolio_definition(
+    payload: Mapping[str, Any],
+    portfolio_id: str,
+) -> PortfolioDefinition:
+    canonical_id = _required_text(
+        portfolio_id,
+        "portfolio_id",
+        PORTFOLIO_ID_PATTERN,
+    )
+    if not isinstance(payload, Mapping):
+        raise ValidationError("portfolio configuration must be a mapping")
+    portfolios = payload.get("portfolios")
+    if not isinstance(portfolios, Mapping):
+        raise ValidationError(
+            "portfolio configuration must define a portfolios mapping"
+        )
+    candidate = portfolios.get(canonical_id)
+    if not isinstance(candidate, Mapping):
+        raise ValidationError(f"portfolio '{canonical_id}' is not configured")
+
+    base_currency = _required_text(
+        candidate.get("base_currency"),
+        "base_currency",
+        CURRENCY_PATTERN,
+    )
+    raw_constituents = candidate.get("constituents")
+    if (
+        not isinstance(raw_constituents, list)
+        or not 2 <= len(raw_constituents) <= MAX_CONSTITUENTS
+    ):
+        raise ValidationError(
+            "portfolio constituents must contain between "
+            f"2 and {MAX_CONSTITUENTS} entries"
+        )
+
+    constituents: list[PortfolioConstituent] = []
+    seen: set[tuple[str, str]] = set()
+    for raw in raw_constituents:
+        if not isinstance(raw, Mapping):
+            raise ValidationError("each portfolio constituent must be a mapping")
+        source = _required_text(
+            raw.get("source"),
+            "constituent source",
+            SOURCE_PATTERN,
+        ).lower()
+        symbol = _symbol(raw.get("symbol"), "constituent symbol")
+        key = (source, symbol)
+        if key in seen:
+            raise ValidationError(
+                "portfolio constituents must be unique by source and symbol"
+            )
+        seen.add(key)
+        constituents.append(
+            PortfolioConstituent(
+                source=source,
+                symbol=symbol,
+                weight=_weight(raw.get("weight")),
+            )
+        )
+
+    total_weight = math.fsum(constituent.weight for constituent in constituents)
+    if not math.isclose(
+        total_weight,
+        1.0,
+        rel_tol=0.0,
+        abs_tol=WEIGHT_TOLERANCE,
+    ):
+        raise ValidationError("portfolio weights must sum to 1")
+
+    return PortfolioDefinition(
+        portfolio_id=canonical_id,
+        base_currency=base_currency,
+        constituents=tuple(
+            sorted(constituents, key=lambda item: (item.source, item.symbol))
+        ),
+    )
+
+
+def load_portfolio_definition(path: Path, portfolio_id: str) -> PortfolioDefinition:
+    try:
+        payload = load_yaml(path)
+    except Exception:
+        raise ValidationError("portfolio configuration could not be loaded") from None
+    if not isinstance(payload, Mapping):
+        raise ValidationError("portfolio configuration must be a mapping")
+    return parse_portfolio_definition(payload, portfolio_id)
+
+
+def _positive_integer(value: int, label: str, maximum: int) -> int:
+    if type(value) is not int or not 2 <= value <= maximum:
+        raise ValidationError(
+            f"{label} must be an integer between 2 and {maximum}"
+        )
+    return value
+
+
+def _confidence(value: float) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ValidationError("var_confidence must be a number between 0 and 1")
+    parsed = float(value)
+    if not math.isfinite(parsed) or not 0 < parsed < 1:
+        raise ValidationError("var_confidence must be a number between 0 and 1")
+    return parsed
+
+
+def _aware_utc(value: Any, label: str) -> datetime:
+    parsed: datetime | None = None
+    if isinstance(value, datetime):
+        parsed = value
+    elif isinstance(value, str):
+        try:
+            parsed = datetime.fromisoformat(value.strip().replace("Z", "+00:00"))
+        except ValueError:
+            parsed = None
+    if parsed is None or parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise ValidationError(f"{label} must be a timezone-aware timestamp")
+    return parsed.astimezone(timezone.utc)
+
+
+def _finite_return(value: Any) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ValidationError(
+            "daily return values must be finite numbers greater than -1"
+        )
+    parsed = float(value)
+    if not math.isfinite(parsed) or parsed <= -1:
+        raise ValidationError(
+            "daily return values must be finite numbers greater than -1"
+        )
+    return parsed
+
+
+def _normalise_return_record(candidate: ReturnInput) -> dict[str, Any]:
+    if not isinstance(candidate, Mapping):
+        raise ValidationError(
+            "portfolio input must contain daily return mappings"
+        )
+    source = _required_text(
+        candidate.get("source"),
+        "return source",
+        SOURCE_PATTERN,
+    ).lower()
+    symbol = _symbol(candidate.get("symbol"), "return symbol")
+    calculation_id = candidate.get("calculation_id")
+    model_version = candidate.get("model_version")
+    source_event_id = candidate.get("source_event_id")
+    for label, value in (
+        ("calculation_id", calculation_id),
+        ("model_version", model_version),
+        ("source_event_id", source_event_id),
+    ):
+        if not isinstance(value, str) or not value.strip():
+            raise ValidationError(f"{label} must be non-empty text")
+
+    ts_event = _aware_utc(candidate.get("ts_event"), "ts_event")
+    if ts_event.time() != time.min:
+        raise ValidationError("daily return timestamps must use UTC midnight")
+    ts_ingest = _aware_utc(candidate.get("ts_ingest"), "ts_ingest")
+    return {
+        "model_version": cast(str, model_version).strip(),
+        "calculation_id": cast(str, calculation_id).strip(),
+        "source": source,
+        "symbol": symbol,
+        "source_event_id": cast(str, source_event_id).strip(),
+        "ts_event": ts_event,
+        "ts_ingest": ts_ingest,
+        "return_1d": _finite_return(candidate.get("return_1d")),
+    }
+
+
+def _record_signature(record: Mapping[str, Any]) -> tuple[Any, ...]:
+    return (
+        record["model_version"],
+        record["source"],
+        record["symbol"],
+        record["source_event_id"],
+        record["ts_event"],
+        record["ts_ingest"],
+        record["return_1d"],
+    )
+
+
+def _current_returns(
+    records: Iterable[ReturnInput],
+    definition: PortfolioDefinition,
+    end_date: date | None,
+) -> tuple[dict[tuple[str, str, date], dict[str, Any]], int]:
+    constituent_keys = {
+        (item.source, item.symbol) for item in definition.constituents
+    }
+    current: dict[tuple[str, str, date], dict[str, Any]] = {}
+    seen_calculations: dict[str, tuple[Any, ...]] = {}
+    matched_records = 0
+    for candidate in records:
+        record = _normalise_return_record(candidate)
+        key = (record["source"], record["symbol"])
+        if key not in constituent_keys:
+            continue
+        event_date = record["ts_event"].date()
+        if end_date is not None and event_date > end_date:
+            continue
+        matched_records += 1
+
+        calculation_id = record["calculation_id"]
+        signature = _record_signature(record)
+        previous_signature = seen_calculations.get(calculation_id)
+        if previous_signature is not None:
+            if previous_signature != signature:
+                raise ValidationError(
+                    "daily return calculation IDs must not contain "
+                    "conflicting records"
+                )
+            continue
+        seen_calculations[calculation_id] = signature
+
+        grain = (record["source"], record["symbol"], event_date)
+        existing = current.get(grain)
+        if existing is None or (
+            record["ts_ingest"],
+            calculation_id,
+        ) > (
+            existing["ts_ingest"],
+            existing["calculation_id"],
+        ):
+            current[grain] = record
+
+    missing_constituents = [
+        item.key
+        for item in definition.constituents
+        if not any(
+            source == item.source and symbol == item.symbol
+            for source, symbol, _event_date in current
+        )
+    ]
+    if missing_constituents:
+        raise ValidationError(
+            "portfolio input is missing configured constituents: "
+            + ", ".join(missing_constituents)
+        )
+    return current, matched_records
+
+
+def _json_mapping(values: Mapping[str, Any]) -> str:
+    return json.dumps(values, sort_keys=True, separators=(",", ":"))
+
+
+def _calculation_id(
+    metric: str,
+    definition: PortfolioDefinition,
+    component_calculation_ids: Iterable[str],
+    parameters: Mapping[str, Any],
+) -> str:
+    payload = {
+        "component_calculation_ids": list(component_calculation_ids),
+        "definition_fingerprint": definition.fingerprint,
+        "metric": metric,
+        "model_version": MODEL_VERSION,
+        "parameters": dict(sorted(parameters.items())),
+    }
+    digest = hashlib.sha256(
+        json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    ).hexdigest()[:24]
+    return f"{MODEL_VERSION}-{metric}-{digest}"
+
+
+def build_portfolio_risk_outputs(
+    records: Iterable[ReturnInput],
+    *,
+    definition: PortfolioDefinition,
+    volatility_window: int = 20,
+    var_window: int = 60,
+    var_confidence: float = 0.95,
+    start_date: date | None = None,
+    end_date: date | None = None,
+) -> PortfolioRiskOutputs:
+    volatility_window = _positive_integer(
+        volatility_window,
+        "volatility_window",
+        TRADING_DAYS_PER_YEAR,
+    )
+    var_window = _positive_integer(
+        var_window,
+        "var_window",
+        10 * TRADING_DAYS_PER_YEAR,
+    )
+    confidence = _confidence(var_confidence)
+    if start_date is not None and end_date is not None and start_date > end_date:
+        raise ValidationError("start_date must be on or before end_date")
+
+    current, matched_records = _current_returns(records, definition, end_date)
+    constituent_count = len(definition.constituents)
+    candidate_dates = sorted({event_date for _, _, event_date in current})
+    aligned_dates = [
+        event_date
+        for event_date in candidate_dates
+        if all(
+            (constituent.source, constituent.symbol, event_date) in current
+            for constituent in definition.constituents
+        )
+    ]
+    if len(aligned_dates) < 2:
+        raise ValidationError(
+            "portfolio risk requires at least two fully aligned return dates"
+        )
+
+    weights = {
+        constituent.key: constituent.weight
+        for constituent in definition.constituents
+    }
+    weights_json = _json_mapping(weights)
+    return_records_all: list[dict[str, Any]] = []
+    portfolio_returns: list[float] = []
+
+    for event_date in aligned_dates:
+        components = [
+            current[(constituent.source, constituent.symbol, event_date)]
+            for constituent in definition.constituents
+        ]
+        component_ids = [component["calculation_id"] for component in components]
+        component_returns = {
+            constituent.key: component["return_1d"]
+            for constituent, component in zip(
+                definition.constituents,
+                components,
+                strict=True,
+            )
+        }
+        contributions = {
+            constituent.key: constituent.weight * component["return_1d"]
+            for constituent, component in zip(
+                definition.constituents,
+                components,
+                strict=True,
+            )
+        }
+        portfolio_return = math.fsum(contributions.values())
+        portfolio_returns.append(portfolio_return)
+        return_records_all.append(
+            {
+                "model_version": MODEL_VERSION,
+                "calculation_id": _calculation_id(
+                    "return",
+                    definition,
+                    component_ids,
+                    {"weighting_method": WEIGHTING_METHOD},
+                ),
+                "portfolio_id": definition.portfolio_id,
+                "base_currency": definition.base_currency,
+                "definition_fingerprint": definition.fingerprint,
+                "weighting_method": WEIGHTING_METHOD,
+                "ts_event": components[0]["ts_event"],
+                "ts_ingest": max(
+                    component["ts_ingest"] for component in components
+                ),
+                "constituent_count": constituent_count,
+                "weights_json": weights_json,
+                "component_calculation_ids_json": _json_mapping(
+                    {
+                        constituent.key: component["calculation_id"]
+                        for constituent, component in zip(
+                            definition.constituents,
+                            components,
+                            strict=True,
+                        )
+                    }
+                ),
+                "component_returns_json": _json_mapping(component_returns),
+                "contributions_json": _json_mapping(contributions),
+                "portfolio_return_1d": portfolio_return,
+            }
+        )
+
+    returns_series = pd.Series(portfolio_returns, dtype="float64")
+    rolling_volatility = (
+        returns_series.rolling(
+            window=volatility_window,
+            min_periods=volatility_window,
+        ).std()
+        * math.sqrt(TRADING_DAYS_PER_YEAR)
+    )
+    wealth = (1.0 + returns_series).cumprod()
+    running_peak = wealth.cummax().clip(lower=1.0)
+    maximum_drawdown = (wealth / running_peak - 1.0).cummin()
+
+    emitted_returns: list[dict[str, Any]] = []
+    summary_records: list[dict[str, Any]] = []
+    for index, return_record in enumerate(return_records_all):
+        event_date = return_record["ts_event"].date()
+        if start_date is not None and event_date < start_date:
+            continue
+        emitted_returns.append(return_record)
+
+        volatility_value = (
+            float(rolling_volatility.iloc[index])
+            if index + 1 >= volatility_window
+            else None
+        )
+        var_start = max(0, index - var_window + 1)
+        var_slice = returns_series.iloc[var_start : index + 1]
+        var_loss = (
+            max(0.0, -value_at_risk(var_slice, confidence=confidence))
+            if len(var_slice) >= 2
+            else None
+        )
+        history = return_records_all[: index + 1]
+        history_ids = [record["calculation_id"] for record in history]
+        ready = index + 1 >= max(volatility_window, var_window)
+        summary_records.append(
+            {
+                "model_version": MODEL_VERSION,
+                "calculation_id": _calculation_id(
+                    "summary",
+                    definition,
+                    history_ids,
+                    {
+                        "annualization_days": TRADING_DAYS_PER_YEAR,
+                        "var_confidence": confidence,
+                        "var_window": var_window,
+                        "volatility_window": volatility_window,
+                        "weighting_method": WEIGHTING_METHOD,
+                    },
+                ),
+                "portfolio_id": definition.portfolio_id,
+                "base_currency": definition.base_currency,
+                "definition_fingerprint": definition.fingerprint,
+                "weighting_method": WEIGHTING_METHOD,
+                "portfolio_return_calculation_id": return_record[
+                    "calculation_id"
+                ],
+                "ts_event": return_record["ts_event"],
+                "ts_ingest": max(record["ts_ingest"] for record in history),
+                "portfolio_return_1d": return_record["portfolio_return_1d"],
+                "volatility_annualized": volatility_value,
+                "volatility_window": volatility_window,
+                "annualization_days": TRADING_DAYS_PER_YEAR,
+                "historical_var_loss": var_loss,
+                "var_confidence": confidence,
+                "var_window": var_window,
+                "var_observations": len(var_slice),
+                "maximum_drawdown": float(maximum_drawdown.iloc[index]),
+                "aligned_observations": index + 1,
+                "constituent_count": constituent_count,
+                "weights_json": weights_json,
+                "history_status": "ready" if ready else "partial",
+                "input_first_calculation_id": history[0]["calculation_id"],
+                "input_last_calculation_id": history[-1]["calculation_id"],
+            }
+        )
+
+    if not emitted_returns or not summary_records:
+        raise ValidationError(
+            "no portfolio risk outputs matched the requested date range"
+        )
+
+    diagnostics = {
+        "portfolio_id": definition.portfolio_id,
+        "weighting_method": WEIGHTING_METHOD,
+        "matched_input_records": matched_records,
+        "current_component_records": len(current),
+        "candidate_dates": len(candidate_dates),
+        "aligned_dates": len(aligned_dates),
+        "dropped_incomplete_dates": len(candidate_dates) - len(aligned_dates),
+        "first_aligned_date": aligned_dates[0].isoformat(),
+        "last_aligned_date": aligned_dates[-1].isoformat(),
+        "constituent_count": constituent_count,
+    }
+    return PortfolioRiskOutputs(
+        returns=tuple(emitted_returns),
+        risk_summary=tuple(summary_records),
+        diagnostics=diagnostics,
+    )

--- a/src/orchestration/run_portfolio_risk.py
+++ b/src/orchestration/run_portfolio_risk.py
@@ -1,0 +1,400 @@
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import sys
+from collections.abc import Callable, Sequence
+from datetime import date, datetime, time, timedelta, timezone
+from pathlib import Path
+from typing import Any
+from uuid import uuid4
+
+from ..analytics.portfolio_risk import (
+    PortfolioDefinition,
+    PortfolioRiskOutputs,
+    build_portfolio_risk_outputs,
+    load_portfolio_definition,
+)
+from ..common.exceptions import StorageError, ValidationError
+from ..storage.s3_writer import write_records
+from ..storage.storage_config import load_storage_config, validate_storage_config
+
+INPUT_DATASET = "daily_returns"
+OUTPUT_DATASETS = {
+    "returns": "portfolio_daily_returns",
+    "risk_summary": "portfolio_daily_risk_summary",
+}
+MAX_INPUT_FILES = 4_096
+MAX_INPUT_BYTES = 1_000_000_000
+MAX_INPUT_ROWS = 250_000
+UTC_EPOCH = datetime(1970, 1, 1, tzinfo=timezone.utc)
+
+Reader = Callable[..., list[dict[str, Any]]]
+Writer = Callable[..., int]
+StorageConfigLoader = Callable[[Path], dict[str, Any]]
+DefinitionLoader = Callable[[Path, str], PortfolioDefinition]
+
+
+def _calendar_date(value: str) -> date:
+    try:
+        parsed = date.fromisoformat(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("must be a calendar date in YYYY-MM-DD format") from exc
+    if value != parsed.isoformat():
+        raise argparse.ArgumentTypeError("must be a calendar date in YYYY-MM-DD format")
+    return parsed
+
+
+def _positive_integer(value: str) -> int:
+    try:
+        parsed = int(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("must be an integer greater than zero") from exc
+    if parsed <= 0:
+        raise argparse.ArgumentTypeError("must be greater than zero")
+    return parsed
+
+
+def _confidence(value: str) -> float:
+    try:
+        parsed = float(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("must be a number between 0 and 1") from exc
+    if not math.isfinite(parsed) or not 0 < parsed < 1:
+        raise argparse.ArgumentTypeError("must be a number between 0 and 1")
+    return parsed
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Build versioned portfolio risk from local daily-return parquet."
+    )
+    parser.add_argument("--portfolio-id", required=True)
+    parser.add_argument(
+        "--portfolio-config",
+        type=Path,
+        default=Path("config/portfolios.yaml"),
+    )
+    parser.add_argument("--start-date", type=_calendar_date)
+    parser.add_argument("--end-date", required=True, type=_calendar_date)
+    parser.add_argument("--vol-window", type=_positive_integer, default=20)
+    parser.add_argument("--var-window", type=_positive_integer, default=60)
+    parser.add_argument("--var-confidence", type=_confidence, default=0.95)
+    parser.add_argument(
+        "--storage-config",
+        type=Path,
+        default=Path("config/storage.yaml"),
+    )
+    parser.add_argument("--summary-json", type=Path)
+    return parser
+
+
+def _timestamp_from_epoch_microseconds(value: Any) -> datetime:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise StorageError("Portfolio input timestamp has an invalid physical value")
+    try:
+        return UTC_EPOCH + timedelta(microseconds=value)
+    except (OverflowError, TypeError, ValueError):
+        raise StorageError("Portfolio input timestamp is outside the supported range") from None
+
+
+def _dataset_files(
+    storage_config: dict[str, Any],
+    dataset_key: str,
+) -> list[Path]:
+    validate_storage_config(storage_config)
+    storage = storage_config["storage"]
+    datasets = storage["curated"]["datasets"]
+    if dataset_key not in datasets:
+        raise StorageError(f"Storage configuration is missing '{dataset_key}'")
+    curated_base = Path(storage["curated"]["base_path"])
+    dataset_path = curated_base / datasets[dataset_key]
+
+    if curated_base.is_symlink() or dataset_path.is_symlink():
+        raise StorageError("Portfolio input path must not be a symbolic link")
+    if not dataset_path.exists():
+        raise ValidationError("No local daily return data is available")
+    if not dataset_path.is_dir():
+        raise StorageError("Portfolio input path must be a directory")
+
+    try:
+        files = sorted(dataset_path.rglob("*.parquet"))
+    except OSError:
+        raise StorageError("Portfolio input could not be inventoried") from None
+    if not files:
+        raise ValidationError("No local daily return data is available")
+    if len(files) > MAX_INPUT_FILES:
+        raise StorageError("Portfolio input exceeds the file scan limit")
+
+    total_bytes = 0
+    for path in files:
+        if path.is_symlink() or not path.is_file():
+            raise StorageError("Portfolio input contains an unsafe file type")
+        try:
+            total_bytes += path.stat().st_size
+        except OSError:
+            raise StorageError("Portfolio input could not be inventoried") from None
+        if total_bytes > MAX_INPUT_BYTES:
+            raise StorageError("Portfolio input exceeds the byte scan limit")
+    return files
+
+
+def load_daily_return_records(
+    *,
+    storage_config: dict[str, Any],
+    end_date: date,
+) -> list[dict[str, Any]]:
+    files = _dataset_files(storage_config, INPUT_DATASET)
+    try:
+        import duckdb
+    except ImportError:
+        raise StorageError("DuckDB is required to read local daily returns") from None
+
+    escaped_paths = [str(path).replace("'", "''") for path in files]
+    quoted_paths = ", ".join(f"'{path}'" for path in escaped_paths)
+    relation = f"read_parquet([{quoted_paths}], union_by_name=true, hive_partitioning=false)"
+    try:
+        end_exclusive = datetime.combine(end_date + timedelta(days=1), time.min, timezone.utc)
+    except OverflowError:
+        raise ValidationError("end_date is outside the supported range") from None
+    end_exclusive_us = int((end_exclusive - UTC_EPOCH).total_seconds() * 1_000_000)
+
+    try:
+        with duckdb.connect() as connection:
+            count_row = connection.execute(
+                f"SELECT COUNT(*) FROM {relation} WHERE epoch_us(ts_event) < ?",
+                [end_exclusive_us],
+            ).fetchone()
+            if count_row is None:
+                raise StorageError("Portfolio input query did not return a row count")
+            row_count = int(count_row[0])
+            if row_count > MAX_INPUT_ROWS:
+                raise StorageError("Portfolio input exceeds the row scan limit")
+            cursor = connection.execute(
+                "SELECT model_version, calculation_id, source, symbol, source_event_id, "
+                "epoch_us(ts_event) AS ts_event, epoch_us(ts_ingest) AS ts_ingest, return_1d "
+                f"FROM {relation} WHERE epoch_us(ts_event) < ? "
+                "ORDER BY ts_event, source, symbol, ts_ingest, calculation_id",
+                [end_exclusive_us],
+            )
+            rows = cursor.fetchall()
+    except (StorageError, ValidationError):
+        raise
+    except Exception:
+        raise StorageError("Unable to read local daily return parquet") from None
+
+    records: list[dict[str, Any]] = []
+    try:
+        for row in rows:
+            records.append(
+                {
+                    "model_version": str(row[0]),
+                    "calculation_id": str(row[1]),
+                    "source": str(row[2]),
+                    "symbol": str(row[3]),
+                    "source_event_id": str(row[4]),
+                    "ts_event": _timestamp_from_epoch_microseconds(row[5]),
+                    "ts_ingest": _timestamp_from_epoch_microseconds(row[6]),
+                    "return_1d": float(row[7]),
+                }
+            )
+    except StorageError:
+        raise
+    except Exception:
+        raise StorageError("Daily return records are incompatible") from None
+    if not records:
+        raise ValidationError("No daily returns matched the requested end date")
+    return records
+
+
+def _require_datasets(storage_config: dict[str, Any]) -> None:
+    validate_storage_config(storage_config)
+    datasets = storage_config["storage"]["curated"]["datasets"]
+    required = {INPUT_DATASET, *OUTPUT_DATASETS.values()}
+    missing = sorted(dataset for dataset in required if dataset not in datasets)
+    if missing:
+        raise StorageError(
+            "Storage configuration is missing portfolio datasets: " + ", ".join(missing)
+        )
+
+
+def _publish_records(
+    records: tuple[dict[str, Any], ...],
+    *,
+    dataset: str,
+    storage_config: dict[str, Any],
+    writer: Writer,
+) -> int:
+    written = 0
+    for record in records:
+        try:
+            result = writer(
+                [record],
+                kind="curated",
+                dataset=dataset,
+                storage_config=storage_config,
+            )
+        except Exception:
+            raise StorageError("Portfolio curated publication failed; rerun is safe") from None
+        if type(result) is not int or result not in {0, 1}:
+            raise StorageError("Portfolio curated publication returned an invalid result")
+        written += result
+    return written
+
+
+def run_portfolio_risk(
+    *,
+    portfolio_id: str,
+    portfolio_config_path: Path,
+    start_date: date | None,
+    end_date: date,
+    volatility_window: int,
+    var_window: int,
+    var_confidence: float,
+    storage_config_path: Path,
+    reader: Reader | None = None,
+    writer: Writer | None = None,
+    storage_config_loader: StorageConfigLoader | None = None,
+    definition_loader: DefinitionLoader | None = None,
+) -> dict[str, Any]:
+    if start_date is not None and start_date > end_date:
+        raise ValidationError("start_date must be on or before end_date")
+
+    selected_storage_loader = storage_config_loader or load_storage_config
+    try:
+        storage_config = selected_storage_loader(storage_config_path)
+    except Exception:
+        raise StorageError("Storage configuration is invalid") from None
+    if not isinstance(storage_config, dict):
+        raise StorageError("Storage configuration is invalid")
+    _require_datasets(storage_config)
+
+    selected_definition_loader = definition_loader or load_portfolio_definition
+    try:
+        definition = selected_definition_loader(portfolio_config_path, portfolio_id)
+    except ValidationError:
+        raise
+    except Exception:
+        raise ValidationError("Portfolio configuration is invalid") from None
+
+    selected_reader = reader or load_daily_return_records
+    try:
+        records = selected_reader(storage_config=storage_config, end_date=end_date)
+    except (StorageError, ValidationError):
+        raise
+    except Exception:
+        raise StorageError("Unable to read local daily returns") from None
+
+    outputs: PortfolioRiskOutputs = build_portfolio_risk_outputs(
+        records,
+        definition=definition,
+        volatility_window=volatility_window,
+        var_window=var_window,
+        var_confidence=var_confidence,
+        start_date=start_date,
+        end_date=end_date,
+    )
+    selected_writer = writer or write_records
+    records_by_dataset = {
+        OUTPUT_DATASETS["returns"]: outputs.returns,
+        OUTPUT_DATASETS["risk_summary"]: outputs.risk_summary,
+    }
+    written_by_dataset = {
+        dataset: _publish_records(
+            output_records,
+            dataset=dataset,
+            storage_config=storage_config,
+            writer=selected_writer,
+        )
+        for dataset, output_records in records_by_dataset.items()
+    }
+
+    latest = outputs.risk_summary[-1]
+    return {
+        "run_id": str(uuid4()),
+        "portfolio_id": definition.portfolio_id,
+        "base_currency": definition.base_currency,
+        "definition_fingerprint": definition.fingerprint,
+        "selection": {
+            "start_date": start_date.isoformat() if start_date is not None else None,
+            "end_date": end_date.isoformat(),
+            **dict(outputs.diagnostics),
+        },
+        "parameters": {
+            "volatility_window": volatility_window,
+            "var_window": var_window,
+            "var_confidence": float(var_confidence),
+        },
+        "curated_output": {
+            dataset: {
+                "records_selected": len(output_records),
+                "records_written": written_by_dataset[dataset],
+                "records_already_present": len(output_records)
+                - written_by_dataset[dataset],
+            }
+            for dataset, output_records in records_by_dataset.items()
+        },
+        "latest_metrics": {
+            "ts_event": latest["ts_event"].isoformat(),
+            "portfolio_return_1d": latest["portfolio_return_1d"],
+            "volatility_annualized": latest["volatility_annualized"],
+            "historical_var_loss": latest["historical_var_loss"],
+            "maximum_drawdown": latest["maximum_drawdown"],
+            "history_status": latest["history_status"],
+            "calculation_id": latest["calculation_id"],
+        },
+    }
+
+
+def _write_summary(path: Path, summary: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary_path = path.with_suffix(path.suffix + ".tmp")
+    try:
+        temporary_path.write_text(
+            json.dumps(summary, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        temporary_path.replace(path)
+    except OSError:
+        temporary_path.unlink(missing_ok=True)
+        raise StorageError("Unable to write the portfolio risk summary") from None
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    try:
+        summary = run_portfolio_risk(
+            portfolio_id=args.portfolio_id,
+            portfolio_config_path=args.portfolio_config,
+            start_date=args.start_date,
+            end_date=args.end_date,
+            volatility_window=args.vol_window,
+            var_window=args.var_window,
+            var_confidence=args.var_confidence,
+            storage_config_path=args.storage_config,
+        )
+        if args.summary_json is not None:
+            _write_summary(args.summary_json, summary)
+    except ValidationError:
+        print(
+            "Portfolio risk pipeline failed: configuration, input data or options were invalid",
+            file=sys.stderr,
+        )
+        return 1
+    except StorageError:
+        print(
+            "Portfolio risk pipeline failed: local storage operation failed; rerun is safe",
+            file=sys.stderr,
+        )
+        return 1
+    except Exception:
+        print("Portfolio risk pipeline failed: unexpected local failure", file=sys.stderr)
+        return 1
+
+    print(json.dumps(summary, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/integration/test_portfolio_risk_pipeline.py
+++ b/tests/integration/test_portfolio_risk_pipeline.py
@@ -1,0 +1,97 @@
+from datetime import date, datetime, timedelta, timezone
+from pathlib import Path
+
+from src.orchestration.run_portfolio_risk import run_portfolio_risk
+from src.storage.s3_writer import write_records
+from tests.storage_config_helpers import build_storage_config, write_storage_config
+
+
+def _daily_returns() -> list[dict]:
+    records: list[dict] = []
+    ingested_at = datetime(2026, 1, 10, 12, tzinfo=timezone.utc)
+    for day, aapl, msft in [(2, 0.10, 0.02), (3, -0.04, 0.0), (4, 0.06, 0.02)]:
+        for symbol, value in [("AAPL", aapl), ("MSFT", msft)]:
+            records.append(
+                {
+                    "model_version": "daily-risk-v2",
+                    "calculation_id": f"{symbol}-{day}",
+                    "source": "alpha_vantage",
+                    "symbol": symbol,
+                    "source_event_id": f"{symbol}-event-{day}",
+                    "previous_source_event_id": f"{symbol}-event-{day - 1}",
+                    "ts_event": datetime(2026, 1, day, tzinfo=timezone.utc),
+                    "ts_ingest": ingested_at + timedelta(minutes=day),
+                    "return_1d": value,
+                }
+            )
+    return records
+
+
+def _portfolio_config(tmp_path: Path) -> Path:
+    path = tmp_path / "portfolios.yaml"
+    path.write_text(
+        """
+portfolios:
+  us-tech-equal:
+    base_currency: USD
+    constituents:
+      - source: alpha_vantage
+        symbol: AAPL
+        weight: 0.5
+      - source: alpha_vantage
+        symbol: MSFT
+        weight: 0.5
+""".lstrip(),
+        encoding="utf-8",
+    )
+    return path
+
+
+def test_portfolio_risk_reads_daily_returns_and_replays_outputs(tmp_path: Path) -> None:
+    storage_config = build_storage_config(tmp_path)
+    storage_config_path = write_storage_config(tmp_path)
+    portfolio_config_path = _portfolio_config(tmp_path)
+    assert (
+        write_records(
+            _daily_returns(),
+            kind="curated",
+            dataset="daily_returns",
+            storage_config=storage_config,
+        )
+        == 6
+    )
+
+    first = run_portfolio_risk(
+        portfolio_id="us-tech-equal",
+        portfolio_config_path=portfolio_config_path,
+        start_date=None,
+        end_date=date(2026, 1, 4),
+        volatility_window=2,
+        var_window=2,
+        var_confidence=0.95,
+        storage_config_path=storage_config_path,
+    )
+    second = run_portfolio_risk(
+        portfolio_id="us-tech-equal",
+        portfolio_config_path=portfolio_config_path,
+        start_date=None,
+        end_date=date(2026, 1, 4),
+        volatility_window=2,
+        var_window=2,
+        var_confidence=0.95,
+        storage_config_path=storage_config_path,
+    )
+
+    assert first["curated_output"]["portfolio_daily_returns"]["records_written"] == 3
+    assert (
+        first["curated_output"]["portfolio_daily_risk_summary"]["records_written"]
+        == 3
+    )
+    assert second["curated_output"]["portfolio_daily_returns"]["records_written"] == 0
+    assert (
+        second["curated_output"]["portfolio_daily_risk_summary"]["records_written"]
+        == 0
+    )
+    assert second["latest_metrics"]["calculation_id"] == first["latest_metrics"][
+        "calculation_id"
+    ]

--- a/tests/storage_config_helpers.py
+++ b/tests/storage_config_helpers.py
@@ -14,6 +14,8 @@ CURATED_DATASETS = {
     "daily_returns": "daily_returns",
     "daily_volatility": "daily_volatility",
     "daily_risk_summary": "daily_risk_summary",
+    "portfolio_daily_returns": "portfolio_daily_returns",
+    "portfolio_daily_risk_summary": "portfolio_daily_risk_summary",
 }
 
 

--- a/tests/unit/test_architecture_contract.py
+++ b/tests/unit/test_architecture_contract.py
@@ -13,9 +13,15 @@ def test_architecture_matches_current_runtime_contract() -> None:
         "risk_platform.daily_risk_summary",
         "latest_daily_risk_summary",
         "daily_risk_semantic_model",
+        "portfolio_daily_returns",
+        "portfolio_daily_risk_summary",
         "issue #51",
     ):
         assert required in architecture
 
     assert "Python 3.10 or newer" not in architecture
     assert "direct schema input can currently remain timezone-naive" not in architecture
+    assert (
+        "Portfolio-level aggregation and correlation risk are not yet implemented"
+        not in architecture
+    )

--- a/tests/unit/test_portfolio_risk.py
+++ b/tests/unit/test_portfolio_risk.py
@@ -1,0 +1,382 @@
+from datetime import date, datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+from src.analytics.portfolio_risk import (
+    MODEL_VERSION,
+    WEIGHTING_METHOD,
+    build_portfolio_risk_outputs,
+    load_portfolio_definition,
+    parse_portfolio_definition,
+)
+from src.common.exceptions import ValidationError
+
+
+def _definition_payload() -> dict:
+    return {
+        "portfolios": {
+            "us-tech-equal": {
+                "base_currency": "USD",
+                "constituents": [
+                    {
+                        "source": "alpha_vantage",
+                        "symbol": "AAPL",
+                        "weight": 0.5,
+                    },
+                    {
+                        "source": "alpha_vantage",
+                        "symbol": "MSFT",
+                        "weight": 0.5,
+                    },
+                ],
+            }
+        }
+    }
+
+
+def _record(
+    symbol: str,
+    day: int,
+    value: float,
+    *,
+    calculation_id: str | None = None,
+    ingested_at: datetime | None = None,
+) -> dict:
+    event = datetime(2026, 1, day, tzinfo=timezone.utc)
+    return {
+        "model_version": "daily-risk-v2",
+        "calculation_id": calculation_id or f"{symbol}-{day}",
+        "source": "alpha_vantage",
+        "symbol": symbol,
+        "source_event_id": f"{symbol}-event-{day}",
+        "ts_event": event,
+        "ts_ingest": ingested_at or event + timedelta(hours=1),
+        "return_1d": value,
+    }
+
+
+def _complete_records() -> list[dict]:
+    return [
+        _record(symbol, day, value)
+        for day, aapl, msft in [
+            (2, 0.10, 0.02),
+            (3, -0.04, 0.0),
+            (4, 0.06, 0.02),
+        ]
+        for symbol, value in [("AAPL", aapl), ("MSFT", msft)]
+    ]
+
+
+def test_parse_portfolio_definition_normalises_and_fingerprints() -> None:
+    definition = parse_portfolio_definition(
+        _definition_payload(),
+        "us-tech-equal",
+    )
+
+    assert definition.portfolio_id == "us-tech-equal"
+    assert definition.base_currency == "USD"
+    assert [item.symbol for item in definition.constituents] == ["AAPL", "MSFT"]
+    assert definition.fingerprint.startswith("portfolio-")
+
+
+def test_load_portfolio_definition_reads_yaml(tmp_path: Path) -> None:
+    path = tmp_path / "portfolios.yaml"
+    path.write_text(
+        """
+portfolios:
+  us-tech-equal:
+    base_currency: USD
+    constituents:
+      - source: alpha_vantage
+        symbol: AAPL
+        weight: 0.5
+      - source: alpha_vantage
+        symbol: MSFT
+        weight: 0.5
+""".lstrip(),
+        encoding="utf-8",
+    )
+
+    assert (
+        load_portfolio_definition(path, "us-tech-equal").portfolio_id
+        == "us-tech-equal"
+    )
+
+
+def test_build_portfolio_risk_outputs_calculates_weighted_metrics() -> None:
+    definition = parse_portfolio_definition(
+        _definition_payload(),
+        "us-tech-equal",
+    )
+
+    outputs = build_portfolio_risk_outputs(
+        _complete_records(),
+        definition=definition,
+        volatility_window=2,
+        var_window=2,
+        var_confidence=0.95,
+    )
+
+    assert len(outputs.returns) == 3
+    assert outputs.returns[0]["portfolio_return_1d"] == pytest.approx(0.06)
+    assert outputs.returns[1]["portfolio_return_1d"] == pytest.approx(-0.02)
+    assert outputs.returns[0]["model_version"] == MODEL_VERSION
+    assert outputs.returns[0]["weighting_method"] == WEIGHTING_METHOD
+    assert outputs.returns[0]["calculation_id"].startswith(
+        f"{MODEL_VERSION}-return-"
+    )
+
+    latest = outputs.risk_summary[-1]
+    assert latest["portfolio_return_1d"] == pytest.approx(0.04)
+    assert latest["volatility_annualized"] > 0
+    assert latest["historical_var_loss"] == pytest.approx(0.017)
+    assert latest["maximum_drawdown"] == pytest.approx(-0.02)
+    assert latest["history_status"] == "ready"
+    assert latest["weighting_method"] == WEIGHTING_METHOD
+    assert latest["aligned_observations"] == 3
+    assert outputs.diagnostics["weighting_method"] == WEIGHTING_METHOD
+
+
+def test_latest_component_version_wins_for_the_same_date() -> None:
+    definition = parse_portfolio_definition(
+        _definition_payload(),
+        "us-tech-equal",
+    )
+    late = datetime(2026, 2, 1, tzinfo=timezone.utc)
+    records = [
+        _record("AAPL", 2, 0.10, calculation_id="old"),
+        _record(
+            "AAPL",
+            2,
+            0.20,
+            calculation_id="new",
+            ingested_at=late,
+        ),
+        _record("MSFT", 2, 0.00),
+        _record("AAPL", 3, 0.00),
+        _record("MSFT", 3, 0.00),
+    ]
+
+    outputs = build_portfolio_risk_outputs(
+        records,
+        definition=definition,
+        volatility_window=2,
+        var_window=2,
+    )
+
+    assert outputs.returns[0]["portfolio_return_1d"] == pytest.approx(0.10)
+    assert outputs.returns[0]["ts_ingest"] == late
+    assert '"alpha_vantage:AAPL":"new"' in outputs.returns[0][
+        "component_calculation_ids_json"
+    ]
+
+
+def test_conflicting_reuse_of_a_calculation_id_fails_closed() -> None:
+    definition = parse_portfolio_definition(
+        _definition_payload(),
+        "us-tech-equal",
+    )
+    records = [
+        _record("AAPL", 2, 0.10, calculation_id="same-id"),
+        _record("AAPL", 2, 0.20, calculation_id="same-id"),
+        _record("MSFT", 2, 0.00),
+        _record("AAPL", 3, 0.00),
+        _record("MSFT", 3, 0.00),
+    ]
+
+    with pytest.raises(ValidationError, match="conflicting records"):
+        build_portfolio_risk_outputs(
+            records,
+            definition=definition,
+            volatility_window=2,
+            var_window=2,
+        )
+
+
+def test_identical_duplicate_input_is_ignored() -> None:
+    definition = parse_portfolio_definition(
+        _definition_payload(),
+        "us-tech-equal",
+    )
+    aapl = _record("AAPL", 2, 0.10)
+    records = [
+        aapl,
+        dict(aapl),
+        _record("MSFT", 2, 0.00),
+        _record("AAPL", 3, 0.00),
+        _record("MSFT", 3, 0.00),
+    ]
+
+    outputs = build_portfolio_risk_outputs(
+        records,
+        definition=definition,
+        volatility_window=2,
+        var_window=2,
+    )
+
+    assert len(outputs.returns) == 2
+    assert outputs.diagnostics["matched_input_records"] == 5
+    assert outputs.diagnostics["current_component_records"] == 4
+
+
+def test_input_order_does_not_change_calculation_identity() -> None:
+    definition = parse_portfolio_definition(
+        _definition_payload(),
+        "us-tech-equal",
+    )
+    records = _complete_records()
+
+    forward = build_portfolio_risk_outputs(
+        records,
+        definition=definition,
+        volatility_window=2,
+        var_window=2,
+    )
+    reverse = build_portfolio_risk_outputs(
+        reversed(records),
+        definition=definition,
+        volatility_window=2,
+        var_window=2,
+    )
+
+    assert forward.returns == reverse.returns
+    assert forward.risk_summary == reverse.risk_summary
+
+
+def test_incomplete_dates_are_dropped_and_reported() -> None:
+    definition = parse_portfolio_definition(
+        _definition_payload(),
+        "us-tech-equal",
+    )
+    records = [
+        _record("AAPL", 2, 0.10),
+        _record("MSFT", 2, 0.02),
+        _record("AAPL", 3, 0.03),
+        _record("AAPL", 4, 0.04),
+        _record("MSFT", 4, 0.02),
+    ]
+
+    outputs = build_portfolio_risk_outputs(
+        records,
+        definition=definition,
+        volatility_window=2,
+        var_window=2,
+    )
+
+    assert [record["ts_event"].date() for record in outputs.returns] == [
+        date(2026, 1, 2),
+        date(2026, 1, 4),
+    ]
+    assert outputs.diagnostics["dropped_incomplete_dates"] == 1
+
+
+def test_start_date_filters_outputs_but_keeps_history_context() -> None:
+    definition = parse_portfolio_definition(
+        _definition_payload(),
+        "us-tech-equal",
+    )
+
+    outputs = build_portfolio_risk_outputs(
+        _complete_records(),
+        definition=definition,
+        volatility_window=2,
+        var_window=2,
+        start_date=date(2026, 1, 4),
+    )
+
+    assert len(outputs.returns) == 1
+    assert outputs.risk_summary[0]["aligned_observations"] == 3
+    assert outputs.risk_summary[0]["history_status"] == "ready"
+
+
+def test_maximum_drawdown_includes_the_initial_portfolio_value() -> None:
+    definition = parse_portfolio_definition(
+        _definition_payload(),
+        "us-tech-equal",
+    )
+    records = [
+        _record("AAPL", 2, -0.10),
+        _record("MSFT", 2, -0.10),
+        _record("AAPL", 3, 0.0),
+        _record("MSFT", 3, 0.0),
+    ]
+
+    outputs = build_portfolio_risk_outputs(
+        records,
+        definition=definition,
+        volatility_window=2,
+        var_window=2,
+    )
+
+    assert outputs.risk_summary[0]["maximum_drawdown"] == pytest.approx(-0.10)
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {
+            "portfolios": {
+                "bad": {
+                    "base_currency": "USD",
+                    "constituents": [
+                        {
+                            "source": "alpha_vantage",
+                            "symbol": "AAPL",
+                            "weight": 0.6,
+                        },
+                        {
+                            "source": "alpha_vantage",
+                            "symbol": "MSFT",
+                            "weight": 0.5,
+                        },
+                    ],
+                }
+            }
+        },
+        {
+            "portfolios": {
+                "bad": {
+                    "base_currency": "USD",
+                    "constituents": [
+                        {
+                            "source": "alpha_vantage",
+                            "symbol": "AAPL",
+                            "weight": 0.5,
+                        },
+                        {
+                            "source": "alpha_vantage",
+                            "symbol": "AAPL",
+                            "weight": 0.5,
+                        },
+                    ],
+                }
+            }
+        },
+    ],
+)
+def test_invalid_portfolio_definitions_fail_closed(payload: dict) -> None:
+    with pytest.raises(ValidationError):
+        parse_portfolio_definition(payload, "bad")
+
+
+def test_missing_constituent_and_insufficient_alignment_fail_closed() -> None:
+    definition = parse_portfolio_definition(
+        _definition_payload(),
+        "us-tech-equal",
+    )
+    with pytest.raises(ValidationError, match="missing configured constituents"):
+        build_portfolio_risk_outputs(
+            [_record("AAPL", 2, 0.1), _record("AAPL", 3, 0.2)],
+            definition=definition,
+            volatility_window=2,
+            var_window=2,
+        )
+
+    with pytest.raises(ValidationError, match="at least two fully aligned"):
+        build_portfolio_risk_outputs(
+            [_record("AAPL", 2, 0.1), _record("MSFT", 2, 0.2)],
+            definition=definition,
+            volatility_window=2,
+            var_window=2,
+        )

--- a/tests/unit/test_run_portfolio_risk.py
+++ b/tests/unit/test_run_portfolio_risk.py
@@ -1,0 +1,184 @@
+from datetime import date, datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from src.analytics.portfolio_risk import parse_portfolio_definition
+from src.common.exceptions import StorageError, ValidationError
+from src.orchestration.run_portfolio_risk import OUTPUT_DATASETS, run_portfolio_risk
+
+
+def _definition():
+    return parse_portfolio_definition(
+        {
+            "portfolios": {
+                "us-tech-equal": {
+                    "base_currency": "USD",
+                    "constituents": [
+                        {"source": "alpha_vantage", "symbol": "AAPL", "weight": 0.5},
+                        {"source": "alpha_vantage", "symbol": "MSFT", "weight": 0.5},
+                    ],
+                }
+            }
+        },
+        "us-tech-equal",
+    )
+
+
+def _records() -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    for day, aapl, msft in [(2, 0.10, 0.02), (3, -0.04, 0.0), (4, 0.06, 0.02)]:
+        event = datetime(2026, 1, day, tzinfo=timezone.utc)
+        for symbol, value in [("AAPL", aapl), ("MSFT", msft)]:
+            rows.append(
+                {
+                    "model_version": "daily-risk-v2",
+                    "calculation_id": f"{symbol}-{day}",
+                    "source": "alpha_vantage",
+                    "symbol": symbol,
+                    "source_event_id": f"{symbol}-event-{day}",
+                    "ts_event": event,
+                    "ts_ingest": event + timedelta(hours=1),
+                    "return_1d": value,
+                }
+            )
+    return rows
+
+
+def _storage_config() -> dict[str, Any]:
+    datasets = {
+        "daily_returns": "daily_returns",
+        "portfolio_daily_returns": "portfolio_daily_returns",
+        "portfolio_daily_risk_summary": "portfolio_daily_risk_summary",
+    }
+    return {
+        "storage": {
+            "base_dir": "unused",
+            "raw": {"base_path": "unused/raw", "dataset": "market_events"},
+            "curated": {"base_path": "unused/curated", "datasets": datasets},
+            "format": "parquet",
+            "partitioning": {"granularity": "hourly"},
+        }
+    }
+
+
+def test_run_portfolio_risk_publishes_versioned_outputs() -> None:
+    writes: list[tuple[str, dict[str, Any]]] = []
+
+    def writer(records: list[dict[str, Any]], *, dataset: str, **_: Any) -> int:
+        assert len(records) == 1
+        writes.append((dataset, records[0]))
+        return 1
+
+    summary = run_portfolio_risk(
+        portfolio_id="us-tech-equal",
+        portfolio_config_path=Path("unused.yaml"),
+        start_date=None,
+        end_date=date(2026, 1, 4),
+        volatility_window=2,
+        var_window=2,
+        var_confidence=0.95,
+        storage_config_path=Path("unused-storage.yaml"),
+        reader=lambda **_: _records(),
+        writer=writer,
+        storage_config_loader=lambda _: _storage_config(),
+        definition_loader=lambda _path, _portfolio_id: _definition(),
+    )
+
+    assert summary["portfolio_id"] == "us-tech-equal"
+    assert summary["selection"]["aligned_dates"] == 3
+    assert summary["latest_metrics"]["history_status"] == "ready"
+    assert summary["curated_output"]["portfolio_daily_returns"]["records_written"] == 3
+    assert (
+        summary["curated_output"]["portfolio_daily_risk_summary"]["records_written"]
+        == 3
+    )
+    assert len(writes) == 6
+    assert {dataset for dataset, _ in writes} == set(OUTPUT_DATASETS.values())
+
+
+def test_run_portfolio_risk_reports_idempotent_replay() -> None:
+    summary = run_portfolio_risk(
+        portfolio_id="us-tech-equal",
+        portfolio_config_path=Path("unused.yaml"),
+        start_date=date(2026, 1, 4),
+        end_date=date(2026, 1, 4),
+        volatility_window=2,
+        var_window=2,
+        var_confidence=0.95,
+        storage_config_path=Path("unused-storage.yaml"),
+        reader=lambda **_: _records(),
+        writer=lambda *_args, **_kwargs: 0,
+        storage_config_loader=lambda _: _storage_config(),
+        definition_loader=lambda _path, _portfolio_id: _definition(),
+    )
+
+    assert summary["curated_output"]["portfolio_daily_returns"] == {
+        "records_selected": 1,
+        "records_written": 0,
+        "records_already_present": 1,
+    }
+    assert (
+        summary["curated_output"]["portfolio_daily_risk_summary"][
+            "records_already_present"
+        ]
+        == 1
+    )
+
+
+def test_run_portfolio_risk_requires_configured_datasets() -> None:
+    config = _storage_config()
+    del config["storage"]["curated"]["datasets"]["portfolio_daily_risk_summary"]
+
+    with pytest.raises(StorageError, match="missing portfolio datasets"):
+        run_portfolio_risk(
+            portfolio_id="us-tech-equal",
+            portfolio_config_path=Path("unused.yaml"),
+            start_date=None,
+            end_date=date(2026, 1, 4),
+            volatility_window=2,
+            var_window=2,
+            var_confidence=0.95,
+            storage_config_path=Path("unused-storage.yaml"),
+            reader=lambda **_: _records(),
+            writer=lambda *_args, **_kwargs: 1,
+            storage_config_loader=lambda _: config,
+            definition_loader=lambda _path, _portfolio_id: _definition(),
+        )
+
+
+def test_run_portfolio_risk_rejects_invalid_writer_result() -> None:
+    with pytest.raises(StorageError, match="invalid result"):
+        run_portfolio_risk(
+            portfolio_id="us-tech-equal",
+            portfolio_config_path=Path("unused.yaml"),
+            start_date=None,
+            end_date=date(2026, 1, 4),
+            volatility_window=2,
+            var_window=2,
+            var_confidence=0.95,
+            storage_config_path=Path("unused-storage.yaml"),
+            reader=lambda **_: _records(),
+            writer=lambda *_args, **_kwargs: 2,
+            storage_config_loader=lambda _: _storage_config(),
+            definition_loader=lambda _path, _portfolio_id: _definition(),
+        )
+
+
+def test_run_portfolio_risk_rejects_invalid_dates_before_reading() -> None:
+    with pytest.raises(ValidationError, match="start_date"):
+        run_portfolio_risk(
+            portfolio_id="us-tech-equal",
+            portfolio_config_path=Path("unused.yaml"),
+            start_date=date(2026, 1, 5),
+            end_date=date(2026, 1, 4),
+            volatility_window=2,
+            var_window=2,
+            var_confidence=0.95,
+            storage_config_path=Path("unused-storage.yaml"),
+            reader=lambda **_: (_ for _ in ()).throw(AssertionError("reader called")),
+            writer=lambda *_args, **_kwargs: 1,
+            storage_config_loader=lambda _: _storage_config(),
+            definition_loader=lambda _path, _portfolio_id: _definition(),
+        )

--- a/tests/unit/test_storage_config.py
+++ b/tests/unit/test_storage_config.py
@@ -15,6 +15,8 @@ def test_storage_config_valid():
         "daily_returns",
         "daily_volatility",
         "daily_risk_summary",
+        "portfolio_daily_returns",
+        "portfolio_daily_risk_summary",
     }.issubset(storage["curated"]["datasets"])
     assert storage["partitioning"]["granularity"]
 


### PR DESCRIPTION
## Outcome

Add a deterministic multi-symbol portfolio-risk layer on top of the existing versioned `daily_returns` dataset:

```text
current daily-return versions
  -> portfolio definition validation
  -> complete-date alignment
  -> constant-weight daily-rebalanced return
  -> annualised rolling volatility
  -> historical VaR loss and maximum drawdown
  -> versioned curated Parquet
```

Primary arc42 block: `analytics`, with bounded interfaces to orchestration, storage configuration and operator documentation.

## Contracts

- Configure two to fifty unique long-only constituents by source, symbol and positive weight.
- Require weights to sum to one.
- Select the current component calculation for each source/symbol/date by `ts_ingest DESC, calculation_id DESC`.
- Ignore identical duplicated rows but fail closed when one calculation ID is reused for conflicting data.
- Process only dates on which every constituent has a return; report incomplete dates and fail when fewer than two aligned dates remain.
- Persist `constant_weight_daily_rebalanced` explicitly so the weighting assumption is queryable rather than implicit.

## Analytics

- Weighted portfolio daily return and per-constituent contribution evidence.
- Annualised sample volatility using 252 trading days.
- Historical VaR expressed as a positive lower-tail loss magnitude.
- Maximum drawdown from compounded wealth, including the initial wealth level of one.
- `partial` and `ready` history states.
- Deterministic calculation IDs based on the portfolio definition, weighting method, current component versions and risk parameters.

## Runtime and storage

Add:

- `src/analytics/portfolio_risk.py`
- `src/orchestration/run_portfolio_risk.py`
- `config/portfolios.yaml`
- `portfolio_daily_returns`
- `portfolio_daily_risk_summary`
- `make portfolio-risk-demo`

The local reader is bounded to 4,096 Parquet files, 1 GB and 250,000 rows and performs no provider request.

## Validation

The first CI attempt exposed a mypy narrowing issue after runtime string validation. The branch was rebuilt as one replacement commit with explicit validated casts; no check was bypassed.

GitHub Actions run `32431158394` (`ci` run 192) passed on exact head `d39285761d1bcbac5cda77671463ac5c13b6ca12`:

- Security guardrails: passed
- Python readiness: passed
  - locked dependencies resolved
  - Ruff passed
  - mypy passed across 43 source files
  - 426 tests passed, including the DuckDB/Parquet portfolio replay integration
  - `pip check` passed
  - `make readiness-check` passed
- Infrastructure validation: passed
  - Kubernetes overlays rendered with the synchronized storage configuration
  - Terraform formatting, initialization and validation passed without applying infrastructure

No unresolved review threads or requested changes are present.

## Scope

The branch is one commit ahead of `main` and zero behind. It changes 14 files as one source-dataset-to-curated-output contract. It does not add portfolio PostgreSQL tables, FX conversion, transaction costs, non-daily rebalancing schedules, leverage, short positions, scheduling, live credentials, deployment or cloud resources. Portfolio warehouse serving is intentionally the next separate increment.

## Acceptance boundary

This PR is validated and ready for squash merge as one analytics increment.