### PR TITLE
Add portfolio attribution warehouse serving

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ VAR_WINDOW ?= 60
 VAR_CONFIDENCE ?= 0.95
 COVARIANCE_WINDOW ?= 20
 
-.PHONY: setup lint type-check test dependency-check format benchmark-io docker-build k8s-render-dev k8s-render-prod k8s-check terraform-check infrastructure-check quality-check iteration-check clean-generated security-check readiness-check sandbox-once overnight-sandbox morning-review daily-risk-demo portfolio-risk-demo portfolio-attribution-demo warehouse-schema daily-risk-warehouse-dry-run daily-risk-warehouse-load check-daily-risk-consistency portfolio-risk-warehouse-dry-run portfolio-risk-warehouse-load check-portfolio-risk-consistency local-db-up local-db-down local-db-wait local-db-logs postgres-shell mongo-shell run-demo load-postgres-demo load-postgres-dry-run check-postgres-consistency consistency-demo
+.PHONY: setup lint type-check test dependency-check format benchmark-io docker-build k8s-render-dev k8s-render-prod k8s-check terraform-check infrastructure-check quality-check iteration-check clean-generated security-check readiness-check sandbox-once overnight-sandbox morning-review daily-risk-demo portfolio-risk-demo portfolio-attribution-demo warehouse-schema daily-risk-warehouse-dry-run daily-risk-warehouse-load check-daily-risk-consistency portfolio-risk-warehouse-dry-run portfolio-risk-warehouse-load check-portfolio-risk-consistency portfolio-attribution-warehouse-dry-run portfolio-attribution-warehouse-load check-portfolio-attribution-consistency local-db-up local-db-down local-db-wait local-db-logs postgres-shell mongo-shell run-demo load-postgres-demo load-postgres-dry-run check-postgres-consistency consistency-demo
 
 setup:
 	python3 -m venv .venv
@@ -142,6 +142,8 @@ warehouse-schema: local-db-wait
 		< sql/postgres_schema.sql
 	docker compose exec -T postgres psql -U risk_user -d risk_platform \
 		< sql/portfolio_schema.sql
+	docker compose exec -T postgres psql -U risk_user -d risk_platform \
+		< sql/portfolio_attribution_schema.sql
 
 daily-risk-warehouse-dry-run:
 	$(PYTHON) -m src.warehouse.postgres_loader --dry-run
@@ -162,6 +164,18 @@ portfolio-risk-warehouse-load: warehouse-schema
 check-portfolio-risk-consistency:
 	docker compose exec -T postgres psql -U risk_user -d risk_platform \
 		< sql/portfolio_risk_consistency_checks.sql
+
+portfolio-attribution-warehouse-dry-run:
+	$(PYTHON) -m src.warehouse.portfolio_attribution_loader --dry-run
+
+portfolio-attribution-warehouse-load: warehouse-schema
+	$(PYTHON) -m src.warehouse.postgres_loader --dsn "$(LOCAL_POSTGRES_DSN)"
+	$(PYTHON) -m src.warehouse.portfolio_attribution_loader \
+		--dsn "$(LOCAL_POSTGRES_DSN)"
+
+check-portfolio-attribution-consistency:
+	docker compose exec -T postgres psql -U risk_user -d risk_platform \
+		< sql/portfolio_attribution_consistency_checks.sql
 
 local-db-up:
 	docker compose up -d postgres mongo

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ grains and interview-ready engineering evidence.
 1. Ingests market data and external signals.
 2. Validates schemas, normalises symbols and deduplicates events.
 3. Retains immutable, partitioned raw Parquet for replay.
-4. Builds minute-oriented, single-symbol daily and portfolio risk analytics.
+4. Builds minute-oriented, single-symbol daily, portfolio and attribution analytics.
 5. Stores curated Parquet and serves versioned outputs through PostgreSQL views.
 
 ## Quickstart
@@ -213,6 +213,60 @@ weight sets using the same portfolio name therefore remain independently
 queryable. See `docs/portfolio-risk.md` for alignment, weighting, versioning,
 serving and reconciliation details.
 
+## Portfolio Covariance And Attribution Path
+
+After portfolio returns exist, calculate one bounded latest-window covariance and
+volatility-attribution snapshot without another provider request:
+
+```bash
+make portfolio-attribution-demo \
+  PORTFOLIO_ID=us-tech-equal \
+  END_DATE=2026-03-31 \
+  COVARIANCE_WINDOW=20
+```
+
+The snapshot stores annualised sample covariance, Pearson correlation,
+constituent volatility, marginal volatility contribution, Euler component
+contribution and contribution shares in:
+
+```text
+data/curated/portfolio_risk_attribution
+```
+
+Inspect, load and reconcile the attribution warehouse contract:
+
+```bash
+make portfolio-attribution-warehouse-dry-run
+make local-db-up
+make portfolio-attribution-warehouse-load
+make check-portfolio-attribution-consistency
+```
+
+PostgreSQL retains every snapshot in:
+
+```text
+risk_platform.portfolio_risk_attribution
+```
+
+Current and row-level reporting contracts are:
+
+```text
+risk_platform.latest_portfolio_risk_attribution
+risk_platform.portfolio_attribution_semantic_model
+risk_platform.portfolio_covariance_model
+risk_platform.portfolio_correlation_model
+risk_platform.portfolio_volatility_contribution_model
+```
+
+The current grain preserves the portfolio definition, event date, model,
+weighting method, covariance and correlation methods, covariance window and
+annualisation basis. Matrix views expose one ordered constituent pair per row;
+the volatility-contribution view exposes one constituent per row. Undefined
+zero-variance correlations remain SQL `NULL`, not non-standard `NaN`.
+
+See `docs/portfolio-attribution.md` for formulas, version selection, JSON
+evidence, warehouse constraints and reconciliation.
+
 ## Data Sources
 
 The implemented external market source is Alpha Vantage daily time series. The
@@ -232,24 +286,25 @@ Additional preparation and operating notes:
 1. `docs/demo-script.md` for a short technical walkthrough
 2. `docs/daily-risk-pipeline.md` for the real daily source-to-serving path
 3. `docs/portfolio-risk.md` for multi-symbol portfolio analytics and serving
-4. `docs/preparation-plan.md` for interview preparation
-5. `docs/interview-stories.md` for interview story rehearsal
-6. `docs/mock-interview.md` for timed interview practice
-7. `docs/elt-mapping.md` for connector-based ELT mapping
-8. `docs/source-document-mapping.md` for nested source document flattening
-9. `docs/postgres-mongodb-walkthrough.md` for local source-to-warehouse inspection
-10. `docs/data-consistency-walkthrough.md` for source-to-warehouse reconciliation
-11. `docs/aws-managed-databases.md` for disabled-by-default database IaC
-12. `docs/lambda-s3-orchestration.md` for AWS orchestration mapping
-13. `sql/postgres_schema.sql` and `sql/ops_queries.sql` for warehouse examples
-14. `docs/agentic-workflows.md` for larger delegated development workflows
-15. `docs/engineering-delivery-workflow.md` for the controlled agent loop
-16. `docs/agent-roles.md` for splitting work across bounded roles
-17. `docs/overnight-sandbox.md` for safe unattended validation runs
-18. `docs/overnight-development.md` for guarded candidate-branch controls
-19. `docs/security-protocols.md` for local and cloud safety controls
-20. `docs/operational-runbook.md` for local failure investigation
-21. `docs/iteration-loop.md` and `docs/iteration-backlog.md` for continued iterations
+4. `docs/portfolio-attribution.md` for covariance and component-risk attribution
+5. `docs/preparation-plan.md` for interview preparation
+6. `docs/interview-stories.md` for interview story rehearsal
+7. `docs/mock-interview.md` for timed interview practice
+8. `docs/elt-mapping.md` for connector-based ELT mapping
+9. `docs/source-document-mapping.md` for nested source document flattening
+10. `docs/postgres-mongodb-walkthrough.md` for local source-to-warehouse inspection
+11. `docs/data-consistency-walkthrough.md` for source-to-warehouse reconciliation
+12. `docs/aws-managed-databases.md` for disabled-by-default database IaC
+13. `docs/lambda-s3-orchestration.md` for AWS orchestration mapping
+14. `sql/postgres_schema.sql` and `sql/ops_queries.sql` for warehouse examples
+15. `docs/agentic-workflows.md` for larger delegated development workflows
+16. `docs/engineering-delivery-workflow.md` for the controlled agent loop
+17. `docs/agent-roles.md` for splitting work across bounded roles
+18. `docs/overnight-sandbox.md` for safe unattended validation runs
+19. `docs/overnight-development.md` for guarded candidate-branch controls
+20. `docs/security-protocols.md` for local and cloud safety controls
+21. `docs/operational-runbook.md` for local failure investigation
+22. `docs/iteration-loop.md` and `docs/iteration-backlog.md` for continued iterations
 
 ## Local Database Playground
 
@@ -272,13 +327,16 @@ flow. The PostgreSQL serving layer includes:
 symbol_dimension_history -> current_symbol_dimension -> finance_risk_semantic_model
                                                   \-> daily_risk_semantic_model
 portfolio_daily_returns -> portfolio_daily_risk_summary
-                         -> portfolio current and contribution views
+                         -> portfolio current and return-contribution views
+portfolio_risk_attribution
+  -> current attribution
+  -> covariance / correlation / volatility-contribution views
 ```
 
 The original semantic view demonstrates SCD Type 2 enrichment for the
 minute-oriented demo. The daily view preserves model versions and performs a
-source-aware dimension join. Portfolio views preserve definition and parameter
-versions and expose constituent-level contributions.
+source-aware dimension join. Portfolio and attribution views preserve definition
+and parameter versions while exposing queryable constituent grains.
 
 ## Performance Benchmark
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,7 @@ services:
       - ./sql/postgres_schema.sql:/docker-entrypoint-initdb.d/01_schema.sql:ro
       - ./sql/postgres_demo_data.sql:/docker-entrypoint-initdb.d/02_demo_data.sql:ro
       - ./sql/portfolio_schema.sql:/docker-entrypoint-initdb.d/03_portfolio_schema.sql:ro
+      - ./sql/portfolio_attribution_schema.sql:/docker-entrypoint-initdb.d/04_portfolio_attribution_schema.sql:ro
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U risk_user -d risk_platform"]
       interval: 5s

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -27,10 +27,12 @@ current daily-return versions
   -> complete-date alignment
   -> versioned portfolio returns and risk summaries
   -> version-preserving PostgreSQL tables
-  -> current-version, semantic and contribution views
+  -> current-version, semantic and return-contribution views
   -> latest-window covariance and correlation
   -> Euler component-volatility attribution
   -> versioned portfolio_risk_attribution Parquet
+  -> version-preserving PostgreSQL attribution snapshots
+  -> current matrix and volatility-contribution views
 ```
 
 The leading quality goals are:
@@ -38,8 +40,8 @@ The leading quality goals are:
 | Priority | Quality goal | Evidence |
 | --- | --- | --- |
 | 1 | Deterministic replay | Stable event IDs, content-addressed Parquet and calculation IDs |
-| 2 | Explicit contracts | Pydantic schemas, dataset grains, SQL constraints and loader specs |
-| 3 | Source-to-serving traceability | Lineage, input fingerprints, JSON evidence and reconciliation SQL |
+| 2 | Explicit contracts | Pydantic schemas, dataset grains, SQL constraints and loader contracts |
+| 3 | Source-to-serving traceability | Input fingerprints, JSONB evidence, views and reconciliation SQL |
 | 4 | Safe operation | Local-first commands, bounded scans, manual deployment and security checks |
 | 5 | Reviewable evolution | Arc42 change blocks, focused tests, CI and squash-merged PRs |
 
@@ -102,11 +104,12 @@ The data plane is split into:
 3. **Analytics** — minute metrics, daily risk, portfolio aggregation, covariance,
    volatility attribution and data quality.
 4. **Storage** — bounded, idempotent raw and curated Parquet publication.
-5. **Orchestration** — sequencing, locks, backfills and summaries.
-6. **Warehouse** — PostgreSQL loading, version retention, views and checks.
+5. **Orchestration** — sequencing, locks, backfills and run summaries.
+6. **Warehouse** — PostgreSQL loading, version retention, row-expansion views and
+   reconciliation.
 
-Minute, single-symbol daily and portfolio semantics stay separate. Daily,
-portfolio and attribution calculations use explicit model versions and
+Minute, single-symbol daily, portfolio and attribution semantics stay separate.
+Daily, portfolio and attribution calculations use explicit model versions and
 deterministic calculation IDs so late source history, changed parameters,
 changed weights or changed covariance windows create new traceable versions
 without overwriting earlier evidence.
@@ -118,10 +121,10 @@ without overwriting earlier evidence.
 | `common` | Configuration, time, logging and exceptions | `src/common/` |
 | `ingestion` | Alpha Vantage and provider-neutral inbound contracts | `src/ingestion/` |
 | `processing` | Validation, normalisation, deduplication and windowing | `src/processing/` |
-| `analytics` | Returns, volatility, VaR, drawdown, covariance, portfolio aggregation, attribution and quality | `src/analytics/` |
+| `analytics` | Returns, VaR, drawdown, covariance, aggregation, attribution and quality | `src/analytics/` |
 | `storage` | Dataset configuration and local Parquet publication | `src/storage/`, `config/storage.yaml` |
-| `orchestration` | Demo pipeline, daily risk, portfolio risk, attribution, locks and backfills | `src/orchestration/` |
-| `warehouse` | Loader specs, SQL schema, current views and reconciliation | `src/warehouse/`, `sql/` |
+| `orchestration` | Demo, daily, portfolio and attribution runners plus locks and backfills | `src/orchestration/` |
+| `warehouse` | Loaders, SQL schemas, current views and reconciliation | `src/warehouse/`, `sql/` |
 | `source-systems` | Local PostgreSQL and MongoDB examples | `docker-compose.yml`, `mongo/` |
 | `deployment` | Image, Kubernetes and Terraform scaffold | `Dockerfile`, `deploy/`, `infra/` |
 | `engineering-controls` | CI, security checks and review evidence | `.github/`, `scripts/`, `AGENTS.md` |
@@ -206,27 +209,6 @@ configured constituent are emitted. Weights are positive, unique by
 source/symbol and sum to one. Component returns, contributions and calculation
 IDs remain embedded as stable JSON evidence.
 
-### Portfolio covariance and volatility attribution
-
-```text
-current portfolio_daily_returns versions
-  -> selected portfolio definition fingerprint
-  -> bounded latest covariance window
-  -> annualised sample covariance
-  -> Pearson correlation
-  -> Euler component contributions to portfolio volatility
-  -> portfolio_risk_attribution
-```
-
-The attribution path validates the persisted portfolio-return evidence against
-the selected definition, ranks corrections by ingest time and calculation ID,
-and requires the full configured window. It writes one latest-window snapshot
-that contains JSON covariance and correlation matrices plus constituent
-volatility, marginal contribution, component contribution and contribution-share
-mappings. Undefined zero-variance correlations are stored as JSON `null`, never
-non-standard `NaN`. Component contributions reconcile to total portfolio
-volatility within a strict numerical tolerance.
-
 ### Portfolio warehouse serving
 
 ```text
@@ -234,7 +216,7 @@ portfolio curated Parquet
   -> JSON-aware calculation-ID upserts
   -> version-preserving portfolio history
   -> definition- and parameter-aware current views
-  -> portfolio summary and constituent contribution views
+  -> portfolio summary and constituent return-contribution views
   -> portfolio reconciliation checks
 ```
 
@@ -252,9 +234,56 @@ queryable.
 
 `portfolio_risk_semantic_model` exposes current portfolio summaries.
 `portfolio_daily_contribution_model` expands each current return into one row per
-constituent with weight, component return, component calculation ID and
-contribution. Attribution remains curated Parquet in the current increment; its
-warehouse serving contract is a separate change.
+constituent with weight, component return, component calculation ID and return
+contribution.
+
+### Portfolio covariance and volatility attribution
+
+```text
+current portfolio_daily_returns versions
+  -> selected portfolio definition fingerprint
+  -> bounded latest covariance window
+  -> annualised sample covariance
+  -> Pearson correlation
+  -> Euler component contributions to portfolio volatility
+  -> portfolio_risk_attribution
+```
+
+The attribution path validates the persisted portfolio-return evidence against
+the selected definition, ranks corrections by ingest time and calculation ID,
+and requires the full configured window. It writes one latest-window snapshot
+that contains covariance and correlation matrices plus constituent volatility,
+marginal contribution, component contribution and contribution-share mappings.
+Undefined zero-variance correlations are stored as JSON `null`, never
+non-standard `NaN`. Component contributions reconcile to total portfolio
+volatility within a strict numerical tolerance.
+
+### Attribution warehouse serving
+
+```text
+portfolio_risk_attribution Parquet
+  -> bounded JSON-aware calculation-ID upsert
+  -> risk_platform.portfolio_risk_attribution history
+  -> latest_portfolio_risk_attribution
+  -> portfolio_attribution_semantic_model
+  -> portfolio_covariance_model
+  -> portfolio_correlation_model
+  -> portfolio_volatility_contribution_model
+  -> attribution reconciliation checks
+```
+
+The base table preserves every deterministic snapshot. The current grain includes
+the portfolio definition, event date, model and weighting method, covariance and
+correlation methods, covariance window and annualisation basis. Within the grain,
+`ts_ingest DESC, calculation_id DESC` selects the current version.
+
+The matrix views expose one row per ordered constituent pair. The contribution
+view exposes one row per constituent without recalculating covariance or
+volatility. `portfolio-attribution-warehouse-load` first loads prerequisite
+portfolio-return facts and then the attribution snapshot.
+`check-portfolio-attribution-consistency` verifies input references, matrix
+shape and symmetry, correlation null semantics, variance/volatility identity and
+Euler reconciliation.
 
 ### Backfill
 
@@ -286,7 +315,8 @@ deploys and never runs `terraform apply`.
 | Replay | Immutable raw data and content-addressed curated files |
 | Versioning | Daily, portfolio and attribution versions are retained rather than overwritten |
 | Configuration | YAML for storage, thresholds, symbols, portfolios and operator choices |
-| Evidence | Component IDs, weights, returns, covariance and contributions persist as JSON-ready mappings |
+| Evidence | Component IDs, weights, returns, matrices and contributions persist as JSONB-ready mappings |
+| Serving | JSON history remains intact while SQL views expose queryable row grains |
 | Data quality | Required fields, nulls, ranges, late and duplicate evidence |
 | Concurrency | Local partition locks and repository-global lease fencing |
 | Recovery | Resume checkpoints and safe reruns |
@@ -299,12 +329,12 @@ deploys and never runs `terraform apply`.
 | --- | --- |
 | Batch before streaming | Lower operational complexity at the cost of latency |
 | Immutable raw before analytics | Explainable replay, but no table-format transactions |
-| Separate minute, daily and portfolio semantics | Clear grains and names, with explicit orchestration paths |
-| Calculation ID as warehouse version key | Retains corrections and parameter versions |
+| Separate minute, daily, portfolio and attribution semantics | Clear grains and explicit orchestration paths |
+| Calculation ID as warehouse version key | Retains corrections, definitions and parameter versions |
 | Portfolio definition fingerprint in current grains | Weight configurations do not silently overwrite one another |
-| JSON evidence plus contribution view | Preserves source calculations while enabling row-level attribution queries |
+| JSONB evidence plus row-expansion views | Preserves deterministic documents while enabling SQL analysis |
 | Latest-window attribution snapshot | Bounded output and simple replay, but not a full historical matrix series |
-| Sample covariance and Euler volatility contribution | Transparent risk decomposition without a factor or shrinkage model |
+| Sample covariance and Euler volatility contribution | Transparent decomposition without a factor or shrinkage model |
 | PostgreSQL serving | Familiar constraints and views, not a distributed warehouse |
 | Local locks | Simple overlap protection, not distributed coordination |
 | Manual cloud activation | Prevents surprise cost and mutation |
@@ -324,11 +354,13 @@ deploys and never runs `terraform apply`.
 | Q8 | Portfolio constituent dates are incomplete | Exclude the date, report the count and fail if alignment is insufficient |
 | Q9 | A portfolio component calculation ID conflicts | Fail rather than make a file-order-dependent choice |
 | Q10 | A portfolio definition or parameter changes | Retain both versions and keep both current grains queryable |
-| Q11 | A consumer asks for portfolio contributions | Return one row per constituent without multiplying portfolio facts |
+| Q11 | A consumer asks for portfolio return contributions | Return one row per constituent without multiplying facts |
 | Q12 | A portfolio covariance window is incomplete | Fail without publishing a partial attribution snapshot |
 | Q13 | A zero-variance constituent has undefined correlation | Persist JSON nulls and explicit status, not NaN |
 | Q14 | Component volatility contributions are calculated | Reconcile their sum to portfolio volatility |
-| Q15 | Default infrastructure checks run | Validate without deployment or resource creation |
+| Q15 | An attribution correction is loaded | Retain history and select the newest row in its declared grain |
+| Q16 | A consumer queries a matrix or attribution vector | Return one row per pair or constituent with no analytical recomputation |
+| Q17 | Default infrastructure checks run | Validate without deployment or resource creation |
 
 ## 11. Risks And Technical Debt
 
@@ -340,8 +372,8 @@ deploys and never runs `terraform apply`.
 5. The default container command runs the minute-oriented demo, not the daily,
    portfolio or attribution operator sequences.
 6. Production scheduling, alerts and dashboards are not implemented.
-7. Attribution is a latest-window curated snapshot only; historical snapshots and
-   PostgreSQL attribution serving are not implemented.
+7. Attribution is a latest-window snapshot only; historical snapshots for every
+   event date are not calculated.
 8. Shrinkage, exponentially weighted and factor covariance estimators, marginal
    VaR, FX conversion, short positions, leverage, transaction costs and
    non-daily rebalancing are not implemented.
@@ -369,5 +401,6 @@ deploys and never runs `terraform apply`.
 | Portfolio definition | Long-only source/symbol constituents and weights that sum to one |
 | Return contribution | Weight multiplied by the constituent daily return |
 | Covariance window | Latest current portfolio-return observations used to estimate the matrix |
+| Attribution snapshot | One retained covariance, correlation and volatility-decomposition calculation |
 | Component volatility contribution | Euler allocation of portfolio volatility to one constituent |
 | Human acceptance | Explicit engineer decision after reviewing code and evidence |

--- a/docs/portfolio-attribution.md
+++ b/docs/portfolio-attribution.md
@@ -2,8 +2,9 @@
 
 ## Outcome
 
-This increment turns retained portfolio daily returns into one deterministic
-risk-attribution snapshot for a configured portfolio definition:
+This path turns retained portfolio daily returns into one deterministic
+risk-attribution snapshot for a configured portfolio definition and serves every
+retained snapshot through PostgreSQL:
 
 ```text
 current portfolio_daily_returns versions
@@ -13,11 +14,15 @@ current portfolio_daily_returns versions
   -> Pearson correlation matrix
   -> Euler component contributions to portfolio volatility
   -> versioned portfolio_risk_attribution Parquet
+  -> version-preserving PostgreSQL history
+  -> current covariance, correlation and contribution views
 ```
 
 The pure calculation is owned by
 `src/analytics/portfolio_attribution.py`. The local runner is
-`src/orchestration/run_portfolio_attribution.py`.
+`src/orchestration/run_portfolio_attribution.py`. The warehouse schema is
+`sql/portfolio_attribution_schema.sql`, and the dedicated loader is
+`src/warehouse/portfolio_attribution_loader.py`.
 
 ## Operator Flow
 
@@ -33,7 +38,7 @@ make portfolio-risk-demo \
   END_DATE=2026-03-31
 ```
 
-Then calculate the latest attribution snapshot without another provider request:
+Calculate the latest attribution snapshot without another provider request:
 
 ```bash
 make portfolio-attribution-demo \
@@ -45,6 +50,26 @@ make portfolio-attribution-demo \
 The credential-free run summary is written to
 `.demo/portfolio-attribution-summary.json`. The curated snapshot is written under
 `data/curated/portfolio_risk_attribution`.
+
+Inspect the attribution warehouse batch without connecting to PostgreSQL:
+
+```bash
+make portfolio-attribution-warehouse-dry-run
+```
+
+Load the prerequisite daily and portfolio calculations, load attribution, and
+run the focused reconciliation checks:
+
+```bash
+make local-db-up
+make portfolio-attribution-warehouse-load
+make check-portfolio-attribution-consistency
+```
+
+`portfolio-attribution-warehouse-load` reapplies the core, portfolio and
+attribution schemas, loads the prerequisite warehouse facts, and then loads the
+attribution snapshot. This allows an already-running local database to receive
+the new objects without recreating its Docker volume.
 
 ## Input Version Selection
 
@@ -120,7 +145,7 @@ have a negative component contribution.
 When portfolio volatility is numerically zero, all marginal, component and share
 values are explicitly set to zero and `volatility_status` is `zero`.
 
-## Dataset Grain
+## Curated Dataset Grain
 
 `portfolio_risk_attribution` contains one row for:
 
@@ -148,9 +173,80 @@ method, covariance window, annualisation basis and ordered current input
 calculation IDs. Replaying the same state writes no duplicate Parquet record. An
 upstream correction, weight change or window change produces a distinct version.
 
+## PostgreSQL Serving Contract
+
+The warehouse retains every calculation in:
+
+```text
+risk_platform.portfolio_risk_attribution
+```
+
+`calculation_id` is the primary and loader conflict key. Replaying an identical
+snapshot converges on one stored row. A corrected input, changed definition or
+changed covariance window remains a distinct retained version.
+
+The current-version grain is:
+
+```text
+portfolio_id
+definition_fingerprint
+ts_event
+model_version
+weighting_method
+covariance_method
+correlation_method
+covariance_window
+annualization_days
+```
+
+Within that grain, `ts_ingest DESC, calculation_id DESC` selects the current
+version through:
+
+```text
+risk_platform.latest_portfolio_risk_attribution
+```
+
+The scalar and JSON snapshot contract is exposed through:
+
+```text
+risk_platform.portfolio_attribution_semantic_model
+```
+
+The matrices and contribution vectors are expanded without recalculating the
+analytics:
+
+```text
+risk_platform.portfolio_covariance_model
+risk_platform.portfolio_correlation_model
+risk_platform.portfolio_volatility_contribution_model
+```
+
+`portfolio_covariance_model` and `portfolio_correlation_model` expose one row per
+ordered constituent pair. Undefined correlation cells remain SQL `NULL`.
+`portfolio_volatility_contribution_model` exposes one row per constituent with
+its weight, annualised standalone volatility, marginal contribution, component
+contribution and contribution share.
+
+## Reconciliation Evidence
+
+`sql/portfolio_attribution_consistency_checks.sql` verifies:
+
+- every retained input calculation ID references a portfolio-return row;
+- the current attribution snapshot uses current portfolio-return versions;
+- input IDs, window boundaries and definition metadata align;
+- JSON vector and matrix keys match the declared constituents;
+- portfolio weights sum to one;
+- covariance is symmetric with non-negative diagonals;
+- correlation is symmetric, bounded and has the declared null count;
+- squared portfolio volatility matches portfolio variance;
+- Euler component contributions and shares reconcile;
+- calculation IDs and current grains remain unique;
+- the latest view selects the newest candidate; and
+- semantic, matrix and contribution views have the expected row counts.
+
 ## Safety Bounds
 
-The local reader:
+The analytics reader:
 
 - accepts only `portfolio_daily_returns` from the configured curated base path;
 - filters to one portfolio ID, definition fingerprint and completed end date;
@@ -159,10 +255,15 @@ The local reader:
 - requires exact portfolio-return fields; and
 - performs no provider request.
 
+The warehouse loader applies the same file, byte and row limits to
+`portfolio_risk_attribution`, rejects unsafe local paths, converts only the
+declared JSON evidence fields to JSONB, and performs no analytical
+recalculation.
+
 ## Current Boundary
 
-This slice produces a curated latest-window attribution snapshot only. It does
-not yet add PostgreSQL attribution tables or views, historical snapshots for
-every event date, shrinkage or exponentially weighted covariance estimators,
-factor models, marginal VaR, FX conversion, leverage, short positions,
-transaction costs, scheduled rebalancing, dashboards or alert delivery.
+This path stores one latest-window snapshot per explicit calculation identity. It
+does not yet calculate historical attribution snapshots for every event date,
+shrinkage or exponentially weighted covariance estimators, factor models,
+marginal VaR, FX conversion, leverage, short positions, transaction costs,
+scheduled rebalancing, production scheduling, dashboards or alert delivery.

--- a/sql/portfolio_attribution_consistency_checks.sql
+++ b/sql/portfolio_attribution_consistency_checks.sql
@@ -1,0 +1,539 @@
+-- Reconciliation checks for portfolio covariance and volatility-attribution serving.
+-- Run after the core, portfolio and attribution schemas are applied and local
+-- Parquet outputs have been loaded into PostgreSQL.
+
+WITH attribution_counts AS (
+    SELECT
+        (SELECT COUNT(*) FROM risk_platform.portfolio_risk_attribution)
+            AS attribution_rows,
+        (SELECT COUNT(*) FROM risk_platform.latest_portfolio_risk_attribution)
+            AS latest_rows,
+        (SELECT COUNT(*) FROM risk_platform.portfolio_attribution_semantic_model)
+            AS semantic_rows,
+        (SELECT COUNT(*) FROM risk_platform.portfolio_covariance_model)
+            AS covariance_rows,
+        (SELECT COUNT(*) FROM risk_platform.portfolio_correlation_model)
+            AS correlation_rows,
+        (
+            SELECT COUNT(*)
+            FROM risk_platform.portfolio_volatility_contribution_model
+        ) AS contribution_rows,
+        (
+            SELECT COALESCE(SUM(constituent_count), 0)
+            FROM risk_platform.latest_portfolio_risk_attribution
+        ) AS expected_contribution_rows,
+        (
+            SELECT COALESCE(SUM(constituent_count * constituent_count), 0)
+            FROM risk_platform.latest_portfolio_risk_attribution
+        ) AS expected_matrix_rows
+),
+integrity AS (
+    SELECT
+        (
+            SELECT COUNT(*)
+            FROM risk_platform.portfolio_risk_attribution attribution
+            CROSS JOIN LATERAL jsonb_array_elements_text(
+                attribution.input_calculation_ids_json
+            ) input_id
+            LEFT JOIN risk_platform.portfolio_daily_returns portfolio_return
+                ON portfolio_return.calculation_id = input_id.value
+            WHERE portfolio_return.calculation_id IS NULL
+        ) AS orphan_input_calculation_ids,
+        (
+            SELECT COUNT(*)
+            FROM risk_platform.latest_portfolio_risk_attribution attribution
+            CROSS JOIN LATERAL jsonb_array_elements_text(
+                attribution.input_calculation_ids_json
+            ) input_id
+            LEFT JOIN risk_platform.latest_portfolio_daily_returns portfolio_return
+                ON portfolio_return.calculation_id = input_id.value
+            WHERE portfolio_return.calculation_id IS NULL
+        ) AS stale_latest_input_calculation_ids,
+        (
+            SELECT COUNT(*)
+            FROM risk_platform.portfolio_risk_attribution attribution
+            WHERE
+                attribution.input_first_calculation_id
+                    <> attribution.input_calculation_ids_json ->> 0
+                OR attribution.input_last_calculation_id
+                    <> attribution.input_calculation_ids_json ->> (
+                        jsonb_array_length(
+                            attribution.input_calculation_ids_json
+                        ) - 1
+                    )
+                OR (
+                    SELECT MIN(portfolio_return.ts_event)
+                    FROM jsonb_array_elements_text(
+                        attribution.input_calculation_ids_json
+                    ) input_id
+                    JOIN risk_platform.portfolio_daily_returns portfolio_return
+                        ON portfolio_return.calculation_id = input_id.value
+                ) <> attribution.window_start
+                OR (
+                    SELECT MAX(portfolio_return.ts_event)
+                    FROM jsonb_array_elements_text(
+                        attribution.input_calculation_ids_json
+                    ) input_id
+                    JOIN risk_platform.portfolio_daily_returns portfolio_return
+                        ON portfolio_return.calculation_id = input_id.value
+                ) <> attribution.window_end
+                OR EXISTS (
+                    SELECT 1
+                    FROM jsonb_array_elements_text(
+                        attribution.input_calculation_ids_json
+                    ) input_id
+                    JOIN risk_platform.portfolio_daily_returns portfolio_return
+                        ON portfolio_return.calculation_id = input_id.value
+                    WHERE
+                        portfolio_return.portfolio_id
+                            <> attribution.portfolio_id
+                        OR portfolio_return.definition_fingerprint
+                            <> attribution.definition_fingerprint
+                        OR portfolio_return.weighting_method
+                            <> attribution.weighting_method
+                        OR portfolio_return.base_currency
+                            <> attribution.base_currency
+                )
+        ) AS invalid_input_windows,
+        (
+            SELECT COUNT(*)
+            FROM risk_platform.portfolio_risk_attribution attribution
+            WHERE
+                (
+                    SELECT COUNT(*)
+                    FROM jsonb_object_keys(attribution.weights_json)
+                ) <> attribution.constituent_count
+                OR (
+                    SELECT COUNT(*)
+                    FROM jsonb_object_keys(
+                        attribution.constituent_volatility_annualized_json
+                    )
+                ) <> attribution.constituent_count
+                OR (
+                    SELECT COUNT(*)
+                    FROM jsonb_object_keys(
+                        attribution.marginal_volatility_contribution_json
+                    )
+                ) <> attribution.constituent_count
+                OR (
+                    SELECT COUNT(*)
+                    FROM jsonb_object_keys(
+                        attribution.component_volatility_contribution_json
+                    )
+                ) <> attribution.constituent_count
+                OR (
+                    SELECT COUNT(*)
+                    FROM jsonb_object_keys(
+                        attribution.component_contribution_share_json
+                    )
+                ) <> attribution.constituent_count
+                OR EXISTS (
+                    SELECT 1
+                    FROM jsonb_object_keys(attribution.weights_json)
+                        AS weight_keys(key)
+                    WHERE NOT (
+                        attribution.constituent_volatility_annualized_json
+                        ? weight_keys.key
+                    )
+                )
+                OR EXISTS (
+                    SELECT 1
+                    FROM jsonb_object_keys(attribution.weights_json)
+                        AS weight_keys(key)
+                    WHERE NOT (
+                        attribution.marginal_volatility_contribution_json
+                        ? weight_keys.key
+                    )
+                )
+                OR EXISTS (
+                    SELECT 1
+                    FROM jsonb_object_keys(attribution.weights_json)
+                        AS weight_keys(key)
+                    WHERE NOT (
+                        attribution.component_volatility_contribution_json
+                        ? weight_keys.key
+                    )
+                )
+                OR EXISTS (
+                    SELECT 1
+                    FROM jsonb_object_keys(attribution.weights_json)
+                        AS weight_keys(key)
+                    WHERE NOT (
+                        attribution.component_contribution_share_json
+                        ? weight_keys.key
+                    )
+                )
+                OR (
+                    SELECT COUNT(*)
+                    FROM jsonb_each(
+                        attribution.covariance_annualized_json
+                    ) matrix_row
+                    CROSS JOIN LATERAL jsonb_each(matrix_row.value) matrix_cell
+                ) <> attribution.constituent_count * attribution.constituent_count
+                OR (
+                    SELECT COUNT(*)
+                    FROM jsonb_each(attribution.correlation_json) matrix_row
+                    CROSS JOIN LATERAL jsonb_each(matrix_row.value) matrix_cell
+                ) <> attribution.constituent_count * attribution.constituent_count
+                OR EXISTS (
+                    SELECT 1
+                    FROM jsonb_each(
+                        attribution.covariance_annualized_json
+                    ) matrix_row
+                    WHERE jsonb_typeof(matrix_row.value) <> 'object'
+                )
+                OR EXISTS (
+                    SELECT 1
+                    FROM jsonb_each(attribution.correlation_json) matrix_row
+                    WHERE jsonb_typeof(matrix_row.value) <> 'object'
+                )
+        ) AS invalid_json_shapes,
+        (
+            SELECT COUNT(*)
+            FROM risk_platform.portfolio_risk_attribution attribution
+            WHERE ABS(
+                (
+                    SELECT SUM(weight.value::TEXT::DOUBLE PRECISION)
+                    FROM jsonb_each(attribution.weights_json) weight
+                ) - 1.0
+            ) > 0.000000001
+        ) AS invalid_weight_totals,
+        (
+            SELECT COUNT(*)
+            FROM risk_platform.portfolio_covariance_model covariance
+            LEFT JOIN risk_platform.portfolio_covariance_model reverse_covariance
+                ON reverse_covariance.attribution_calculation_id
+                    = covariance.attribution_calculation_id
+                AND reverse_covariance.row_constituent_key
+                    = covariance.column_constituent_key
+                AND reverse_covariance.column_constituent_key
+                    = covariance.row_constituent_key
+            WHERE
+                reverse_covariance.attribution_calculation_id IS NULL
+                OR ABS(
+                    covariance.covariance_annualized
+                    - reverse_covariance.covariance_annualized
+                ) > 0.0000000001
+                OR (
+                    covariance.row_constituent_key
+                        = covariance.column_constituent_key
+                    AND covariance.covariance_annualized < -0.000000000001
+                )
+        ) AS invalid_covariance_cells,
+        (
+            SELECT COUNT(*)
+            FROM risk_platform.portfolio_correlation_model correlation
+            LEFT JOIN risk_platform.portfolio_correlation_model reverse_correlation
+                ON reverse_correlation.attribution_calculation_id
+                    = correlation.attribution_calculation_id
+                AND reverse_correlation.row_constituent_key
+                    = correlation.column_constituent_key
+                AND reverse_correlation.column_constituent_key
+                    = correlation.row_constituent_key
+            WHERE
+                reverse_correlation.attribution_calculation_id IS NULL
+                OR (
+                    (correlation.correlation IS NULL)
+                    <> (reverse_correlation.correlation IS NULL)
+                )
+                OR (
+                    correlation.correlation IS NOT NULL
+                    AND reverse_correlation.correlation IS NOT NULL
+                    AND ABS(
+                        correlation.correlation
+                        - reverse_correlation.correlation
+                    ) > 0.0000000001
+                )
+                OR (
+                    correlation.correlation IS NOT NULL
+                    AND (
+                        correlation.correlation < -1.0000000001
+                        OR correlation.correlation > 1.0000000001
+                    )
+                )
+                OR (
+                    correlation.row_constituent_key
+                        = correlation.column_constituent_key
+                    AND correlation.correlation IS NOT NULL
+                    AND ABS(correlation.correlation - 1.0)
+                        > 0.0000000001
+                )
+        ) AS invalid_correlation_cells,
+        (
+            SELECT COUNT(*)
+            FROM risk_platform.portfolio_risk_attribution attribution
+            WHERE
+                (
+                    SELECT COUNT(*)
+                    FROM risk_platform.portfolio_correlation_model correlation
+                    WHERE
+                        correlation.attribution_calculation_id
+                            = attribution.calculation_id
+                        AND correlation.correlation_undefined
+                ) <> attribution.undefined_correlation_cells
+        ) AS invalid_undefined_correlation_counts,
+        (
+            SELECT COUNT(*)
+            FROM risk_platform.portfolio_risk_attribution attribution
+            WHERE ABS(
+                attribution.portfolio_variance_annualized
+                - POWER(attribution.portfolio_volatility_annualized, 2)
+            ) > 0.0000000001
+        ) AS invalid_variance_volatility_rows,
+        (
+            SELECT COUNT(*)
+            FROM risk_platform.latest_portfolio_risk_attribution attribution
+            LEFT JOIN LATERAL (
+                SELECT
+                    SUM(contribution.component_volatility_contribution)
+                        AS component_total,
+                    SUM(contribution.contribution_share) AS share_total,
+                    SUM(contribution.weight) AS weight_total,
+                    COUNT(*) AS component_count
+                FROM risk_platform.portfolio_volatility_contribution_model
+                    contribution
+                WHERE
+                    contribution.attribution_calculation_id
+                        = attribution.calculation_id
+            ) totals ON true
+            WHERE
+                totals.component_count <> attribution.constituent_count
+                OR ABS(
+                    totals.component_total
+                    - attribution.portfolio_volatility_annualized
+                ) > 0.000000001
+                OR ABS(totals.weight_total - 1.0) > 0.000000001
+                OR (
+                    attribution.volatility_status = 'positive'
+                    AND ABS(totals.share_total - 1.0) > 0.000000001
+                )
+                OR (
+                    attribution.volatility_status = 'zero'
+                    AND ABS(totals.share_total) > 0.000000001
+                )
+                OR ABS(attribution.euler_residual) > 0.00000001
+        ) AS invalid_euler_rows,
+        (
+            SELECT COUNT(*) - COUNT(DISTINCT calculation_id)
+            FROM risk_platform.portfolio_risk_attribution
+        ) AS duplicate_calculation_ids,
+        (
+            SELECT COUNT(*)
+            FROM (
+                SELECT
+                    portfolio_id,
+                    definition_fingerprint,
+                    ts_event,
+                    model_version,
+                    weighting_method,
+                    covariance_method,
+                    correlation_method,
+                    covariance_window,
+                    annualization_days
+                FROM risk_platform.latest_portfolio_risk_attribution
+                GROUP BY
+                    portfolio_id,
+                    definition_fingerprint,
+                    ts_event,
+                    model_version,
+                    weighting_method,
+                    covariance_method,
+                    correlation_method,
+                    covariance_window,
+                    annualization_days
+                HAVING COUNT(*) > 1
+            ) duplicate_grains
+        ) AS duplicate_latest_grains,
+        (
+            SELECT COUNT(*)
+            FROM risk_platform.latest_portfolio_risk_attribution latest
+            JOIN risk_platform.portfolio_risk_attribution candidate
+                ON candidate.portfolio_id = latest.portfolio_id
+                AND candidate.definition_fingerprint
+                    = latest.definition_fingerprint
+                AND candidate.ts_event = latest.ts_event
+                AND candidate.model_version = latest.model_version
+                AND candidate.weighting_method = latest.weighting_method
+                AND candidate.covariance_method = latest.covariance_method
+                AND candidate.correlation_method = latest.correlation_method
+                AND candidate.covariance_window = latest.covariance_window
+                AND candidate.annualization_days = latest.annualization_days
+                AND (
+                    candidate.ts_ingest > latest.ts_ingest
+                    OR (
+                        candidate.ts_ingest = latest.ts_ingest
+                        AND candidate.calculation_id > latest.calculation_id
+                    )
+                )
+        ) AS stale_latest_rows
+)
+SELECT
+    'portfolio_attribution_rows_present' AS check_name,
+    'at least 1' AS expected,
+    attribution_rows::TEXT AS actual,
+    CASE WHEN attribution_rows > 0 THEN 'pass' ELSE 'fail' END AS status
+FROM attribution_counts
+
+UNION ALL
+
+SELECT
+    'portfolio_attribution_inputs_reference_portfolio_returns',
+    '0',
+    orphan_input_calculation_ids::TEXT,
+    CASE WHEN orphan_input_calculation_ids = 0 THEN 'pass' ELSE 'fail' END
+FROM integrity
+
+UNION ALL
+
+SELECT
+    'latest_portfolio_attribution_uses_current_returns',
+    '0',
+    stale_latest_input_calculation_ids::TEXT,
+    CASE WHEN stale_latest_input_calculation_ids = 0 THEN 'pass' ELSE 'fail' END
+FROM integrity
+
+UNION ALL
+
+SELECT
+    'portfolio_attribution_window_evidence_aligns',
+    '0',
+    invalid_input_windows::TEXT,
+    CASE WHEN invalid_input_windows = 0 THEN 'pass' ELSE 'fail' END
+FROM integrity
+
+UNION ALL
+
+SELECT
+    'portfolio_attribution_json_shapes_align',
+    '0',
+    invalid_json_shapes::TEXT,
+    CASE WHEN invalid_json_shapes = 0 THEN 'pass' ELSE 'fail' END
+FROM integrity
+
+UNION ALL
+
+SELECT
+    'portfolio_attribution_weights_sum_to_one',
+    '0',
+    invalid_weight_totals::TEXT,
+    CASE WHEN invalid_weight_totals = 0 THEN 'pass' ELSE 'fail' END
+FROM integrity
+
+UNION ALL
+
+SELECT
+    'portfolio_covariance_is_symmetric_and_nonnegative_on_diagonal',
+    '0',
+    invalid_covariance_cells::TEXT,
+    CASE WHEN invalid_covariance_cells = 0 THEN 'pass' ELSE 'fail' END
+FROM integrity
+
+UNION ALL
+
+SELECT
+    'portfolio_correlation_is_symmetric_and_bounded',
+    '0',
+    invalid_correlation_cells::TEXT,
+    CASE WHEN invalid_correlation_cells = 0 THEN 'pass' ELSE 'fail' END
+FROM integrity
+
+UNION ALL
+
+SELECT
+    'portfolio_correlation_null_count_matches_status',
+    '0',
+    invalid_undefined_correlation_counts::TEXT,
+    CASE
+        WHEN invalid_undefined_correlation_counts = 0 THEN 'pass'
+        ELSE 'fail'
+    END
+FROM integrity
+
+UNION ALL
+
+SELECT
+    'portfolio_variance_matches_squared_volatility',
+    '0',
+    invalid_variance_volatility_rows::TEXT,
+    CASE
+        WHEN invalid_variance_volatility_rows = 0 THEN 'pass'
+        ELSE 'fail'
+    END
+FROM integrity
+
+UNION ALL
+
+SELECT
+    'portfolio_volatility_contributions_reconcile',
+    '0',
+    invalid_euler_rows::TEXT,
+    CASE WHEN invalid_euler_rows = 0 THEN 'pass' ELSE 'fail' END
+FROM integrity
+
+UNION ALL
+
+SELECT
+    'portfolio_attribution_calculation_ids_unique',
+    '0',
+    duplicate_calculation_ids::TEXT,
+    CASE WHEN duplicate_calculation_ids = 0 THEN 'pass' ELSE 'fail' END
+FROM integrity
+
+UNION ALL
+
+SELECT
+    'latest_portfolio_attribution_grain_unique',
+    '0',
+    duplicate_latest_grains::TEXT,
+    CASE WHEN duplicate_latest_grains = 0 THEN 'pass' ELSE 'fail' END
+FROM integrity
+
+UNION ALL
+
+SELECT
+    'latest_portfolio_attribution_selects_current_version',
+    '0',
+    stale_latest_rows::TEXT,
+    CASE WHEN stale_latest_rows = 0 THEN 'pass' ELSE 'fail' END
+FROM integrity
+
+UNION ALL
+
+SELECT
+    'portfolio_attribution_semantic_rows_match_latest',
+    latest_rows::TEXT,
+    semantic_rows::TEXT,
+    CASE WHEN latest_rows = semantic_rows THEN 'pass' ELSE 'fail' END
+FROM attribution_counts
+
+UNION ALL
+
+SELECT
+    'portfolio_covariance_rows_match_matrix_grain',
+    expected_matrix_rows::TEXT,
+    covariance_rows::TEXT,
+    CASE WHEN expected_matrix_rows = covariance_rows THEN 'pass' ELSE 'fail' END
+FROM attribution_counts
+
+UNION ALL
+
+SELECT
+    'portfolio_correlation_rows_match_matrix_grain',
+    expected_matrix_rows::TEXT,
+    correlation_rows::TEXT,
+    CASE WHEN expected_matrix_rows = correlation_rows THEN 'pass' ELSE 'fail' END
+FROM attribution_counts
+
+UNION ALL
+
+SELECT
+    'portfolio_attribution_contribution_rows_match_constituents',
+    expected_contribution_rows::TEXT,
+    contribution_rows::TEXT,
+    CASE
+        WHEN expected_contribution_rows = contribution_rows THEN 'pass'
+        ELSE 'fail'
+    END
+FROM attribution_counts
+
+ORDER BY check_name;

--- a/sql/portfolio_attribution_schema.sql
+++ b/sql/portfolio_attribution_schema.sql
@@ -1,0 +1,315 @@
+-- PostgreSQL serving contract for versioned portfolio covariance and volatility attribution.
+-- Apply after sql/portfolio_schema.sql so retained portfolio-return calculations exist.
+
+CREATE SCHEMA IF NOT EXISTS risk_platform;
+
+CREATE TABLE IF NOT EXISTS risk_platform.portfolio_risk_attribution (
+    calculation_id TEXT PRIMARY KEY,
+    model_version TEXT NOT NULL,
+    portfolio_id TEXT NOT NULL,
+    base_currency CHAR(3) NOT NULL,
+    definition_fingerprint TEXT NOT NULL,
+    weighting_method TEXT NOT NULL,
+    covariance_method TEXT NOT NULL,
+    correlation_method TEXT NOT NULL,
+    covariance_window INTEGER NOT NULL CHECK (
+        covariance_window >= 2 AND covariance_window <= 2520
+    ),
+    window_start TIMESTAMPTZ NOT NULL,
+    window_end TIMESTAMPTZ NOT NULL,
+    window_observations INTEGER NOT NULL CHECK (window_observations >= 2),
+    annualization_days INTEGER NOT NULL CHECK (annualization_days > 0),
+    ts_event TIMESTAMPTZ NOT NULL,
+    ts_ingest TIMESTAMPTZ NOT NULL,
+    constituent_count INTEGER NOT NULL CHECK (
+        constituent_count >= 2 AND constituent_count <= 50
+    ),
+    weights_json JSONB NOT NULL,
+    input_calculation_ids_json JSONB NOT NULL,
+    input_first_calculation_id TEXT NOT NULL REFERENCES
+        risk_platform.portfolio_daily_returns (calculation_id),
+    input_last_calculation_id TEXT NOT NULL REFERENCES
+        risk_platform.portfolio_daily_returns (calculation_id),
+    covariance_annualized_json JSONB NOT NULL,
+    correlation_json JSONB NOT NULL,
+    constituent_volatility_annualized_json JSONB NOT NULL,
+    marginal_volatility_contribution_json JSONB NOT NULL,
+    component_volatility_contribution_json JSONB NOT NULL,
+    component_contribution_share_json JSONB NOT NULL,
+    portfolio_variance_annualized DOUBLE PRECISION NOT NULL CHECK (
+        portfolio_variance_annualized >= 0
+        AND portfolio_variance_annualized < 'Infinity'::DOUBLE PRECISION
+    ),
+    portfolio_volatility_annualized DOUBLE PRECISION NOT NULL CHECK (
+        portfolio_volatility_annualized >= 0
+        AND portfolio_volatility_annualized < 'Infinity'::DOUBLE PRECISION
+    ),
+    volatility_status TEXT NOT NULL CHECK (
+        volatility_status IN ('positive', 'zero')
+    ),
+    correlation_status TEXT NOT NULL CHECK (
+        correlation_status IN ('complete', 'undefined_zero_variance')
+    ),
+    undefined_correlation_cells INTEGER NOT NULL CHECK (
+        undefined_correlation_cells >= 0
+    ),
+    euler_residual DOUBLE PRECISION NOT NULL CHECK (
+        euler_residual > '-Infinity'::DOUBLE PRECISION
+        AND euler_residual < 'Infinity'::DOUBLE PRECISION
+        AND ABS(euler_residual) <= 0.00000001
+    ),
+    loaded_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    CHECK (calculation_id <> ''),
+    CHECK (model_version <> ''),
+    CHECK (portfolio_id <> ''),
+    CHECK (base_currency = UPPER(base_currency)),
+    CHECK (definition_fingerprint <> ''),
+    CHECK (weighting_method <> ''),
+    CHECK (covariance_method <> ''),
+    CHECK (correlation_method <> ''),
+    CHECK (input_first_calculation_id <> ''),
+    CHECK (input_last_calculation_id <> ''),
+    CHECK (window_start < window_end),
+    CHECK (window_end = ts_event),
+    CHECK (ts_ingest >= ts_event),
+    CHECK (window_observations = covariance_window),
+    CHECK (jsonb_typeof(weights_json) = 'object'),
+    CHECK (jsonb_typeof(input_calculation_ids_json) = 'array'),
+    CHECK (
+        jsonb_array_length(input_calculation_ids_json) = window_observations
+    ),
+    CHECK (jsonb_typeof(covariance_annualized_json) = 'object'),
+    CHECK (jsonb_typeof(correlation_json) = 'object'),
+    CHECK (
+        jsonb_typeof(constituent_volatility_annualized_json) = 'object'
+    ),
+    CHECK (
+        jsonb_typeof(marginal_volatility_contribution_json) = 'object'
+    ),
+    CHECK (
+        jsonb_typeof(component_volatility_contribution_json) = 'object'
+    ),
+    CHECK (jsonb_typeof(component_contribution_share_json) = 'object'),
+    CHECK (
+        undefined_correlation_cells <= constituent_count * constituent_count
+    ),
+    CHECK (
+        (correlation_status = 'complete' AND undefined_correlation_cells = 0)
+        OR (
+            correlation_status = 'undefined_zero_variance'
+            AND undefined_correlation_cells > 0
+        )
+    ),
+    CHECK (
+        (volatility_status = 'zero'
+            AND portfolio_variance_annualized = 0
+            AND portfolio_volatility_annualized = 0)
+        OR (
+            volatility_status = 'positive'
+            AND portfolio_variance_annualized > 0
+            AND portfolio_volatility_annualized > 0
+        )
+    ),
+    CHECK (
+        model_version <> 'portfolio-attribution-v1'
+        OR (
+            weighting_method = 'constant_weight_daily_rebalanced'
+            AND covariance_method = 'sample_annualized'
+            AND correlation_method = 'pearson'
+            AND annualization_days = 252
+        )
+    )
+);
+
+CREATE INDEX IF NOT EXISTS idx_portfolio_attribution_version_lookup
+    ON risk_platform.portfolio_risk_attribution (
+        portfolio_id,
+        definition_fingerprint,
+        ts_event DESC,
+        model_version,
+        weighting_method,
+        covariance_method,
+        correlation_method,
+        covariance_window,
+        annualization_days,
+        ts_ingest DESC,
+        calculation_id DESC
+    );
+
+CREATE INDEX IF NOT EXISTS idx_portfolio_attribution_inputs
+    ON risk_platform.portfolio_risk_attribution
+    USING GIN (input_calculation_ids_json);
+
+CREATE OR REPLACE VIEW risk_platform.latest_portfolio_risk_attribution AS
+SELECT
+    calculation_id,
+    model_version,
+    portfolio_id,
+    base_currency,
+    definition_fingerprint,
+    weighting_method,
+    covariance_method,
+    correlation_method,
+    covariance_window,
+    window_start,
+    window_end,
+    window_observations,
+    annualization_days,
+    ts_event,
+    ts_ingest,
+    constituent_count,
+    weights_json,
+    input_calculation_ids_json,
+    input_first_calculation_id,
+    input_last_calculation_id,
+    covariance_annualized_json,
+    correlation_json,
+    constituent_volatility_annualized_json,
+    marginal_volatility_contribution_json,
+    component_volatility_contribution_json,
+    component_contribution_share_json,
+    portfolio_variance_annualized,
+    portfolio_volatility_annualized,
+    volatility_status,
+    correlation_status,
+    undefined_correlation_cells,
+    euler_residual
+FROM (
+    SELECT
+        attribution.*,
+        ROW_NUMBER() OVER (
+            PARTITION BY
+                portfolio_id,
+                definition_fingerprint,
+                ts_event,
+                model_version,
+                weighting_method,
+                covariance_method,
+                correlation_method,
+                covariance_window,
+                annualization_days
+            ORDER BY ts_ingest DESC, calculation_id DESC
+        ) AS version_rank
+    FROM risk_platform.portfolio_risk_attribution attribution
+) ranked
+WHERE version_rank = 1;
+
+CREATE OR REPLACE VIEW risk_platform.portfolio_attribution_semantic_model AS
+SELECT
+    calculation_id,
+    model_version,
+    portfolio_id,
+    base_currency,
+    definition_fingerprint,
+    weighting_method,
+    covariance_method,
+    correlation_method,
+    covariance_window,
+    window_start,
+    window_end,
+    window_observations,
+    annualization_days,
+    ts_event AS metric_ts,
+    ts_ingest AS calculation_ts,
+    constituent_count,
+    weights_json,
+    input_calculation_ids_json,
+    covariance_annualized_json,
+    correlation_json,
+    constituent_volatility_annualized_json,
+    marginal_volatility_contribution_json,
+    component_volatility_contribution_json,
+    component_contribution_share_json,
+    portfolio_variance_annualized,
+    portfolio_volatility_annualized,
+    volatility_status,
+    correlation_status,
+    undefined_correlation_cells,
+    euler_residual
+FROM risk_platform.latest_portfolio_risk_attribution;
+
+CREATE OR REPLACE VIEW risk_platform.portfolio_covariance_model AS
+SELECT
+    attribution.calculation_id AS attribution_calculation_id,
+    attribution.model_version,
+    attribution.portfolio_id,
+    attribution.base_currency,
+    attribution.definition_fingerprint,
+    attribution.weighting_method,
+    attribution.covariance_method,
+    attribution.covariance_window,
+    attribution.annualization_days,
+    attribution.window_start,
+    attribution.window_end,
+    attribution.ts_event AS metric_ts,
+    matrix_row.key AS row_constituent_key,
+    matrix_cell.key AS column_constituent_key,
+    matrix_cell.value::TEXT::DOUBLE PRECISION AS covariance_annualized
+FROM risk_platform.latest_portfolio_risk_attribution attribution
+CROSS JOIN LATERAL jsonb_each(
+    attribution.covariance_annualized_json
+) matrix_row
+CROSS JOIN LATERAL jsonb_each(
+    matrix_row.value
+) matrix_cell;
+
+CREATE OR REPLACE VIEW risk_platform.portfolio_correlation_model AS
+SELECT
+    attribution.calculation_id AS attribution_calculation_id,
+    attribution.model_version,
+    attribution.portfolio_id,
+    attribution.base_currency,
+    attribution.definition_fingerprint,
+    attribution.weighting_method,
+    attribution.correlation_method,
+    attribution.covariance_window,
+    attribution.window_start,
+    attribution.window_end,
+    attribution.ts_event AS metric_ts,
+    matrix_row.key AS row_constituent_key,
+    matrix_cell.key AS column_constituent_key,
+    NULLIF(matrix_cell.value::TEXT, 'null')::DOUBLE PRECISION AS correlation,
+    matrix_cell.value = 'null'::JSONB AS correlation_undefined
+FROM risk_platform.latest_portfolio_risk_attribution attribution
+CROSS JOIN LATERAL jsonb_each(
+    attribution.correlation_json
+) matrix_row
+CROSS JOIN LATERAL jsonb_each(
+    matrix_row.value
+) matrix_cell;
+
+CREATE OR REPLACE VIEW risk_platform.portfolio_volatility_contribution_model AS
+SELECT
+    attribution.calculation_id AS attribution_calculation_id,
+    attribution.model_version,
+    attribution.portfolio_id,
+    attribution.base_currency,
+    attribution.definition_fingerprint,
+    attribution.weighting_method,
+    attribution.covariance_method,
+    attribution.covariance_window,
+    attribution.annualization_days,
+    attribution.window_start,
+    attribution.window_end,
+    attribution.ts_event AS metric_ts,
+    component.key AS constituent_key,
+    (attribution.weights_json ->> component.key)::DOUBLE PRECISION AS weight,
+    (
+        attribution.constituent_volatility_annualized_json
+        ->> component.key
+    )::DOUBLE PRECISION AS constituent_volatility_annualized,
+    (
+        attribution.marginal_volatility_contribution_json
+        ->> component.key
+    )::DOUBLE PRECISION AS marginal_volatility_contribution,
+    component.value::DOUBLE PRECISION AS component_volatility_contribution,
+    (
+        attribution.component_contribution_share_json
+        ->> component.key
+    )::DOUBLE PRECISION AS contribution_share,
+    attribution.portfolio_volatility_annualized,
+    attribution.volatility_status
+FROM risk_platform.latest_portfolio_risk_attribution attribution
+CROSS JOIN LATERAL jsonb_each_text(
+    attribution.component_volatility_contribution_json
+) component;

--- a/src/warehouse/portfolio_attribution_loader.py
+++ b/src/warehouse/portfolio_attribution_loader.py
@@ -1,0 +1,304 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+import duckdb
+import pandas as pd
+
+from src.common.exceptions import StorageError
+from src.storage.storage_config import load_storage_config, validate_storage_config
+
+DEFAULT_POSTGRES_DSN = (
+    "postgresql://risk_user:risk_password@localhost:5433/risk_platform"
+)
+DATASET_KEY = "portfolio_risk_attribution"
+TABLE_NAME = "portfolio_risk_attribution"
+MAX_INPUT_FILES = 4_096
+MAX_INPUT_BYTES = 1_000_000_000
+MAX_INPUT_ROWS = 250_000
+
+COLUMNS = (
+    "calculation_id",
+    "model_version",
+    "portfolio_id",
+    "base_currency",
+    "definition_fingerprint",
+    "weighting_method",
+    "covariance_method",
+    "correlation_method",
+    "covariance_window",
+    "window_start",
+    "window_end",
+    "window_observations",
+    "annualization_days",
+    "ts_event",
+    "ts_ingest",
+    "constituent_count",
+    "weights_json",
+    "input_calculation_ids_json",
+    "input_first_calculation_id",
+    "input_last_calculation_id",
+    "covariance_annualized_json",
+    "correlation_json",
+    "constituent_volatility_annualized_json",
+    "marginal_volatility_contribution_json",
+    "component_volatility_contribution_json",
+    "component_contribution_share_json",
+    "portfolio_variance_annualized",
+    "portfolio_volatility_annualized",
+    "volatility_status",
+    "correlation_status",
+    "undefined_correlation_cells",
+    "euler_residual",
+)
+
+JSONB_COLUMNS = frozenset(
+    {
+        "weights_json",
+        "input_calculation_ids_json",
+        "covariance_annualized_json",
+        "correlation_json",
+        "constituent_volatility_annualized_json",
+        "marginal_volatility_contribution_json",
+        "component_volatility_contribution_json",
+        "component_contribution_share_json",
+    }
+)
+
+
+def _dataset_files(storage_config: dict[str, Any]) -> list[Path]:
+    validate_storage_config(storage_config)
+    storage = storage_config["storage"]
+    datasets = storage["curated"]["datasets"]
+    if DATASET_KEY not in datasets:
+        raise StorageError(
+            f"Storage configuration is missing '{DATASET_KEY}'"
+        )
+
+    curated_base = Path(storage["curated"]["base_path"])
+    dataset_path = curated_base / datasets[DATASET_KEY]
+    if curated_base.is_symlink() or dataset_path.is_symlink():
+        raise StorageError(
+            "Portfolio attribution warehouse path must not be a symbolic link"
+        )
+    if not dataset_path.exists():
+        return []
+    if not dataset_path.is_dir():
+        raise StorageError(
+            "Portfolio attribution warehouse path must be a directory"
+        )
+
+    try:
+        files = sorted(dataset_path.rglob("*.parquet"))
+    except OSError:
+        raise StorageError(
+            "Portfolio attribution warehouse input could not be inventoried"
+        ) from None
+    if len(files) > MAX_INPUT_FILES:
+        raise StorageError(
+            "Portfolio attribution warehouse input exceeds the file scan limit"
+        )
+
+    total_bytes = 0
+    for path in files:
+        if path.is_symlink() or not path.is_file():
+            raise StorageError(
+                "Portfolio attribution warehouse input contains an unsafe file type"
+            )
+        try:
+            total_bytes += path.stat().st_size
+        except OSError:
+            raise StorageError(
+                "Portfolio attribution warehouse input could not be inventoried"
+            ) from None
+        if total_bytes > MAX_INPUT_BYTES:
+            raise StorageError(
+                "Portfolio attribution warehouse input exceeds the byte scan limit"
+            )
+    return files
+
+
+def _normalise_value(value: Any) -> Any:
+    if value is None:
+        return None
+    if isinstance(value, float) and pd.isna(value):
+        return None
+    if pd.isna(value) is True:
+        return None
+    if hasattr(value, "to_pydatetime"):
+        return value.to_pydatetime()
+    if isinstance(value, pd.Timestamp):
+        return value.to_pydatetime()
+    return value
+
+
+def collect_attribution_records(
+    storage_config_path: Path = Path("config/storage.yaml"),
+) -> list[dict[str, Any]]:
+    storage_config = load_storage_config(storage_config_path)
+    files = _dataset_files(storage_config)
+    if not files:
+        return []
+
+    escaped_paths = [str(path).replace("'", "''") for path in files]
+    quoted_paths = ", ".join(f"'{path}'" for path in escaped_paths)
+    relation = (
+        f"read_parquet([{quoted_paths}], union_by_name=true, "
+        "hive_partitioning=false)"
+    )
+    selected_columns = ", ".join(_quote_identifier(column) for column in COLUMNS)
+
+    try:
+        with duckdb.connect() as connection:
+            count_row = connection.execute(
+                f"SELECT COUNT(*) FROM {relation}"
+            ).fetchone()
+            if count_row is None:
+                raise StorageError(
+                    "Portfolio attribution warehouse query returned no row count"
+                )
+            row_count = int(count_row[0])
+            if row_count > MAX_INPUT_ROWS:
+                raise StorageError(
+                    "Portfolio attribution warehouse input exceeds the row scan limit"
+                )
+            frame = connection.execute(
+                f"SELECT {selected_columns} FROM {relation} "
+                "ORDER BY ts_event, ts_ingest, calculation_id"
+            ).df()
+    except StorageError:
+        raise
+    except Exception:
+        raise StorageError(
+            "Unable to read portfolio attribution parquet for warehouse loading"
+        ) from None
+
+    return [
+        {
+            key: _normalise_value(value)
+            for key, value in record.items()
+        }
+        for record in frame.to_dict("records")
+    ]
+
+
+def build_upsert_sql(schema_name: str = "risk_platform") -> str:
+    quoted_columns = ", ".join(_quote_identifier(column) for column in COLUMNS)
+    placeholders = ", ".join(["%s"] * len(COLUMNS))
+    updates = ", ".join(
+        f"{_quote_identifier(column)} = EXCLUDED.{_quote_identifier(column)}"
+        for column in COLUMNS
+        if column != "calculation_id"
+    )
+    return (
+        f"INSERT INTO {_quote_identifier(schema_name)}."
+        f"{_quote_identifier(TABLE_NAME)} ({quoted_columns}) "
+        f"VALUES ({placeholders}) "
+        f"ON CONFLICT ({_quote_identifier('calculation_id')}) "
+        f"DO UPDATE SET {updates}, loaded_at = now()"
+    )
+
+
+def load_attribution_to_postgres(
+    *,
+    dsn: str,
+    storage_config_path: Path = Path("config/storage.yaml"),
+    schema_name: str = "risk_platform",
+    dry_run: bool = False,
+) -> int:
+    records = collect_attribution_records(storage_config_path)
+    if dry_run or not records:
+        return len(records)
+
+    try:
+        import psycopg
+        from psycopg.types.json import Jsonb
+    except ImportError as exc:
+        raise RuntimeError(
+            "PostgreSQL loading requires psycopg. Run `make setup` first."
+        ) from exc
+
+    statement = build_upsert_sql(schema_name)
+    rows = [
+        tuple(
+            _postgres_value(
+                record[column],
+                jsonb=column in JSONB_COLUMNS,
+                jsonb_wrapper=Jsonb,
+            )
+            for column in COLUMNS
+        )
+        for record in records
+    ]
+
+    with psycopg.connect(dsn) as connection:
+        with connection.cursor() as cursor:
+            cursor.executemany(statement, rows)
+        connection.commit()
+    return len(records)
+
+
+def _postgres_value(value: Any, *, jsonb: bool, jsonb_wrapper: Any) -> Any:
+    if not jsonb or value is None:
+        return value
+    if isinstance(value, str):
+        try:
+            value = json.loads(value)
+        except (TypeError, ValueError):
+            raise StorageError(
+                "Portfolio attribution warehouse JSON evidence is invalid"
+            ) from None
+    return jsonb_wrapper(value)
+
+
+def _quote_identifier(value: str) -> str:
+    escaped = value.replace('"', '""')
+    return f'"{escaped}"'
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Load local portfolio-attribution parquet into PostgreSQL "
+            "without recalculating analytics."
+        )
+    )
+    parser.add_argument(
+        "--dsn",
+        default=os.environ.get(
+            "WAREHOUSE_POSTGRES_DSN",
+            DEFAULT_POSTGRES_DSN,
+        ),
+    )
+    parser.add_argument(
+        "--storage-config",
+        type=Path,
+        default=Path("config/storage.yaml"),
+    )
+    parser.add_argument("--schema", default="risk_platform")
+    parser.add_argument("--dry-run", action="store_true")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = _parse_args()
+    count = load_attribution_to_postgres(
+        dsn=args.dsn,
+        storage_config_path=args.storage_config,
+        schema_name=args.schema,
+        dry_run=args.dry_run,
+    )
+    print(
+        "Portfolio attribution warehouse load summary at "
+        f"{datetime.utcnow().isoformat()}Z"
+    )
+    print(f"{TABLE_NAME}: {count}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/test_docker_compose_contract.py
+++ b/tests/unit/test_docker_compose_contract.py
@@ -31,6 +31,10 @@ def test_local_database_seed_mounts_are_read_only() -> None:
         "./sql/postgres_schema.sql:/docker-entrypoint-initdb.d/01_schema.sql:ro",
         "./sql/postgres_demo_data.sql:/docker-entrypoint-initdb.d/02_demo_data.sql:ro",
         "./sql/portfolio_schema.sql:/docker-entrypoint-initdb.d/03_portfolio_schema.sql:ro",
+        (
+            "./sql/portfolio_attribution_schema.sql:"
+            "/docker-entrypoint-initdb.d/04_portfolio_attribution_schema.sql:ro"
+        ),
     ]
     assert services["mongo"]["volumes"] == [
         "./mongo/init:/docker-entrypoint-initdb.d:ro"

--- a/tests/unit/test_portfolio_attribution_architecture_contract.py
+++ b/tests/unit/test_portfolio_attribution_architecture_contract.py
@@ -1,0 +1,31 @@
+from pathlib import Path
+
+
+def test_architecture_documents_attribution_warehouse_serving() -> None:
+    architecture = Path("docs/architecture.md").read_text(encoding="utf-8")
+    attribution = Path("docs/portfolio-attribution.md").read_text(
+        encoding="utf-8"
+    )
+    readme = Path("README.md").read_text(encoding="utf-8")
+
+    for required in (
+        "risk_platform.portfolio_risk_attribution",
+        "latest_portfolio_risk_attribution",
+        "portfolio_attribution_semantic_model",
+        "portfolio_covariance_model",
+        "portfolio_correlation_model",
+        "portfolio_volatility_contribution_model",
+        "portfolio-attribution-warehouse-load",
+        "check-portfolio-attribution-consistency",
+    ):
+        assert required in architecture
+        assert required in attribution or required in readme
+
+    stale = (
+        "Attribution remains curated Parquet in the current increment",
+        "PostgreSQL attribution serving are not implemented",
+        "does not yet add PostgreSQL attribution tables or views",
+    )
+    for statement in stale:
+        assert statement not in architecture
+        assert statement not in attribution

--- a/tests/unit/test_portfolio_attribution_loader.py
+++ b/tests/unit/test_portfolio_attribution_loader.py
@@ -1,0 +1,203 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+from src.analytics.portfolio_attribution import build_portfolio_attribution
+from src.analytics.portfolio_risk import (
+    build_portfolio_risk_outputs,
+    parse_portfolio_definition,
+)
+from src.common.exceptions import StorageError
+from src.storage.s3_writer import write_records
+from src.warehouse.portfolio_attribution_loader import (
+    COLUMNS,
+    DATASET_KEY,
+    JSONB_COLUMNS,
+    TABLE_NAME,
+    _postgres_value,
+    build_upsert_sql,
+    collect_attribution_records,
+    load_attribution_to_postgres,
+)
+from tests.storage_config_helpers import build_storage_config, write_storage_config
+
+
+def _definition():
+    return parse_portfolio_definition(
+        {
+            "portfolios": {
+                "us-tech-equal": {
+                    "base_currency": "USD",
+                    "constituents": [
+                        {
+                            "source": "alpha_vantage",
+                            "symbol": "AAPL",
+                            "weight": 0.5,
+                        },
+                        {
+                            "source": "alpha_vantage",
+                            "symbol": "MSFT",
+                            "weight": 0.5,
+                        },
+                    ],
+                }
+            }
+        },
+        "us-tech-equal",
+    )
+
+
+def _component_returns() -> list[dict[str, object]]:
+    ingested_at = datetime(2026, 1, 10, 12, tzinfo=timezone.utc)
+    records: list[dict[str, object]] = []
+    for day, aapl, msft in [
+        (2, 0.10, 0.02),
+        (3, -0.04, 0.00),
+        (4, 0.06, 0.02),
+        (5, 0.02, -0.01),
+    ]:
+        for symbol, value in (("AAPL", aapl), ("MSFT", msft)):
+            records.append(
+                {
+                    "model_version": "daily-risk-v2",
+                    "calculation_id": f"{symbol}-{day}",
+                    "source": "alpha_vantage",
+                    "symbol": symbol,
+                    "source_event_id": f"{symbol}-event-{day}",
+                    "ts_event": datetime(
+                        2026,
+                        1,
+                        day,
+                        tzinfo=timezone.utc,
+                    ),
+                    "ts_ingest": ingested_at + timedelta(minutes=day),
+                    "return_1d": value,
+                }
+            )
+    return records
+
+
+def _snapshot() -> dict[str, object]:
+    definition = _definition()
+    portfolio = build_portfolio_risk_outputs(
+        _component_returns(),
+        definition=definition,
+        volatility_window=2,
+        var_window=2,
+        var_confidence=0.95,
+    )
+    return build_portfolio_attribution(
+        portfolio.returns,
+        definition=definition,
+        covariance_window=3,
+    ).snapshot
+
+
+def test_collect_attribution_records_preserves_json_evidence(
+    tmp_path: Path,
+) -> None:
+    storage_config = build_storage_config(tmp_path)
+    storage_config_path = write_storage_config(tmp_path)
+    snapshot = _snapshot()
+
+    assert write_records(
+        [snapshot],
+        kind="curated",
+        dataset=DATASET_KEY,
+        storage_config=storage_config,
+    ) == 1
+
+    records = collect_attribution_records(storage_config_path)
+
+    assert len(records) == 1
+    record = records[0]
+    assert tuple(record) == COLUMNS
+    assert record["calculation_id"] == snapshot["calculation_id"]
+    assert record["covariance_window"] == 3
+    assert record["window_observations"] == 3
+    assert record["portfolio_volatility_annualized"] > 0
+    assert set(json.loads(record["weights_json"])) == {
+        "alpha_vantage:AAPL",
+        "alpha_vantage:MSFT",
+    }
+    covariance = json.loads(record["covariance_annualized_json"])
+    assert set(covariance) == {
+        "alpha_vantage:AAPL",
+        "alpha_vantage:MSFT",
+    }
+    assert len(json.loads(record["input_calculation_ids_json"])) == 3
+
+
+def test_attribution_loader_dry_run_is_safe_when_dataset_is_absent(
+    tmp_path: Path,
+) -> None:
+    storage_config_path = write_storage_config(tmp_path)
+
+    assert collect_attribution_records(storage_config_path) == []
+    assert (
+        load_attribution_to_postgres(
+            dsn="postgresql://example",
+            storage_config_path=storage_config_path,
+            dry_run=True,
+        )
+        == 0
+    )
+
+
+def test_attribution_upsert_uses_calculation_id_and_jsonb_contract() -> None:
+    statement = build_upsert_sql()
+
+    assert TABLE_NAME == "portfolio_risk_attribution"
+    assert 'INSERT INTO "risk_platform"."portfolio_risk_attribution"' in statement
+    assert 'ON CONFLICT ("calculation_id") DO UPDATE' in statement
+    assert (
+        '"covariance_annualized_json" = EXCLUDED."covariance_annualized_json"'
+        in statement
+    )
+    assert JSONB_COLUMNS == frozenset(
+        {
+            "weights_json",
+            "input_calculation_ids_json",
+            "covariance_annualized_json",
+            "correlation_json",
+            "constituent_volatility_annualized_json",
+            "marginal_volatility_contribution_json",
+            "component_volatility_contribution_json",
+            "component_contribution_share_json",
+        }
+    )
+
+
+def test_postgres_value_parses_standard_json_and_rejects_invalid_json() -> None:
+    wrapped = _postgres_value(
+        '{"alpha_vantage:AAPL":0.5}',
+        jsonb=True,
+        jsonb_wrapper=lambda value: value,
+    )
+    assert wrapped == {"alpha_vantage:AAPL": 0.5}
+
+    with pytest.raises(StorageError, match="JSON evidence is invalid"):
+        _postgres_value(
+            "{not-json}",
+            jsonb=True,
+            jsonb_wrapper=lambda value: value,
+        )
+
+
+def test_attribution_loader_rejects_symbolic_link_dataset(
+    tmp_path: Path,
+) -> None:
+    storage_config = build_storage_config(tmp_path)
+    storage_config_path = write_storage_config(tmp_path)
+    curated_base = Path(storage_config["storage"]["curated"]["base_path"])
+    curated_base.mkdir(parents=True)
+    target = tmp_path / "target"
+    target.mkdir()
+    (curated_base / DATASET_KEY).symlink_to(target, target_is_directory=True)
+
+    with pytest.raises(StorageError, match="symbolic link"):
+        collect_attribution_records(storage_config_path)

--- a/tests/unit/test_portfolio_attribution_reporting_sql_contract.py
+++ b/tests/unit/test_portfolio_attribution_reporting_sql_contract.py
@@ -1,0 +1,241 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+
+import duckdb
+
+
+def _read_sql(path: str) -> str:
+    return Path(path).read_text(encoding="utf-8")
+
+
+def _extract_statement(sql: str, prefix: str) -> str:
+    start = sql.index(prefix)
+    end = sql.index(";", start) + 1
+    return sql[start:end]
+
+
+def test_attribution_schema_exposes_versioned_serving_contract() -> None:
+    schema_sql = _read_sql("sql/portfolio_attribution_schema.sql")
+
+    assert (
+        "CREATE TABLE IF NOT EXISTS "
+        "risk_platform.portfolio_risk_attribution"
+    ) in schema_sql
+    assert "calculation_id TEXT PRIMARY KEY" in schema_sql
+    assert "input_first_calculation_id TEXT NOT NULL REFERENCES" in schema_sql
+    assert "risk_platform.portfolio_daily_returns" in schema_sql
+    assert "covariance_annualized_json JSONB NOT NULL" in schema_sql
+    assert "correlation_json JSONB NOT NULL" in schema_sql
+    assert "component_volatility_contribution_json JSONB NOT NULL" in schema_sql
+    assert "component_contribution_share_json JSONB NOT NULL" in schema_sql
+    assert "portfolio-attribution-v1" in schema_sql
+    assert "sample_annualized" in schema_sql
+    assert "undefined_zero_variance" in schema_sql
+    assert "ABS(euler_residual) <= 0.00000001" in schema_sql
+
+    for view_name in (
+        "latest_portfolio_risk_attribution",
+        "portfolio_attribution_semantic_model",
+        "portfolio_covariance_model",
+        "portfolio_correlation_model",
+        "portfolio_volatility_contribution_model",
+    ):
+        assert (
+            f"CREATE OR REPLACE VIEW risk_platform.{view_name}"
+            in schema_sql
+        )
+
+    assert "jsonb_each(" in schema_sql
+    assert "jsonb_each_text(" in schema_sql
+    assert "NULLIF(matrix_cell.value::TEXT, 'null')" in schema_sql
+
+
+def test_latest_attribution_view_preserves_definition_and_window_grains() -> None:
+    schema_sql = _read_sql("sql/portfolio_attribution_schema.sql")
+    latest_view = _extract_statement(
+        schema_sql,
+        "CREATE OR REPLACE VIEW "
+        "risk_platform.latest_portfolio_risk_attribution AS",
+    )
+    semantic_view = _extract_statement(
+        schema_sql,
+        "CREATE OR REPLACE VIEW "
+        "risk_platform.portfolio_attribution_semantic_model AS",
+    )
+
+    with duckdb.connect() as connection:
+        connection.execute("CREATE SCHEMA risk_platform")
+        connection.execute(
+            """
+            CREATE TABLE risk_platform.portfolio_risk_attribution (
+                calculation_id TEXT,
+                model_version TEXT,
+                portfolio_id TEXT,
+                base_currency TEXT,
+                definition_fingerprint TEXT,
+                weighting_method TEXT,
+                covariance_method TEXT,
+                correlation_method TEXT,
+                covariance_window INTEGER,
+                window_start TIMESTAMPTZ,
+                window_end TIMESTAMPTZ,
+                window_observations INTEGER,
+                annualization_days INTEGER,
+                ts_event TIMESTAMPTZ,
+                ts_ingest TIMESTAMPTZ,
+                constituent_count INTEGER,
+                weights_json TEXT,
+                input_calculation_ids_json TEXT,
+                input_first_calculation_id TEXT,
+                input_last_calculation_id TEXT,
+                covariance_annualized_json TEXT,
+                correlation_json TEXT,
+                constituent_volatility_annualized_json TEXT,
+                marginal_volatility_contribution_json TEXT,
+                component_volatility_contribution_json TEXT,
+                component_contribution_share_json TEXT,
+                portfolio_variance_annualized DOUBLE,
+                portfolio_volatility_annualized DOUBLE,
+                volatility_status TEXT,
+                correlation_status TEXT,
+                undefined_correlation_cells INTEGER,
+                euler_residual DOUBLE
+            )
+            """
+        )
+
+        metric_time = datetime(2026, 1, 31, tzinfo=timezone.utc)
+        window_start = datetime(2026, 1, 2, tzinfo=timezone.utc)
+        old_time = datetime(2026, 2, 1, 12, tzinfo=timezone.utc)
+        new_time = datetime(2026, 2, 2, 12, tzinfo=timezone.utc)
+        weights = '{"alpha_vantage:AAPL":0.5,"alpha_vantage:MSFT":0.5}'
+        inputs = '["portfolio-return-1","portfolio-return-2"]'
+        covariance = (
+            '{"alpha_vantage:AAPL":{"alpha_vantage:AAPL":0.04,'
+            '"alpha_vantage:MSFT":0.01},'
+            '"alpha_vantage:MSFT":{"alpha_vantage:AAPL":0.01,'
+            '"alpha_vantage:MSFT":0.09}}'
+        )
+        correlation = (
+            '{"alpha_vantage:AAPL":{"alpha_vantage:AAPL":1.0,'
+            '"alpha_vantage:MSFT":0.1666666667},'
+            '"alpha_vantage:MSFT":{"alpha_vantage:AAPL":0.1666666667,'
+            '"alpha_vantage:MSFT":1.0}}'
+        )
+        vector = '{"alpha_vantage:AAPL":0.2,"alpha_vantage:MSFT":0.3}'
+        marginal = '{"alpha_vantage:AAPL":0.15,"alpha_vantage:MSFT":0.2}'
+        component = '{"alpha_vantage:AAPL":0.075,"alpha_vantage:MSFT":0.1}'
+        shares = (
+            '{"alpha_vantage:AAPL":0.4285714286,'
+            '"alpha_vantage:MSFT":0.5714285714}'
+        )
+
+        def row(
+            calculation_id: str,
+            definition: str,
+            covariance_window: int,
+            ingested_at: datetime,
+        ) -> tuple[object, ...]:
+            return (
+                calculation_id,
+                "portfolio-attribution-v1",
+                "us-tech",
+                "USD",
+                definition,
+                "constant_weight_daily_rebalanced",
+                "sample_annualized",
+                "pearson",
+                covariance_window,
+                window_start,
+                metric_time,
+                covariance_window,
+                252,
+                metric_time,
+                ingested_at,
+                2,
+                weights,
+                inputs,
+                "portfolio-return-1",
+                "portfolio-return-2",
+                covariance,
+                correlation,
+                vector,
+                marginal,
+                component,
+                shares,
+                0.030625,
+                0.175,
+                "positive",
+                "complete",
+                0,
+                0.0,
+            )
+
+        rows = [
+            row("attribution-old", "definition-a", 20, old_time),
+            row("attribution-new", "definition-a", 20, new_time),
+            row("attribution-window-10", "definition-a", 10, old_time),
+            row("attribution-definition-b", "definition-b", 20, old_time),
+        ]
+        placeholders = ", ".join(["?"] * len(rows[0]))
+        connection.executemany(
+            "INSERT INTO risk_platform.portfolio_risk_attribution VALUES "
+            f"({placeholders})",
+            rows,
+        )
+
+        connection.execute(latest_view)
+        connection.execute(semantic_view)
+
+        assert connection.execute(
+            """
+            SELECT calculation_id, definition_fingerprint, covariance_window
+            FROM risk_platform.latest_portfolio_risk_attribution
+            ORDER BY definition_fingerprint, covariance_window
+            """
+        ).fetchall() == [
+            ("attribution-window-10", "definition-a", 10),
+            ("attribution-new", "definition-a", 20),
+            ("attribution-definition-b", "definition-b", 20),
+        ]
+        assert connection.execute(
+            "SELECT COUNT(*) "
+            "FROM risk_platform.portfolio_attribution_semantic_model"
+        ).fetchone() == (3,)
+
+
+def test_attribution_consistency_checks_cover_matrix_and_euler_evidence() -> None:
+    consistency_sql = _read_sql(
+        "sql/portfolio_attribution_consistency_checks.sql"
+    )
+
+    for check_name in (
+        "portfolio_attribution_rows_present",
+        "portfolio_attribution_inputs_reference_portfolio_returns",
+        "latest_portfolio_attribution_uses_current_returns",
+        "portfolio_attribution_window_evidence_aligns",
+        "portfolio_attribution_json_shapes_align",
+        "portfolio_attribution_weights_sum_to_one",
+        "portfolio_covariance_is_symmetric_and_nonnegative_on_diagonal",
+        "portfolio_correlation_is_symmetric_and_bounded",
+        "portfolio_correlation_null_count_matches_status",
+        "portfolio_variance_matches_squared_volatility",
+        "portfolio_volatility_contributions_reconcile",
+        "portfolio_attribution_calculation_ids_unique",
+        "latest_portfolio_attribution_grain_unique",
+        "latest_portfolio_attribution_selects_current_version",
+        "portfolio_attribution_semantic_rows_match_latest",
+        "portfolio_covariance_rows_match_matrix_grain",
+        "portfolio_correlation_rows_match_matrix_grain",
+        "portfolio_attribution_contribution_rows_match_constituents",
+    ):
+        assert check_name in consistency_sql
+
+    assert "jsonb_array_elements_text" in consistency_sql
+    assert "jsonb_object_keys" in consistency_sql
+    assert (
+        "POWER(attribution.portfolio_volatility_annualized, 2)"
+        in consistency_sql
+    )


### PR DESCRIPTION
## Outcome

Complete the portfolio covariance and volatility-attribution path from versioned curated Parquet into PostgreSQL history, current-version serving, row-level matrix views and reconciliation:

```text
portfolio_risk_attribution Parquet
  -> bounded JSON-aware calculation-ID upsert
  -> version-preserving PostgreSQL history
  -> method-, definition- and window-aware current view
  -> covariance / correlation pair views
  -> constituent volatility-contribution view
  -> focused reconciliation evidence
```

Primary arc42 block: `warehouse`, with explicit interfaces to portfolio attribution, curated storage and the local Docker operator path.

## Table and loader

Add:

- `risk_platform.portfolio_risk_attribution`
- `src.warehouse.portfolio_attribution_loader`

The table retains every deterministic `calculation_id`. The dedicated loader accepts only the configured `portfolio_risk_attribution` dataset, caps scans at 4,096 files, 1 GB and 250,000 rows, rejects symbolic links and unsafe file types, converts only declared evidence documents to JSONB and performs no analytical recalculation.

The schema constrains the v1 methods, complete covariance window, JSON types, finite scalar metrics, correlation status/null counts, positive-versus-zero volatility semantics and Euler residual.

## Current-version grain

`latest_portfolio_risk_attribution` ranks corrections within:

```text
portfolio_id
definition_fingerprint
ts_event
model_version
weighting_method
covariance_method
correlation_method
covariance_window
annualization_days
```

Within the grain, `ts_ingest DESC, calculation_id DESC` selects the current version. Different definitions, methods and windows remain independently queryable.

## Serving views

- `portfolio_attribution_semantic_model` exposes the complete current snapshot.
- `portfolio_covariance_model` expands annualised covariance to one ordered constituent pair per row.
- `portfolio_correlation_model` expands correlation while preserving undefined zero-variance cells as SQL `NULL`.
- `portfolio_volatility_contribution_model` exposes one row per constituent with weight, standalone volatility, marginal contribution, Euler component contribution and contribution share.

## Reconciliation

Add `sql/portfolio_attribution_consistency_checks.sql` to verify:

- retained input IDs reference portfolio-return calculations;
- current attribution uses current portfolio-return versions;
- input ordering, window boundaries and definition metadata align;
- vector and matrix JSON shapes align to the declared constituents;
- weights sum to one;
- covariance is symmetric with non-negative diagonals;
- correlation is symmetric, bounded and has the declared null count;
- portfolio variance equals squared volatility;
- Euler contributions, contribution shares and weights reconcile;
- calculation IDs and current grains remain unique;
- the latest view selects the newest candidate; and
- semantic, matrix and contribution views have the expected row counts.

## Operator path

```bash
make portfolio-attribution-warehouse-dry-run
make local-db-up
make portfolio-attribution-warehouse-load
make check-portfolio-attribution-consistency
```

Docker initializes the attribution schema read-only after the core and portfolio schemas. `warehouse-schema` reapplies all three idempotent schemas for an already-running local database. The attribution load first loads prerequisite daily and portfolio facts, then the attribution snapshots.

## Validation

GitHub Actions run `32483872040` (`ci` run 199) passed on exact head `42dfc26a8d5c9c352d6d9d2f8025c4c27e6e94b0`:

- Security guardrails: passed
- Python readiness: passed
  - locked dependencies resolved
  - Ruff passed
  - mypy passed across 46 source files
  - 452 tests passed, including bounded Parquet loader and executable DuckDB current-view ranking
  - `pip check` passed
  - `make readiness-check` passed
- Infrastructure validation: passed
  - Kubernetes overlays rendered
  - Terraform formatting, initialization and validation passed without applying infrastructure

The dry-run path remains safe when attribution Parquet is absent. No unresolved review threads or requested changes are present.

## Scope

The branch is one commit ahead of `main` and zero behind. It changes 12 files with 1,922 additions and 78 deletions as one attribution curated-to-serving contract.

No provider request, credential change, managed database, scheduler, dashboard, deployment or Terraform apply is included. Historical attribution for every event date, shrinkage/EWMA/factor covariance, marginal VaR, FX conversion, leverage, shorting, transaction costs and non-daily rebalancing remain out of scope.

## Acceptance boundary

This PR is validated and ready for squash merge as one warehouse increment.