### PR TITLE
Add rolling portfolio attribution history

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,8 +14,9 @@ VOL_WINDOW ?= 20
 VAR_WINDOW ?= 60
 VAR_CONFIDENCE ?= 0.95
 COVARIANCE_WINDOW ?= 20
+ATTRIBUTION_MAX_SNAPSHOTS ?= 2500
 
-.PHONY: setup lint type-check test dependency-check format benchmark-io docker-build k8s-render-dev k8s-render-prod k8s-check terraform-check infrastructure-check quality-check iteration-check clean-generated security-check readiness-check sandbox-once overnight-sandbox morning-review daily-risk-demo portfolio-risk-demo portfolio-attribution-demo warehouse-schema daily-risk-warehouse-dry-run daily-risk-warehouse-load check-daily-risk-consistency portfolio-risk-warehouse-dry-run portfolio-risk-warehouse-load check-portfolio-risk-consistency portfolio-attribution-warehouse-dry-run portfolio-attribution-warehouse-load check-portfolio-attribution-consistency local-db-up local-db-down local-db-wait local-db-logs postgres-shell mongo-shell run-demo load-postgres-demo load-postgres-dry-run check-postgres-consistency consistency-demo
+.PHONY: setup lint type-check test dependency-check format benchmark-io docker-build k8s-render-dev k8s-render-prod k8s-check terraform-check infrastructure-check quality-check iteration-check clean-generated security-check readiness-check sandbox-once overnight-sandbox morning-review daily-risk-demo portfolio-risk-demo portfolio-attribution-demo portfolio-attribution-history-demo warehouse-schema daily-risk-warehouse-dry-run daily-risk-warehouse-load check-daily-risk-consistency portfolio-risk-warehouse-dry-run portfolio-risk-warehouse-load check-portfolio-risk-consistency portfolio-attribution-warehouse-dry-run portfolio-attribution-warehouse-load check-portfolio-attribution-consistency local-db-up local-db-down local-db-wait local-db-logs postgres-shell mongo-shell run-demo load-postgres-demo load-postgres-dry-run check-postgres-consistency consistency-demo
 
 setup:
 	python3 -m venv .venv
@@ -136,6 +137,23 @@ portfolio-attribution-demo:
 		--end-date "$$end_date" \
 		--covariance-window "$(COVARIANCE_WINDOW)" \
 		--summary-json .demo/portfolio-attribution-summary.json
+
+portfolio-attribution-history-demo:
+	@set -eu; \
+	end_date="$(END_DATE)"; \
+	if [ -z "$$end_date" ]; then \
+		end_date="$$($(PYTHON) -c 'from datetime import datetime, timedelta, timezone; print((datetime.now(timezone.utc).date() - timedelta(days=1)).isoformat())')"; \
+	fi; \
+	start_args=""; \
+	if [ -n "$(START_DATE)" ]; then start_args="--start-date $(START_DATE)"; fi; \
+	$(PYTHON) -m src.orchestration.run_portfolio_attribution_history \
+		--portfolio-id "$(PORTFOLIO_ID)" \
+		--portfolio-config "$(PORTFOLIO_CONFIG)" \
+		$$start_args \
+		--end-date "$$end_date" \
+		--covariance-window "$(COVARIANCE_WINDOW)" \
+		--max-snapshots "$(ATTRIBUTION_MAX_SNAPSHOTS)" \
+		--summary-json .demo/portfolio-attribution-history-summary.json
 
 warehouse-schema: local-db-wait
 	docker compose exec -T postgres psql -U risk_user -d risk_platform \

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,8 +1,8 @@
 # Architecture
 
-This document uses the arc42 structure to describe behaviour that is implemented
-and tested in this repository. Cloud resources and deployment manifests are
-described only as scaffolding unless executable evidence exists for them.
+This arc42 document describes behaviour that is implemented and tested in this
+repository. Cloud manifests are described as scaffolding unless executable
+evidence exists for them.
 
 ## 1. Introduction And Goals
 
@@ -12,285 +12,215 @@ The platform demonstrates three related market-risk paths:
 provider-neutral market events
   -> validation, normalisation and deduplication
   -> replayable raw Parquet
-  -> minute-oriented demo analytics
+  -> minute-oriented analytics
   -> PostgreSQL serving and reconciliation
 
 Alpha Vantage daily closes
-  -> canonical timezone-aware market events
+  -> timezone-aware canonical market events
   -> immutable raw Parquet
-  -> versioned daily returns and risk analytics
+  -> daily-risk-v2 returns and risk analytics
   -> version-preserving PostgreSQL tables
   -> current-version and semantic views
 
 current daily-return versions
   -> configured long-only portfolio weights
   -> complete-date alignment
-  -> versioned portfolio returns and risk summaries
-  -> version-preserving PostgreSQL tables
-  -> current-version, semantic and return-contribution views
-  -> latest-window covariance and correlation
+  -> portfolio_daily_returns and portfolio_daily_risk_summary
+  -> PostgreSQL portfolio serving
+  -> rolling historical covariance and correlation
   -> Euler component-volatility attribution
   -> versioned portfolio_risk_attribution Parquet
-  -> version-preserving PostgreSQL attribution snapshots
-  -> current matrix and volatility-contribution views
+  -> PostgreSQL attribution history and row-level views
 ```
-
-The leading quality goals are:
 
 | Priority | Quality goal | Evidence |
 | --- | --- | --- |
 | 1 | Deterministic replay | Stable event IDs, content-addressed Parquet and calculation IDs |
 | 2 | Explicit contracts | Pydantic schemas, dataset grains, SQL constraints and loader contracts |
-| 3 | Source-to-serving traceability | Input fingerprints, JSONB evidence, views and reconciliation SQL |
-| 4 | Safe operation | Local-first commands, bounded scans, manual deployment and security checks |
-| 5 | Reviewable evolution | Arc42 change blocks, focused tests, CI and squash-merged PRs |
+| 3 | Traceability | Input fingerprints, JSONB evidence, current views and reconciliation SQL |
+| 4 | Safe operation | Local-first commands, bounded scans and disabled cloud defaults |
+| 5 | Reviewable evolution | Focused tests, CI and squash-merged PRs |
 
 ## 2. Architecture Constraints
 
 1. Python **3.11** is the supported and CI-tested runtime.
-2. `MarketEvent` requires timezone-aware event and ingest timestamps and
-   normalises accepted values to UTC through Pydantic `AwareDatetime`.
-3. The implemented runtime is batch or micro-batch, not a production streaming
-   service.
-4. Local Parquet models raw and curated object-storage layouts; it is not an AWS
-   S3 client or transactional lakehouse.
-5. PostgreSQL is the demonstrated serving contract. MongoDB is a seeded
-   source-shape playground.
+2. `MarketEvent` uses Pydantic `AwareDatetime` and normalises accepted timestamps
+   to UTC.
+3. Runtime execution is batch or micro-batch, not production streaming.
+4. Local Parquet models object-storage layouts; it is not a transactional
+   lakehouse.
+5. PostgreSQL is the demonstrated serving contract.
 6. Dependency resolution is constrained by `requirements.lock`.
-7. Managed cloud resources remain disabled by default, and deployment is manual.
-8. Generated data, local state, credentials and evidence are excluded from Git.
-9. Tests must substantiate repository claims; scaffolding is not described as
-   production ownership.
+7. Managed cloud resources remain disabled by default and deployment is manual.
+8. Generated data, local state and credentials are excluded from Git.
+9. Repository claims require tests or executable evidence.
 
 ## 3. Context And Scope
 
-### Business context
-
 ```text
-market-data source ----+
-                       |
-external signals ------+--> financial risk platform
-                       |        |          |
-                       v        v          v
-                    raw data  analytics  warehouse views
-                                             |
-                                             v
-                                    engineer / reviewer
+market data ----+
+                |
+external risk --+--> ingestion -> raw -> analytics -> warehouse views
+                                                |
+                                                v
+                                         engineer / reviewer
 ```
 
-The platform owns validation, immutable local landing, analytical derivation,
-local warehouse loading and reconciliation. Production alert delivery,
-persistent cloud storage, provider availability and live cloud operations remain
+The repository owns validation, immutable local landing, analytical derivation,
+local warehouse loading and reconciliation. Provider availability, durable cloud
+storage, production scheduling, alert delivery and live cloud operations remain
 outside the implemented boundary.
-
-### Technical neighbours
 
 | Neighbour | Interface | Contract |
 | --- | --- | --- |
-| Alpha Vantage | HTTPS `TIME_SERIES_DAILY` | Bounded adapter, stable daily event ID and completed dates |
-| Landed files | CSV, JSON, JSONL or NDJSON | Provider-neutral market and signal loaders |
-| Local filesystem | Partitioned Parquet | Paths and datasets from `config/storage.yaml` |
-| PostgreSQL | Psycopg and SQL | Version history, current views and reconciliation in `sql/` |
-| MongoDB | Seeded local documents | Source-system modelling playground |
+| Alpha Vantage | HTTPS `TIME_SERIES_DAILY` | Bounded adapter and completed dates |
+| Landed files | CSV, JSON, JSONL or NDJSON | Provider-neutral event inputs |
+| Local filesystem | Partitioned Parquet | Paths from `config/storage.yaml` |
+| PostgreSQL | Psycopg and SQL | Version history, views and checks under `sql/` |
 | Operator | Make targets and Python CLIs | Summaries, dry runs, loads and reconciliation |
-| GitHub Actions | CI and manual deploy | Read-only validation; explicit deployment dispatch |
+| GitHub Actions | CI and manual deploy | Validation without implicit deployment |
 
 ## 4. Solution Strategy
 
-The data plane is split into:
+The data plane is separated into:
 
 1. **Ingestion** — source adapters and canonical schemas.
 2. **Processing** — validation, normalisation, deduplication and windowing.
-3. **Analytics** — minute metrics, daily risk, portfolio aggregation, covariance,
-   volatility attribution and data quality.
+3. **Analytics** — returns, VaR, drawdown, portfolio aggregation, covariance and
+   volatility attribution.
 4. **Storage** — bounded, idempotent raw and curated Parquet publication.
-5. **Orchestration** — sequencing, locks, backfills and run summaries.
-6. **Warehouse** — PostgreSQL loading, version retention, row-expansion views and
+5. **Orchestration** — daily, portfolio, latest-attribution and history runners.
+6. **Warehouse** — version-preserving PostgreSQL loading, row-expansion views and
    reconciliation.
 
-Minute, single-symbol daily, portfolio and attribution semantics stay separate.
-Daily, portfolio and attribution calculations use explicit model versions and
-deterministic calculation IDs so late source history, changed parameters,
-changed weights or changed covariance windows create new traceable versions
-without overwriting earlier evidence.
+Minute, single-symbol daily, portfolio and attribution semantics remain separate.
+Late source history, changed parameters, changed weights or changed covariance
+windows create new deterministic versions rather than overwriting evidence.
 
 ## 5. Building Block View
 
 | Block | Responsibility | Principal paths |
 | --- | --- | --- |
-| `common` | Configuration, time, logging and exceptions | `src/common/` |
-| `ingestion` | Alpha Vantage and provider-neutral inbound contracts | `src/ingestion/` |
-| `processing` | Validation, normalisation, deduplication and windowing | `src/processing/` |
-| `analytics` | Returns, VaR, drawdown, covariance, aggregation, attribution and quality | `src/analytics/` |
-| `storage` | Dataset configuration and local Parquet publication | `src/storage/`, `config/storage.yaml` |
-| `orchestration` | Demo, daily, portfolio and attribution runners plus locks and backfills | `src/orchestration/` |
-| `warehouse` | Loaders, SQL schemas, current views and reconciliation | `src/warehouse/`, `sql/` |
-| `source-systems` | Local PostgreSQL and MongoDB examples | `docker-compose.yml`, `mongo/` |
-| `deployment` | Image, Kubernetes and Terraform scaffold | `Dockerfile`, `deploy/`, `infra/` |
-| `engineering-controls` | CI, security checks and review evidence | `.github/`, `scripts/`, `AGENTS.md` |
+| `common` | Configuration, time and exceptions | `src/common/` |
+| `ingestion` | External and landed input contracts | `src/ingestion/` |
+| `processing` | Validation, deduplication and windows | `src/processing/` |
+| `analytics` | Daily risk, portfolio risk and attribution | `src/analytics/` |
+| `storage` | Parquet configuration and publication | `src/storage/`, `config/storage.yaml` |
+| `orchestration` | Pipeline and bounded operator runners | `src/orchestration/` |
+| `warehouse` | Loaders, schemas, current views and checks | `src/warehouse/`, `sql/` |
+| `deployment` | Container, Kubernetes and Terraform scaffold | `Dockerfile`, `deploy/`, `infra/` |
+| `engineering-controls` | CI, security and review evidence | `.github/`, `scripts/`, `AGENTS.md` |
 
-Each PR names one primary block. A vertical slice may cross interfaces only when
-the acceptance criterion requires an end-to-end contract. Data-plane,
-deployment-plane and engineering-control changes remain separate unless runtime
-compatibility requires otherwise.
+Each PR names one primary block. Interface crossings are included only when an
+acceptance criterion requires an end-to-end contract.
 
 ## 6. Runtime View
 
 ### Minute-oriented demo
 
 ```text
-JSON events
-  -> required-field, null and numeric validation
+landed events
+  -> required-field and range validation
   -> UTC-normalised MarketEvent rows
   -> event-ID deduplication
-  -> returns, rolling volatility, quality and risk summaries
-  -> partition locks
+  -> returns, volatility, quality and risk summaries
   -> raw and curated Parquet
   -> optional PostgreSQL load
 ```
 
-Late and duplicate records remain visible in quality metrics. Individual dataset
-writes are idempotent, but the local filesystem does not provide one
-multi-dataset transaction.
-
-### Alpha Vantage daily risk
+### Single-symbol daily risk
 
 ```text
-bounded provider request
-  -> completed daily closes
-  -> immutable raw MarketEvent Parquet
-  -> daily-risk-v2 calculations
+Alpha Vantage daily closes
+  -> immutable raw events
   -> daily_returns
   -> daily_volatility
   -> daily_risk_summary
 ```
 
-The daily contract records close-to-close return, annualised sample volatility,
-historical VaR loss, maximum drawdown, window parameters, history readiness and
-source fingerprints. Identical inputs and parameters reproduce identical files.
-Late history changes the fingerprint and creates a distinguishable version.
-
-### Daily warehouse serving
-
-```text
-daily curated Parquet
-  -> calculation-ID upserts
-  -> version-preserving history tables
-  -> parameter-aware latest view
-  -> source-aware symbol enrichment
-  -> reconciliation checks
-```
-
-The daily tables are:
+The warehouse retains:
 
 - `risk_platform.daily_returns`
 - `risk_platform.daily_volatility`
 - `risk_platform.daily_risk_summary`
 
-`latest_daily_risk_summary` selects one current row per source, symbol, event
-date, model version and parameter set. `daily_risk_semantic_model` joins symbol
-reference data on both `source` and `symbol`.
+`latest_daily_risk_summary` selects current rows per source, symbol, event date,
+model and parameter set. `daily_risk_semantic_model` joins reference data on both
+source and symbol.
 
-### Portfolio daily risk
+### Portfolio risk
 
 ```text
-current daily_returns versions
-  -> portfolio definition and weight validation
-  -> complete-date alignment across constituents
-  -> constant-weight daily-rebalanced portfolio returns
-  -> annualised volatility, historical VaR and drawdown
+current daily_returns
+  -> portfolio definition validation
+  -> complete-date alignment
+  -> constant-weight daily-rebalanced returns
+  -> rolling volatility, historical VaR and drawdown
   -> portfolio_daily_returns
   -> portfolio_daily_risk_summary
 ```
 
-The portfolio path selects the latest component calculation per source, symbol
-and event date using ingest time and calculation ID. Only dates with every
-configured constituent are emitted. Weights are positive, unique by
-source/symbol and sum to one. Component returns, contributions and calculation
-IDs remain embedded as stable JSON evidence.
-
-### Portfolio warehouse serving
-
-```text
-portfolio curated Parquet
-  -> JSON-aware calculation-ID upserts
-  -> version-preserving portfolio history
-  -> definition- and parameter-aware current views
-  -> portfolio summary and constituent return-contribution views
-  -> portfolio reconciliation checks
-```
-
-The portfolio tables are:
+The warehouse retains:
 
 - `risk_platform.portfolio_daily_returns`
 - `risk_platform.portfolio_daily_risk_summary`
 
-`latest_portfolio_daily_returns` ranks corrections within a portfolio definition,
-event date, model version and weighting method.
-`latest_portfolio_daily_risk_summary` adds volatility and VaR parameters to that
-grain. The `definition_fingerprint` remains part of both grains, so two weight
-definitions using the same human-readable `portfolio_id` stay independently
-queryable.
+`latest_portfolio_daily_risk_summary` preserves definition and parameter grains.
+`portfolio_risk_semantic_model` exposes current summaries.
+`portfolio_daily_contribution_model` exposes one constituent return contribution
+per row.
 
-`portfolio_risk_semantic_model` exposes current portfolio summaries.
-`portfolio_daily_contribution_model` expands each current return into one row per
-constituent with weight, component return, component calculation ID and return
-contribution.
-
-### Portfolio covariance and volatility attribution
+### Covariance and volatility attribution
 
 ```text
-current portfolio_daily_returns versions
-  -> selected portfolio definition fingerprint
-  -> bounded latest covariance window
+current portfolio_daily_returns
+  -> exact definition fingerprint
+  -> complete covariance windows
   -> annualised sample covariance
   -> Pearson correlation
-  -> Euler component contributions to portfolio volatility
+  -> Euler component-volatility attribution
   -> portfolio_risk_attribution
 ```
 
-The attribution path validates the persisted portfolio-return evidence against
-the selected definition, ranks corrections by ingest time and calculation ID,
-and requires the full configured window. It writes one latest-window snapshot
-that contains covariance and correlation matrices plus constituent volatility,
-marginal contribution, component contribution and contribution-share mappings.
-Undefined zero-variance correlations are stored as JSON `null`, never
-non-standard `NaN`. Component contributions reconcile to total portfolio
-volatility within a strict numerical tolerance.
+`portfolio-attribution-demo` writes only the latest complete window.
+`portfolio-attribution-history-demo` expands the same canonical current-version
+input into one snapshot per eligible rolling end date. `START_DATE` filters
+emitted snapshot dates while preserving earlier observations needed by the first
+window. One request is bounded by `MAX_HISTORY_SNAPSHOTS = 2_500`.
+
+A late correction is applied to the current portfolio-return version for its
+business date. Every affected rolling window receives a new deterministic
+calculation ID; earlier attribution versions remain retained.
+
+Undefined zero-variance correlations are stored as JSON `null`, not NaN.
+Component volatility contributions reconcile to portfolio volatility within a
+strict tolerance.
 
 ### Attribution warehouse serving
 
 ```text
 portfolio_risk_attribution Parquet
-  -> bounded JSON-aware calculation-ID upsert
-  -> risk_platform.portfolio_risk_attribution history
+  -> bounded JSON-aware upsert
+  -> risk_platform.portfolio_risk_attribution
   -> latest_portfolio_risk_attribution
   -> portfolio_attribution_semantic_model
   -> portfolio_covariance_model
   -> portfolio_correlation_model
   -> portfolio_volatility_contribution_model
-  -> attribution reconciliation checks
 ```
 
-The base table preserves every deterministic snapshot. The current grain includes
-the portfolio definition, event date, model and weighting method, covariance and
-correlation methods, covariance window and annualisation basis. Within the grain,
+The current grain includes portfolio definition, event date, model, methods,
+covariance window and annualisation basis. Within the grain,
 `ts_ingest DESC, calculation_id DESC` selects the current version.
 
-The matrix views expose one row per ordered constituent pair. The contribution
-view exposes one row per constituent without recalculating covariance or
-volatility. `portfolio-attribution-warehouse-load` first loads prerequisite
-portfolio-return facts and then the attribution snapshot.
-`check-portfolio-attribution-consistency` verifies input references, matrix
-shape and symmetry, correlation null semantics, variance/volatility identity and
-Euler reconciliation.
+`portfolio_covariance_model` and `portfolio_correlation_model` expose one ordered
+constituent pair per row. `portfolio_volatility_contribution_model` exposes one
+constituent per row without analytical recomputation.
 
-### Backfill
-
-The hourly backfill runner reads immutable raw partitions, resumes after the last
-successful checkpoint, uses the same partition locks as live processing and
-updates local resume state only after success. Daily Alpha Vantage observations
-are excluded from the minute-oriented backfill path.
+`portfolio-attribution-warehouse-load` loads prerequisite portfolio facts and all
+retained attribution snapshots. `check-portfolio-attribution-consistency`
+verifies input references, matrix shape and symmetry, correlation null semantics,
+variance/volatility identity and Euler reconciliation.
 
 ## 7. Deployment View
 
@@ -298,109 +228,89 @@ are excluded from the minute-oriented backfill path.
 | --- | --- |
 | Developer workstation | Python, local Parquet and optional Docker databases |
 | GitHub Actions | Security, Python readiness and infrastructure validation |
-| Container | Non-root packaging of the default demo runtime |
+| Container | Non-root packaging of the default demo |
 | Kubernetes | CronJob, ConfigMaps, service account, network policy and overlays |
-| AWS scaffold | ECR/OIDC plus disabled optional database examples |
+| AWS scaffold | Disabled-by-default examples and manual deployment workflow |
 
-Kubernetes currently uses ephemeral storage. Terraform does not provision the
-EKS cluster expected by the manual deployment workflow. Normal validation never
-deploys and never runs `terraform apply`.
+Kubernetes storage is ephemeral. Terraform does not provision the EKS cluster
+expected by the manual deployment workflow. Normal validation never runs
+`terraform apply`.
 
 ## 8. Cross-Cutting Concepts
 
 | Concept | Approach |
 | --- | --- |
-| Time | Aware timestamps only at the canonical event boundary; UTC internally |
-| Identity | Stable source event IDs and deterministic calculation IDs |
+| Time | Aware UTC timestamps at canonical boundaries |
+| Identity | Stable event IDs and deterministic calculation IDs |
 | Replay | Immutable raw data and content-addressed curated files |
-| Versioning | Daily, portfolio and attribution versions are retained rather than overwritten |
-| Configuration | YAML for storage, thresholds, symbols, portfolios and operator choices |
-| Evidence | Component IDs, weights, returns, matrices and contributions persist as JSONB-ready mappings |
-| Serving | JSON history remains intact while SQL views expose queryable row grains |
-| Data quality | Required fields, nulls, ranges, late and duplicate evidence |
-| Concurrency | Local partition locks and repository-global lease fencing |
-| Recovery | Resume checkpoints and safe reruns |
-| Security | No committed secrets, bounded I/O and disabled cloud defaults |
-| Human authority | Automated output is evidence; merge and deployment remain explicit decisions |
+| Versioning | Daily, portfolio and attribution versions are retained |
+| Current state | Explicit grains ranked by ingest time and calculation ID |
+| Evidence | IDs, weights, returns, matrices and contributions persist as JSONB-ready documents |
+| Serving | JSON history remains intact while SQL views expose row grains |
+| Safety | File, byte, row and snapshot caps; no implicit provider or cloud action |
+| Human authority | Automated evidence does not imply merge or deployment approval |
 
 ## 9. Architecture Decisions
 
 | Decision | Consequence |
 | --- | --- |
 | Batch before streaming | Lower operational complexity at the cost of latency |
-| Immutable raw before analytics | Explainable replay, but no table-format transactions |
-| Separate minute, daily, portfolio and attribution semantics | Clear grains and explicit orchestration paths |
-| Calculation ID as warehouse version key | Retains corrections, definitions and parameter versions |
-| Portfolio definition fingerprint in current grains | Weight configurations do not silently overwrite one another |
-| JSONB evidence plus row-expansion views | Preserves deterministic documents while enabling SQL analysis |
-| Latest-window attribution snapshot | Bounded output and simple replay, but not a full historical matrix series |
-| Sample covariance and Euler volatility contribution | Transparent decomposition without a factor or shrinkage model |
-| PostgreSQL serving | Familiar constraints and views, not a distributed warehouse |
-| Local locks | Simple overlap protection, not distributed coordination |
+| Immutable raw before analytics | Explainable replay without table-format transactions |
+| Calculation ID as version key | Corrections and parameter changes remain distinguishable |
+| Portfolio definition fingerprint | Weight configurations do not overwrite one another |
+| Sample covariance and Euler allocation | Transparent decomposition without a factor model |
+| Bounded rolling attribution history | Queryable risk trends with explicit output limits |
+| JSONB documents plus row-expansion views | Preserve deterministic evidence and support SQL analysis |
+| PostgreSQL serving | Familiar constraints, not a distributed warehouse |
 | Manual cloud activation | Prevents surprise cost and mutation |
-| Arc42 blocks for PR scope | Improves reviewability and limits mixed concerns |
 
 ## 10. Quality Scenarios
 
 | ID | Scenario | Required response |
 | --- | --- | --- |
 | Q1 | The same source batch is replayed | Write no duplicate raw, curated or warehouse facts |
-| Q2 | A source event is corrected late | Preserve the earlier version and create traceable new calculations |
-| Q3 | A timestamp lacks a timezone | Reject it at the canonical schema boundary |
-| Q4 | A required field or numeric range is invalid | Stop before curated publication |
-| Q5 | Live and backfill work overlap | Block on the active partition lock |
-| Q6 | Daily history is insufficient | Emit `partial` rather than implying full readiness |
-| Q7 | A warehouse consumer asks for current daily risk | Return one row per parameterised grain |
-| Q8 | Portfolio constituent dates are incomplete | Exclude the date, report the count and fail if alignment is insufficient |
-| Q9 | A portfolio component calculation ID conflicts | Fail rather than make a file-order-dependent choice |
-| Q10 | A portfolio definition or parameter changes | Retain both versions and keep both current grains queryable |
-| Q11 | A consumer asks for portfolio return contributions | Return one row per constituent without multiplying facts |
-| Q12 | A portfolio covariance window is incomplete | Fail without publishing a partial attribution snapshot |
-| Q13 | A zero-variance constituent has undefined correlation | Persist JSON nulls and explicit status, not NaN |
-| Q14 | Component volatility contributions are calculated | Reconcile their sum to portfolio volatility |
-| Q15 | An attribution correction is loaded | Retain history and select the newest row in its declared grain |
-| Q16 | A consumer queries a matrix or attribution vector | Return one row per pair or constituent with no analytical recomputation |
-| Q17 | Default infrastructure checks run | Validate without deployment or resource creation |
+| Q2 | A source event is corrected late | Preserve prior versions and create traceable replacements |
+| Q3 | A timestamp lacks a timezone | Reject it at the canonical boundary |
+| Q4 | A portfolio date is incomplete | Exclude it and report the alignment gap |
+| Q5 | A covariance window is incomplete | Publish no partial attribution snapshot |
+| Q6 | Historical attribution is requested | Emit every complete selected window in date order |
+| Q7 | A start date is supplied | Filter outputs while retaining prior window context |
+| Q8 | A history request exceeds 2,500 snapshots | Fail before publication and require a bounded split |
+| Q9 | A zero-variance constituent has undefined correlation | Persist JSON null and explicit status |
+| Q10 | Component contributions are calculated | Reconcile their sum to portfolio volatility |
+| Q11 | A corrected attribution is loaded | Retain history and select the newest declared grain |
+| Q12 | A consumer queries a matrix or vector | Return one pair or constituent per row without recomputation |
+| Q13 | Default infrastructure checks run | Validate without deployment or resource creation |
 
 ## 11. Risks And Technical Debt
 
-1. `main` still requires repository-level protection to enforce the CI gates;
-   issue #51 tracks the administrative setting.
+1. `main` still requires repository-level protection; issue #51 tracks the
+   administrative setting.
 2. Local Parquet is not durable cloud storage or a transactional table format.
 3. Kubernetes storage is ephemeral.
 4. S3, Glue and Kinesis Terraform files remain placeholders.
-5. The default container command runs the minute-oriented demo, not the daily,
-   portfolio or attribution operator sequences.
+5. The default container command runs the minute-oriented demo rather than the
+   daily, portfolio or attribution flows.
 6. Production scheduling, alerts and dashboards are not implemented.
-7. Attribution is a latest-window snapshot only; historical snapshots for every
-   event date are not calculated.
-8. Shrinkage, exponentially weighted and factor covariance estimators, marginal
+7. Shrinkage, exponentially weighted and factor covariance estimators, marginal
    VaR, FX conversion, short positions, leverage, transaction costs and
    non-daily rebalancing are not implemented.
-9. Portfolio definitions do not yet carry effective-from/to dates; the definition
-   fingerprint distinguishes weight sets but does not model a scheduled mandate.
-10. Exchange-specific trading calendars are not used; daily observations are
-    consecutive available closes, not guaranteed calendar-day intervals.
-11. PostgreSQL reconciliation is an explicit local operator step rather than a
-    CI database service.
-12. Repository control documentation is extensive relative to the compact data
-    runtime and should not grow ahead of product evidence.
+8. Portfolio definitions do not model effective-from/to mandate periods.
+9. Exchange-specific trading calendars are not used.
+10. PostgreSQL reconciliation remains an explicit local operator action rather
+    than a CI database service.
 
 ## 12. Glossary
 
 | Term | Meaning |
 | --- | --- |
-| Raw | Validated, normalised event-level Parquet retained for replay |
+| Raw | Validated event-level Parquet retained for replay |
 | Curated | Derived analytical Parquet |
-| Event time | When the market observation occurred |
-| Ingest time | When the platform accepted the observation |
-| Calculation ID | Deterministic identity of model version, parameters and inputs |
-| Definition fingerprint | Deterministic identity of portfolio constituents, weights and base currency |
-| Current version | Latest ingest/calculation within a declared serving grain |
-| Partial history | Valid output without enough observations for every configured window |
-| Portfolio definition | Long-only source/symbol constituents and weights that sum to one |
-| Return contribution | Weight multiplied by the constituent daily return |
-| Covariance window | Latest current portfolio-return observations used to estimate the matrix |
-| Attribution snapshot | One retained covariance, correlation and volatility-decomposition calculation |
+| Calculation ID | Deterministic identity of model, parameters and inputs |
+| Definition fingerprint | Identity of portfolio constituents, weights and currency |
+| Current version | Latest ingest/calculation inside an explicit grain |
+| Covariance window | Current return observations used to estimate one matrix |
+| Attribution snapshot | One covariance, correlation and volatility-decomposition result |
+| Rolling attribution history | One complete attribution snapshot per selected window end date |
 | Component volatility contribution | Euler allocation of portfolio volatility to one constituent |
 | Human acceptance | Explicit engineer decision after reviewing code and evidence |

--- a/docs/portfolio-attribution.md
+++ b/docs/portfolio-attribution.md
@@ -2,14 +2,14 @@
 
 ## Outcome
 
-This path turns retained portfolio daily returns into one deterministic
-risk-attribution snapshot for a configured portfolio definition and serves every
-retained snapshot through PostgreSQL:
+This path turns retained portfolio daily returns into deterministic covariance,
+correlation and Euler volatility-attribution snapshots and serves every retained
+version through PostgreSQL:
 
 ```text
 current portfolio_daily_returns versions
   -> exact definition-fingerprint selection
-  -> bounded covariance window
+  -> complete rolling covariance windows
   -> annualised sample covariance matrix
   -> Pearson correlation matrix
   -> Euler component contributions to portfolio volatility
@@ -18,15 +18,21 @@ current portfolio_daily_returns versions
   -> current covariance, correlation and contribution views
 ```
 
-The pure calculation is owned by
-`src/analytics/portfolio_attribution.py`. The local runner is
-`src/orchestration/run_portfolio_attribution.py`. The warehouse schema is
-`sql/portfolio_attribution_schema.sql`, and the dedicated loader is
-`src/warehouse/portfolio_attribution_loader.py`.
+The latest-snapshot calculation is owned by
+`src/analytics/portfolio_attribution.py`. Rolling historical attribution is
+owned by `src/analytics/portfolio_attribution_history.py`. The runners are:
+
+```text
+src/orchestration/run_portfolio_attribution.py
+src/orchestration/run_portfolio_attribution_history.py
+```
+
+The warehouse schema is `sql/portfolio_attribution_schema.sql`, and the dedicated
+loader is `src/warehouse/portfolio_attribution_loader.py`.
 
 ## Operator Flow
 
-Generate the constituent and portfolio history first:
+Generate constituent and portfolio history first:
 
 ```bash
 export ALPHA_VANTAGE_API_KEY='set-locally-do-not-commit'
@@ -38,7 +44,9 @@ make portfolio-risk-demo \
   END_DATE=2026-03-31
 ```
 
-Calculate the latest attribution snapshot without another provider request:
+### Latest snapshot
+
+Calculate only the latest complete window:
 
 ```bash
 make portfolio-attribution-demo \
@@ -47,36 +55,42 @@ make portfolio-attribution-demo \
   COVARIANCE_WINDOW=20
 ```
 
-The credential-free run summary is written to
-`.demo/portfolio-attribution-summary.json`. The curated snapshot is written under
-`data/curated/portfolio_risk_attribution`.
+The summary is written to `.demo/portfolio-attribution-summary.json`.
 
-Inspect the attribution warehouse batch without connecting to PostgreSQL:
+### Rolling history
 
-```bash
-make portfolio-attribution-warehouse-dry-run
-```
-
-Load the prerequisite daily and portfolio calculations, load attribution, and
-run the focused reconciliation checks:
+Calculate one snapshot for every eligible window end date:
 
 ```bash
-make local-db-up
-make portfolio-attribution-warehouse-load
-make check-portfolio-attribution-consistency
+make portfolio-attribution-history-demo \
+  PORTFOLIO_ID=us-tech-equal \
+  START_DATE=2026-01-01 \
+  END_DATE=2026-03-31 \
+  COVARIANCE_WINDOW=20
 ```
 
-`portfolio-attribution-warehouse-load` reapplies the core, portfolio and
-attribution schemas, loads the prerequisite warehouse facts, and then loads the
-attribution snapshot. This allows an already-running local database to receive
-the new objects without recreating its Docker volume.
+`START_DATE` filters emitted snapshot dates. Earlier current portfolio returns are
+still retained as calculation context so the first selected date can use its full
+covariance window. Omitting `START_DATE` emits every complete window no later than
+`END_DATE`.
+
+The rolling command writes a credential-free summary to
+`.demo/portfolio-attribution-history-summary.json`. Both commands publish to:
+
+```text
+data/curated/portfolio_risk_attribution
+```
+
+The history command is bounded by `MAX_HISTORY_SNAPSHOTS = 2_500`. A larger
+request fails before publication and should be split into date ranges. Each
+snapshot is published independently, so a partial local failure is replay-safe.
 
 ## Input Version Selection
 
 `portfolio_daily_returns` can retain several calculations for one portfolio
-definition and event date after an upstream component correction. The attribution
-runner filters to the fingerprint produced by the selected entry in
-`config/portfolios.yaml`, then chooses the current row for each event date by:
+definition and event date after an upstream correction. Both attribution paths
+filter to the fingerprint produced by the selected entry in
+`config/portfolios.yaml`, then choose the current row for each event date by:
 
 ```text
 ts_ingest DESC
@@ -94,10 +108,15 @@ Every selected record is checked against the configured definition:
 - component calculation IDs and finite component returns; and
 - persisted portfolio return equal to the weighted component returns.
 
+Historical snapshots are recalculated from the **current** version of each
+portfolio-return date. A late correction therefore creates new deterministic
+snapshot versions for every affected rolling window while preserving the earlier
+warehouse rows.
+
 ## Covariance And Correlation
 
-For a window of aligned constituent-return vectors `r_t`, the calculation uses
-the sample covariance matrix:
+For a complete window of aligned constituent-return vectors `r_t`, the
+calculation uses:
 
 ```text
 Sigma_daily = sample_covariance(r_t)
@@ -108,7 +127,7 @@ The persisted covariance matrix is annualised. Correlation is the ordinary
 Pearson correlation matrix calculated over the same observations.
 
 A zero-variance constituent makes its correlations undefined. Those cells are
-persisted as JSON `null` rather than non-standard `NaN`, and the snapshot records:
+persisted as JSON `null`, not non-standard `NaN`, and the snapshot records:
 
 ```text
 correlation_status = undefined_zero_variance
@@ -151,27 +170,28 @@ values are explicitly set to zero and `volatility_status` is `zero`.
 
 ```text
 portfolio definition fingerprint
-+ requested end date/current final event date
++ snapshot event date
 + covariance window
 + attribution model version
-+ weighting method
++ weighting, covariance and correlation methods
++ ordered current portfolio-return calculation IDs
 ```
 
-The row includes:
+Each row includes:
 
 - `portfolio-attribution-v1` and a deterministic calculation ID;
-- the selected window boundaries and ordered portfolio-return calculation IDs;
+- selected window boundaries and ordered input calculation IDs;
 - weights and annualised constituent volatilities;
-- annualised covariance and correlation matrices;
+- annualised covariance and Pearson correlation matrices;
 - marginal and component volatility contributions;
 - contribution shares;
 - annualised portfolio variance and volatility; and
 - correlation, zero-volatility and Euler-reconciliation evidence.
 
-The deterministic calculation ID binds the definition fingerprint, weighting
-method, covariance window, annualisation basis and ordered current input
-calculation IDs. Replaying the same state writes no duplicate Parquet record. An
-upstream correction, weight change or window change produces a distinct version.
+The deterministic calculation ID binds the definition fingerprint, methods,
+covariance window, annualisation basis and ordered current input IDs. Replaying
+the same state writes no duplicate Parquet record. A correction, definition
+change or window change produces a distinguishable version.
 
 ## PostgreSQL Serving Contract
 
@@ -182,10 +202,10 @@ risk_platform.portfolio_risk_attribution
 ```
 
 `calculation_id` is the primary and loader conflict key. Replaying an identical
-snapshot converges on one stored row. A corrected input, changed definition or
-changed covariance window remains a distinct retained version.
+snapshot converges on one stored row. Rolling history requires no schema change:
+`ts_event` already belongs to the current-version grain.
 
-The current-version grain is:
+The current grain is:
 
 ```text
 portfolio_id
@@ -206,14 +226,13 @@ version through:
 risk_platform.latest_portfolio_risk_attribution
 ```
 
-The scalar and JSON snapshot contract is exposed through:
+The complete current snapshot is exposed through:
 
 ```text
 risk_platform.portfolio_attribution_semantic_model
 ```
 
-The matrices and contribution vectors are expanded without recalculating the
-analytics:
+Matrices and contribution vectors are expanded without recalculation:
 
 ```text
 risk_platform.portfolio_covariance_model
@@ -221,49 +240,66 @@ risk_platform.portfolio_correlation_model
 risk_platform.portfolio_volatility_contribution_model
 ```
 
-`portfolio_covariance_model` and `portfolio_correlation_model` expose one row per
-ordered constituent pair. Undefined correlation cells remain SQL `NULL`.
-`portfolio_volatility_contribution_model` exposes one row per constituent with
-its weight, annualised standalone volatility, marginal contribution, component
-contribution and contribution share.
+The matrix views expose one row per ordered constituent pair. Undefined
+correlation cells remain SQL `NULL`. The contribution view exposes one row per
+constituent with weight, annualised standalone volatility, marginal contribution,
+Euler component contribution and contribution share.
 
-## Reconciliation Evidence
+## Warehouse Operation And Reconciliation
+
+Inspect the attribution batch without connecting to PostgreSQL:
+
+```bash
+make portfolio-attribution-warehouse-dry-run
+```
+
+Load prerequisites, attribution history and reconciliation evidence:
+
+```bash
+make local-db-up
+make portfolio-attribution-warehouse-load
+make check-portfolio-attribution-consistency
+```
+
+`portfolio-attribution-warehouse-load` reapplies the core, portfolio and
+attribution schemas, loads prerequisite facts, then loads all retained attribution
+snapshots.
 
 `sql/portfolio_attribution_consistency_checks.sql` verifies:
 
-- every retained input calculation ID references a portfolio-return row;
-- the current attribution snapshot uses current portfolio-return versions;
+- every retained input ID references a portfolio-return row;
+- current attribution uses current portfolio-return versions;
 - input IDs, window boundaries and definition metadata align;
 - JSON vector and matrix keys match the declared constituents;
-- portfolio weights sum to one;
+- weights sum to one;
 - covariance is symmetric with non-negative diagonals;
 - correlation is symmetric, bounded and has the declared null count;
 - squared portfolio volatility matches portfolio variance;
 - Euler component contributions and shares reconcile;
 - calculation IDs and current grains remain unique;
 - the latest view selects the newest candidate; and
-- semantic, matrix and contribution views have the expected row counts.
+- semantic, matrix and contribution views have expected row counts.
 
 ## Safety Bounds
 
-The analytics reader:
+The analytics readers:
 
-- accepts only `portfolio_daily_returns` from the configured curated base path;
-- filters to one portfolio ID, definition fingerprint and completed end date;
-- rejects symbolic-link paths and non-regular Parquet files;
-- caps the scan at 4,096 files, 1 GB and 250,000 matching rows;
-- requires exact portfolio-return fields; and
-- performs no provider request.
+- accept only `portfolio_daily_returns` from the configured curated base path;
+- filter to one portfolio ID, definition fingerprint and completed end date;
+- reject symbolic-link paths and non-regular Parquet files;
+- cap the scan at 4,096 files, 1 GB and 250,000 matching rows;
+- require exact portfolio-return fields;
+- cap one history request at 2,500 snapshots; and
+- perform no provider request.
 
-The warehouse loader applies the same file, byte and row limits to
-`portfolio_risk_attribution`, rejects unsafe local paths, converts only the
-declared JSON evidence fields to JSONB, and performs no analytical
-recalculation.
+The warehouse loader applies equivalent file, byte and row limits to
+`portfolio_risk_attribution`, converts only declared evidence fields to JSONB,
+and performs no analytical recalculation.
 
 ## Current Boundary
 
-This path stores one latest-window snapshot per explicit calculation identity. It
-does not yet calculate historical attribution snapshots for every event date,
-shrinkage or exponentially weighted covariance estimators, factor models,
-marginal VaR, FX conversion, leverage, short positions, transaction costs,
-scheduled rebalancing, production scheduling, dashboards or alert delivery.
+This path implements current-version rolling historical attribution with sample
+covariance and Euler volatility allocation. It does not implement shrinkage or
+exponentially weighted covariance estimators, factor models, marginal VaR, FX
+conversion, leverage, short positions, transaction costs, scheduled rebalancing,
+production scheduling, dashboards or alert delivery.

--- a/src/analytics/portfolio_attribution_history.py
+++ b/src/analytics/portfolio_attribution_history.py
@@ -1,0 +1,151 @@
+from __future__ import annotations
+
+import json
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
+from datetime import date
+from typing import Any
+
+from ..common.exceptions import ValidationError
+from .portfolio_attribution import (
+    MAX_COVARIANCE_WINDOW,
+    PortfolioReturnInput,
+    _current_records,
+    build_portfolio_attribution,
+)
+from .portfolio_risk import PortfolioDefinition
+
+MAX_HISTORY_SNAPSHOTS = 2_500
+
+
+@dataclass(frozen=True, slots=True)
+class PortfolioAttributionHistoryOutput:
+    snapshots: tuple[dict[str, Any], ...]
+    diagnostics: Mapping[str, Any]
+
+
+def _snapshot_limit(value: int) -> int:
+    if type(value) is not int or not 1 <= value <= MAX_HISTORY_SNAPSHOTS:
+        raise ValidationError(
+            "max_snapshots must be an integer between "
+            f"1 and {MAX_HISTORY_SNAPSHOTS}"
+        )
+    return value
+
+
+def _covariance_window(value: int) -> int:
+    if type(value) is not int or not 2 <= value <= MAX_COVARIANCE_WINDOW:
+        raise ValidationError(
+            "covariance_window must be an integer between "
+            f"2 and {MAX_COVARIANCE_WINDOW}"
+        )
+    return value
+
+
+def _normalised_input_record(record: Mapping[str, Any]) -> dict[str, Any]:
+    return {
+        "model_version": record["model_version"],
+        "calculation_id": record["calculation_id"],
+        "portfolio_id": record["portfolio_id"],
+        "base_currency": record["base_currency"],
+        "definition_fingerprint": record["definition_fingerprint"],
+        "weighting_method": record["weighting_method"],
+        "ts_event": record["ts_event"],
+        "ts_ingest": record["ts_ingest"],
+        "constituent_count": record["constituent_count"],
+        "weights_json": json.dumps(
+            record["weights"],
+            sort_keys=True,
+            separators=(",", ":"),
+        ),
+        "component_calculation_ids_json": json.dumps(
+            record["component_calculation_ids"],
+            sort_keys=True,
+            separators=(",", ":"),
+        ),
+        "component_returns_json": json.dumps(
+            record["component_returns"],
+            sort_keys=True,
+            separators=(",", ":"),
+        ),
+        "portfolio_return_1d": record["portfolio_return_1d"],
+    }
+
+
+def build_portfolio_attribution_history(
+    records: Iterable[PortfolioReturnInput],
+    *,
+    definition: PortfolioDefinition,
+    covariance_window: int = 20,
+    start_date: date | None = None,
+    end_date: date | None = None,
+    max_snapshots: int = MAX_HISTORY_SNAPSHOTS,
+) -> PortfolioAttributionHistoryOutput:
+    covariance_window = _covariance_window(covariance_window)
+    max_snapshots = _snapshot_limit(max_snapshots)
+    if start_date is not None and end_date is not None and start_date > end_date:
+        raise ValidationError("start_date must be on or before end_date")
+
+    # Reuse the canonical validation and current-version selection contract.
+    # This increment changes only window expansion, not input semantics.
+    current, matched_records = _current_records(records, definition, end_date)
+    if len(current) < covariance_window:
+        raise ValidationError(
+            "portfolio attribution history requires at least "
+            f"{covariance_window} current portfolio return observations"
+        )
+
+    all_end_indexes = list(range(covariance_window - 1, len(current)))
+    selected_end_indexes = [
+        index
+        for index in all_end_indexes
+        if start_date is None or current[index]["ts_event"].date() >= start_date
+    ]
+    if not selected_end_indexes:
+        raise ValidationError(
+            "no portfolio attribution snapshots matched the requested date range"
+        )
+    if len(selected_end_indexes) > max_snapshots:
+        raise ValidationError(
+            "portfolio attribution history exceeds max_snapshots; provide a later "
+            "start_date or split the bounded request"
+        )
+
+    snapshots: list[dict[str, Any]] = []
+    for end_index in selected_end_indexes:
+        window = current[
+            end_index - covariance_window + 1 : end_index + 1
+        ]
+        output = build_portfolio_attribution(
+            (_normalised_input_record(record) for record in window),
+            definition=definition,
+            covariance_window=covariance_window,
+            end_date=window[-1]["ts_event"].date(),
+        )
+        snapshots.append(output.snapshot)
+
+    first_snapshot = snapshots[0]
+    last_snapshot = snapshots[-1]
+    diagnostics = {
+        "matched_input_records": matched_records,
+        "current_portfolio_return_records": len(current),
+        "covariance_window": covariance_window,
+        "available_snapshot_dates": len(all_end_indexes),
+        "snapshots_selected": len(snapshots),
+        "snapshots_skipped_before_start_date": (
+            len(all_end_indexes) - len(selected_end_indexes)
+        ),
+        "first_snapshot_date": first_snapshot["ts_event"].date().isoformat(),
+        "last_snapshot_date": last_snapshot["ts_event"].date().isoformat(),
+        "start_date": start_date.isoformat() if start_date is not None else None,
+        "end_date": (
+            end_date.isoformat()
+            if end_date is not None
+            else last_snapshot["ts_event"].date().isoformat()
+        ),
+        "max_snapshots": max_snapshots,
+    }
+    return PortfolioAttributionHistoryOutput(
+        snapshots=tuple(snapshots),
+        diagnostics=diagnostics,
+    )

--- a/src/orchestration/run_portfolio_attribution_history.py
+++ b/src/orchestration/run_portfolio_attribution_history.py
@@ -1,0 +1,312 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections.abc import Callable, Sequence
+from datetime import date
+from pathlib import Path
+from typing import Any
+from uuid import uuid4
+
+from ..analytics.portfolio_attribution_history import (
+    MAX_HISTORY_SNAPSHOTS,
+    PortfolioAttributionHistoryOutput,
+    build_portfolio_attribution_history,
+)
+from ..analytics.portfolio_risk import (
+    PortfolioDefinition,
+    load_portfolio_definition,
+)
+from ..common.exceptions import StorageError, ValidationError
+from ..storage.s3_writer import write_records
+from ..storage.storage_config import load_storage_config
+from .run_portfolio_attribution import (
+    OUTPUT_DATASET,
+    _require_datasets,
+    load_portfolio_return_records,
+)
+
+Reader = Callable[..., list[dict[str, Any]]]
+Writer = Callable[..., int]
+StorageConfigLoader = Callable[[Path], dict[str, Any]]
+DefinitionLoader = Callable[[Path, str], PortfolioDefinition]
+
+
+def _calendar_date(value: str) -> date:
+    try:
+        parsed = date.fromisoformat(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(
+            "must be a calendar date in YYYY-MM-DD format"
+        ) from exc
+    if value != parsed.isoformat():
+        raise argparse.ArgumentTypeError(
+            "must be a calendar date in YYYY-MM-DD format"
+        )
+    return parsed
+
+
+def _integer_at_least(value: str, minimum: int, label: str) -> int:
+    try:
+        parsed = int(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(
+            f"{label} must be an integer of at least {minimum}"
+        ) from exc
+    if parsed < minimum:
+        raise argparse.ArgumentTypeError(
+            f"{label} must be an integer of at least {minimum}"
+        )
+    return parsed
+
+
+def _covariance_window(value: str) -> int:
+    return _integer_at_least(value, 2, "covariance_window")
+
+
+def _max_snapshots(value: str) -> int:
+    parsed = _integer_at_least(value, 1, "max_snapshots")
+    if parsed > MAX_HISTORY_SNAPSHOTS:
+        raise argparse.ArgumentTypeError(
+            f"max_snapshots must not exceed {MAX_HISTORY_SNAPSHOTS}"
+        )
+    return parsed
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Build rolling covariance, correlation and component-risk history "
+            "from local portfolio-return parquet."
+        )
+    )
+    parser.add_argument("--portfolio-id", required=True)
+    parser.add_argument(
+        "--portfolio-config",
+        type=Path,
+        default=Path("config/portfolios.yaml"),
+    )
+    parser.add_argument("--start-date", type=_calendar_date)
+    parser.add_argument("--end-date", required=True, type=_calendar_date)
+    parser.add_argument(
+        "--covariance-window",
+        type=_covariance_window,
+        default=20,
+    )
+    parser.add_argument(
+        "--max-snapshots",
+        type=_max_snapshots,
+        default=MAX_HISTORY_SNAPSHOTS,
+    )
+    parser.add_argument(
+        "--storage-config",
+        type=Path,
+        default=Path("config/storage.yaml"),
+    )
+    parser.add_argument("--summary-json", type=Path)
+    return parser
+
+
+def _publish_snapshots(
+    snapshots: tuple[dict[str, Any], ...],
+    *,
+    storage_config: dict[str, Any],
+    writer: Writer,
+) -> int:
+    written = 0
+    for snapshot in snapshots:
+        try:
+            result = writer(
+                [snapshot],
+                kind="curated",
+                dataset=OUTPUT_DATASET,
+                storage_config=storage_config,
+            )
+        except Exception:
+            raise StorageError(
+                "Portfolio attribution history publication failed; rerun is safe"
+            ) from None
+        if type(result) is not int or result not in {0, 1}:
+            raise StorageError(
+                "Portfolio attribution history publication returned an invalid result"
+            )
+        written += result
+    return written
+
+
+def run_portfolio_attribution_history(
+    *,
+    portfolio_id: str,
+    portfolio_config_path: Path,
+    end_date: date,
+    covariance_window: int,
+    storage_config_path: Path,
+    start_date: date | None = None,
+    max_snapshots: int = MAX_HISTORY_SNAPSHOTS,
+    reader: Reader | None = None,
+    writer: Writer | None = None,
+    storage_config_loader: StorageConfigLoader | None = None,
+    definition_loader: DefinitionLoader | None = None,
+) -> dict[str, Any]:
+    if start_date is not None and start_date > end_date:
+        raise ValidationError("start_date must be on or before end_date")
+
+    selected_storage_loader = storage_config_loader or load_storage_config
+    try:
+        storage_config = selected_storage_loader(storage_config_path)
+    except Exception:
+        raise StorageError("Storage configuration is invalid") from None
+    if not isinstance(storage_config, dict):
+        raise StorageError("Storage configuration is invalid")
+    _require_datasets(storage_config)
+
+    selected_definition_loader = definition_loader or load_portfolio_definition
+    try:
+        definition = selected_definition_loader(
+            portfolio_config_path,
+            portfolio_id,
+        )
+    except ValidationError:
+        raise
+    except Exception:
+        raise ValidationError("Portfolio configuration is invalid") from None
+
+    selected_reader = reader or load_portfolio_return_records
+    try:
+        records = selected_reader(
+            storage_config=storage_config,
+            portfolio_id=definition.portfolio_id,
+            definition_fingerprint=definition.fingerprint,
+            end_date=end_date,
+        )
+    except (StorageError, ValidationError):
+        raise
+    except Exception:
+        raise StorageError("Unable to read local portfolio returns") from None
+
+    output: PortfolioAttributionHistoryOutput = (
+        build_portfolio_attribution_history(
+            records,
+            definition=definition,
+            covariance_window=covariance_window,
+            start_date=start_date,
+            end_date=end_date,
+            max_snapshots=max_snapshots,
+        )
+    )
+    selected_writer = writer or write_records
+    written = _publish_snapshots(
+        output.snapshots,
+        storage_config=storage_config,
+        writer=selected_writer,
+    )
+
+    latest = output.snapshots[-1]
+    components = json.loads(
+        latest["component_volatility_contribution_json"]
+    )
+    largest_component = max(
+        sorted(components),
+        key=lambda key: abs(float(components[key])),
+    )
+    selected = len(output.snapshots)
+    return {
+        "run_id": str(uuid4()),
+        "portfolio_id": definition.portfolio_id,
+        "base_currency": definition.base_currency,
+        "definition_fingerprint": definition.fingerprint,
+        "selection": {
+            "start_date": (
+                start_date.isoformat() if start_date is not None else None
+            ),
+            "end_date": end_date.isoformat(),
+            **dict(output.diagnostics),
+        },
+        "parameters": {
+            "covariance_window": covariance_window,
+            "max_snapshots": max_snapshots,
+        },
+        "curated_output": {
+            OUTPUT_DATASET: {
+                "records_selected": selected,
+                "records_written": written,
+                "records_already_present": selected - written,
+            }
+        },
+        "latest_metrics": {
+            "ts_event": latest["ts_event"].isoformat(),
+            "portfolio_variance_annualized": latest[
+                "portfolio_variance_annualized"
+            ],
+            "portfolio_volatility_annualized": latest[
+                "portfolio_volatility_annualized"
+            ],
+            "volatility_status": latest["volatility_status"],
+            "correlation_status": latest["correlation_status"],
+            "largest_absolute_component": largest_component,
+            "largest_absolute_component_contribution": components[
+                largest_component
+            ],
+            "calculation_id": latest["calculation_id"],
+        },
+    }
+
+
+def _write_summary(path: Path, summary: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary_path = path.with_suffix(path.suffix + ".tmp")
+    try:
+        temporary_path.write_text(
+            json.dumps(summary, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        temporary_path.replace(path)
+    except OSError:
+        temporary_path.unlink(missing_ok=True)
+        raise StorageError(
+            "Unable to write the portfolio attribution history summary"
+        ) from None
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    try:
+        summary = run_portfolio_attribution_history(
+            portfolio_id=args.portfolio_id,
+            portfolio_config_path=args.portfolio_config,
+            start_date=args.start_date,
+            end_date=args.end_date,
+            covariance_window=args.covariance_window,
+            max_snapshots=args.max_snapshots,
+            storage_config_path=args.storage_config,
+        )
+        if args.summary_json is not None:
+            _write_summary(args.summary_json, summary)
+    except ValidationError:
+        print(
+            "Portfolio attribution history failed: configuration, input data "
+            "or options were invalid",
+            file=sys.stderr,
+        )
+        return 1
+    except StorageError:
+        print(
+            "Portfolio attribution history failed: local storage operation "
+            "failed; rerun is safe",
+            file=sys.stderr,
+        )
+        return 1
+    except Exception:
+        print(
+            "Portfolio attribution history failed: unexpected local failure",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(json.dumps(summary, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/integration/test_portfolio_attribution_history_pipeline.py
+++ b/tests/integration/test_portfolio_attribution_history_pipeline.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+import json
+from datetime import date, datetime, timedelta, timezone
+from pathlib import Path
+
+from src.analytics.portfolio_risk import (
+    WEIGHTING_METHOD,
+    load_portfolio_definition,
+)
+from src.orchestration.run_portfolio_attribution_history import (
+    run_portfolio_attribution_history,
+)
+from src.storage.s3_writer import write_records
+from tests.storage_config_helpers import build_storage_config, write_storage_config
+
+
+def _portfolio_config(tmp_path: Path) -> Path:
+    path = tmp_path / "portfolios.yaml"
+    path.write_text(
+        """
+portfolios:
+  us-tech-equal:
+    base_currency: USD
+    constituents:
+      - source: alpha_vantage
+        symbol: AAPL
+        weight: 0.5
+      - source: alpha_vantage
+        symbol: MSFT
+        weight: 0.5
+""".lstrip(),
+        encoding="utf-8",
+    )
+    return path
+
+
+def _portfolio_returns(definition_fingerprint: str) -> list[dict[str, object]]:
+    records: list[dict[str, object]] = []
+    ingested_at = datetime(2026, 1, 10, 12, tzinfo=timezone.utc)
+    for day, aapl, msft in [
+        (2, 0.10, 0.02),
+        (3, -0.04, 0.00),
+        (4, 0.06, 0.02),
+        (5, 0.01, -0.01),
+        (6, -0.02, 0.03),
+    ]:
+        component_returns = {
+            "alpha_vantage:AAPL": aapl,
+            "alpha_vantage:MSFT": msft,
+        }
+        records.append(
+            {
+                "model_version": "portfolio-risk-v1",
+                "calculation_id": f"portfolio-{day}",
+                "portfolio_id": "us-tech-equal",
+                "base_currency": "USD",
+                "definition_fingerprint": definition_fingerprint,
+                "weighting_method": WEIGHTING_METHOD,
+                "ts_event": datetime(2026, 1, day, tzinfo=timezone.utc),
+                "ts_ingest": ingested_at + timedelta(minutes=day),
+                "constituent_count": 2,
+                "weights_json": json.dumps(
+                    {
+                        "alpha_vantage:AAPL": 0.5,
+                        "alpha_vantage:MSFT": 0.5,
+                    },
+                    sort_keys=True,
+                ),
+                "component_calculation_ids_json": json.dumps(
+                    {
+                        "alpha_vantage:AAPL": f"AAPL-{day}",
+                        "alpha_vantage:MSFT": f"MSFT-{day}",
+                    },
+                    sort_keys=True,
+                ),
+                "component_returns_json": json.dumps(
+                    component_returns,
+                    sort_keys=True,
+                ),
+                "contributions_json": json.dumps(
+                    {
+                        key: 0.5 * value
+                        for key, value in component_returns.items()
+                    },
+                    sort_keys=True,
+                ),
+                "portfolio_return_1d": 0.5 * aapl + 0.5 * msft,
+            }
+        )
+    return records
+
+
+def test_portfolio_attribution_history_replays_rolling_snapshots(
+    tmp_path: Path,
+) -> None:
+    storage_config = build_storage_config(tmp_path)
+    storage_config_path = write_storage_config(tmp_path)
+    portfolio_config_path = _portfolio_config(tmp_path)
+    definition = load_portfolio_definition(
+        portfolio_config_path,
+        "us-tech-equal",
+    )
+    assert (
+        write_records(
+            _portfolio_returns(definition.fingerprint),
+            kind="curated",
+            dataset="portfolio_daily_returns",
+            storage_config=storage_config,
+        )
+        == 5
+    )
+
+    first = run_portfolio_attribution_history(
+        portfolio_id="us-tech-equal",
+        portfolio_config_path=portfolio_config_path,
+        start_date=date(2026, 1, 5),
+        end_date=date(2026, 1, 6),
+        covariance_window=3,
+        max_snapshots=10,
+        storage_config_path=storage_config_path,
+    )
+    second = run_portfolio_attribution_history(
+        portfolio_id="us-tech-equal",
+        portfolio_config_path=portfolio_config_path,
+        start_date=date(2026, 1, 5),
+        end_date=date(2026, 1, 6),
+        covariance_window=3,
+        max_snapshots=10,
+        storage_config_path=storage_config_path,
+    )
+
+    assert first["curated_output"]["portfolio_risk_attribution"] == {
+        "records_selected": 2,
+        "records_written": 2,
+        "records_already_present": 0,
+    }
+    assert second["curated_output"]["portfolio_risk_attribution"] == {
+        "records_selected": 2,
+        "records_written": 0,
+        "records_already_present": 2,
+    }
+    assert first["selection"]["first_snapshot_date"] == "2026-01-05"
+    assert first["selection"]["last_snapshot_date"] == "2026-01-06"
+    assert second["latest_metrics"]["calculation_id"] == first[
+        "latest_metrics"
+    ]["calculation_id"]

--- a/tests/unit/test_portfolio_attribution_history.py
+++ b/tests/unit/test_portfolio_attribution_history.py
@@ -1,0 +1,164 @@
+from __future__ import annotations
+
+import json
+from datetime import date, datetime, timedelta, timezone
+
+import pytest
+
+from src.analytics.portfolio_attribution_history import (
+    build_portfolio_attribution_history,
+)
+from src.analytics.portfolio_risk import (
+    WEIGHTING_METHOD,
+    PortfolioDefinition,
+    parse_portfolio_definition,
+)
+from src.common.exceptions import ValidationError
+
+
+def _definition() -> PortfolioDefinition:
+    return parse_portfolio_definition(
+        {
+            "portfolios": {
+                "us-tech-equal": {
+                    "base_currency": "USD",
+                    "constituents": [
+                        {
+                            "source": "alpha_vantage",
+                            "symbol": "AAPL",
+                            "weight": 0.5,
+                        },
+                        {
+                            "source": "alpha_vantage",
+                            "symbol": "MSFT",
+                            "weight": 0.5,
+                        },
+                    ],
+                }
+            }
+        },
+        "us-tech-equal",
+    )
+
+
+def _record(day: int, aapl: float, msft: float) -> dict[str, object]:
+    definition = _definition()
+    event = datetime(2026, 1, day, tzinfo=timezone.utc)
+    component_returns = {
+        "alpha_vantage:AAPL": aapl,
+        "alpha_vantage:MSFT": msft,
+    }
+    return {
+        "model_version": "portfolio-risk-v1",
+        "calculation_id": f"portfolio-{day}",
+        "portfolio_id": "us-tech-equal",
+        "base_currency": "USD",
+        "definition_fingerprint": definition.fingerprint,
+        "weighting_method": WEIGHTING_METHOD,
+        "ts_event": event,
+        "ts_ingest": event + timedelta(hours=1),
+        "constituent_count": 2,
+        "weights_json": json.dumps(
+            {
+                "alpha_vantage:AAPL": 0.5,
+                "alpha_vantage:MSFT": 0.5,
+            },
+            sort_keys=True,
+        ),
+        "component_calculation_ids_json": json.dumps(
+            {
+                "alpha_vantage:AAPL": f"AAPL-{day}",
+                "alpha_vantage:MSFT": f"MSFT-{day}",
+            },
+            sort_keys=True,
+        ),
+        "component_returns_json": json.dumps(
+            component_returns,
+            sort_keys=True,
+        ),
+        "portfolio_return_1d": 0.5 * aapl + 0.5 * msft,
+    }
+
+
+def _records() -> list[dict[str, object]]:
+    return [
+        _record(2, 0.10, 0.02),
+        _record(3, -0.04, 0.00),
+        _record(4, 0.06, 0.02),
+        _record(5, 0.01, -0.01),
+        _record(6, -0.02, 0.03),
+    ]
+
+
+def test_history_emits_every_complete_rolling_window() -> None:
+    output = build_portfolio_attribution_history(
+        _records(),
+        definition=_definition(),
+        covariance_window=3,
+        end_date=date(2026, 1, 6),
+    )
+
+    assert [snapshot["ts_event"].date() for snapshot in output.snapshots] == [
+        date(2026, 1, 4),
+        date(2026, 1, 5),
+        date(2026, 1, 6),
+    ]
+    assert [
+        snapshot["window_start"].date() for snapshot in output.snapshots
+    ] == [
+        date(2026, 1, 2),
+        date(2026, 1, 3),
+        date(2026, 1, 4),
+    ]
+    assert len({snapshot["calculation_id"] for snapshot in output.snapshots}) == 3
+    assert output.diagnostics["available_snapshot_dates"] == 3
+    assert output.diagnostics["snapshots_selected"] == 3
+
+
+def test_start_date_filters_emission_but_preserves_prior_window_context() -> None:
+    output = build_portfolio_attribution_history(
+        _records(),
+        definition=_definition(),
+        covariance_window=3,
+        start_date=date(2026, 1, 6),
+        end_date=date(2026, 1, 6),
+    )
+
+    assert len(output.snapshots) == 1
+    assert output.snapshots[0]["window_start"].date() == date(2026, 1, 4)
+    assert output.snapshots[0]["ts_event"].date() == date(2026, 1, 6)
+    assert output.diagnostics["snapshots_skipped_before_start_date"] == 2
+
+
+def test_history_is_input_order_independent() -> None:
+    forward = build_portfolio_attribution_history(
+        _records(),
+        definition=_definition(),
+        covariance_window=3,
+    )
+    reverse = build_portfolio_attribution_history(
+        reversed(_records()),
+        definition=_definition(),
+        covariance_window=3,
+    )
+
+    assert forward == reverse
+
+
+def test_history_range_and_snapshot_limit_fail_closed() -> None:
+    with pytest.raises(ValidationError, match="start_date"):
+        build_portfolio_attribution_history(
+            _records(),
+            definition=_definition(),
+            covariance_window=3,
+            start_date=date(2026, 1, 6),
+            end_date=date(2026, 1, 5),
+        )
+
+    with pytest.raises(ValidationError, match="exceeds max_snapshots"):
+        build_portfolio_attribution_history(
+            _records(),
+            definition=_definition(),
+            covariance_window=3,
+            max_snapshots=2,
+        )

--- a/tests/unit/test_portfolio_attribution_history_architecture_contract.py
+++ b/tests/unit/test_portfolio_attribution_history_architecture_contract.py
@@ -1,0 +1,29 @@
+from pathlib import Path
+
+
+def test_architecture_documents_rolling_attribution_history() -> None:
+    architecture = Path("docs/architecture.md").read_text(encoding="utf-8")
+    attribution = Path("docs/portfolio-attribution.md").read_text(
+        encoding="utf-8"
+    )
+    makefile = Path("Makefile").read_text(encoding="utf-8")
+
+    for required in (
+        "rolling historical attribution",
+        "portfolio-attribution-history-demo",
+        "MAX_HISTORY_SNAPSHOTS = 2_500",
+        "one snapshot per eligible rolling end date",
+        "start date is supplied",
+    ):
+        assert required.lower() in (
+            architecture + attribution + makefile
+        ).lower()
+
+    for stale in (
+        "Attribution is a latest-window snapshot only",
+        "historical snapshots for every event date are not calculated",
+        "does not yet calculate historical attribution snapshots",
+        "This path stores one latest-window snapshot",
+    ):
+        assert stale not in architecture
+        assert stale not in attribution

--- a/tests/unit/test_run_portfolio_attribution_history.py
+++ b/tests/unit/test_run_portfolio_attribution_history.py
@@ -1,0 +1,205 @@
+from __future__ import annotations
+
+import json
+from datetime import date, datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from src.analytics.portfolio_risk import (
+    WEIGHTING_METHOD,
+    PortfolioDefinition,
+    parse_portfolio_definition,
+)
+from src.common.exceptions import StorageError, ValidationError
+from src.orchestration.run_portfolio_attribution_history import (
+    OUTPUT_DATASET,
+    run_portfolio_attribution_history,
+)
+
+
+def _definition() -> PortfolioDefinition:
+    return parse_portfolio_definition(
+        {
+            "portfolios": {
+                "us-tech-equal": {
+                    "base_currency": "USD",
+                    "constituents": [
+                        {
+                            "source": "alpha_vantage",
+                            "symbol": "AAPL",
+                            "weight": 0.5,
+                        },
+                        {
+                            "source": "alpha_vantage",
+                            "symbol": "MSFT",
+                            "weight": 0.5,
+                        },
+                    ],
+                }
+            }
+        },
+        "us-tech-equal",
+    )
+
+
+def _records() -> list[dict[str, object]]:
+    definition = _definition()
+    records: list[dict[str, object]] = []
+    for day, aapl, msft in [
+        (2, 0.10, 0.02),
+        (3, -0.04, 0.00),
+        (4, 0.06, 0.02),
+        (5, 0.01, -0.01),
+    ]:
+        event = datetime(2026, 1, day, tzinfo=timezone.utc)
+        component_returns = {
+            "alpha_vantage:AAPL": aapl,
+            "alpha_vantage:MSFT": msft,
+        }
+        records.append(
+            {
+                "model_version": "portfolio-risk-v1",
+                "calculation_id": f"portfolio-{day}",
+                "portfolio_id": "us-tech-equal",
+                "base_currency": "USD",
+                "definition_fingerprint": definition.fingerprint,
+                "weighting_method": WEIGHTING_METHOD,
+                "ts_event": event,
+                "ts_ingest": event + timedelta(hours=1),
+                "constituent_count": 2,
+                "weights_json": json.dumps(
+                    {
+                        "alpha_vantage:AAPL": 0.5,
+                        "alpha_vantage:MSFT": 0.5,
+                    }
+                ),
+                "component_calculation_ids_json": json.dumps(
+                    {
+                        "alpha_vantage:AAPL": f"AAPL-{day}",
+                        "alpha_vantage:MSFT": f"MSFT-{day}",
+                    }
+                ),
+                "component_returns_json": json.dumps(component_returns),
+                "portfolio_return_1d": 0.5 * aapl + 0.5 * msft,
+            }
+        )
+    return records
+
+
+def _storage_config() -> dict[str, Any]:
+    return {
+        "storage": {
+            "base_dir": "unused",
+            "raw": {
+                "base_path": "unused/raw",
+                "dataset": "market_events",
+            },
+            "curated": {
+                "base_path": "unused/curated",
+                "datasets": {
+                    "portfolio_daily_returns": "portfolio_daily_returns",
+                    OUTPUT_DATASET: OUTPUT_DATASET,
+                },
+            },
+            "format": "parquet",
+            "partitioning": {"granularity": "hourly"},
+        }
+    }
+
+
+def test_runner_publishes_each_selected_snapshot() -> None:
+    writes: list[dict[str, Any]] = []
+
+    def writer(
+        records: list[dict[str, Any]],
+        *,
+        dataset: str,
+        **_: Any,
+    ) -> int:
+        assert dataset == OUTPUT_DATASET
+        assert len(records) == 1
+        writes.append(records[0])
+        return 1
+
+    summary = run_portfolio_attribution_history(
+        portfolio_id="us-tech-equal",
+        portfolio_config_path=Path("unused.yaml"),
+        end_date=date(2026, 1, 5),
+        covariance_window=3,
+        max_snapshots=10,
+        storage_config_path=Path("unused-storage.yaml"),
+        reader=lambda **_: _records(),
+        writer=writer,
+        storage_config_loader=lambda _: _storage_config(),
+        definition_loader=lambda *_: _definition(),
+    )
+
+    assert summary["curated_output"][OUTPUT_DATASET] == {
+        "records_selected": 2,
+        "records_written": 2,
+        "records_already_present": 0,
+    }
+    assert [record["ts_event"].date() for record in writes] == [
+        date(2026, 1, 4),
+        date(2026, 1, 5),
+    ]
+    assert summary["latest_metrics"]["portfolio_volatility_annualized"] >= 0
+
+
+def test_runner_start_date_filters_and_reports_replay() -> None:
+    summary = run_portfolio_attribution_history(
+        portfolio_id="us-tech-equal",
+        portfolio_config_path=Path("unused.yaml"),
+        start_date=date(2026, 1, 5),
+        end_date=date(2026, 1, 5),
+        covariance_window=3,
+        max_snapshots=10,
+        storage_config_path=Path("unused-storage.yaml"),
+        reader=lambda **_: _records(),
+        writer=lambda *_args, **_kwargs: 0,
+        storage_config_loader=lambda _: _storage_config(),
+        definition_loader=lambda *_: _definition(),
+    )
+
+    assert summary["curated_output"][OUTPUT_DATASET] == {
+        "records_selected": 1,
+        "records_written": 0,
+        "records_already_present": 1,
+    }
+    assert summary["selection"]["first_snapshot_date"] == "2026-01-05"
+
+
+def test_runner_rejects_invalid_range_before_io() -> None:
+    with pytest.raises(ValidationError, match="start_date"):
+        run_portfolio_attribution_history(
+            portfolio_id="us-tech-equal",
+            portfolio_config_path=Path("unused.yaml"),
+            start_date=date(2026, 1, 6),
+            end_date=date(2026, 1, 5),
+            covariance_window=3,
+            storage_config_path=Path("unused-storage.yaml"),
+            reader=lambda **_: (_ for _ in ()).throw(AssertionError()),
+            writer=lambda *_args, **_kwargs: 1,
+            storage_config_loader=lambda _: (_ for _ in ()).throw(
+                AssertionError()
+            ),
+            definition_loader=lambda *_: _definition(),
+        )
+
+
+def test_runner_rejects_invalid_writer_result() -> None:
+    with pytest.raises(StorageError, match="invalid result"):
+        run_portfolio_attribution_history(
+            portfolio_id="us-tech-equal",
+            portfolio_config_path=Path("unused.yaml"),
+            end_date=date(2026, 1, 5),
+            covariance_window=3,
+            max_snapshots=10,
+            storage_config_path=Path("unused-storage.yaml"),
+            reader=lambda **_: _records(),
+            writer=lambda *_args, **_kwargs: 2,
+            storage_config_loader=lambda _: _storage_config(),
+            definition_loader=lambda *_: _definition(),
+        )


### PR DESCRIPTION
## Outcome

Extend the existing latest-window attribution calculation into a bounded rolling historical series without changing the covariance model or PostgreSQL grain:

```text
current portfolio_daily_returns versions
  -> exact definition fingerprint
  -> complete rolling covariance windows
  -> annualised sample covariance and Pearson correlation
  -> Euler component-volatility attribution
  -> one versioned portfolio_risk_attribution snapshot per eligible end date
  -> existing PostgreSQL history and row-level views
```

Primary arc42 block: `analytics`, with bounded interfaces to orchestration, curated publication, the existing attribution warehouse contract and directly affected documentation.

## Analytics contract

Add `src.analytics.portfolio_attribution_history` with:

- one canonical call to the existing current-version selector;
- complete-window expansion in event-date order;
- the existing `portfolio-attribution-v1` calculation for every window;
- deterministic identities based on each ordered set of current portfolio-return calculation IDs;
- optional `start_date` filtering of emitted snapshot dates while preserving prior window context;
- an explicit `MAX_HISTORY_SNAPSHOTS = 2_500` request bound; and
- failure before publication for invalid ranges, incomplete history or oversized requests.

Historical output is current-version history, not point-in-time-as-known history. A late correction creates new calculation IDs for every affected window while earlier warehouse versions remain retained.

## Orchestration

Add `src.orchestration.run_portfolio_attribution_history` and:

```bash
make portfolio-attribution-history-demo \
  PORTFOLIO_ID=us-tech-equal \
  START_DATE=2026-01-01 \
  END_DATE=2026-03-31 \
  COVARIANCE_WINDOW=20
```

The runner reuses the existing bounded portfolio-return reader, publishes each snapshot independently through the content-addressed writer and reports selected, written and already-present counts. Partial local publication is replay-safe.

The request bound is configurable up to 2,500 through `ATTRIBUTION_MAX_SNAPSHOTS` / `--max-snapshots`.

## Warehouse compatibility

No schema migration is required. `risk_platform.portfolio_risk_attribution` and `latest_portfolio_risk_attribution` already include `ts_event` in their version grain, and the existing covariance, correlation and contribution views naturally expose the rolling series after the standard attribution warehouse load.

## Validation

GitHub Actions run `32486951203` (`ci` run 201) passed on exact head `750f432737cae001b88ce3eb79d1c5a4cd868db9`:

- Security guardrails: passed
- Python readiness: passed
  - locked dependencies resolved
  - Ruff passed
  - mypy passed across 48 source files
  - 462 tests passed, including rolling-window, bounded-range, publication and Parquet replay coverage
  - `pip check` passed
  - `make readiness-check` passed
- Infrastructure validation: passed
  - Kubernetes overlays rendered
  - Terraform formatting, initialization and validation passed without applying infrastructure

No unresolved review threads or requested changes are present.

## Scope

The branch is one commit ahead of `main` and zero behind. It changes nine files with 1,290 additions and 318 deletions as one rolling-attribution analytics increment.

It does not add a new model, schema, provider request, credential, scheduler, dashboard, deployment or Terraform apply. Shrinkage/EWMA/factor covariance, marginal VaR, FX conversion, leverage, shorting, transaction costs and non-daily rebalancing remain out of scope.

## Acceptance boundary

This PR is validated and ready for squash merge as one analytics increment.