### PR TITLE
Add portfolio risk-limit monitoring

### DIFF
--- a/config/portfolio_risk_limits.yaml
+++ b/config/portfolio_risk_limits.yaml
@@ -1,0 +1,12 @@
+policies:
+  us-tech-standard:
+    portfolio_id: us-tech-equal
+    covariance_window: 20
+    annualization_days: 252
+    limits:
+      portfolio_volatility_annualized:
+        warning: 0.30
+        critical: 0.45
+      largest_absolute_component_contribution_share:
+        warning: 0.65
+        critical: 0.80

--- a/config/storage.yaml
+++ b/config/storage.yaml
@@ -17,6 +17,7 @@ storage:
       portfolio_daily_returns: "portfolio_daily_returns"
       portfolio_daily_risk_summary: "portfolio_daily_risk_summary"
       portfolio_risk_attribution: "portfolio_risk_attribution"
+      portfolio_risk_limit_evaluations: "portfolio_risk_limit_evaluations"
   format: "parquet"
   partitioning:
     granularity: "hourly"

--- a/deploy/kubernetes/base/config/storage.yaml
+++ b/deploy/kubernetes/base/config/storage.yaml
@@ -17,6 +17,7 @@ storage:
       portfolio_daily_returns: "portfolio_daily_returns"
       portfolio_daily_risk_summary: "portfolio_daily_risk_summary"
       portfolio_risk_attribution: "portfolio_risk_attribution"
+      portfolio_risk_limit_evaluations: "portfolio_risk_limit_evaluations"
   format: "parquet"
   partitioning:
     granularity: "hourly"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ services:
       - ./sql/postgres_demo_data.sql:/docker-entrypoint-initdb.d/02_demo_data.sql:ro
       - ./sql/portfolio_schema.sql:/docker-entrypoint-initdb.d/03_portfolio_schema.sql:ro
       - ./sql/portfolio_attribution_schema.sql:/docker-entrypoint-initdb.d/04_portfolio_attribution_schema.sql:ro
+      - ./sql/portfolio_risk_limits_schema.sql:/docker-entrypoint-initdb.d/05_portfolio_risk_limits_schema.sql:ro
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U risk_user -d risk_platform"]
       interval: 5s

--- a/docs/portfolio-risk-limits.md
+++ b/docs/portfolio-risk-limits.md
@@ -1,0 +1,170 @@
+# Portfolio Risk-Limit Monitoring
+
+## Outcome
+
+This increment evaluates the rolling portfolio-attribution series against a
+versioned local policy and retains deterministic evidence for every metric:
+
+```text
+current portfolio_risk_attribution snapshots
+  -> selected portfolio definition and covariance window
+  -> versioned risk-limit policy
+  -> portfolio-volatility evaluation
+  -> largest absolute component-contribution-share evaluation
+  -> versioned portfolio_risk_limit_evaluations Parquet
+  -> PostgreSQL history, current breach and snapshot-status views
+```
+
+It provides monitoring evidence only. It does not send alerts, block trades,
+change positions or make an approval decision.
+
+## Policy
+
+Policies are configured in `config/portfolio_risk_limits.yaml`:
+
+```yaml
+policies:
+  us-tech-standard:
+    portfolio_id: us-tech-equal
+    covariance_window: 20
+    annualization_days: 252
+    limits:
+      portfolio_volatility_annualized:
+        warning: 0.30
+        critical: 0.45
+      largest_absolute_component_contribution_share:
+        warning: 0.65
+        critical: 0.80
+```
+
+Each policy receives a deterministic fingerprint from its portfolio, window,
+annualisation basis and thresholds. Changing a threshold creates a new policy
+version rather than silently relabelling prior evidence.
+
+The first two metrics are deliberately narrow:
+
+- annualised portfolio volatility from the attribution snapshot;
+- the absolute value of the largest Euler component-contribution share.
+
+The signed component share and constituent key remain in the output so a
+risk-reducing negative contribution is not misrepresented.
+
+## Evaluation Semantics
+
+For each current attribution snapshot, two records are emitted. Status is:
+
+```text
+observed < warning                 -> ok
+warning <= observed < critical     -> warning
+observed >= critical               -> critical
+```
+
+Warning and critical rows record the applicable threshold and non-negative
+excess. `ok` rows retain a null breach threshold and zero excess.
+
+The evaluator filters to the policy portfolio, exact definition fingerprint,
+covariance window, annualisation basis and supported attribution methods. When
+several attribution calculations exist for one event date, current input is
+selected by:
+
+```text
+ts_ingest DESC
+calculation_id DESC
+```
+
+Identical duplicate calculations are ignored. Reusing one attribution
+calculation ID for conflicting content fails closed.
+
+Evaluation identity binds:
+
+```text
+portfolio-risk-limits-v1
++ policy fingerprint
++ attribution calculation ID
++ metric name
+```
+
+An identical rerun therefore writes no duplicate evidence. A corrected
+attribution snapshot or policy change creates a distinguishable evaluation.
+
+## Operator Flow
+
+Generate rolling attribution first, then evaluate the requested date range:
+
+```bash
+.venv/bin/python -m src.orchestration.run_portfolio_attribution_history \
+  --portfolio-id us-tech-equal \
+  --start-date 2026-01-01 \
+  --end-date 2026-03-31 \
+  --covariance-window 20
+
+.venv/bin/python -m src.orchestration.run_portfolio_risk_limits \
+  --policy-id us-tech-standard \
+  --start-date 2026-01-01 \
+  --end-date 2026-03-31 \
+  --summary-json .demo/portfolio-risk-limits-summary.json
+```
+
+The result dataset is:
+
+```text
+data/curated/portfolio_risk_limit_evaluations
+```
+
+One request is capped at 10,000 evaluation records. Because two metrics are
+emitted per current attribution date, a single request covers at most 5,000
+snapshots. Larger histories must be split into bounded ranges.
+
+## PostgreSQL Serving
+
+Apply `sql/portfolio_risk_limits_schema.sql` after the attribution schema, then
+load the Parquet evidence:
+
+```bash
+docker compose exec -T postgres psql -U risk_user -d risk_platform \
+  < sql/portfolio_risk_limits_schema.sql
+
+.venv/bin/python -m src.warehouse.portfolio_risk_limits_loader \
+  --dsn postgresql://risk_user:risk_password@localhost:5433/risk_platform
+
+docker compose exec -T postgres psql -U risk_user -d risk_platform \
+  < sql/portfolio_risk_limits_consistency_checks.sql
+```
+
+The history table is:
+
+```text
+risk_platform.portfolio_risk_limit_evaluations
+```
+
+Current and reporting views are:
+
+```text
+risk_platform.latest_portfolio_risk_limit_evaluations
+risk_platform.portfolio_risk_limit_breaches
+risk_platform.portfolio_risk_limit_snapshot_status
+```
+
+The current grain includes policy fingerprint, portfolio definition, event date,
+models, methods, covariance window, annualisation basis and metric. It excludes
+the constituent subject key so a corrected snapshot that changes the largest
+component can replace the previous current metric while retaining both history
+rows.
+
+`portfolio_risk_limit_snapshot_status` combines the two current metrics into one
+portfolio-date status using critical > warning > ok precedence.
+
+## Safety And Boundary
+
+The input and warehouse readers retain the existing bounded local pattern:
+
+- at most 4,096 Parquet files;
+- at most 1 GB of physical input;
+- at most 250,000 rows;
+- symbolic-link and unsafe-file rejection; and
+- no provider request or cloud mutation.
+
+The policy is a transparent demonstration, not a regulatory limit framework.
+Production ownership would additionally require authorised policy lifecycle,
+maker-checker approval, effective dating, alert routing, acknowledgement,
+escalation, exception management and audit retention controls.

--- a/sql/portfolio_risk_limits_consistency_checks.sql
+++ b/sql/portfolio_risk_limits_consistency_checks.sql
@@ -1,0 +1,274 @@
+-- Reconciliation checks for portfolio risk-limit monitoring.
+-- Run after attribution and limit outputs have been loaded into PostgreSQL.
+
+WITH counts AS (
+    SELECT
+        (SELECT COUNT(*)
+         FROM risk_platform.portfolio_risk_limit_evaluations) AS history_rows,
+        (SELECT COUNT(*)
+         FROM risk_platform.latest_portfolio_risk_limit_evaluations) AS latest_rows,
+        (SELECT COUNT(*)
+         FROM risk_platform.portfolio_risk_limit_breaches) AS breach_rows,
+        (SELECT COUNT(*)
+         FROM risk_platform.latest_portfolio_risk_limit_evaluations
+         WHERE is_breach) AS expected_breach_rows,
+        (SELECT COUNT(*)
+         FROM risk_platform.portfolio_risk_limit_snapshot_status) AS status_rows,
+        (SELECT COUNT(*) FROM (
+            SELECT DISTINCT
+                policy_id,
+                policy_fingerprint,
+                portfolio_id,
+                definition_fingerprint,
+                attribution_calculation_id,
+                ts_event
+            FROM risk_platform.latest_portfolio_risk_limit_evaluations
+        ) snapshots) AS expected_status_rows
+),
+integrity AS (
+    SELECT
+        (SELECT COUNT(*)
+         FROM risk_platform.portfolio_risk_limit_evaluations evaluation
+         LEFT JOIN risk_platform.portfolio_risk_attribution attribution
+           ON attribution.calculation_id = evaluation.attribution_calculation_id
+         WHERE attribution.calculation_id IS NULL) AS orphan_attributions,
+        (SELECT COUNT(*)
+         FROM risk_platform.portfolio_risk_limit_evaluations evaluation
+         JOIN risk_platform.portfolio_risk_attribution attribution
+           ON attribution.calculation_id = evaluation.attribution_calculation_id
+         WHERE evaluation.portfolio_id <> attribution.portfolio_id
+            OR evaluation.base_currency <> attribution.base_currency
+            OR evaluation.definition_fingerprint
+                <> attribution.definition_fingerprint
+            OR evaluation.attribution_model_version <> attribution.model_version
+            OR evaluation.weighting_method <> attribution.weighting_method
+            OR evaluation.covariance_method <> attribution.covariance_method
+            OR evaluation.correlation_method <> attribution.correlation_method
+            OR evaluation.covariance_window <> attribution.covariance_window
+            OR evaluation.annualization_days <> attribution.annualization_days
+            OR evaluation.ts_event <> attribution.ts_event
+            OR evaluation.ts_ingest <> attribution.ts_ingest)
+            AS mismatched_attribution_metadata,
+        (SELECT COUNT(*)
+         FROM risk_platform.latest_portfolio_risk_limit_evaluations evaluation
+         LEFT JOIN risk_platform.latest_portfolio_risk_attribution attribution
+           ON attribution.calculation_id = evaluation.attribution_calculation_id
+         WHERE attribution.calculation_id IS NULL)
+            AS stale_attribution_references,
+        (SELECT COUNT(*)
+         FROM risk_platform.portfolio_risk_limit_evaluations evaluation
+         JOIN risk_platform.portfolio_risk_attribution attribution
+           ON attribution.calculation_id = evaluation.attribution_calculation_id
+         WHERE
+            (evaluation.metric_name = 'portfolio_volatility_annualized'
+             AND ABS(
+                 evaluation.observed_value
+                 - attribution.portfolio_volatility_annualized
+             ) > 0.0000000001)
+            OR
+            (evaluation.metric_name
+                = 'largest_absolute_component_contribution_share'
+             AND ABS(
+                 evaluation.observed_value
+                 - (
+                    SELECT MAX(ABS(component.value::DOUBLE PRECISION))
+                    FROM jsonb_each_text(
+                        attribution.component_contribution_share_json
+                    ) component
+                 )
+             ) > 0.0000000001)
+            OR
+            (evaluation.metric_name
+                = 'largest_absolute_component_contribution_share'
+             AND ABS(
+                 evaluation.observed_signed_value
+                 - (
+                    attribution.component_contribution_share_json
+                    ->> evaluation.subject_key
+                 )::DOUBLE PRECISION
+             ) > 0.0000000001)) AS mismatched_observed_values,
+        (SELECT COUNT(*) - COUNT(DISTINCT calculation_id)
+         FROM risk_platform.portfolio_risk_limit_evaluations)
+            AS duplicate_calculation_ids,
+        (SELECT COUNT(*) FROM (
+            SELECT
+                policy_id,
+                policy_fingerprint,
+                portfolio_id,
+                definition_fingerprint,
+                ts_event,
+                model_version,
+                attribution_model_version,
+                weighting_method,
+                covariance_method,
+                correlation_method,
+                covariance_window,
+                annualization_days,
+                metric_name,
+                COUNT(*) AS row_count
+            FROM risk_platform.latest_portfolio_risk_limit_evaluations
+            GROUP BY
+                policy_id,
+                policy_fingerprint,
+                portfolio_id,
+                definition_fingerprint,
+                ts_event,
+                model_version,
+                attribution_model_version,
+                weighting_method,
+                covariance_method,
+                correlation_method,
+                covariance_window,
+                annualization_days,
+                metric_name
+            HAVING COUNT(*) <> 1
+        ) duplicate_grains) AS duplicate_latest_grains,
+        (SELECT COUNT(*)
+         FROM risk_platform.latest_portfolio_risk_limit_evaluations latest
+         WHERE EXISTS (
+            SELECT 1
+            FROM risk_platform.portfolio_risk_limit_evaluations candidate
+            WHERE candidate.policy_id = latest.policy_id
+              AND candidate.policy_fingerprint = latest.policy_fingerprint
+              AND candidate.portfolio_id = latest.portfolio_id
+              AND candidate.definition_fingerprint
+                    = latest.definition_fingerprint
+              AND candidate.ts_event = latest.ts_event
+              AND candidate.model_version = latest.model_version
+              AND candidate.attribution_model_version
+                    = latest.attribution_model_version
+              AND candidate.weighting_method = latest.weighting_method
+              AND candidate.covariance_method = latest.covariance_method
+              AND candidate.correlation_method = latest.correlation_method
+              AND candidate.covariance_window = latest.covariance_window
+              AND candidate.annualization_days = latest.annualization_days
+              AND candidate.metric_name = latest.metric_name
+              AND (candidate.ts_ingest, candidate.calculation_id)
+                    > (latest.ts_ingest, latest.calculation_id)
+         )) AS stale_latest_rows,
+        (SELECT COUNT(*) FROM (
+            SELECT
+                policy_id,
+                policy_fingerprint,
+                portfolio_id,
+                definition_fingerprint,
+                attribution_calculation_id,
+                ts_event,
+                COUNT(*) AS metric_count,
+                COUNT(DISTINCT metric_name) AS distinct_metric_count
+            FROM risk_platform.latest_portfolio_risk_limit_evaluations
+            GROUP BY
+                policy_id,
+                policy_fingerprint,
+                portfolio_id,
+                definition_fingerprint,
+                attribution_calculation_id,
+                ts_event
+            HAVING COUNT(*) <> 2 OR COUNT(DISTINCT metric_name) <> 2
+        ) invalid_snapshots) AS invalid_snapshot_metric_counts,
+        (SELECT COUNT(*)
+         FROM risk_platform.portfolio_risk_limit_snapshot_status status_row
+         JOIN LATERAL (
+            SELECT
+                COUNT(*) AS metric_count,
+                COUNT(*) FILTER (WHERE is_breach) AS breach_count,
+                CASE MAX(
+                    CASE status
+                        WHEN 'critical' THEN 2
+                        WHEN 'warning' THEN 1
+                        ELSE 0
+                    END
+                )
+                    WHEN 2 THEN 'critical'
+                    WHEN 1 THEN 'warning'
+                    ELSE 'ok'
+                END AS overall_status
+            FROM risk_platform.latest_portfolio_risk_limit_evaluations evaluation
+            WHERE evaluation.policy_id = status_row.policy_id
+              AND evaluation.policy_fingerprint = status_row.policy_fingerprint
+              AND evaluation.portfolio_id = status_row.portfolio_id
+              AND evaluation.definition_fingerprint
+                    = status_row.definition_fingerprint
+              AND evaluation.attribution_calculation_id
+                    = status_row.attribution_calculation_id
+              AND evaluation.ts_event = status_row.metric_ts
+         ) expected ON TRUE
+         WHERE status_row.metric_count <> expected.metric_count
+            OR status_row.breach_count <> expected.breach_count
+            OR status_row.overall_status <> expected.overall_status)
+            AS invalid_snapshot_status_rows
+)
+SELECT
+    'portfolio_risk_limit_rows_present' AS check_name,
+    '>=0' AS expected,
+    history_rows::TEXT AS actual,
+    'pass' AS status
+FROM counts
+
+UNION ALL
+SELECT 'portfolio_risk_limit_attribution_references_valid', '0',
+       orphan_attributions::TEXT,
+       CASE WHEN orphan_attributions = 0 THEN 'pass' ELSE 'fail' END
+FROM integrity
+
+UNION ALL
+SELECT 'portfolio_risk_limit_attribution_metadata_aligns', '0',
+       mismatched_attribution_metadata::TEXT,
+       CASE WHEN mismatched_attribution_metadata = 0 THEN 'pass' ELSE 'fail' END
+FROM integrity
+
+UNION ALL
+SELECT 'portfolio_risk_limit_uses_current_attribution_versions', '0',
+       stale_attribution_references::TEXT,
+       CASE WHEN stale_attribution_references = 0 THEN 'pass' ELSE 'fail' END
+FROM integrity
+
+UNION ALL
+SELECT 'portfolio_risk_limit_observed_values_match_attribution', '0',
+       mismatched_observed_values::TEXT,
+       CASE WHEN mismatched_observed_values = 0 THEN 'pass' ELSE 'fail' END
+FROM integrity
+
+UNION ALL
+SELECT 'portfolio_risk_limit_calculation_ids_unique', '0',
+       duplicate_calculation_ids::TEXT,
+       CASE WHEN duplicate_calculation_ids = 0 THEN 'pass' ELSE 'fail' END
+FROM integrity
+
+UNION ALL
+SELECT 'latest_portfolio_risk_limit_grain_unique', '0',
+       duplicate_latest_grains::TEXT,
+       CASE WHEN duplicate_latest_grains = 0 THEN 'pass' ELSE 'fail' END
+FROM integrity
+
+UNION ALL
+SELECT 'latest_portfolio_risk_limit_selects_current_version', '0',
+       stale_latest_rows::TEXT,
+       CASE WHEN stale_latest_rows = 0 THEN 'pass' ELSE 'fail' END
+FROM integrity
+
+UNION ALL
+SELECT 'portfolio_risk_limit_snapshot_has_two_metrics', '0',
+       invalid_snapshot_metric_counts::TEXT,
+       CASE WHEN invalid_snapshot_metric_counts = 0 THEN 'pass' ELSE 'fail' END
+FROM integrity
+
+UNION ALL
+SELECT 'portfolio_risk_limit_breach_view_matches_current_breaches',
+       expected_breach_rows::TEXT, breach_rows::TEXT,
+       CASE WHEN expected_breach_rows = breach_rows THEN 'pass' ELSE 'fail' END
+FROM counts
+
+UNION ALL
+SELECT 'portfolio_risk_limit_snapshot_status_rows_match_current_snapshots',
+       expected_status_rows::TEXT, status_rows::TEXT,
+       CASE WHEN expected_status_rows = status_rows THEN 'pass' ELSE 'fail' END
+FROM counts
+
+UNION ALL
+SELECT 'portfolio_risk_limit_snapshot_status_values_reconcile', '0',
+       invalid_snapshot_status_rows::TEXT,
+       CASE WHEN invalid_snapshot_status_rows = 0 THEN 'pass' ELSE 'fail' END
+FROM integrity
+
+ORDER BY check_name;

--- a/sql/portfolio_risk_limits_schema.sql
+++ b/sql/portfolio_risk_limits_schema.sql
@@ -1,0 +1,252 @@
+-- PostgreSQL serving contract for deterministic portfolio risk-limit evaluations.
+-- Apply after sql/portfolio_attribution_schema.sql.
+
+CREATE SCHEMA IF NOT EXISTS risk_platform;
+
+CREATE TABLE IF NOT EXISTS risk_platform.portfolio_risk_limit_evaluations (
+    calculation_id TEXT PRIMARY KEY,
+    model_version TEXT NOT NULL,
+    policy_id TEXT NOT NULL,
+    policy_fingerprint TEXT NOT NULL,
+    portfolio_id TEXT NOT NULL,
+    base_currency CHAR(3) NOT NULL,
+    definition_fingerprint TEXT NOT NULL,
+    attribution_calculation_id TEXT NOT NULL REFERENCES
+        risk_platform.portfolio_risk_attribution (calculation_id),
+    attribution_model_version TEXT NOT NULL,
+    weighting_method TEXT NOT NULL,
+    covariance_method TEXT NOT NULL,
+    correlation_method TEXT NOT NULL,
+    covariance_window INTEGER NOT NULL CHECK (
+        covariance_window >= 2 AND covariance_window <= 2520
+    ),
+    annualization_days INTEGER NOT NULL CHECK (
+        annualization_days > 0 AND annualization_days <= 2520
+    ),
+    ts_event TIMESTAMPTZ NOT NULL,
+    ts_ingest TIMESTAMPTZ NOT NULL,
+    metric_name TEXT NOT NULL CHECK (
+        metric_name IN (
+            'portfolio_volatility_annualized',
+            'largest_absolute_component_contribution_share'
+        )
+    ),
+    subject_type TEXT NOT NULL CHECK (
+        subject_type IN ('portfolio', 'constituent')
+    ),
+    subject_key TEXT NOT NULL,
+    unit TEXT NOT NULL CHECK (
+        unit IN ('annualized_decimal', 'absolute_share')
+    ),
+    observed_value DOUBLE PRECISION NOT NULL,
+    observed_signed_value DOUBLE PRECISION NOT NULL,
+    warning_threshold DOUBLE PRECISION NOT NULL,
+    critical_threshold DOUBLE PRECISION NOT NULL,
+    status TEXT NOT NULL CHECK (status IN ('ok', 'warning', 'critical')),
+    is_breach BOOLEAN NOT NULL,
+    breach_threshold DOUBLE PRECISION,
+    breach_excess DOUBLE PRECISION NOT NULL,
+    loaded_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    CHECK (calculation_id <> ''),
+    CHECK (model_version <> ''),
+    CHECK (policy_id <> ''),
+    CHECK (policy_fingerprint <> ''),
+    CHECK (portfolio_id <> ''),
+    CHECK (base_currency = UPPER(base_currency)),
+    CHECK (definition_fingerprint <> ''),
+    CHECK (attribution_calculation_id <> ''),
+    CHECK (attribution_model_version <> ''),
+    CHECK (weighting_method <> ''),
+    CHECK (covariance_method <> ''),
+    CHECK (correlation_method <> ''),
+    CHECK (subject_key <> ''),
+    CHECK (ts_ingest >= ts_event),
+    CHECK (
+        observed_value >= 0
+        AND observed_value < 'Infinity'::DOUBLE PRECISION
+        AND observed_value <> 'NaN'::DOUBLE PRECISION
+    ),
+    CHECK (
+        observed_signed_value > '-Infinity'::DOUBLE PRECISION
+        AND observed_signed_value < 'Infinity'::DOUBLE PRECISION
+        AND observed_signed_value <> 'NaN'::DOUBLE PRECISION
+    ),
+    CHECK (
+        warning_threshold > 0
+        AND critical_threshold > warning_threshold
+        AND critical_threshold < 'Infinity'::DOUBLE PRECISION
+    ),
+    CHECK (
+        breach_excess >= 0
+        AND breach_excess < 'Infinity'::DOUBLE PRECISION
+    ),
+    CHECK (
+        (status = 'ok'
+            AND NOT is_breach
+            AND breach_threshold IS NULL
+            AND breach_excess = 0
+            AND observed_value < warning_threshold)
+        OR (status = 'warning'
+            AND is_breach
+            AND breach_threshold = warning_threshold
+            AND observed_value >= warning_threshold
+            AND observed_value < critical_threshold
+            AND ABS(breach_excess - (observed_value - warning_threshold))
+                <= 0.0000000001)
+        OR (status = 'critical'
+            AND is_breach
+            AND breach_threshold = critical_threshold
+            AND observed_value >= critical_threshold
+            AND ABS(breach_excess - (observed_value - critical_threshold))
+                <= 0.0000000001)
+    ),
+    CHECK (
+        (metric_name = 'portfolio_volatility_annualized'
+            AND subject_type = 'portfolio'
+            AND subject_key = portfolio_id
+            AND unit = 'annualized_decimal'
+            AND observed_signed_value = observed_value)
+        OR (metric_name = 'largest_absolute_component_contribution_share'
+            AND subject_type = 'constituent'
+            AND unit = 'absolute_share'
+            AND ABS(ABS(observed_signed_value) - observed_value)
+                <= 0.0000000001)
+    ),
+    CHECK (
+        model_version <> 'portfolio-risk-limits-v1'
+        OR (
+            attribution_model_version = 'portfolio-attribution-v1'
+            AND weighting_method = 'constant_weight_daily_rebalanced'
+            AND covariance_method = 'sample_annualized'
+            AND correlation_method = 'pearson'
+        )
+    )
+);
+
+CREATE INDEX IF NOT EXISTS idx_portfolio_risk_limits_version_lookup
+    ON risk_platform.portfolio_risk_limit_evaluations (
+        policy_id,
+        policy_fingerprint,
+        portfolio_id,
+        definition_fingerprint,
+        ts_event DESC,
+        model_version,
+        attribution_model_version,
+        weighting_method,
+        covariance_method,
+        correlation_method,
+        covariance_window,
+        annualization_days,
+        metric_name,
+        ts_ingest DESC,
+        calculation_id DESC
+    );
+
+CREATE INDEX IF NOT EXISTS idx_portfolio_risk_limits_breaches
+    ON risk_platform.portfolio_risk_limit_evaluations (
+        policy_id,
+        portfolio_id,
+        ts_event DESC,
+        status
+    )
+    WHERE is_breach;
+
+CREATE OR REPLACE VIEW risk_platform.latest_portfolio_risk_limit_evaluations AS
+SELECT
+    calculation_id,
+    model_version,
+    policy_id,
+    policy_fingerprint,
+    portfolio_id,
+    base_currency,
+    definition_fingerprint,
+    attribution_calculation_id,
+    attribution_model_version,
+    weighting_method,
+    covariance_method,
+    correlation_method,
+    covariance_window,
+    annualization_days,
+    ts_event,
+    ts_ingest,
+    metric_name,
+    subject_type,
+    subject_key,
+    unit,
+    observed_value,
+    observed_signed_value,
+    warning_threshold,
+    critical_threshold,
+    status,
+    is_breach,
+    breach_threshold,
+    breach_excess
+FROM (
+    SELECT
+        evaluation.*,
+        ROW_NUMBER() OVER (
+            PARTITION BY
+                policy_id,
+                policy_fingerprint,
+                portfolio_id,
+                definition_fingerprint,
+                ts_event,
+                model_version,
+                attribution_model_version,
+                weighting_method,
+                covariance_method,
+                correlation_method,
+                covariance_window,
+                annualization_days,
+                metric_name
+            ORDER BY ts_ingest DESC, calculation_id DESC
+        ) AS version_rank
+    FROM risk_platform.portfolio_risk_limit_evaluations evaluation
+) ranked
+WHERE version_rank = 1;
+
+CREATE OR REPLACE VIEW risk_platform.portfolio_risk_limit_breaches AS
+SELECT *
+FROM risk_platform.latest_portfolio_risk_limit_evaluations
+WHERE is_breach;
+
+CREATE OR REPLACE VIEW risk_platform.portfolio_risk_limit_snapshot_status AS
+SELECT
+    policy_id,
+    policy_fingerprint,
+    portfolio_id,
+    base_currency,
+    definition_fingerprint,
+    attribution_calculation_id,
+    attribution_model_version,
+    weighting_method,
+    covariance_method,
+    correlation_method,
+    covariance_window,
+    annualization_days,
+    ts_event AS metric_ts,
+    MAX(ts_ingest) AS calculation_ts,
+    COUNT(*) AS metric_count,
+    COUNT(*) FILTER (WHERE is_breach) AS breach_count,
+    CASE MAX(
+        CASE status WHEN 'critical' THEN 2 WHEN 'warning' THEN 1 ELSE 0 END
+    )
+        WHEN 2 THEN 'critical'
+        WHEN 1 THEN 'warning'
+        ELSE 'ok'
+    END AS overall_status
+FROM risk_platform.latest_portfolio_risk_limit_evaluations
+GROUP BY
+    policy_id,
+    policy_fingerprint,
+    portfolio_id,
+    base_currency,
+    definition_fingerprint,
+    attribution_calculation_id,
+    attribution_model_version,
+    weighting_method,
+    covariance_method,
+    correlation_method,
+    covariance_window,
+    annualization_days,
+    ts_event;

--- a/src/analytics/portfolio_risk_limits.py
+++ b/src/analytics/portfolio_risk_limits.py
@@ -1,0 +1,621 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import re
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
+from datetime import date, datetime, time, timezone
+from pathlib import Path
+from typing import Any, TypeAlias
+
+from ..common.config import load_yaml
+from ..common.exceptions import ValidationError
+from .portfolio_attribution import (
+    CORRELATION_METHOD,
+    COVARIANCE_METHOD,
+    MODEL_VERSION as ATTRIBUTION_MODEL_VERSION,
+    VARIANCE_EPSILON,
+)
+from .portfolio_risk import TRADING_DAYS_PER_YEAR, WEIGHTING_METHOD
+
+MODEL_VERSION = "portfolio-risk-limits-v1"
+VOLATILITY_METRIC = "portfolio_volatility_annualized"
+CONCENTRATION_METRIC = "largest_absolute_component_contribution_share"
+MAX_LIMIT_EVALUATIONS = 10_000
+POLICY_ID_PATTERN = re.compile(r"^[a-z0-9][a-z0-9_-]{0,63}$")
+PORTFOLIO_ID_PATTERN = re.compile(r"^[a-z0-9][a-z0-9_-]{0,63}$")
+
+AttributionInput: TypeAlias = Mapping[str, Any]
+
+
+@dataclass(frozen=True, slots=True)
+class RiskLimitThresholds:
+    warning: float
+    critical: float
+
+
+@dataclass(frozen=True, slots=True)
+class PortfolioRiskLimitPolicy:
+    policy_id: str
+    portfolio_id: str
+    covariance_window: int
+    annualization_days: int
+    portfolio_volatility: RiskLimitThresholds
+    component_concentration: RiskLimitThresholds
+
+    @property
+    def fingerprint(self) -> str:
+        payload = {
+            "annualization_days": self.annualization_days,
+            "covariance_window": self.covariance_window,
+            "limits": {
+                CONCENTRATION_METRIC: {
+                    "critical": self.component_concentration.critical,
+                    "warning": self.component_concentration.warning,
+                },
+                VOLATILITY_METRIC: {
+                    "critical": self.portfolio_volatility.critical,
+                    "warning": self.portfolio_volatility.warning,
+                },
+            },
+            "policy_id": self.policy_id,
+            "portfolio_id": self.portfolio_id,
+        }
+        digest = hashlib.sha256(
+            json.dumps(payload, sort_keys=True, separators=(",", ":")).encode(
+                "utf-8"
+            )
+        ).hexdigest()[:24]
+        return f"risk-limit-policy-{digest}"
+
+
+@dataclass(frozen=True, slots=True)
+class PortfolioRiskLimitOutput:
+    evaluations: tuple[dict[str, Any], ...]
+    diagnostics: Mapping[str, Any]
+
+
+def _required_identifier(
+    value: Any,
+    label: str,
+    pattern: re.Pattern[str],
+) -> str:
+    if not isinstance(value, str):
+        raise ValidationError(f"{label} must be text")
+    parsed = value.strip()
+    if pattern.fullmatch(parsed) is None:
+        raise ValidationError(f"{label} has an invalid format")
+    return parsed
+
+
+def _positive_integer(value: Any, label: str, maximum: int) -> int:
+    if type(value) is not int or not 1 <= value <= maximum:
+        raise ValidationError(
+            f"{label} must be an integer between 1 and {maximum}"
+        )
+    return value
+
+
+def _finite_number(
+    value: Any,
+    label: str,
+    *,
+    minimum: float | None = None,
+) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ValidationError(f"{label} must be a finite number")
+    parsed = float(value)
+    if not math.isfinite(parsed):
+        raise ValidationError(f"{label} must be a finite number")
+    if minimum is not None and parsed < minimum:
+        raise ValidationError(f"{label} must be at least {minimum}")
+    return parsed
+
+
+def _thresholds(value: Any, label: str) -> RiskLimitThresholds:
+    if not isinstance(value, Mapping):
+        raise ValidationError(f"{label} must be a mapping")
+    warning = _finite_number(value.get("warning"), f"{label}.warning", minimum=0.0)
+    critical = _finite_number(
+        value.get("critical"), f"{label}.critical", minimum=0.0
+    )
+    if warning <= 0 or critical <= warning:
+        raise ValidationError(
+            f"{label} must satisfy 0 < warning < critical"
+        )
+    return RiskLimitThresholds(warning=warning, critical=critical)
+
+
+def parse_portfolio_risk_limit_policy(
+    payload: Mapping[str, Any],
+    policy_id: str,
+) -> PortfolioRiskLimitPolicy:
+    canonical_policy_id = _required_identifier(
+        policy_id,
+        "policy_id",
+        POLICY_ID_PATTERN,
+    )
+    if not isinstance(payload, Mapping):
+        raise ValidationError("risk-limit configuration must be a mapping")
+    policies = payload.get("policies")
+    if not isinstance(policies, Mapping):
+        raise ValidationError(
+            "risk-limit configuration must define a policies mapping"
+        )
+    candidate = policies.get(canonical_policy_id)
+    if not isinstance(candidate, Mapping):
+        raise ValidationError(
+            f"risk-limit policy '{canonical_policy_id}' is not configured"
+        )
+    limits = candidate.get("limits")
+    if not isinstance(limits, Mapping):
+        raise ValidationError("risk-limit policy must define a limits mapping")
+
+    covariance_window = _positive_integer(
+        candidate.get("covariance_window"),
+        "covariance_window",
+        10 * TRADING_DAYS_PER_YEAR,
+    )
+    if covariance_window < 2:
+        raise ValidationError("covariance_window must be at least 2")
+    annualization_days = _positive_integer(
+        candidate.get("annualization_days"),
+        "annualization_days",
+        10 * TRADING_DAYS_PER_YEAR,
+    )
+    return PortfolioRiskLimitPolicy(
+        policy_id=canonical_policy_id,
+        portfolio_id=_required_identifier(
+            candidate.get("portfolio_id"),
+            "portfolio_id",
+            PORTFOLIO_ID_PATTERN,
+        ),
+        covariance_window=covariance_window,
+        annualization_days=annualization_days,
+        portfolio_volatility=_thresholds(
+            limits.get(VOLATILITY_METRIC),
+            VOLATILITY_METRIC,
+        ),
+        component_concentration=_thresholds(
+            limits.get(CONCENTRATION_METRIC),
+            CONCENTRATION_METRIC,
+        ),
+    )
+
+
+def load_portfolio_risk_limit_policy(
+    path: Path,
+    policy_id: str,
+) -> PortfolioRiskLimitPolicy:
+    try:
+        payload = load_yaml(path)
+    except Exception:
+        raise ValidationError(
+            "risk-limit configuration could not be loaded"
+        ) from None
+    if not isinstance(payload, Mapping):
+        raise ValidationError("risk-limit configuration must be a mapping")
+    return parse_portfolio_risk_limit_policy(payload, policy_id)
+
+
+def _aware_utc(value: Any, label: str) -> datetime:
+    parsed: datetime | None = None
+    if isinstance(value, datetime):
+        parsed = value
+    elif isinstance(value, str):
+        try:
+            parsed = datetime.fromisoformat(value.strip().replace("Z", "+00:00"))
+        except ValueError:
+            parsed = None
+    if parsed is None or parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise ValidationError(f"{label} must be a timezone-aware timestamp")
+    return parsed.astimezone(timezone.utc)
+
+
+def _required_text(value: Any, label: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ValidationError(f"{label} must be non-empty text")
+    return value.strip()
+
+
+def _json_number_object(value: Any, label: str) -> dict[str, float]:
+    if isinstance(value, Mapping):
+        parsed: Any = dict(value)
+    elif isinstance(value, str):
+        def reject_duplicate_keys(
+            pairs: list[tuple[str, Any]],
+        ) -> dict[str, Any]:
+            result: dict[str, Any] = {}
+            for key, item in pairs:
+                if key in result:
+                    raise ValidationError(
+                        f"{label} must not contain duplicate keys"
+                    )
+                result[key] = item
+            return result
+
+        try:
+            parsed = json.loads(value, object_pairs_hook=reject_duplicate_keys)
+        except ValidationError:
+            raise
+        except (TypeError, ValueError):
+            raise ValidationError(f"{label} must be valid JSON") from None
+    else:
+        raise ValidationError(f"{label} must be a JSON object")
+    if not isinstance(parsed, dict) or len(parsed) < 2:
+        raise ValidationError(
+            f"{label} must contain at least two constituent values"
+        )
+
+    values: dict[str, float] = {}
+    for key, item in parsed.items():
+        if not isinstance(key, str) or not key:
+            raise ValidationError(f"{label} must use non-empty text keys")
+        values[key] = _finite_number(item, f"{label}.{key}")
+    return dict(sorted(values.items()))
+
+
+def _normalise_attribution_record(
+    candidate: AttributionInput,
+    *,
+    policy: PortfolioRiskLimitPolicy,
+    definition_fingerprint: str,
+    end_date: date | None,
+) -> dict[str, Any] | None:
+    if not isinstance(candidate, Mapping):
+        raise ValidationError("risk-limit input must contain attribution mappings")
+
+    portfolio_id = candidate.get("portfolio_id")
+    fingerprint = candidate.get("definition_fingerprint")
+    covariance_window = candidate.get("covariance_window")
+    if portfolio_id != policy.portfolio_id or fingerprint != definition_fingerprint:
+        return None
+    if type(covariance_window) is not int:
+        raise ValidationError("covariance_window must be an integer")
+    if covariance_window != policy.covariance_window:
+        return None
+
+    ts_event = _aware_utc(candidate.get("ts_event"), "ts_event")
+    if ts_event.time() != time.min:
+        raise ValidationError("attribution timestamps must use UTC midnight")
+    if end_date is not None and ts_event.date() > end_date:
+        return None
+    ts_ingest = _aware_utc(candidate.get("ts_ingest"), "ts_ingest")
+    if ts_ingest < ts_event:
+        raise ValidationError("ts_ingest must be on or after ts_event")
+
+    model_version = _required_text(
+        candidate.get("model_version"), "attribution model_version"
+    )
+    weighting_method = _required_text(
+        candidate.get("weighting_method"), "weighting_method"
+    )
+    covariance_method = _required_text(
+        candidate.get("covariance_method"), "covariance_method"
+    )
+    correlation_method = _required_text(
+        candidate.get("correlation_method"), "correlation_method"
+    )
+    annualization_days = candidate.get("annualization_days")
+    if (
+        model_version != ATTRIBUTION_MODEL_VERSION
+        or weighting_method != WEIGHTING_METHOD
+        or covariance_method != COVARIANCE_METHOD
+        or correlation_method != CORRELATION_METHOD
+        or annualization_days != policy.annualization_days
+    ):
+        raise ValidationError(
+            "attribution record does not match the supported policy model contract"
+        )
+
+    volatility = _finite_number(
+        candidate.get("portfolio_volatility_annualized"),
+        "portfolio_volatility_annualized",
+        minimum=0.0,
+    )
+    volatility_status = _required_text(
+        candidate.get("volatility_status"), "volatility_status"
+    )
+    if volatility_status not in {"positive", "zero"}:
+        raise ValidationError("volatility_status is invalid")
+    if (
+        volatility_status == "zero"
+        and volatility > VARIANCE_EPSILON
+    ) or (
+        volatility_status == "positive"
+        and volatility <= VARIANCE_EPSILON
+    ):
+        raise ValidationError(
+            "volatility_status does not match portfolio volatility"
+        )
+
+    component_shares = _json_number_object(
+        candidate.get("component_contribution_share_json"),
+        "component_contribution_share_json",
+    )
+    return {
+        "calculation_id": _required_text(
+            candidate.get("calculation_id"), "attribution calculation_id"
+        ),
+        "model_version": model_version,
+        "portfolio_id": policy.portfolio_id,
+        "base_currency": _required_text(
+            candidate.get("base_currency"), "base_currency"
+        ),
+        "definition_fingerprint": definition_fingerprint,
+        "weighting_method": weighting_method,
+        "covariance_method": covariance_method,
+        "correlation_method": correlation_method,
+        "covariance_window": policy.covariance_window,
+        "annualization_days": policy.annualization_days,
+        "ts_event": ts_event,
+        "ts_ingest": ts_ingest,
+        "portfolio_volatility_annualized": volatility,
+        "component_contribution_shares": component_shares,
+    }
+
+
+def _record_signature(record: Mapping[str, Any]) -> tuple[Any, ...]:
+    return (
+        record["model_version"],
+        record["portfolio_id"],
+        record["base_currency"],
+        record["definition_fingerprint"],
+        record["weighting_method"],
+        record["covariance_method"],
+        record["correlation_method"],
+        record["covariance_window"],
+        record["annualization_days"],
+        record["ts_event"],
+        record["ts_ingest"],
+        record["portfolio_volatility_annualized"],
+        tuple(record["component_contribution_shares"].items()),
+    )
+
+
+def _current_attributions(
+    records: Iterable[AttributionInput],
+    *,
+    policy: PortfolioRiskLimitPolicy,
+    definition_fingerprint: str,
+    end_date: date | None,
+) -> tuple[list[dict[str, Any]], int]:
+    current: dict[date, dict[str, Any]] = {}
+    seen_calculations: dict[str, tuple[Any, ...]] = {}
+    matched_records = 0
+    for candidate in records:
+        record = _normalise_attribution_record(
+            candidate,
+            policy=policy,
+            definition_fingerprint=definition_fingerprint,
+            end_date=end_date,
+        )
+        if record is None:
+            continue
+        matched_records += 1
+        calculation_id = record["calculation_id"]
+        signature = _record_signature(record)
+        previous_signature = seen_calculations.get(calculation_id)
+        if previous_signature is not None:
+            if previous_signature != signature:
+                raise ValidationError(
+                    "attribution calculation IDs must not contain conflicting records"
+                )
+            continue
+        seen_calculations[calculation_id] = signature
+
+        event_date = record["ts_event"].date()
+        existing = current.get(event_date)
+        if existing is None or (
+            record["ts_ingest"],
+            calculation_id,
+        ) > (
+            existing["ts_ingest"],
+            existing["calculation_id"],
+        ):
+            current[event_date] = record
+
+    if not current:
+        raise ValidationError(
+            "no attribution snapshots matched the selected policy and definition"
+        )
+    return [current[event_date] for event_date in sorted(current)], matched_records
+
+
+def _status(
+    observed_value: float,
+    thresholds: RiskLimitThresholds,
+) -> tuple[str, bool, float | None, float]:
+    if observed_value >= thresholds.critical:
+        return (
+            "critical",
+            True,
+            thresholds.critical,
+            observed_value - thresholds.critical,
+        )
+    if observed_value >= thresholds.warning:
+        return (
+            "warning",
+            True,
+            thresholds.warning,
+            observed_value - thresholds.warning,
+        )
+    return "ok", False, None, 0.0
+
+
+def _evaluation_id(
+    *,
+    policy: PortfolioRiskLimitPolicy,
+    attribution_calculation_id: str,
+    metric_name: str,
+) -> str:
+    payload = {
+        "attribution_calculation_id": attribution_calculation_id,
+        "metric_name": metric_name,
+        "model_version": MODEL_VERSION,
+        "policy_fingerprint": policy.fingerprint,
+    }
+    digest = hashlib.sha256(
+        json.dumps(payload, sort_keys=True, separators=(",", ":")).encode(
+            "utf-8"
+        )
+    ).hexdigest()[:24]
+    return f"{MODEL_VERSION}-evaluation-{digest}"
+
+
+def _evaluation_record(
+    *,
+    record: Mapping[str, Any],
+    policy: PortfolioRiskLimitPolicy,
+    metric_name: str,
+    subject_type: str,
+    subject_key: str,
+    unit: str,
+    observed_value: float,
+    observed_signed_value: float,
+    thresholds: RiskLimitThresholds,
+) -> dict[str, Any]:
+    status, is_breach, breach_threshold, breach_excess = _status(
+        observed_value,
+        thresholds,
+    )
+    return {
+        "model_version": MODEL_VERSION,
+        "calculation_id": _evaluation_id(
+            policy=policy,
+            attribution_calculation_id=record["calculation_id"],
+            metric_name=metric_name,
+        ),
+        "policy_id": policy.policy_id,
+        "policy_fingerprint": policy.fingerprint,
+        "portfolio_id": policy.portfolio_id,
+        "base_currency": record["base_currency"],
+        "definition_fingerprint": record["definition_fingerprint"],
+        "attribution_calculation_id": record["calculation_id"],
+        "attribution_model_version": record["model_version"],
+        "weighting_method": record["weighting_method"],
+        "covariance_method": record["covariance_method"],
+        "correlation_method": record["correlation_method"],
+        "covariance_window": record["covariance_window"],
+        "annualization_days": record["annualization_days"],
+        "ts_event": record["ts_event"],
+        "ts_ingest": record["ts_ingest"],
+        "metric_name": metric_name,
+        "subject_type": subject_type,
+        "subject_key": subject_key,
+        "unit": unit,
+        "observed_value": observed_value,
+        "observed_signed_value": observed_signed_value,
+        "warning_threshold": thresholds.warning,
+        "critical_threshold": thresholds.critical,
+        "status": status,
+        "is_breach": is_breach,
+        "breach_threshold": breach_threshold,
+        "breach_excess": breach_excess,
+    }
+
+
+def evaluate_portfolio_risk_limits(
+    records: Iterable[AttributionInput],
+    *,
+    policy: PortfolioRiskLimitPolicy,
+    definition_fingerprint: str,
+    start_date: date | None = None,
+    end_date: date | None = None,
+    max_evaluations: int = MAX_LIMIT_EVALUATIONS,
+) -> PortfolioRiskLimitOutput:
+    if not isinstance(definition_fingerprint, str) or not definition_fingerprint:
+        raise ValidationError("definition_fingerprint must be non-empty text")
+    if start_date is not None and end_date is not None and start_date > end_date:
+        raise ValidationError("start_date must be on or before end_date")
+    max_evaluations = _positive_integer(
+        max_evaluations,
+        "max_evaluations",
+        MAX_LIMIT_EVALUATIONS,
+    )
+
+    current, matched_records = _current_attributions(
+        records,
+        policy=policy,
+        definition_fingerprint=definition_fingerprint,
+        end_date=end_date,
+    )
+    selected = [
+        record
+        for record in current
+        if start_date is None or record["ts_event"].date() >= start_date
+    ]
+    if not selected:
+        raise ValidationError(
+            "no risk-limit evaluations matched the requested date range"
+        )
+    if len(selected) * 2 > max_evaluations:
+        raise ValidationError(
+            "risk-limit evaluation exceeds max_evaluations; split the date range"
+        )
+
+    evaluations: list[dict[str, Any]] = []
+    for record in selected:
+        evaluations.append(
+            _evaluation_record(
+                record=record,
+                policy=policy,
+                metric_name=VOLATILITY_METRIC,
+                subject_type="portfolio",
+                subject_key=policy.portfolio_id,
+                unit="annualized_decimal",
+                observed_value=record["portfolio_volatility_annualized"],
+                observed_signed_value=record[
+                    "portfolio_volatility_annualized"
+                ],
+                thresholds=policy.portfolio_volatility,
+            )
+        )
+        component_shares = record["component_contribution_shares"]
+        largest_component = min(
+            component_shares,
+            key=lambda key: (-abs(component_shares[key]), key),
+        )
+        signed_share = component_shares[largest_component]
+        evaluations.append(
+            _evaluation_record(
+                record=record,
+                policy=policy,
+                metric_name=CONCENTRATION_METRIC,
+                subject_type="constituent",
+                subject_key=largest_component,
+                unit="absolute_share",
+                observed_value=abs(signed_share),
+                observed_signed_value=signed_share,
+                thresholds=policy.component_concentration,
+            )
+        )
+
+    status_counts = {
+        status: sum(1 for item in evaluations if item["status"] == status)
+        for status in ("ok", "warning", "critical")
+    }
+    diagnostics = {
+        "policy_id": policy.policy_id,
+        "policy_fingerprint": policy.fingerprint,
+        "matched_input_records": matched_records,
+        "current_attribution_snapshots": len(current),
+        "snapshots_selected": len(selected),
+        "evaluations_selected": len(evaluations),
+        "status_counts": status_counts,
+        "first_evaluation_date": selected[0]["ts_event"].date().isoformat(),
+        "last_evaluation_date": selected[-1]["ts_event"].date().isoformat(),
+        "start_date": start_date.isoformat() if start_date is not None else None,
+        "end_date": (
+            end_date.isoformat()
+            if end_date is not None
+            else selected[-1]["ts_event"].date().isoformat()
+        ),
+        "max_evaluations": max_evaluations,
+    }
+    return PortfolioRiskLimitOutput(
+        evaluations=tuple(evaluations),
+        diagnostics=diagnostics,
+    )

--- a/src/orchestration/run_portfolio_risk_limits.py
+++ b/src/orchestration/run_portfolio_risk_limits.py
@@ -1,0 +1,309 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections.abc import Callable, Sequence
+from datetime import date
+from pathlib import Path
+from typing import Any
+from uuid import uuid4
+
+from ..analytics.portfolio_risk import PortfolioDefinition, load_portfolio_definition
+from ..analytics.portfolio_risk_limits import (
+    MAX_LIMIT_EVALUATIONS,
+    PortfolioRiskLimitPolicy,
+    evaluate_portfolio_risk_limits,
+    load_portfolio_risk_limit_policy,
+)
+from ..common.exceptions import StorageError, ValidationError
+from ..storage.s3_writer import write_records
+from ..storage.storage_config import load_storage_config, validate_storage_config
+from ..warehouse.portfolio_attribution_loader import collect_attribution_records
+
+INPUT_DATASET = "portfolio_risk_attribution"
+OUTPUT_DATASET = "portfolio_risk_limit_evaluations"
+
+Reader = Callable[[Path], list[dict[str, Any]]]
+Writer = Callable[..., int]
+StorageConfigLoader = Callable[[Path], dict[str, Any]]
+DefinitionLoader = Callable[[Path, str], PortfolioDefinition]
+PolicyLoader = Callable[[Path, str], PortfolioRiskLimitPolicy]
+
+
+def _calendar_date(value: str) -> date:
+    try:
+        parsed = date.fromisoformat(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(
+            "must be a calendar date in YYYY-MM-DD format"
+        ) from exc
+    if value != parsed.isoformat():
+        raise argparse.ArgumentTypeError(
+            "must be a calendar date in YYYY-MM-DD format"
+        )
+    return parsed
+
+
+def _max_evaluations(value: str) -> int:
+    try:
+        parsed = int(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(
+            "max_evaluations must be a positive integer"
+        ) from exc
+    if not 1 <= parsed <= MAX_LIMIT_EVALUATIONS:
+        raise argparse.ArgumentTypeError(
+            f"max_evaluations must be between 1 and {MAX_LIMIT_EVALUATIONS}"
+        )
+    return parsed
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Evaluate current portfolio-attribution history against a versioned "
+            "local risk-limit policy."
+        )
+    )
+    parser.add_argument("--policy-id", required=True)
+    parser.add_argument(
+        "--limits-config",
+        type=Path,
+        default=Path("config/portfolio_risk_limits.yaml"),
+    )
+    parser.add_argument(
+        "--portfolio-config",
+        type=Path,
+        default=Path("config/portfolios.yaml"),
+    )
+    parser.add_argument("--start-date", type=_calendar_date)
+    parser.add_argument("--end-date", required=True, type=_calendar_date)
+    parser.add_argument(
+        "--max-evaluations",
+        type=_max_evaluations,
+        default=MAX_LIMIT_EVALUATIONS,
+    )
+    parser.add_argument(
+        "--storage-config",
+        type=Path,
+        default=Path("config/storage.yaml"),
+    )
+    parser.add_argument("--summary-json", type=Path)
+    return parser
+
+
+def _require_datasets(storage_config: dict[str, Any]) -> None:
+    validate_storage_config(storage_config)
+    datasets = storage_config["storage"]["curated"]["datasets"]
+    missing = sorted(
+        dataset
+        for dataset in (INPUT_DATASET, OUTPUT_DATASET)
+        if dataset not in datasets
+    )
+    if missing:
+        raise StorageError(
+            "Storage configuration is missing portfolio risk-limit datasets: "
+            + ", ".join(missing)
+        )
+
+
+def _publish(
+    evaluations: tuple[dict[str, Any], ...],
+    *,
+    storage_config: dict[str, Any],
+    writer: Writer,
+) -> int:
+    written = 0
+    for evaluation in evaluations:
+        try:
+            result = writer(
+                [evaluation],
+                kind="curated",
+                dataset=OUTPUT_DATASET,
+                storage_config=storage_config,
+            )
+        except Exception:
+            raise StorageError(
+                "Portfolio risk-limit publication failed; rerun is safe"
+            ) from None
+        if type(result) is not int or result not in {0, 1}:
+            raise StorageError(
+                "Portfolio risk-limit publication returned an invalid result"
+            )
+        written += result
+    return written
+
+
+def run_portfolio_risk_limits(
+    *,
+    policy_id: str,
+    limits_config_path: Path,
+    portfolio_config_path: Path,
+    end_date: date,
+    storage_config_path: Path,
+    start_date: date | None = None,
+    max_evaluations: int = MAX_LIMIT_EVALUATIONS,
+    reader: Reader | None = None,
+    writer: Writer | None = None,
+    storage_config_loader: StorageConfigLoader | None = None,
+    definition_loader: DefinitionLoader | None = None,
+    policy_loader: PolicyLoader | None = None,
+) -> dict[str, Any]:
+    if start_date is not None and start_date > end_date:
+        raise ValidationError("start_date must be on or before end_date")
+
+    selected_storage_loader = storage_config_loader or load_storage_config
+    try:
+        storage_config = selected_storage_loader(storage_config_path)
+    except Exception:
+        raise StorageError("Storage configuration is invalid") from None
+    if not isinstance(storage_config, dict):
+        raise StorageError("Storage configuration is invalid")
+    _require_datasets(storage_config)
+
+    selected_policy_loader = policy_loader or load_portfolio_risk_limit_policy
+    try:
+        policy = selected_policy_loader(limits_config_path, policy_id)
+    except ValidationError:
+        raise
+    except Exception:
+        raise ValidationError("Portfolio risk-limit policy is invalid") from None
+
+    selected_definition_loader = definition_loader or load_portfolio_definition
+    try:
+        definition = selected_definition_loader(
+            portfolio_config_path,
+            policy.portfolio_id,
+        )
+    except ValidationError:
+        raise
+    except Exception:
+        raise ValidationError("Portfolio configuration is invalid") from None
+
+    selected_reader = reader or collect_attribution_records
+    try:
+        records = selected_reader(storage_config_path)
+    except StorageError:
+        raise
+    except Exception:
+        raise StorageError("Unable to read local portfolio attribution") from None
+
+    output = evaluate_portfolio_risk_limits(
+        records,
+        policy=policy,
+        definition_fingerprint=definition.fingerprint,
+        start_date=start_date,
+        end_date=end_date,
+        max_evaluations=max_evaluations,
+    )
+    selected_writer = writer or write_records
+    written = _publish(
+        output.evaluations,
+        storage_config=storage_config,
+        writer=selected_writer,
+    )
+
+    latest_date = max(item["ts_event"] for item in output.evaluations)
+    latest = [
+        item for item in output.evaluations if item["ts_event"] == latest_date
+    ]
+    severity = {"ok": 0, "warning": 1, "critical": 2}
+    latest_status = max(latest, key=lambda item: severity[item["status"]])[
+        "status"
+    ]
+    selected = len(output.evaluations)
+    return {
+        "run_id": str(uuid4()),
+        "policy_id": policy.policy_id,
+        "policy_fingerprint": policy.fingerprint,
+        "portfolio_id": policy.portfolio_id,
+        "definition_fingerprint": definition.fingerprint,
+        "selection": dict(output.diagnostics),
+        "parameters": {
+            "start_date": start_date.isoformat() if start_date else None,
+            "end_date": end_date.isoformat(),
+            "max_evaluations": max_evaluations,
+        },
+        "curated_output": {
+            OUTPUT_DATASET: {
+                "records_selected": selected,
+                "records_written": written,
+                "records_already_present": selected - written,
+            }
+        },
+        "latest_status": {
+            "ts_event": latest_date.isoformat(),
+            "status": latest_status,
+            "metrics": [
+                {
+                    "metric_name": item["metric_name"],
+                    "subject_key": item["subject_key"],
+                    "observed_value": item["observed_value"],
+                    "status": item["status"],
+                    "is_breach": item["is_breach"],
+                    "calculation_id": item["calculation_id"],
+                }
+                for item in sorted(latest, key=lambda item: item["metric_name"])
+            ],
+        },
+    }
+
+
+def _write_summary(path: Path, summary: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary_path = path.with_suffix(path.suffix + ".tmp")
+    try:
+        temporary_path.write_text(
+            json.dumps(summary, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        temporary_path.replace(path)
+    except OSError:
+        temporary_path.unlink(missing_ok=True)
+        raise StorageError(
+            "Unable to write the portfolio risk-limit summary"
+        ) from None
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    try:
+        summary = run_portfolio_risk_limits(
+            policy_id=args.policy_id,
+            limits_config_path=args.limits_config,
+            portfolio_config_path=args.portfolio_config,
+            start_date=args.start_date,
+            end_date=args.end_date,
+            max_evaluations=args.max_evaluations,
+            storage_config_path=args.storage_config,
+        )
+        if args.summary_json is not None:
+            _write_summary(args.summary_json, summary)
+    except ValidationError:
+        print(
+            "Portfolio risk-limit evaluation failed: configuration, input data "
+            "or options were invalid",
+            file=sys.stderr,
+        )
+        return 1
+    except StorageError:
+        print(
+            "Portfolio risk-limit evaluation failed: local storage operation "
+            "failed; rerun is safe",
+            file=sys.stderr,
+        )
+        return 1
+    except Exception:
+        print(
+            "Portfolio risk-limit evaluation failed: unexpected local failure",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(json.dumps(summary, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/warehouse/portfolio_risk_limits_loader.py
+++ b/src/warehouse/portfolio_risk_limits_loader.py
@@ -1,0 +1,237 @@
+from __future__ import annotations
+
+import argparse
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+import duckdb
+import pandas as pd
+
+from src.common.exceptions import StorageError
+from src.storage.storage_config import load_storage_config, validate_storage_config
+
+DEFAULT_POSTGRES_DSN = (
+    "postgresql://risk_user:risk_password@localhost:5433/risk_platform"
+)
+DATASET_KEY = "portfolio_risk_limit_evaluations"
+TABLE_NAME = "portfolio_risk_limit_evaluations"
+MAX_INPUT_FILES = 4_096
+MAX_INPUT_BYTES = 1_000_000_000
+MAX_INPUT_ROWS = 250_000
+
+COLUMNS = (
+    "calculation_id",
+    "model_version",
+    "policy_id",
+    "policy_fingerprint",
+    "portfolio_id",
+    "base_currency",
+    "definition_fingerprint",
+    "attribution_calculation_id",
+    "attribution_model_version",
+    "weighting_method",
+    "covariance_method",
+    "correlation_method",
+    "covariance_window",
+    "annualization_days",
+    "ts_event",
+    "ts_ingest",
+    "metric_name",
+    "subject_type",
+    "subject_key",
+    "unit",
+    "observed_value",
+    "observed_signed_value",
+    "warning_threshold",
+    "critical_threshold",
+    "status",
+    "is_breach",
+    "breach_threshold",
+    "breach_excess",
+)
+
+
+def _quote_identifier(value: str) -> str:
+    return '"' + value.replace('"', '""') + '"'
+
+
+def _dataset_files(storage_config: dict[str, Any]) -> list[Path]:
+    validate_storage_config(storage_config)
+    storage = storage_config["storage"]
+    datasets = storage["curated"]["datasets"]
+    if DATASET_KEY not in datasets:
+        raise StorageError(f"Storage configuration is missing '{DATASET_KEY}'")
+    curated_base = Path(storage["curated"]["base_path"])
+    dataset_path = curated_base / datasets[DATASET_KEY]
+    if curated_base.is_symlink() or dataset_path.is_symlink():
+        raise StorageError(
+            "Portfolio risk-limit warehouse path must not be a symbolic link"
+        )
+    if not dataset_path.exists():
+        return []
+    if not dataset_path.is_dir():
+        raise StorageError(
+            "Portfolio risk-limit warehouse path must be a directory"
+        )
+    try:
+        files = sorted(dataset_path.rglob("*.parquet"))
+    except OSError:
+        raise StorageError(
+            "Portfolio risk-limit warehouse input could not be inventoried"
+        ) from None
+    if len(files) > MAX_INPUT_FILES:
+        raise StorageError(
+            "Portfolio risk-limit warehouse input exceeds the file scan limit"
+        )
+    total_bytes = 0
+    for path in files:
+        if path.is_symlink() or not path.is_file():
+            raise StorageError(
+                "Portfolio risk-limit warehouse input contains an unsafe file type"
+            )
+        try:
+            total_bytes += path.stat().st_size
+        except OSError:
+            raise StorageError(
+                "Portfolio risk-limit warehouse input could not be inventoried"
+            ) from None
+        if total_bytes > MAX_INPUT_BYTES:
+            raise StorageError(
+                "Portfolio risk-limit warehouse input exceeds the byte scan limit"
+            )
+    return files
+
+
+def _normalise_value(value: Any) -> Any:
+    if value is None:
+        return None
+    if isinstance(value, float) and pd.isna(value):
+        return None
+    if pd.isna(value) is True:
+        return None
+    if hasattr(value, "to_pydatetime"):
+        return value.to_pydatetime()
+    return value
+
+
+def collect_limit_records(
+    storage_config_path: Path = Path("config/storage.yaml"),
+) -> list[dict[str, Any]]:
+    storage_config = load_storage_config(storage_config_path)
+    files = _dataset_files(storage_config)
+    if not files:
+        return []
+    paths = ", ".join(
+        f"'{str(path).replace(chr(39), chr(39) * 2)}'" for path in files
+    )
+    relation = (
+        f"read_parquet([{paths}], union_by_name=true, "
+        "hive_partitioning=false)"
+    )
+    selected = ", ".join(_quote_identifier(column) for column in COLUMNS)
+    try:
+        with duckdb.connect() as connection:
+            count_row = connection.execute(
+                f"SELECT COUNT(*) FROM {relation}"
+            ).fetchone()
+            if count_row is None:
+                raise StorageError(
+                    "Portfolio risk-limit warehouse query returned no row count"
+                )
+            if int(count_row[0]) > MAX_INPUT_ROWS:
+                raise StorageError(
+                    "Portfolio risk-limit warehouse input exceeds the row scan limit"
+                )
+            frame = connection.execute(
+                f"SELECT {selected} FROM {relation} "
+                "ORDER BY ts_event, metric_name, ts_ingest, calculation_id"
+            ).df()
+    except StorageError:
+        raise
+    except Exception:
+        raise StorageError(
+            "Unable to read portfolio risk-limit parquet for warehouse loading"
+        ) from None
+    return [
+        {key: _normalise_value(value) for key, value in row.items()}
+        for row in frame.to_dict("records")
+    ]
+
+
+def build_upsert_sql(schema_name: str = "risk_platform") -> str:
+    columns = ", ".join(_quote_identifier(column) for column in COLUMNS)
+    placeholders = ", ".join(["%s"] * len(COLUMNS))
+    updates = ", ".join(
+        f"{_quote_identifier(column)} = EXCLUDED.{_quote_identifier(column)}"
+        for column in COLUMNS
+        if column != "calculation_id"
+    )
+    return (
+        f"INSERT INTO {_quote_identifier(schema_name)}."
+        f"{_quote_identifier(TABLE_NAME)} ({columns}) VALUES ({placeholders}) "
+        f"ON CONFLICT ({_quote_identifier('calculation_id')}) "
+        f"DO UPDATE SET {updates}, loaded_at = now()"
+    )
+
+
+def load_limits_to_postgres(
+    *,
+    dsn: str,
+    storage_config_path: Path = Path("config/storage.yaml"),
+    schema_name: str = "risk_platform",
+    dry_run: bool = False,
+) -> int:
+    records = collect_limit_records(storage_config_path)
+    if dry_run or not records:
+        return len(records)
+    try:
+        import psycopg
+    except ImportError as exc:
+        raise RuntimeError(
+            "PostgreSQL loading requires psycopg. Run `make setup` first."
+        ) from exc
+    rows = [tuple(record[column] for column in COLUMNS) for record in records]
+    with psycopg.connect(dsn) as connection:
+        with connection.cursor() as cursor:
+            cursor.executemany(build_upsert_sql(schema_name), rows)
+        connection.commit()
+    return len(records)
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Load portfolio risk-limit Parquet into PostgreSQL."
+    )
+    parser.add_argument(
+        "--dsn",
+        default=os.environ.get("WAREHOUSE_POSTGRES_DSN", DEFAULT_POSTGRES_DSN),
+    )
+    parser.add_argument(
+        "--storage-config",
+        type=Path,
+        default=Path("config/storage.yaml"),
+    )
+    parser.add_argument("--schema", default="risk_platform")
+    parser.add_argument("--dry-run", action="store_true")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = _parse_args()
+    count = load_limits_to_postgres(
+        dsn=args.dsn,
+        storage_config_path=args.storage_config,
+        schema_name=args.schema,
+        dry_run=args.dry_run,
+    )
+    print(
+        "Portfolio risk-limit warehouse load summary at "
+        f"{datetime.utcnow().isoformat()}Z"
+    )
+    print(f"{TABLE_NAME}: {count}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/integration/test_portfolio_risk_limits_pipeline.py
+++ b/tests/integration/test_portfolio_risk_limits_pipeline.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+import json
+from datetime import date, datetime, timedelta, timezone
+from pathlib import Path
+
+from src.analytics.portfolio_attribution import build_portfolio_attribution
+from src.analytics.portfolio_risk import WEIGHTING_METHOD, load_portfolio_definition
+from src.orchestration.run_portfolio_risk_limits import run_portfolio_risk_limits
+from src.storage.s3_writer import write_records
+from tests.storage_config_helpers import build_storage_config, write_storage_config
+
+
+def _portfolio_config(tmp_path: Path) -> Path:
+    path = tmp_path / "portfolios.yaml"
+    path.write_text(
+        """
+portfolios:
+  us-tech-equal:
+    base_currency: USD
+    constituents:
+      - source: alpha_vantage
+        symbol: AAPL
+        weight: 0.5
+      - source: alpha_vantage
+        symbol: MSFT
+        weight: 0.5
+""".lstrip(),
+        encoding="utf-8",
+    )
+    return path
+
+
+def _limits_config(tmp_path: Path) -> Path:
+    path = tmp_path / "limits.yaml"
+    path.write_text(
+        """
+policies:
+  test-policy:
+    portfolio_id: us-tech-equal
+    covariance_window: 3
+    annualization_days: 252
+    limits:
+      portfolio_volatility_annualized:
+        warning: 0.30
+        critical: 0.45
+      largest_absolute_component_contribution_share:
+        warning: 0.65
+        critical: 0.80
+""".lstrip(),
+        encoding="utf-8",
+    )
+    return path
+
+
+def _portfolio_returns(fingerprint: str) -> list[dict[str, object]]:
+    records: list[dict[str, object]] = []
+    ingested = datetime(2026, 1, 10, 12, tzinfo=timezone.utc)
+    for day, aapl, msft in [(2, 0.10, 0.02), (3, -0.04, 0.0), (4, 0.06, 0.02)]:
+        event = datetime(2026, 1, day, tzinfo=timezone.utc)
+        component_returns = {
+            "alpha_vantage:AAPL": aapl,
+            "alpha_vantage:MSFT": msft,
+        }
+        records.append(
+            {
+                "model_version": "portfolio-risk-v1",
+                "calculation_id": f"portfolio-{day}",
+                "portfolio_id": "us-tech-equal",
+                "base_currency": "USD",
+                "definition_fingerprint": fingerprint,
+                "weighting_method": WEIGHTING_METHOD,
+                "ts_event": event,
+                "ts_ingest": ingested + timedelta(minutes=day),
+                "constituent_count": 2,
+                "weights_json": json.dumps(
+                    {"alpha_vantage:AAPL": 0.5, "alpha_vantage:MSFT": 0.5}
+                ),
+                "component_calculation_ids_json": json.dumps(
+                    {
+                        "alpha_vantage:AAPL": f"AAPL-{day}",
+                        "alpha_vantage:MSFT": f"MSFT-{day}",
+                    }
+                ),
+                "component_returns_json": json.dumps(component_returns),
+                "portfolio_return_1d": 0.5 * aapl + 0.5 * msft,
+            }
+        )
+    return records
+
+
+def test_portfolio_risk_limits_read_attribution_and_replay(tmp_path: Path) -> None:
+    storage_config = build_storage_config(tmp_path)
+    storage_config_path = write_storage_config(tmp_path)
+    portfolio_config = _portfolio_config(tmp_path)
+    limits_config = _limits_config(tmp_path)
+    definition = load_portfolio_definition(portfolio_config, "us-tech-equal")
+    attribution = build_portfolio_attribution(
+        _portfolio_returns(definition.fingerprint),
+        definition=definition,
+        covariance_window=3,
+        end_date=date(2026, 1, 4),
+    )
+    assert write_records(
+        [attribution.snapshot],
+        kind="curated",
+        dataset="portfolio_risk_attribution",
+        storage_config=storage_config,
+    ) == 1
+
+    first = run_portfolio_risk_limits(
+        policy_id="test-policy",
+        limits_config_path=limits_config,
+        portfolio_config_path=portfolio_config,
+        end_date=date(2026, 1, 4),
+        storage_config_path=storage_config_path,
+    )
+    second = run_portfolio_risk_limits(
+        policy_id="test-policy",
+        limits_config_path=limits_config,
+        portfolio_config_path=portfolio_config,
+        end_date=date(2026, 1, 4),
+        storage_config_path=storage_config_path,
+    )
+
+    first_output = first["curated_output"]["portfolio_risk_limit_evaluations"]
+    second_output = second["curated_output"]["portfolio_risk_limit_evaluations"]
+    assert first_output["records_selected"] == 2
+    assert first_output["records_written"] == 2
+    assert second_output["records_written"] == 0
+    assert second_output["records_already_present"] == 2
+    assert second["latest_status"] == first["latest_status"]

--- a/tests/storage_config_helpers.py
+++ b/tests/storage_config_helpers.py
@@ -17,6 +17,7 @@ CURATED_DATASETS = {
     "portfolio_daily_returns": "portfolio_daily_returns",
     "portfolio_daily_risk_summary": "portfolio_daily_risk_summary",
     "portfolio_risk_attribution": "portfolio_risk_attribution",
+    "portfolio_risk_limit_evaluations": "portfolio_risk_limit_evaluations",
 }
 
 

--- a/tests/unit/test_docker_compose_contract.py
+++ b/tests/unit/test_docker_compose_contract.py
@@ -13,28 +13,23 @@ def _load_compose() -> dict[str, Any]:
 
 def test_local_database_services_are_present() -> None:
     compose = _load_compose()
-
     assert {"postgres", "mongo"} <= set(compose["services"])
 
 
 def test_local_database_ports_are_bound_to_loopback_only() -> None:
     services = _load_compose()["services"]
-
     assert services["postgres"]["ports"] == ["127.0.0.1:5433:5432"]
     assert services["mongo"]["ports"] == ["127.0.0.1:27018:27017"]
 
 
-def test_local_database_seed_mounts_are_read_only() -> None:
+def test_local_database_seed_mounts_are_read_only_and_ordered() -> None:
     services = _load_compose()["services"]
-
     assert services["postgres"]["volumes"] == [
         "./sql/postgres_schema.sql:/docker-entrypoint-initdb.d/01_schema.sql:ro",
         "./sql/postgres_demo_data.sql:/docker-entrypoint-initdb.d/02_demo_data.sql:ro",
         "./sql/portfolio_schema.sql:/docker-entrypoint-initdb.d/03_portfolio_schema.sql:ro",
-        (
-            "./sql/portfolio_attribution_schema.sql:"
-            "/docker-entrypoint-initdb.d/04_portfolio_attribution_schema.sql:ro"
-        ),
+        "./sql/portfolio_attribution_schema.sql:/docker-entrypoint-initdb.d/04_portfolio_attribution_schema.sql:ro",
+        "./sql/portfolio_risk_limits_schema.sql:/docker-entrypoint-initdb.d/05_portfolio_risk_limits_schema.sql:ro",
     ]
     assert services["mongo"]["volumes"] == [
         "./mongo/init:/docker-entrypoint-initdb.d:ro"
@@ -43,7 +38,6 @@ def test_local_database_seed_mounts_are_read_only() -> None:
 
 def test_local_database_services_have_healthchecks() -> None:
     services = _load_compose()["services"]
-
     assert (
         "pg_isready -U risk_user -d risk_platform"
         in services["postgres"]["healthcheck"]["test"]
@@ -57,7 +51,6 @@ def test_local_database_services_have_healthchecks() -> None:
 
 def test_postgres_uses_demo_only_credentials() -> None:
     environment = _load_compose()["services"]["postgres"]["environment"]
-
     assert environment == {
         "POSTGRES_DB": "risk_platform",
         "POSTGRES_USER": "risk_user",

--- a/tests/unit/test_portfolio_risk_limits.py
+++ b/tests/unit/test_portfolio_risk_limits.py
@@ -1,0 +1,206 @@
+from __future__ import annotations
+
+import json
+from datetime import date, datetime, timedelta, timezone
+
+import pytest
+
+from src.analytics.portfolio_risk_limits import (
+    CONCENTRATION_METRIC,
+    MODEL_VERSION,
+    VOLATILITY_METRIC,
+    evaluate_portfolio_risk_limits,
+    parse_portfolio_risk_limit_policy,
+)
+from src.common.exceptions import ValidationError
+
+FINGERPRINT = "portfolio-definition-test"
+
+
+def _policy_payload(
+    volatility_warning: float = 0.30,
+) -> dict[str, object]:
+    return {
+        "policies": {
+            "test-policy": {
+                "portfolio_id": "us-tech-equal",
+                "covariance_window": 3,
+                "annualization_days": 252,
+                "limits": {
+                    VOLATILITY_METRIC: {
+                        "warning": volatility_warning,
+                        "critical": 0.45,
+                    },
+                    CONCENTRATION_METRIC: {
+                        "warning": 0.65,
+                        "critical": 0.80,
+                    },
+                },
+            }
+        }
+    }
+
+
+def _record(
+    day: int,
+    volatility: float,
+    aapl_share: float,
+    msft_share: float,
+    *,
+    calculation_id: str | None = None,
+    ingested_at: datetime | None = None,
+) -> dict[str, object]:
+    event = datetime(2026, 1, day, tzinfo=timezone.utc)
+    return {
+        "model_version": "portfolio-attribution-v1",
+        "calculation_id": calculation_id or f"attribution-{day}",
+        "portfolio_id": "us-tech-equal",
+        "base_currency": "USD",
+        "definition_fingerprint": FINGERPRINT,
+        "weighting_method": "constant_weight_daily_rebalanced",
+        "covariance_method": "sample_annualized",
+        "correlation_method": "pearson",
+        "covariance_window": 3,
+        "annualization_days": 252,
+        "ts_event": event,
+        "ts_ingest": ingested_at or event + timedelta(hours=1),
+        "portfolio_volatility_annualized": volatility,
+        "volatility_status": "positive" if volatility > 0 else "zero",
+        "component_contribution_share_json": json.dumps(
+            {
+                "alpha_vantage:AAPL": aapl_share,
+                "alpha_vantage:MSFT": msft_share,
+            },
+            sort_keys=True,
+        ),
+    }
+
+
+def _policy(volatility_warning: float = 0.30):
+    return parse_portfolio_risk_limit_policy(
+        _policy_payload(volatility_warning),
+        "test-policy",
+    )
+
+
+def test_evaluates_two_metrics_with_deterministic_statuses() -> None:
+    output = evaluate_portfolio_risk_limits(
+        [_record(4, 0.50, 0.82, 0.18)],
+        policy=_policy(),
+        definition_fingerprint=FINGERPRINT,
+    )
+
+    assert len(output.evaluations) == 2
+    by_metric = {item["metric_name"]: item for item in output.evaluations}
+    assert by_metric[VOLATILITY_METRIC]["status"] == "critical"
+    assert by_metric[VOLATILITY_METRIC]["breach_excess"] == pytest.approx(0.05)
+    concentration = by_metric[CONCENTRATION_METRIC]
+    assert concentration["status"] == "critical"
+    assert concentration["subject_key"] == "alpha_vantage:AAPL"
+    assert concentration["observed_signed_value"] == pytest.approx(0.82)
+    assert all(item["model_version"] == MODEL_VERSION for item in output.evaluations)
+
+
+def test_latest_attribution_version_wins_and_input_order_is_irrelevant() -> None:
+    late = datetime(2026, 2, 1, tzinfo=timezone.utc)
+    records = [
+        _record(4, 0.20, 0.55, 0.45, calculation_id="old"),
+        _record(
+            4,
+            0.35,
+            -0.70,
+            0.30,
+            calculation_id="new",
+            ingested_at=late,
+        ),
+    ]
+    forward = evaluate_portfolio_risk_limits(
+        records,
+        policy=_policy(),
+        definition_fingerprint=FINGERPRINT,
+    )
+    reverse = evaluate_portfolio_risk_limits(
+        reversed(records),
+        policy=_policy(),
+        definition_fingerprint=FINGERPRINT,
+    )
+
+    assert forward.evaluations == reverse.evaluations
+    assert {item["attribution_calculation_id"] for item in forward.evaluations} == {
+        "new"
+    }
+    concentration = next(
+        item
+        for item in forward.evaluations
+        if item["metric_name"] == CONCENTRATION_METRIC
+    )
+    assert concentration["observed_value"] == pytest.approx(0.70)
+    assert concentration["observed_signed_value"] == pytest.approx(-0.70)
+
+
+def test_policy_change_creates_new_fingerprint_and_evaluation_ids() -> None:
+    record = _record(4, 0.35, 0.60, 0.40)
+    original = evaluate_portfolio_risk_limits(
+        [record],
+        policy=_policy(0.30),
+        definition_fingerprint=FINGERPRINT,
+    )
+    changed = evaluate_portfolio_risk_limits(
+        [record],
+        policy=_policy(0.25),
+        definition_fingerprint=FINGERPRINT,
+    )
+
+    assert original.diagnostics["policy_fingerprint"] != changed.diagnostics[
+        "policy_fingerprint"
+    ]
+    assert {item["calculation_id"] for item in original.evaluations}.isdisjoint(
+        item["calculation_id"] for item in changed.evaluations
+    )
+
+
+def test_invalid_policy_conflict_and_request_bound_fail_closed() -> None:
+    invalid = _policy_payload()
+    invalid["policies"]["test-policy"]["limits"][VOLATILITY_METRIC] = {
+        "warning": 0.50,
+        "critical": 0.40,
+    }
+    with pytest.raises(ValidationError, match="warning < critical"):
+        parse_portfolio_risk_limit_policy(invalid, "test-policy")
+
+    conflicting = [
+        _record(4, 0.20, 0.50, 0.50, calculation_id="same"),
+        _record(4, 0.30, 0.50, 0.50, calculation_id="same"),
+    ]
+    with pytest.raises(ValidationError, match="conflicting records"):
+        evaluate_portfolio_risk_limits(
+            conflicting,
+            policy=_policy(),
+            definition_fingerprint=FINGERPRINT,
+        )
+
+    with pytest.raises(ValidationError, match="max_evaluations"):
+        evaluate_portfolio_risk_limits(
+            [_record(4, 0.20, 0.50, 0.50)],
+            policy=_policy(),
+            definition_fingerprint=FINGERPRINT,
+            max_evaluations=1,
+        )
+
+
+def test_start_date_filters_evaluation_dates() -> None:
+    output = evaluate_portfolio_risk_limits(
+        [
+            _record(3, 0.20, 0.50, 0.50),
+            _record(4, 0.35, 0.70, 0.30),
+        ],
+        policy=_policy(),
+        definition_fingerprint=FINGERPRINT,
+        start_date=date(2026, 1, 4),
+        end_date=date(2026, 1, 4),
+    )
+
+    assert len(output.evaluations) == 2
+    assert {item["ts_event"].date() for item in output.evaluations} == {
+        date(2026, 1, 4)
+    }

--- a/tests/unit/test_portfolio_risk_limits_architecture_contract.py
+++ b/tests/unit/test_portfolio_risk_limits_architecture_contract.py
@@ -1,0 +1,28 @@
+from pathlib import Path
+
+
+def test_portfolio_risk_limit_contract_is_documented() -> None:
+    document = Path("docs/portfolio-risk-limits.md").read_text(encoding="utf-8")
+    policy = Path("config/portfolio_risk_limits.yaml").read_text(encoding="utf-8")
+    schema = Path("sql/portfolio_risk_limits_schema.sql").read_text(
+        encoding="utf-8"
+    )
+
+    for required in (
+        "portfolio-risk-limits-v1",
+        "portfolio_volatility_annualized",
+        "largest_absolute_component_contribution_share",
+        "policy fingerprint",
+        "portfolio_risk_limit_evaluations",
+        "latest_portfolio_risk_limit_evaluations",
+        "portfolio_risk_limit_breaches",
+        "portfolio_risk_limit_snapshot_status",
+        "does not send alerts",
+    ):
+        assert required in document
+
+    assert "us-tech-standard" in policy
+    assert "warning: 0.30" in policy
+    assert "critical: 0.45" in policy
+    assert "policy_fingerprint" in schema
+    assert "attribution_calculation_id" in schema

--- a/tests/unit/test_portfolio_risk_limits_loader.py
+++ b/tests/unit/test_portfolio_risk_limits_loader.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+
+from src.analytics.portfolio_risk_limits import (
+    evaluate_portfolio_risk_limits,
+    parse_portfolio_risk_limit_policy,
+)
+from src.storage.s3_writer import write_records
+from src.warehouse.portfolio_risk_limits_loader import (
+    COLUMNS,
+    build_upsert_sql,
+    collect_limit_records,
+    load_limits_to_postgres,
+)
+from tests.storage_config_helpers import build_storage_config, write_storage_config
+
+
+def _evaluations() -> list[dict]:
+    policy = parse_portfolio_risk_limit_policy(
+        {
+            "policies": {
+                "test-policy": {
+                    "portfolio_id": "us-tech-equal",
+                    "covariance_window": 3,
+                    "annualization_days": 252,
+                    "limits": {
+                        "portfolio_volatility_annualized": {
+                            "warning": 0.30,
+                            "critical": 0.45,
+                        },
+                        "largest_absolute_component_contribution_share": {
+                            "warning": 0.65,
+                            "critical": 0.80,
+                        },
+                    },
+                }
+            }
+        },
+        "test-policy",
+    )
+    event = datetime(2026, 1, 4, tzinfo=timezone.utc)
+    output = evaluate_portfolio_risk_limits(
+        [
+            {
+                "model_version": "portfolio-attribution-v1",
+                "calculation_id": "attribution-4",
+                "portfolio_id": "us-tech-equal",
+                "base_currency": "USD",
+                "definition_fingerprint": "definition-a",
+                "weighting_method": "constant_weight_daily_rebalanced",
+                "covariance_method": "sample_annualized",
+                "correlation_method": "pearson",
+                "covariance_window": 3,
+                "annualization_days": 252,
+                "ts_event": event,
+                "ts_ingest": event + timedelta(hours=1),
+                "portfolio_volatility_annualized": 0.50,
+                "volatility_status": "positive",
+                "component_contribution_share_json": json.dumps(
+                    {"alpha_vantage:AAPL": 0.82, "alpha_vantage:MSFT": 0.18}
+                ),
+            }
+        ],
+        policy=policy,
+        definition_fingerprint="definition-a",
+    )
+    return list(output.evaluations)
+
+
+def test_loader_collects_evaluations_and_dry_run_counts(tmp_path) -> None:
+    config = build_storage_config(tmp_path)
+    config_path = write_storage_config(tmp_path)
+    assert write_records(
+        _evaluations(),
+        kind="curated",
+        dataset="portfolio_risk_limit_evaluations",
+        storage_config=config,
+    ) == 2
+
+    records = collect_limit_records(config_path)
+    assert len(records) == 2
+    assert set(records[0]) == set(COLUMNS)
+    assert {record["status"] for record in records} == {"critical"}
+    assert load_limits_to_postgres(
+        dsn="postgresql://unused",
+        storage_config_path=config_path,
+        dry_run=True,
+    ) == 2
+
+
+def test_loader_returns_zero_when_dataset_is_absent(tmp_path) -> None:
+    config_path = write_storage_config(tmp_path)
+    assert collect_limit_records(config_path) == []
+    assert load_limits_to_postgres(
+        dsn="postgresql://unused",
+        storage_config_path=config_path,
+        dry_run=True,
+    ) == 0
+
+
+def test_upsert_uses_calculation_id_and_updates_evidence() -> None:
+    statement = build_upsert_sql()
+    assert 'INSERT INTO "risk_platform"."portfolio_risk_limit_evaluations"' in statement
+    assert 'ON CONFLICT ("calculation_id") DO UPDATE' in statement
+    assert '"policy_fingerprint" = EXCLUDED."policy_fingerprint"' in statement
+    assert len(COLUMNS) == 28

--- a/tests/unit/test_portfolio_risk_limits_reporting_sql_contract.py
+++ b/tests/unit/test_portfolio_risk_limits_reporting_sql_contract.py
@@ -1,0 +1,217 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+
+import duckdb
+
+
+def _read(path: str) -> str:
+    return Path(path).read_text(encoding="utf-8")
+
+
+def _statement(sql: str, prefix: str) -> str:
+    start = sql.index(prefix)
+    return sql[start : sql.index(";", start) + 1]
+
+
+def test_limit_schema_exposes_history_and_reporting_views() -> None:
+    sql = _read("sql/portfolio_risk_limits_schema.sql")
+    assert (
+        "CREATE TABLE IF NOT EXISTS "
+        "risk_platform.portfolio_risk_limit_evaluations" in sql
+    )
+    assert "attribution_calculation_id TEXT NOT NULL REFERENCES" in sql
+    assert "portfolio-risk-limits-v1" in sql
+    assert "warning_threshold > 0" in sql
+    assert "critical_threshold > warning_threshold" in sql
+    for view in (
+        "latest_portfolio_risk_limit_evaluations",
+        "portfolio_risk_limit_breaches",
+        "portfolio_risk_limit_snapshot_status",
+    ):
+        assert f"CREATE OR REPLACE VIEW risk_platform.{view}" in sql
+
+
+def test_latest_view_ranks_corrections_without_collapsing_policy_versions() -> None:
+    sql = _read("sql/portfolio_risk_limits_schema.sql")
+    latest = _statement(
+        sql,
+        "CREATE OR REPLACE VIEW "
+        "risk_platform.latest_portfolio_risk_limit_evaluations AS",
+    )
+    with duckdb.connect() as connection:
+        connection.execute("CREATE SCHEMA risk_platform")
+        connection.execute(
+            """
+            CREATE TABLE risk_platform.portfolio_risk_limit_evaluations (
+                calculation_id TEXT,
+                model_version TEXT,
+                policy_id TEXT,
+                policy_fingerprint TEXT,
+                portfolio_id TEXT,
+                base_currency TEXT,
+                definition_fingerprint TEXT,
+                attribution_calculation_id TEXT,
+                attribution_model_version TEXT,
+                weighting_method TEXT,
+                covariance_method TEXT,
+                correlation_method TEXT,
+                covariance_window INTEGER,
+                annualization_days INTEGER,
+                ts_event TIMESTAMPTZ,
+                ts_ingest TIMESTAMPTZ,
+                metric_name TEXT,
+                subject_type TEXT,
+                subject_key TEXT,
+                unit TEXT,
+                observed_value DOUBLE,
+                observed_signed_value DOUBLE,
+                warning_threshold DOUBLE,
+                critical_threshold DOUBLE,
+                status TEXT,
+                is_breach BOOLEAN,
+                breach_threshold DOUBLE,
+                breach_excess DOUBLE
+            )
+            """
+        )
+        metric_time = datetime(2026, 1, 4, tzinfo=timezone.utc)
+        old_time = datetime(2026, 1, 10, tzinfo=timezone.utc)
+        new_time = datetime(2026, 2, 1, tzinfo=timezone.utc)
+        common = (
+            "portfolio-risk-limits-v1",
+            "test-policy",
+            "policy-a",
+            "us-tech-equal",
+            "USD",
+            "definition-a",
+            "portfolio-attribution-v1",
+            "constant_weight_daily_rebalanced",
+            "sample_annualized",
+            "pearson",
+            20,
+            252,
+            metric_time,
+        )
+        rows = [
+            (
+                "old-vol",
+                *common[:6],
+                "attribution-old",
+                *common[6:],
+                old_time,
+                "portfolio_volatility_annualized",
+                "portfolio",
+                "us-tech-equal",
+                "annualized_decimal",
+                0.30,
+                0.30,
+                0.30,
+                0.45,
+                "warning",
+                True,
+                0.30,
+                0.0,
+            ),
+            (
+                "new-vol",
+                *common[:6],
+                "attribution-new",
+                *common[6:],
+                new_time,
+                "portfolio_volatility_annualized",
+                "portfolio",
+                "us-tech-equal",
+                "annualized_decimal",
+                0.50,
+                0.50,
+                0.30,
+                0.45,
+                "critical",
+                True,
+                0.45,
+                0.05,
+            ),
+            (
+                "concentration",
+                *common[:6],
+                "attribution-new",
+                *common[6:],
+                new_time,
+                "largest_absolute_component_contribution_share",
+                "constituent",
+                "alpha_vantage:AAPL",
+                "absolute_share",
+                0.82,
+                0.82,
+                0.65,
+                0.80,
+                "critical",
+                True,
+                0.80,
+                0.02,
+            ),
+            (
+                "other-policy",
+                common[0],
+                common[1],
+                "policy-b",
+                *common[3:6],
+                "attribution-new",
+                *common[6:],
+                new_time,
+                "portfolio_volatility_annualized",
+                "portfolio",
+                "us-tech-equal",
+                "annualized_decimal",
+                0.50,
+                0.50,
+                0.35,
+                0.55,
+                "warning",
+                True,
+                0.35,
+                0.15,
+            ),
+        ]
+        placeholders = ", ".join(["?"] * len(rows[0]))
+        connection.executemany(
+            "INSERT INTO risk_platform.portfolio_risk_limit_evaluations "
+            f"VALUES ({placeholders})",
+            rows,
+        )
+        connection.execute(latest)
+        assert connection.execute(
+            """
+            SELECT calculation_id, policy_fingerprint, metric_name
+            FROM risk_platform.latest_portfolio_risk_limit_evaluations
+            ORDER BY policy_fingerprint, metric_name
+            """
+        ).fetchall() == [
+            (
+                "concentration",
+                "policy-a",
+                "largest_absolute_component_contribution_share",
+            ),
+            ("new-vol", "policy-a", "portfolio_volatility_annualized"),
+            ("other-policy", "policy-b", "portfolio_volatility_annualized"),
+        ]
+
+
+def test_consistency_sql_covers_limit_evidence() -> None:
+    sql = _read("sql/portfolio_risk_limits_consistency_checks.sql")
+    for name in (
+        "portfolio_risk_limit_attribution_references_valid",
+        "portfolio_risk_limit_attribution_metadata_aligns",
+        "portfolio_risk_limit_uses_current_attribution_versions",
+        "portfolio_risk_limit_observed_values_match_attribution",
+        "portfolio_risk_limit_calculation_ids_unique",
+        "latest_portfolio_risk_limit_grain_unique",
+        "latest_portfolio_risk_limit_selects_current_version",
+        "portfolio_risk_limit_snapshot_has_two_metrics",
+        "portfolio_risk_limit_breach_view_matches_current_breaches",
+        "portfolio_risk_limit_snapshot_status_values_reconcile",
+    ):
+        assert name in sql
+    assert "jsonb_each_text" in sql

--- a/tests/unit/test_run_portfolio_risk_limits.py
+++ b/tests/unit/test_run_portfolio_risk_limits.py
@@ -1,0 +1,184 @@
+from __future__ import annotations
+
+import json
+from datetime import date, datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from src.analytics.portfolio_risk import parse_portfolio_definition
+from src.analytics.portfolio_risk_limits import parse_portfolio_risk_limit_policy
+from src.common.exceptions import StorageError
+from src.orchestration.run_portfolio_risk_limits import (
+    OUTPUT_DATASET,
+    run_portfolio_risk_limits,
+)
+
+
+def _definition():
+    return parse_portfolio_definition(
+        {
+            "portfolios": {
+                "us-tech-equal": {
+                    "base_currency": "USD",
+                    "constituents": [
+                        {
+                            "source": "alpha_vantage",
+                            "symbol": "AAPL",
+                            "weight": 0.5,
+                        },
+                        {
+                            "source": "alpha_vantage",
+                            "symbol": "MSFT",
+                            "weight": 0.5,
+                        },
+                    ],
+                }
+            }
+        },
+        "us-tech-equal",
+    )
+
+
+def _policy():
+    return parse_portfolio_risk_limit_policy(
+        {
+            "policies": {
+                "test-policy": {
+                    "portfolio_id": "us-tech-equal",
+                    "covariance_window": 3,
+                    "annualization_days": 252,
+                    "limits": {
+                        "portfolio_volatility_annualized": {
+                            "warning": 0.30,
+                            "critical": 0.45,
+                        },
+                        "largest_absolute_component_contribution_share": {
+                            "warning": 0.65,
+                            "critical": 0.80,
+                        },
+                    },
+                }
+            }
+        },
+        "test-policy",
+    )
+
+
+def _storage_config() -> dict[str, Any]:
+    return {
+        "storage": {
+            "base_dir": "unused",
+            "raw": {"base_path": "unused/raw", "dataset": "market_events"},
+            "curated": {
+                "base_path": "unused/curated",
+                "datasets": {
+                    "portfolio_risk_attribution": "portfolio_risk_attribution",
+                    OUTPUT_DATASET: OUTPUT_DATASET,
+                },
+            },
+            "format": "parquet",
+            "partitioning": {"granularity": "hourly"},
+        }
+    }
+
+
+def _records() -> list[dict[str, object]]:
+    definition = _definition()
+    records: list[dict[str, object]] = []
+    for day, volatility, aapl, msft in [
+        (3, 0.20, 0.55, 0.45),
+        (4, 0.50, 0.82, 0.18),
+    ]:
+        event = datetime(2026, 1, day, tzinfo=timezone.utc)
+        records.append(
+            {
+                "model_version": "portfolio-attribution-v1",
+                "calculation_id": f"attribution-{day}",
+                "portfolio_id": "us-tech-equal",
+                "base_currency": "USD",
+                "definition_fingerprint": definition.fingerprint,
+                "weighting_method": "constant_weight_daily_rebalanced",
+                "covariance_method": "sample_annualized",
+                "correlation_method": "pearson",
+                "covariance_window": 3,
+                "annualization_days": 252,
+                "ts_event": event,
+                "ts_ingest": event + timedelta(hours=1),
+                "portfolio_volatility_annualized": volatility,
+                "volatility_status": "positive",
+                "component_contribution_share_json": json.dumps(
+                    {
+                        "alpha_vantage:AAPL": aapl,
+                        "alpha_vantage:MSFT": msft,
+                    }
+                ),
+            }
+        )
+    return records
+
+
+def test_runner_publishes_and_summarises_limit_evaluations() -> None:
+    writes: list[dict[str, Any]] = []
+
+    def writer(records: list[dict[str, Any]], *, dataset: str, **_: Any) -> int:
+        assert dataset == OUTPUT_DATASET
+        writes.append(records[0])
+        return 1
+
+    summary = run_portfolio_risk_limits(
+        policy_id="test-policy",
+        limits_config_path=Path("unused-limits.yaml"),
+        portfolio_config_path=Path("unused-portfolios.yaml"),
+        start_date=date(2026, 1, 4),
+        end_date=date(2026, 1, 4),
+        storage_config_path=Path("unused-storage.yaml"),
+        reader=lambda _: _records(),
+        writer=writer,
+        storage_config_loader=lambda _: _storage_config(),
+        definition_loader=lambda *_: _definition(),
+        policy_loader=lambda *_: _policy(),
+    )
+
+    assert summary["curated_output"][OUTPUT_DATASET] == {
+        "records_selected": 2,
+        "records_written": 2,
+        "records_already_present": 0,
+    }
+    assert summary["latest_status"]["status"] == "critical"
+    assert len(summary["latest_status"]["metrics"]) == 2
+    assert len(writes) == 2
+
+
+def test_runner_reports_replay_and_rejects_invalid_writer_result() -> None:
+    replay = run_portfolio_risk_limits(
+        policy_id="test-policy",
+        limits_config_path=Path("unused-limits.yaml"),
+        portfolio_config_path=Path("unused-portfolios.yaml"),
+        end_date=date(2026, 1, 4),
+        storage_config_path=Path("unused-storage.yaml"),
+        reader=lambda _: _records(),
+        writer=lambda *_args, **_kwargs: 0,
+        storage_config_loader=lambda _: _storage_config(),
+        definition_loader=lambda *_: _definition(),
+        policy_loader=lambda *_: _policy(),
+    )
+    assert replay["curated_output"][OUTPUT_DATASET]["records_written"] == 0
+    assert replay["curated_output"][OUTPUT_DATASET][
+        "records_already_present"
+    ] == 4
+
+    with pytest.raises(StorageError, match="invalid result"):
+        run_portfolio_risk_limits(
+            policy_id="test-policy",
+            limits_config_path=Path("unused-limits.yaml"),
+            portfolio_config_path=Path("unused-portfolios.yaml"),
+            end_date=date(2026, 1, 4),
+            storage_config_path=Path("unused-storage.yaml"),
+            reader=lambda _: _records(),
+            writer=lambda *_args, **_kwargs: 2,
+            storage_config_loader=lambda _: _storage_config(),
+            definition_loader=lambda *_: _definition(),
+            policy_loader=lambda *_: _policy(),
+        )

--- a/tests/unit/test_storage_config.py
+++ b/tests/unit/test_storage_config.py
@@ -18,6 +18,7 @@ def test_storage_config_valid():
         "portfolio_daily_returns",
         "portfolio_daily_risk_summary",
         "portfolio_risk_attribution",
+        "portfolio_risk_limit_evaluations",
     }.issubset(storage["curated"]["datasets"])
     assert storage["partitioning"]["granularity"]
 


### PR DESCRIPTION
## Outcome

Add deterministic monitoring over the rolling portfolio-attribution series:

```text
current portfolio_risk_attribution snapshots
  -> exact definition, methods and covariance window
  -> versioned local risk-limit policy
  -> portfolio-volatility evaluation
  -> largest absolute component-contribution-share evaluation
  -> replay-safe portfolio_risk_limit_evaluations Parquet
  -> PostgreSQL history, current breach and snapshot-status views
```

Primary arc42 block: `analytics`, with explicit interfaces to orchestration, curated storage and PostgreSQL serving.

## Policy and evidence

Add `config/portfolio_risk_limits.yaml` with a bounded demonstration policy. Each policy receives a deterministic fingerprint from its portfolio, covariance window, annualisation basis and thresholds. Threshold changes therefore create a new policy version instead of relabelling earlier evidence.

Every current attribution snapshot emits exactly two records:

- `portfolio_volatility_annualized`;
- `largest_absolute_component_contribution_share`.

Each evaluation records the observed value, signed value, subject, warning and critical thresholds, status, breach threshold and excess. The concentration metric keeps the constituent key and signed Euler share while evaluating its absolute magnitude.

Evaluation identity binds the policy fingerprint, attribution calculation ID, metric name and `portfolio-risk-limits-v1` model version.

## Current input selection and bounds

The evaluator filters to the policy portfolio, exact portfolio-definition fingerprint, covariance window, annualisation basis and supported attribution methods. Corrections are selected per event date using:

```text
ts_ingest DESC
calculation_id DESC
```

Identical duplicate calculations are ignored; conflicting reuse of one calculation ID fails closed.

One request is capped at 10,000 evaluations. Local attribution and warehouse reads retain the existing 4,096-file, 1 GB and 250,000-row bounds and reject symbolic links and unsafe file types.

## PostgreSQL serving

Add:

- `risk_platform.portfolio_risk_limit_evaluations`;
- `latest_portfolio_risk_limit_evaluations`;
- `portfolio_risk_limit_breaches`;
- `portfolio_risk_limit_snapshot_status`.

The current grain preserves policy fingerprint, definition, event date, models, methods, covariance window, annualisation basis and metric. It deliberately excludes the constituent subject key, allowing a corrected attribution snapshot to change the current largest component while retaining both history rows.

The snapshot-status view combines the two current metrics using critical > warning > ok precedence.

## Reconciliation

`sql/portfolio_risk_limits_consistency_checks.sql` verifies attribution references and metadata, current-version input selection, observed values, unique identities and current grains, two metrics per snapshot, breach-view counts and aggregate snapshot status.

## Operator path

```bash
.venv/bin/python -m src.orchestration.run_portfolio_risk_limits \
  --policy-id us-tech-standard \
  --start-date 2026-01-01 \
  --end-date 2026-03-31 \
  --summary-json .demo/portfolio-risk-limits-summary.json

.venv/bin/python -m src.warehouse.portfolio_risk_limits_loader --dry-run
```

The Docker PostgreSQL initializer applies the risk-limit schema after the attribution schema. Existing databases can apply the new SQL explicitly as documented in `docs/portfolio-risk-limits.md`.

## Validation

GitHub Actions run `32499598039` (`ci` run 203) passed on exact head `46c3f28944428ac2c358e5060b72d9c632a7ce07`:

- Security guardrails: passed.
- Python readiness: passed.
  - locked dependencies resolved;
  - Ruff passed;
  - mypy passed across 51 source files;
  - 477 tests passed, including policy versioning, corrected current input, Parquet replay, bounded loading and executable DuckDB current-view ranking;
  - `pip check` passed;
  - `make readiness-check` passed.
- Infrastructure validation: passed.
  - Kubernetes overlays rendered with the synchronized storage configuration;
  - Terraform formatting, initialization and validation passed without applying infrastructure.

No unresolved review threads or requested changes are present.

## Scope

The branch is one commit ahead of `main` and zero behind. It changes 19 files with 2,758 additions and 10 deletions as one monitoring-to-serving contract.

No provider request, credential change, live alert delivery, trading control, acknowledgement workflow, managed database, scheduler, dashboard, deployment or Terraform apply is included.

## Acceptance boundary

This PR is validated and ready for review. It has not been merged.