### PR TITLE
Add append-only risk-limit acknowledgements

### DIFF
--- a/docs/portfolio-risk-limits.md
+++ b/docs/portfolio-risk-limits.md
@@ -2,8 +2,8 @@
 
 ## Outcome
 
-This increment evaluates the rolling portfolio-attribution series against a
-versioned local policy and retains deterministic evidence for every metric:
+This path evaluates the rolling portfolio-attribution series against a versioned
+local policy and retains deterministic evidence for every metric:
 
 ```text
 current portfolio_risk_attribution snapshots
@@ -13,10 +13,12 @@ current portfolio_risk_attribution snapshots
   -> largest absolute component-contribution-share evaluation
   -> versioned portfolio_risk_limit_evaluations Parquet
   -> PostgreSQL history, current breach and snapshot-status views
+  -> append-only human acknowledgement evidence
+  -> open and acknowledged breach views
 ```
 
-It provides monitoring evidence only. It does not send alerts, block trades,
-change positions or make an approval decision.
+It provides monitoring and review evidence only. It does not send alerts, block
+trades, change positions or make an approval decision.
 
 ## Policy
 
@@ -154,6 +156,76 @@ rows.
 `portfolio_risk_limit_snapshot_status` combines the two current metrics into one
 portfolio-date status using critical > warning > ok precedence.
 
+## Breach Acknowledgement
+
+A human reviewer can append an acknowledgement to one current breach:
+
+```bash
+.venv/bin/python -m src.warehouse.portfolio_risk_limit_acknowledger \
+  --calculation-id portfolio-risk-limits-v1-example \
+  --request-id INC-2026-001 \
+  --acknowledged-by reviewer@example.com \
+  --disposition investigating \
+  --reason 'Reviewing the component concentration and source inputs.'
+```
+
+The supported dispositions are:
+
+```text
+investigating
+accepted
+false_positive
+```
+
+The acknowledgement model is `portfolio-risk-limit-ack-v1`. Its deterministic
+identity binds the target evaluation and caller-supplied request ID. Retrying the
+same request with the same immutable content is idempotent. Reusing the request
+ID with different actor, disposition or reason is rejected.
+
+Acknowledgements are stored in:
+
+```text
+risk_platform.portfolio_risk_limit_acknowledgements
+```
+
+The table is append-only. PostgreSQL triggers reject updates and deletes, and an
+insert trigger requires the target evaluation to be a breach with a
+timezone-aware acknowledgement time on or after the breach event.
+
+The reporting contracts are:
+
+```text
+risk_platform.portfolio_risk_limit_acknowledgement_history
+risk_platform.portfolio_risk_limit_breach_status
+risk_platform.portfolio_risk_limit_open_breaches
+risk_platform.portfolio_risk_limit_acknowledged_breaches
+```
+
+`portfolio_risk_limit_breach_status` attaches the latest acknowledgement to each
+current breach while retaining an acknowledgement count. The open and
+acknowledged views partition current breaches for operator triage.
+
+An acknowledgement **does not change the breach status**, rewrite a risk-limit
+evaluation, approve a trade or remove historical evidence. It records that a
+named human reviewed the current breach. If a corrected attribution creates a
+new current evaluation, that replacement requires its own acknowledgement.
+
+## Reconciliation Evidence
+
+`sql/portfolio_risk_limits_consistency_checks.sql` validates both the monitoring
+and acknowledgement contracts. In addition to the evaluation checks, it verifies:
+
+- every acknowledgement references a retained breach evaluation;
+- acknowledgement timestamps do not precede the breach event;
+- request IDs are unique within each evaluation;
+- acknowledgement history matches the append-only table;
+- breach status selects the latest acknowledgement deterministically;
+- open and acknowledged views partition current breaches; and
+- all three validation and mutation-prevention triggers are enabled.
+
+The required `PostgreSQL contract` CI job applies the schema and executes these
+checks against PostgreSQL 16 on every pull request.
+
 ## Safety And Boundary
 
 The input and warehouse readers retain the existing bounded local pattern:
@@ -164,7 +236,11 @@ The input and warehouse readers retain the existing bounded local pattern:
 - symbolic-link and unsafe-file rejection; and
 - no provider request or cloud mutation.
 
+Acknowledgement actor and reason fields are bounded and reject control
+characters. The CLI reports identifiers and disposition but does not echo the
+free-text reason.
+
 The policy is a transparent demonstration, not a regulatory limit framework.
 Production ownership would additionally require authorised policy lifecycle,
-maker-checker approval, effective dating, alert routing, acknowledgement,
-escalation, exception management and audit retention controls.
+maker-checker approval, effective dating, alert routing, escalation, exception
+expiry, access control and formal audit-retention controls.

--- a/sql/portfolio_risk_limits_consistency_checks.sql
+++ b/sql/portfolio_risk_limits_consistency_checks.sql
@@ -1,4 +1,4 @@
--- Reconciliation checks for portfolio risk-limit monitoring.
+-- Reconciliation checks for portfolio risk-limit monitoring and human acknowledgements.
 -- Run after attribution and limit outputs have been loaded into PostgreSQL.
 
 WITH counts AS (
@@ -23,7 +23,22 @@ WITH counts AS (
                 attribution_calculation_id,
                 ts_event
             FROM risk_platform.latest_portfolio_risk_limit_evaluations
-        ) snapshots) AS expected_status_rows
+        ) snapshots) AS expected_status_rows,
+        (SELECT COUNT(*)
+         FROM risk_platform.portfolio_risk_limit_acknowledgements)
+            AS acknowledgement_rows,
+        (SELECT COUNT(*)
+         FROM risk_platform.portfolio_risk_limit_acknowledgement_history)
+            AS acknowledgement_history_rows,
+        (SELECT COUNT(*)
+         FROM risk_platform.portfolio_risk_limit_breach_status)
+            AS breach_status_rows,
+        (SELECT COUNT(*)
+         FROM risk_platform.portfolio_risk_limit_open_breaches)
+            AS open_breach_rows,
+        (SELECT COUNT(*)
+         FROM risk_platform.portfolio_risk_limit_acknowledged_breaches)
+            AS acknowledged_breach_rows
 ),
 integrity AS (
     SELECT
@@ -196,7 +211,76 @@ integrity AS (
          WHERE status_row.metric_count <> expected.metric_count
             OR status_row.breach_count <> expected.breach_count
             OR status_row.overall_status <> expected.overall_status)
-            AS invalid_snapshot_status_rows
+            AS invalid_snapshot_status_rows,
+        (SELECT COUNT(*)
+         FROM risk_platform.portfolio_risk_limit_acknowledgements acknowledgement
+         LEFT JOIN risk_platform.portfolio_risk_limit_evaluations evaluation
+           ON evaluation.calculation_id
+                = acknowledgement.evaluation_calculation_id
+         WHERE evaluation.calculation_id IS NULL)
+            AS orphan_acknowledgements,
+        (SELECT COUNT(*)
+         FROM risk_platform.portfolio_risk_limit_acknowledgements acknowledgement
+         JOIN risk_platform.portfolio_risk_limit_evaluations evaluation
+           ON evaluation.calculation_id
+                = acknowledgement.evaluation_calculation_id
+         WHERE
+            NOT evaluation.is_breach
+            OR acknowledgement.acknowledged_at < evaluation.ts_event)
+            AS invalid_acknowledgement_targets,
+        (SELECT COUNT(*)
+         FROM (
+            SELECT
+                evaluation_calculation_id,
+                request_id,
+                COUNT(*) AS row_count
+            FROM risk_platform.portfolio_risk_limit_acknowledgements
+            GROUP BY evaluation_calculation_id, request_id
+            HAVING COUNT(*) > 1
+         ) duplicate_requests)
+            AS duplicate_acknowledgement_requests,
+        (SELECT COUNT(*)
+         FROM risk_platform.portfolio_risk_limit_breach_status breach_status
+         WHERE
+            breach_status.acknowledgement_count <> (
+                SELECT COUNT(*)
+                FROM risk_platform.portfolio_risk_limit_acknowledgements acknowledgement
+                WHERE acknowledgement.evaluation_calculation_id
+                    = breach_status.calculation_id
+            )
+            OR breach_status.acknowledgement_id IS DISTINCT FROM (
+                SELECT acknowledgement.acknowledgement_id
+                FROM risk_platform.portfolio_risk_limit_acknowledgements acknowledgement
+                WHERE acknowledgement.evaluation_calculation_id
+                    = breach_status.calculation_id
+                ORDER BY
+                    acknowledgement.acknowledged_at DESC,
+                    acknowledgement.acknowledgement_id DESC
+                LIMIT 1
+            )
+            OR breach_status.acknowledgement_status <> CASE
+                WHEN EXISTS (
+                    SELECT 1
+                    FROM risk_platform.portfolio_risk_limit_acknowledgements acknowledgement
+                    WHERE acknowledgement.evaluation_calculation_id
+                        = breach_status.calculation_id
+                ) THEN 'acknowledged'
+                ELSE 'unacknowledged'
+            END)
+            AS invalid_breach_status_rows,
+        (SELECT COUNT(*)
+         FROM pg_trigger
+         WHERE
+            tgrelid = (
+                'risk_platform.portfolio_risk_limit_acknowledgements'
+            )::REGCLASS
+            AND NOT tgisinternal
+            AND tgenabled <> 'D'
+            AND tgname IN (
+                'validate_risk_limit_acknowledgement_insert',
+                'prevent_risk_limit_acknowledgement_update',
+                'prevent_risk_limit_acknowledgement_delete'
+            )) AS enabled_control_triggers
 )
 SELECT
     'portfolio_risk_limit_rows_present' AS check_name,
@@ -269,6 +353,73 @@ UNION ALL
 SELECT 'portfolio_risk_limit_snapshot_status_values_reconcile', '0',
        invalid_snapshot_status_rows::TEXT,
        CASE WHEN invalid_snapshot_status_rows = 0 THEN 'pass' ELSE 'fail' END
+FROM integrity
+
+UNION ALL
+SELECT 'portfolio_risk_limit_acknowledgement_rows_valid', '>=0',
+       acknowledgement_rows::TEXT, 'pass'
+FROM counts
+
+UNION ALL
+SELECT 'portfolio_risk_limit_acknowledgements_reference_breaches', '0',
+       orphan_acknowledgements::TEXT,
+       CASE WHEN orphan_acknowledgements = 0 THEN 'pass' ELSE 'fail' END
+FROM integrity
+
+UNION ALL
+SELECT 'portfolio_risk_limit_acknowledgement_targets_are_valid', '0',
+       invalid_acknowledgement_targets::TEXT,
+       CASE
+           WHEN invalid_acknowledgement_targets = 0 THEN 'pass'
+           ELSE 'fail'
+       END
+FROM integrity
+
+UNION ALL
+SELECT 'portfolio_risk_limit_acknowledgement_requests_unique', '0',
+       duplicate_acknowledgement_requests::TEXT,
+       CASE
+           WHEN duplicate_acknowledgement_requests = 0 THEN 'pass'
+           ELSE 'fail'
+       END
+FROM integrity
+
+UNION ALL
+SELECT 'portfolio_risk_limit_acknowledgement_history_matches_base',
+       acknowledgement_rows::TEXT, acknowledgement_history_rows::TEXT,
+       CASE
+           WHEN acknowledgement_rows = acknowledgement_history_rows THEN 'pass'
+           ELSE 'fail'
+       END
+FROM counts
+
+UNION ALL
+SELECT 'portfolio_risk_limit_breach_status_matches_current_breaches',
+       breach_rows::TEXT, breach_status_rows::TEXT,
+       CASE WHEN breach_rows = breach_status_rows THEN 'pass' ELSE 'fail' END
+FROM counts
+
+UNION ALL
+SELECT 'portfolio_risk_limit_open_and_acknowledged_partition_breaches',
+       breach_rows::TEXT,
+       (open_breach_rows + acknowledged_breach_rows)::TEXT,
+       CASE
+           WHEN breach_rows = open_breach_rows + acknowledged_breach_rows
+               THEN 'pass'
+           ELSE 'fail'
+       END
+FROM counts
+
+UNION ALL
+SELECT 'portfolio_risk_limit_breach_status_selects_latest_acknowledgement', '0',
+       invalid_breach_status_rows::TEXT,
+       CASE WHEN invalid_breach_status_rows = 0 THEN 'pass' ELSE 'fail' END
+FROM integrity
+
+UNION ALL
+SELECT 'portfolio_risk_limit_acknowledgement_triggers_enabled', '3',
+       enabled_control_triggers::TEXT,
+       CASE WHEN enabled_control_triggers = 3 THEN 'pass' ELSE 'fail' END
 FROM integrity
 
 ORDER BY check_name;

--- a/sql/portfolio_risk_limits_schema.sql
+++ b/sql/portfolio_risk_limits_schema.sql
@@ -250,3 +250,170 @@ GROUP BY
     covariance_window,
     annualization_days,
     ts_event;
+
+-- Human acknowledgements are immutable evidence attached to current breaches.
+-- They do not modify or delete the underlying risk-limit evaluation.
+CREATE TABLE IF NOT EXISTS risk_platform.portfolio_risk_limit_acknowledgements (
+    acknowledgement_id TEXT PRIMARY KEY,
+    model_version TEXT NOT NULL CHECK (
+        model_version = 'portfolio-risk-limit-ack-v1'
+    ),
+    evaluation_calculation_id TEXT NOT NULL REFERENCES
+        risk_platform.portfolio_risk_limit_evaluations (calculation_id),
+    request_id TEXT NOT NULL,
+    acknowledged_at TIMESTAMPTZ NOT NULL,
+    acknowledged_by TEXT NOT NULL,
+    disposition TEXT NOT NULL CHECK (
+        disposition IN ('investigating', 'accepted', 'false_positive')
+    ),
+    reason TEXT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    UNIQUE (evaluation_calculation_id, request_id),
+    CHECK (acknowledgement_id <> ''),
+    CHECK (request_id ~ '^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$'),
+    CHECK (
+        acknowledged_by = BTRIM(acknowledged_by)
+        AND CHAR_LENGTH(acknowledged_by) BETWEEN 1 AND 128
+        AND acknowledged_by !~ '[[:cntrl:]]'
+    ),
+    CHECK (
+        reason = BTRIM(reason)
+        AND CHAR_LENGTH(reason) BETWEEN 1 AND 2000
+        AND reason !~ '[[:cntrl:]]'
+    )
+);
+
+CREATE INDEX IF NOT EXISTS idx_portfolio_risk_limit_acknowledgements_target
+    ON risk_platform.portfolio_risk_limit_acknowledgements (
+        evaluation_calculation_id,
+        acknowledged_at DESC,
+        acknowledgement_id DESC
+    );
+
+CREATE OR REPLACE FUNCTION risk_platform.validate_risk_limit_acknowledgement()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    target_is_breach BOOLEAN;
+    target_ts_event TIMESTAMPTZ;
+BEGIN
+    SELECT evaluation.is_breach, evaluation.ts_event
+    INTO target_is_breach, target_ts_event
+    FROM risk_platform.portfolio_risk_limit_evaluations evaluation
+    WHERE evaluation.calculation_id = NEW.evaluation_calculation_id;
+
+    IF NOT FOUND THEN
+        RAISE EXCEPTION 'risk-limit acknowledgement target does not exist';
+    END IF;
+    IF NOT target_is_breach THEN
+        RAISE EXCEPTION 'risk-limit acknowledgement target must be a breach';
+    END IF;
+    IF NEW.acknowledged_at < target_ts_event THEN
+        RAISE EXCEPTION 'acknowledged_at must be on or after the breach event';
+    END IF;
+    RETURN NEW;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION risk_platform.prevent_risk_limit_acknowledgement_mutation()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    RAISE EXCEPTION 'risk-limit acknowledgements are append-only'
+        USING ERRCODE = '55000';
+END;
+$$;
+
+DROP TRIGGER IF EXISTS validate_risk_limit_acknowledgement_insert
+    ON risk_platform.portfolio_risk_limit_acknowledgements;
+CREATE TRIGGER validate_risk_limit_acknowledgement_insert
+BEFORE INSERT ON risk_platform.portfolio_risk_limit_acknowledgements
+FOR EACH ROW
+EXECUTE FUNCTION risk_platform.validate_risk_limit_acknowledgement();
+
+DROP TRIGGER IF EXISTS prevent_risk_limit_acknowledgement_update
+    ON risk_platform.portfolio_risk_limit_acknowledgements;
+CREATE TRIGGER prevent_risk_limit_acknowledgement_update
+BEFORE UPDATE ON risk_platform.portfolio_risk_limit_acknowledgements
+FOR EACH ROW
+EXECUTE FUNCTION risk_platform.prevent_risk_limit_acknowledgement_mutation();
+
+DROP TRIGGER IF EXISTS prevent_risk_limit_acknowledgement_delete
+    ON risk_platform.portfolio_risk_limit_acknowledgements;
+CREATE TRIGGER prevent_risk_limit_acknowledgement_delete
+BEFORE DELETE ON risk_platform.portfolio_risk_limit_acknowledgements
+FOR EACH ROW
+EXECUTE FUNCTION risk_platform.prevent_risk_limit_acknowledgement_mutation();
+
+CREATE OR REPLACE VIEW risk_platform.portfolio_risk_limit_acknowledgement_history AS
+SELECT
+    acknowledgement.acknowledgement_id,
+    acknowledgement.model_version,
+    acknowledgement.evaluation_calculation_id,
+    acknowledgement.request_id,
+    acknowledgement.acknowledged_at,
+    acknowledgement.acknowledged_by,
+    acknowledgement.disposition,
+    acknowledgement.reason,
+    acknowledgement.created_at,
+    evaluation.policy_id,
+    evaluation.policy_fingerprint,
+    evaluation.portfolio_id,
+    evaluation.definition_fingerprint,
+    evaluation.ts_event AS metric_ts,
+    evaluation.metric_name,
+    evaluation.subject_type,
+    evaluation.subject_key,
+    evaluation.status AS breach_status,
+    evaluation.observed_value,
+    evaluation.breach_threshold,
+    evaluation.breach_excess
+FROM risk_platform.portfolio_risk_limit_acknowledgements acknowledgement
+JOIN risk_platform.portfolio_risk_limit_evaluations evaluation
+    ON evaluation.calculation_id = acknowledgement.evaluation_calculation_id;
+
+CREATE OR REPLACE VIEW risk_platform.portfolio_risk_limit_breach_status AS
+SELECT
+    breach.*,
+    COALESCE(latest_acknowledgement.acknowledgement_count, 0)
+        AS acknowledgement_count,
+    latest_acknowledgement.acknowledgement_id,
+    latest_acknowledgement.request_id AS latest_acknowledgement_request_id,
+    latest_acknowledgement.acknowledged_at AS latest_acknowledged_at,
+    latest_acknowledgement.acknowledged_by AS latest_acknowledged_by,
+    latest_acknowledgement.disposition AS latest_acknowledgement_disposition,
+    latest_acknowledgement.reason AS latest_acknowledgement_reason,
+    CASE
+        WHEN latest_acknowledgement.acknowledgement_id IS NULL
+            THEN 'unacknowledged'
+        ELSE 'acknowledged'
+    END AS acknowledgement_status
+FROM risk_platform.portfolio_risk_limit_breaches breach
+LEFT JOIN LATERAL (
+    SELECT
+        COUNT(*) OVER () AS acknowledgement_count,
+        acknowledgement.acknowledgement_id,
+        acknowledgement.request_id,
+        acknowledgement.acknowledged_at,
+        acknowledgement.acknowledged_by,
+        acknowledgement.disposition,
+        acknowledgement.reason
+    FROM risk_platform.portfolio_risk_limit_acknowledgements acknowledgement
+    WHERE acknowledgement.evaluation_calculation_id = breach.calculation_id
+    ORDER BY
+        acknowledgement.acknowledged_at DESC,
+        acknowledgement.acknowledgement_id DESC
+    LIMIT 1
+) latest_acknowledgement ON TRUE;
+
+CREATE OR REPLACE VIEW risk_platform.portfolio_risk_limit_open_breaches AS
+SELECT *
+FROM risk_platform.portfolio_risk_limit_breach_status
+WHERE acknowledgement_status = 'unacknowledged';
+
+CREATE OR REPLACE VIEW risk_platform.portfolio_risk_limit_acknowledged_breaches AS
+SELECT *
+FROM risk_platform.portfolio_risk_limit_breach_status
+WHERE acknowledgement_status = 'acknowledged';

--- a/src/warehouse/portfolio_risk_limit_acknowledger.py
+++ b/src/warehouse/portfolio_risk_limit_acknowledger.py
@@ -1,0 +1,280 @@
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import sys
+from datetime import datetime, timezone
+from typing import Any
+
+from src.common.exceptions import StorageError, ValidationError
+
+DEFAULT_POSTGRES_DSN = (
+    "postgresql://risk_user:risk_password@localhost:5433/risk_platform"
+)
+MODEL_VERSION = "portfolio-risk-limit-ack-v1"
+REQUEST_ID_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$")
+DISPOSITIONS = frozenset({"investigating", "accepted", "false_positive"})
+MAX_CALCULATION_ID_LENGTH = 256
+MAX_ACTOR_LENGTH = 128
+MAX_REASON_LENGTH = 2_000
+
+
+def _bounded_text(value: Any, label: str, maximum: int) -> str:
+    if not isinstance(value, str):
+        raise ValidationError(f"{label} must be text")
+    parsed = value.strip()
+    if not parsed or len(parsed) > maximum:
+        raise ValidationError(
+            f"{label} must contain between 1 and {maximum} characters"
+        )
+    if any(ord(character) < 32 or ord(character) == 127 for character in parsed):
+        raise ValidationError(f"{label} must not contain control characters")
+    return parsed
+
+
+def _request_id(value: Any) -> str:
+    parsed = _bounded_text(value, "request_id", 128)
+    if REQUEST_ID_PATTERN.fullmatch(parsed) is None:
+        raise ValidationError("request_id has an invalid format")
+    return parsed
+
+
+def _disposition(value: Any) -> str:
+    parsed = _bounded_text(value, "disposition", 32).lower()
+    if parsed not in DISPOSITIONS:
+        raise ValidationError(
+            "disposition must be investigating, accepted or false_positive"
+        )
+    return parsed
+
+
+def _aware_utc(value: datetime | str | None) -> datetime:
+    if value is None:
+        return datetime.now(timezone.utc)
+    parsed: datetime | None = None
+    if isinstance(value, datetime):
+        parsed = value
+    elif isinstance(value, str):
+        try:
+            parsed = datetime.fromisoformat(value.strip().replace("Z", "+00:00"))
+        except ValueError:
+            parsed = None
+    if parsed is None or parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise ValidationError("acknowledged_at must be a timezone-aware timestamp")
+    return parsed.astimezone(timezone.utc)
+
+
+def acknowledgement_id(evaluation_calculation_id: str, request_id: str) -> str:
+    calculation_id = _bounded_text(
+        evaluation_calculation_id,
+        "evaluation_calculation_id",
+        MAX_CALCULATION_ID_LENGTH,
+    )
+    canonical_request_id = _request_id(request_id)
+    payload = {
+        "evaluation_calculation_id": calculation_id,
+        "model_version": MODEL_VERSION,
+        "request_id": canonical_request_id,
+    }
+    digest = hashlib.sha256(
+        json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    ).hexdigest()[:24]
+    return f"{MODEL_VERSION}-{digest}"
+
+
+def acknowledge_current_breach(
+    *,
+    dsn: str,
+    evaluation_calculation_id: str,
+    request_id: str,
+    acknowledged_by: str,
+    reason: str,
+    disposition: str,
+    acknowledged_at: datetime | str | None = None,
+) -> dict[str, Any]:
+    calculation_id = _bounded_text(
+        evaluation_calculation_id,
+        "evaluation_calculation_id",
+        MAX_CALCULATION_ID_LENGTH,
+    )
+    canonical_request_id = _request_id(request_id)
+    actor = _bounded_text(acknowledged_by, "acknowledged_by", MAX_ACTOR_LENGTH)
+    canonical_reason = _bounded_text(reason, "reason", MAX_REASON_LENGTH)
+    canonical_disposition = _disposition(disposition)
+    timestamp = _aware_utc(acknowledged_at)
+    ack_id = acknowledgement_id(calculation_id, canonical_request_id)
+
+    try:
+        import psycopg
+    except ImportError as exc:  # pragma: no cover - dependency is required in CI.
+        raise RuntimeError("Risk-limit acknowledgement requires psycopg") from exc
+
+    stored: tuple[Any, ...] | None = None
+    created = False
+    try:
+        with psycopg.connect(dsn) as connection:
+            with connection.cursor() as cursor:
+                cursor.execute(
+                    """
+                    SELECT calculation_id, ts_event
+                    FROM risk_platform.portfolio_risk_limit_breaches
+                    WHERE calculation_id = %s
+                    """,
+                    (calculation_id,),
+                )
+                target = cursor.fetchone()
+                if target is None:
+                    raise ValidationError(
+                        "evaluation_calculation_id must identify a current breach"
+                    )
+                if timestamp < target[1]:
+                    raise ValidationError(
+                        "acknowledged_at must be on or after the breach event"
+                    )
+
+                cursor.execute(
+                    """
+                    INSERT INTO risk_platform.portfolio_risk_limit_acknowledgements (
+                        acknowledgement_id,
+                        model_version,
+                        evaluation_calculation_id,
+                        request_id,
+                        acknowledged_at,
+                        acknowledged_by,
+                        disposition,
+                        reason
+                    )
+                    VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
+                    ON CONFLICT (acknowledgement_id) DO NOTHING
+                    RETURNING acknowledgement_id
+                    """,
+                    (
+                        ack_id,
+                        MODEL_VERSION,
+                        calculation_id,
+                        canonical_request_id,
+                        timestamp,
+                        actor,
+                        canonical_disposition,
+                        canonical_reason,
+                    ),
+                )
+                created = cursor.fetchone() is not None
+                cursor.execute(
+                    """
+                    SELECT
+                        acknowledgement_id,
+                        model_version,
+                        evaluation_calculation_id,
+                        request_id,
+                        acknowledged_at,
+                        acknowledged_by,
+                        disposition,
+                        reason
+                    FROM risk_platform.portfolio_risk_limit_acknowledgements
+                    WHERE acknowledgement_id = %s
+                    """,
+                    (ack_id,),
+                )
+                stored = cursor.fetchone()
+                if stored is None:
+                    raise StorageError(
+                        "Risk-limit acknowledgement could not be read after insert"
+                    )
+                immutable = (
+                    ack_id,
+                    MODEL_VERSION,
+                    calculation_id,
+                    canonical_request_id,
+                    actor,
+                    canonical_disposition,
+                    canonical_reason,
+                )
+                stored_immutable = (
+                    stored[0],
+                    stored[1],
+                    stored[2],
+                    stored[3],
+                    stored[5],
+                    stored[6],
+                    stored[7],
+                )
+                if stored_immutable != immutable:
+                    raise ValidationError(
+                        "request_id already exists with different acknowledgement content"
+                    )
+            connection.commit()
+    except (ValidationError, StorageError):
+        raise
+    except Exception:
+        raise StorageError("Risk-limit acknowledgement database operation failed") from None
+
+    if stored is None:  # pragma: no cover - guarded by the transaction above.
+        raise StorageError("Risk-limit acknowledgement result is unavailable")
+    stored_timestamp = stored[4]
+    if not isinstance(stored_timestamp, datetime):
+        raise StorageError("Stored acknowledgement timestamp is incompatible")
+    return {
+        "acknowledgement_id": ack_id,
+        "model_version": MODEL_VERSION,
+        "evaluation_calculation_id": calculation_id,
+        "request_id": canonical_request_id,
+        "acknowledged_at": stored_timestamp.astimezone(timezone.utc).isoformat(),
+        "acknowledged_by": actor,
+        "disposition": canonical_disposition,
+        "created": created,
+    }
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Append an idempotent human acknowledgement for one current "
+            "portfolio risk-limit breach."
+        )
+    )
+    parser.add_argument(
+        "--dsn",
+        default=os.environ.get("WAREHOUSE_POSTGRES_DSN", DEFAULT_POSTGRES_DSN),
+    )
+    parser.add_argument("--calculation-id", required=True)
+    parser.add_argument("--request-id", required=True)
+    parser.add_argument("--acknowledged-by", required=True)
+    parser.add_argument("--reason", required=True)
+    parser.add_argument(
+        "--disposition",
+        required=True,
+        choices=sorted(DISPOSITIONS),
+    )
+    parser.add_argument("--acknowledged-at")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = _parse_args()
+    try:
+        summary = acknowledge_current_breach(
+            dsn=args.dsn,
+            evaluation_calculation_id=args.calculation_id,
+            request_id=args.request_id,
+            acknowledged_by=args.acknowledged_by,
+            reason=args.reason,
+            disposition=args.disposition,
+            acknowledged_at=args.acknowledged_at,
+        )
+    except ValidationError as exc:
+        print(f"Risk-limit acknowledgement rejected: {exc}", file=sys.stderr)
+        return 1
+    except (StorageError, RuntimeError) as exc:
+        print(f"Risk-limit acknowledgement failed: {exc}", file=sys.stderr)
+        return 1
+
+    print(json.dumps(summary, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/test_portfolio_risk_limit_acknowledgement_sql_contract.py
+++ b/tests/unit/test_portfolio_risk_limit_acknowledgement_sql_contract.py
@@ -1,0 +1,70 @@
+from pathlib import Path
+
+
+def _read(path: str) -> str:
+    return Path(path).read_text(encoding="utf-8")
+
+
+def test_risk_limit_schema_exposes_append_only_acknowledgements() -> None:
+    sql = _read("sql/portfolio_risk_limits_schema.sql")
+
+    assert (
+        "CREATE TABLE IF NOT EXISTS "
+        "risk_platform.portfolio_risk_limit_acknowledgements" in sql
+    )
+    assert "portfolio-risk-limit-ack-v1" in sql
+    assert "UNIQUE (evaluation_calculation_id, request_id)" in sql
+    assert "validate_risk_limit_acknowledgement_insert" in sql
+    assert "prevent_risk_limit_acknowledgement_update" in sql
+    assert "prevent_risk_limit_acknowledgement_delete" in sql
+    assert "risk-limit acknowledgements are append-only" in sql
+
+    for view in (
+        "portfolio_risk_limit_acknowledgement_history",
+        "portfolio_risk_limit_breach_status",
+        "portfolio_risk_limit_open_breaches",
+        "portfolio_risk_limit_acknowledged_breaches",
+    ):
+        assert f"CREATE OR REPLACE VIEW risk_platform.{view}" in sql
+
+    assert (
+        "acknowledgement.evaluation_calculation_id = breach.calculation_id" in sql
+    )
+    assert "acknowledgement.acknowledged_at DESC" in sql
+    assert "acknowledgement.acknowledgement_id DESC" in sql
+    assert "THEN 'unacknowledged'" in sql
+
+
+def test_acknowledgement_consistency_contract_covers_views_and_controls() -> None:
+    sql = _read("sql/portfolio_risk_limits_consistency_checks.sql")
+
+    for check_name in (
+        "portfolio_risk_limit_acknowledgement_rows_valid",
+        "portfolio_risk_limit_acknowledgements_reference_breaches",
+        "portfolio_risk_limit_acknowledgement_targets_are_valid",
+        "portfolio_risk_limit_acknowledgement_requests_unique",
+        "portfolio_risk_limit_acknowledgement_history_matches_base",
+        "portfolio_risk_limit_breach_status_matches_current_breaches",
+        "portfolio_risk_limit_open_and_acknowledged_partition_breaches",
+        "portfolio_risk_limit_breach_status_selects_latest_acknowledgement",
+        "portfolio_risk_limit_acknowledgement_triggers_enabled",
+    ):
+        assert check_name in sql
+
+    assert "pg_trigger" in sql
+    assert "enabled_control_triggers = 3" in sql
+    assert "IS DISTINCT FROM" in sql
+
+
+def test_acknowledgement_documentation_keeps_human_authority_explicit() -> None:
+    documentation = _read("docs/portfolio-risk-limits.md")
+
+    for required in (
+        "portfolio_risk_limit_acknowledgements",
+        "portfolio_risk_limit_open_breaches",
+        "portfolio_risk_limit_acknowledged_breaches",
+        "portfolio-risk-limit-ack-v1",
+        "append-only",
+        "does not change the breach status",
+    ):
+        assert required in documentation

--- a/tests/unit/test_portfolio_risk_limit_acknowledger.py
+++ b/tests/unit/test_portfolio_risk_limit_acknowledger.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from src.common.exceptions import ValidationError
+from src.warehouse.portfolio_risk_limit_acknowledger import (
+    MODEL_VERSION,
+    _aware_utc,
+    _bounded_text,
+    _disposition,
+    acknowledgement_id,
+)
+
+
+def test_acknowledgement_id_is_deterministic_and_request_scoped() -> None:
+    first = acknowledgement_id("evaluation-1", "INC-2026-001")
+    second = acknowledgement_id("evaluation-1", "INC-2026-001")
+    other_request = acknowledgement_id("evaluation-1", "INC-2026-002")
+    other_evaluation = acknowledgement_id("evaluation-2", "INC-2026-001")
+
+    assert first == second
+    assert first.startswith(f"{MODEL_VERSION}-")
+    assert len(first.rsplit("-", maxsplit=1)[-1]) == 24
+    assert len({first, other_request, other_evaluation}) == 3
+
+
+def test_acknowledged_at_requires_timezone_and_normalises_to_utc() -> None:
+    value = datetime(2026, 2, 1, 12, tzinfo=timezone(timedelta(hours=2)))
+
+    assert _aware_utc(value) == datetime(2026, 2, 1, 10, tzinfo=timezone.utc)
+    assert _aware_utc("2026-02-01T10:00:00Z") == datetime(
+        2026, 2, 1, 10, tzinfo=timezone.utc
+    )
+    with pytest.raises(ValidationError, match="timezone-aware"):
+        _aware_utc("2026-02-01T10:00:00")
+
+
+def test_acknowledgement_text_and_disposition_are_bounded() -> None:
+    assert _bounded_text("  reviewer@example.com  ", "actor", 128) == (
+        "reviewer@example.com"
+    )
+    assert _disposition("INVESTIGATING") == "investigating"
+
+    with pytest.raises(ValidationError, match="control characters"):
+        _bounded_text("line\nbreak", "reason", 2_000)
+    with pytest.raises(ValidationError, match="disposition"):
+        _disposition("closed")
+    with pytest.raises(ValidationError, match="invalid format"):
+        acknowledgement_id("evaluation-1", "request id with spaces")


### PR DESCRIPTION
## Outcome

Add an auditable human-review layer over current portfolio risk-limit breaches:

```text
current warning or critical evaluation
  -> deterministic request-scoped acknowledgement
  -> append-only PostgreSQL evidence
  -> latest acknowledgement attached to current breach
  -> open and acknowledged breach views
  -> real-PostgreSQL reconciliation
```

Primary arc42 block: `warehouse`, with a bounded operator CLI and documentation interface.

## Acknowledgement contract

Add `risk_platform.portfolio_risk_limit_acknowledgements` with model version `portfolio-risk-limit-ack-v1`. Each event records the target evaluation, caller-supplied request ID, aware UTC timestamp, actor, disposition and bounded reason.

The acknowledgement ID binds the evaluation calculation ID, request ID and model version. Retrying the same request with identical immutable content is idempotent. Reusing the request ID with different actor, disposition or reason is rejected.

Supported dispositions are:

- `investigating`
- `accepted`
- `false_positive`

## Append-only enforcement

PostgreSQL enforces that:

- the target evaluation exists and is a breach;
- acknowledgement time is on or after the breach event;
- one request ID is unique within the target evaluation; and
- acknowledgements cannot be updated or deleted.

The mutation-prevention rule is implemented with database triggers rather than relying only on the CLI.

## Operator interface

Add:

```bash
.venv/bin/python -m src.warehouse.portfolio_risk_limit_acknowledger \
  --calculation-id <current-breach-calculation-id> \
  --request-id INC-2026-001 \
  --acknowledged-by reviewer@example.com \
  --disposition investigating \
  --reason 'Reviewing the concentration and source inputs.'
```

Actor and reason fields are bounded and reject control characters. The result summary does not echo the free-text reason.

## Serving views

Add:

- `portfolio_risk_limit_acknowledgement_history`
- `portfolio_risk_limit_breach_status`
- `portfolio_risk_limit_open_breaches`
- `portfolio_risk_limit_acknowledged_breaches`

The status view selects the latest acknowledgement by `acknowledged_at DESC, acknowledgement_id DESC` and retains the full acknowledgement count.

Acknowledgement does not change the warning/critical status, rewrite an evaluation, approve a trade, or delete evidence. A corrected attribution that creates a replacement current evaluation requires a separate acknowledgement.

## Reconciliation

Extend the existing risk-limit SQL suite so the required `PostgreSQL contract` CI job verifies:

- acknowledgement references and breach-only targets;
- timestamp validity and request uniqueness;
- history/base row-count equality;
- current-breach status row equality;
- open/acknowledged partition completeness;
- deterministic latest-acknowledgement selection; and
- all three insert/update/delete control triggers remain enabled.

## Validation

GitHub Actions run `32580445120` (`ci` run 209) passed on exact head `0567429d2c1859774007d04dd748aa10e36bf5ec`:

- Security guardrails: passed with publication disabled and the byte-pinned four-job CI contract unchanged.
- Python readiness: passed, including Ruff, mypy, the complete test suite, dependency integrity and readiness replay.
- PostgreSQL contract: passed after applying the acknowledgement table, PL/pgSQL functions, three triggers and four serving views. The prior real-engine contract remained green and nine new acknowledgement reconciliation assertions passed.
- Infrastructure validation: passed; Kubernetes rendered and Terraform format/init/validate completed without applying infrastructure.

There are no unresolved review threads or requested changes.

## Scope

The branch is one commit ahead of `main` and zero behind. It changes six files with 804 additions and nine deletions.

No live alert delivery, automatic escalation, trade control, policy approval, scheduler, credential, provider request, cloud deployment or Terraform apply is included.

## Acceptance boundary

This PR is validated and ready for squash merge as one warehouse/operator-control increment.