### PR TITLE
Define effective-dated portfolio mandate contract

### DIFF
--- a/config/portfolios.yaml
+++ b/config/portfolios.yaml
@@ -1,6 +1,9 @@
 portfolios:
   us-tech-equal:
     description: Equal-weighted US technology equity demo
+    mandate_id: us-tech-equal-v1
+    effective_from: 2020-01-01
+    effective_to: null
     base_currency: USD
     constituents:
       - source: alpha_vantage
@@ -12,6 +15,9 @@ portfolios:
 
   us-tech-60-40:
     description: Parameterised weight comparison using the same source universe
+    mandate_id: us-tech-60-40-v1
+    effective_from: 2020-01-01
+    effective_to: null
     base_currency: USD
     constituents:
       - source: alpha_vantage

--- a/docs/portfolio-mandates.md
+++ b/docs/portfolio-mandates.md
@@ -1,0 +1,151 @@
+# Effective-Dated Portfolio Mandates
+
+## Purpose
+
+A portfolio definition is not only a set of weights. It is a mandate that owns a
+bounded period of time. Historical calculations must resolve the definition that
+was effective for the requested date rather than silently applying today's
+weights to earlier observations.
+
+The mandate selector lives in:
+
+```text
+src/analytics/portfolio_mandates.py
+```
+
+The repository configuration now gives each demonstration portfolio an explicit
+mandate identity and validity range:
+
+```yaml
+portfolios:
+  us-tech-equal:
+    mandate_id: us-tech-equal-v1
+    effective_from: 2020-01-01
+    effective_to: null
+    base_currency: USD
+    constituents:
+      - source: alpha_vantage
+        symbol: AAPL
+        weight: 0.5
+      - source: alpha_vantage
+        symbol: MSFT
+        weight: 0.5
+```
+
+`effective_from` is inclusive. `effective_to` is exclusive. A null upper bound is
+open-ended and may appear only on the final mandate.
+
+## Multiple Mandates
+
+The selector also accepts an ordered mandate history:
+
+```yaml
+portfolios:
+  us-tech:
+    description: Effective-dated portfolio
+    mandates:
+      - mandate_id: us-tech-v1
+        effective_from: 2025-01-01
+        effective_to: 2026-01-01
+        base_currency: USD
+        constituents:
+          - source: alpha_vantage
+            symbol: AAPL
+            weight: 0.5
+          - source: alpha_vantage
+            symbol: MSFT
+            weight: 0.5
+
+      - mandate_id: us-tech-v2
+        effective_from: 2026-01-01
+        effective_to: null
+        base_currency: USD
+        constituents:
+          - source: alpha_vantage
+            symbol: AAPL
+            weight: 0.6
+          - source: alpha_vantage
+            symbol: MSFT
+            weight: 0.4
+```
+
+All mandates are parsed and validated before one is selected. The contract rejects:
+
+- duplicate mandate IDs;
+- invalid or non-canonical dates;
+- an end date that is not after its start date;
+- overlapping mandate ranges;
+- an open-ended mandate followed by another mandate;
+- mixed direct and `mandates` definitions; and
+- a requested date that has no unique covering mandate.
+
+Gaps are permitted because a portfolio may be inactive. A calculation within a
+gap fails explicitly rather than selecting the nearest definition.
+
+## Identity
+
+Two deterministic identities are exposed:
+
+```text
+constituent_definition_fingerprint
+mandate_fingerprint
+```
+
+The constituent-definition fingerprint matches the existing portfolio identity:
+portfolio ID, base currency, sources, symbols and weights.
+
+The mandate fingerprint additionally binds:
+
+```text
+mandate ID
+effective_from
+effective_to
+constituent-definition fingerprint
+```
+
+Therefore a formally renewed mandate remains distinguishable even when its
+weights are unchanged.
+
+## Range Semantics
+
+A bounded calculation must fit within one selected mandate:
+
+```text
+selected effective_from <= start_date <= end_date < selected effective_to
+```
+
+The upper check is omitted for an open-ended mandate. A request that crosses a
+boundary must be split into one run per mandate. The selector does not blend two
+weight definitions into one return, covariance or risk-limit calculation.
+
+When a caller omits `start_date`, records can be filtered through
+`filter_records_to_mandate`. This excludes observations before the selected
+mandate without accepting malformed or timezone-naive event timestamps.
+
+## Compatibility Boundary
+
+`parse_portfolio_definition` remains available for pure analytical unit tests and
+legacy in-memory payloads. It ignores the additional direct mandate metadata and
+continues to produce the existing constituent definition.
+
+The effective selector is the governed contract for operator-facing workflows:
+
+```python
+mandate = load_portfolio_mandate(
+    Path("config/portfolios.yaml"),
+    "us-tech-equal",
+    date(2026, 1, 26),
+)
+```
+
+This increment establishes and tests the schema, selection, range and identity
+rules. Wiring the portfolio, attribution and risk-limit operator commands to this
+selector is deliberately delivered as a separate PR so configuration validation
+and orchestration changes remain independently reviewable.
+
+## Remaining Boundary
+
+This repository does not yet provide a mandate approval workflow, maker-checker
+sign-off, scheduled activation, automatic range splitting or database-managed
+configuration history. YAML remains the reviewed source of truth, and activating
+a new mandate requires a normal pull request and green CI evidence.

--- a/src/analytics/portfolio_mandates.py
+++ b/src/analytics/portfolio_mandates.py
@@ -1,0 +1,302 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
+from datetime import date, datetime
+from pathlib import Path
+from typing import Any, TypeAlias
+
+from ..common.config import load_yaml
+from ..common.exceptions import ValidationError
+from .portfolio_risk import PortfolioDefinition, parse_portfolio_definition
+
+MAX_MANDATES = 100
+MANDATE_ID_PATTERN = re.compile(r"^[a-z0-9][a-z0-9._-]{0,127}$")
+
+MandateInput: TypeAlias = Mapping[str, Any]
+MandateRecord: TypeAlias = Mapping[str, Any]
+
+
+@dataclass(frozen=True, slots=True)
+class PortfolioMandate(PortfolioDefinition):
+    mandate_id: str
+    effective_from: date
+    effective_to: date | None
+
+    @property
+    def constituent_definition_fingerprint(self) -> str:
+        payload = {
+            "base_currency": self.base_currency,
+            "constituents": [
+                {
+                    "source": constituent.source,
+                    "symbol": constituent.symbol,
+                    "weight": constituent.weight,
+                }
+                for constituent in self.constituents
+            ],
+            "portfolio_id": self.portfolio_id,
+        }
+        digest = hashlib.sha256(
+            json.dumps(payload, sort_keys=True, separators=(",", ":")).encode(
+                "utf-8"
+            )
+        ).hexdigest()[:24]
+        return f"portfolio-{digest}"
+
+    @property
+    def fingerprint(self) -> str:
+        payload = {
+            "constituent_definition_fingerprint": (
+                self.constituent_definition_fingerprint
+            ),
+            "effective_from": self.effective_from.isoformat(),
+            "effective_to": (
+                self.effective_to.isoformat()
+                if self.effective_to is not None
+                else None
+            ),
+            "mandate_id": self.mandate_id,
+            "portfolio_id": self.portfolio_id,
+        }
+        digest = hashlib.sha256(
+            json.dumps(payload, sort_keys=True, separators=(",", ":")).encode(
+                "utf-8"
+            )
+        ).hexdigest()[:24]
+        return f"portfolio-mandate-{digest}"
+
+    def contains(self, event_date: date) -> bool:
+        return self.effective_from <= event_date and (
+            self.effective_to is None or event_date < self.effective_to
+        )
+
+
+def _strict_date(value: Any, label: str, *, allow_none: bool = False) -> date | None:
+    if value is None and allow_none:
+        return None
+    if isinstance(value, datetime):
+        raise ValidationError(f"{label} must be a calendar date")
+    if isinstance(value, date):
+        return value
+    if not isinstance(value, str):
+        raise ValidationError(f"{label} must be a calendar date")
+    try:
+        parsed = date.fromisoformat(value.strip())
+    except ValueError:
+        raise ValidationError(
+            f"{label} must be a calendar date in YYYY-MM-DD format"
+        ) from None
+    if value.strip() != parsed.isoformat():
+        raise ValidationError(
+            f"{label} must be a calendar date in YYYY-MM-DD format"
+        )
+    return parsed
+
+
+def _mandate_id(value: Any) -> str:
+    if not isinstance(value, str):
+        raise ValidationError("mandate_id must be text")
+    parsed = value.strip().lower()
+    if MANDATE_ID_PATTERN.fullmatch(parsed) is None:
+        raise ValidationError("mandate_id has an invalid format")
+    return parsed
+
+
+def _portfolio_candidate(
+    payload: Mapping[str, Any],
+    portfolio_id: str,
+) -> Mapping[str, Any]:
+    portfolios = payload.get("portfolios")
+    if not isinstance(portfolios, Mapping):
+        raise ValidationError(
+            "portfolio configuration must define a portfolios mapping"
+        )
+    candidate = portfolios.get(portfolio_id)
+    if not isinstance(candidate, Mapping):
+        raise ValidationError(f"portfolio '{portfolio_id}' is not configured")
+    return candidate
+
+
+def _build_mandate(
+    *,
+    portfolio_id: str,
+    raw: MandateInput,
+) -> PortfolioMandate:
+    mandate_id = _mandate_id(raw.get("mandate_id"))
+    effective_from = _strict_date(raw.get("effective_from"), "effective_from")
+    effective_to = _strict_date(
+        raw.get("effective_to"),
+        "effective_to",
+        allow_none=True,
+    )
+    if effective_from is None:  # pragma: no cover - required above.
+        raise ValidationError("effective_from is required")
+    if effective_to is not None and effective_to <= effective_from:
+        raise ValidationError("effective_to must be after effective_from")
+
+    base = parse_portfolio_definition(
+        {
+            "portfolios": {
+                portfolio_id: {
+                    "base_currency": raw.get("base_currency"),
+                    "constituents": raw.get("constituents"),
+                }
+            }
+        },
+        portfolio_id,
+    )
+    return PortfolioMandate(
+        portfolio_id=base.portfolio_id,
+        base_currency=base.base_currency,
+        constituents=base.constituents,
+        mandate_id=mandate_id,
+        effective_from=effective_from,
+        effective_to=effective_to,
+    )
+
+
+def parse_portfolio_mandates(
+    payload: Mapping[str, Any],
+    portfolio_id: str,
+) -> tuple[PortfolioMandate, ...]:
+    if not isinstance(payload, Mapping):
+        raise ValidationError("portfolio configuration must be a mapping")
+    candidate = _portfolio_candidate(payload, portfolio_id)
+    raw_mandates = candidate.get("mandates")
+
+    if raw_mandates is None:
+        raw_entries: list[MandateInput] = [candidate]
+    else:
+        if "base_currency" in candidate or "constituents" in candidate:
+            raise ValidationError(
+                "portfolio configuration must not mix direct and mandate definitions"
+            )
+        if (
+            not isinstance(raw_mandates, list)
+            or not 1 <= len(raw_mandates) <= MAX_MANDATES
+        ):
+            raise ValidationError(
+                "portfolio mandates must contain between 1 and "
+                f"{MAX_MANDATES} entries"
+            )
+        if any(not isinstance(entry, Mapping) for entry in raw_mandates):
+            raise ValidationError("each portfolio mandate must be a mapping")
+        raw_entries = list(raw_mandates)
+
+    mandates = tuple(
+        sorted(
+            (
+                _build_mandate(portfolio_id=portfolio_id, raw=entry)
+                for entry in raw_entries
+            ),
+            key=lambda item: (item.effective_from, item.mandate_id),
+        )
+    )
+    mandate_ids = [item.mandate_id for item in mandates]
+    if len(mandate_ids) != len(set(mandate_ids)):
+        raise ValidationError("portfolio mandate IDs must be unique")
+
+    for previous, current in zip(mandates, mandates[1:], strict=False):
+        if previous.effective_to is None:
+            raise ValidationError(
+                "an open-ended portfolio mandate must be the final mandate"
+            )
+        if current.effective_from < previous.effective_to:
+            raise ValidationError("portfolio mandates must not overlap")
+    return mandates
+
+
+def select_portfolio_mandate(
+    payload: Mapping[str, Any],
+    portfolio_id: str,
+    as_of_date: date,
+) -> PortfolioMandate:
+    if isinstance(as_of_date, datetime) or not isinstance(as_of_date, date):
+        raise ValidationError("as_of_date must be a calendar date")
+    mandates = parse_portfolio_mandates(payload, portfolio_id)
+    matches = [mandate for mandate in mandates if mandate.contains(as_of_date)]
+    if len(matches) != 1:
+        raise ValidationError(
+            f"portfolio '{portfolio_id}' has no unique mandate for "
+            f"{as_of_date.isoformat()}"
+        )
+    return matches[0]
+
+
+def load_portfolio_mandate(
+    path: Path,
+    portfolio_id: str,
+    as_of_date: date,
+) -> PortfolioMandate:
+    try:
+        payload = load_yaml(path)
+    except Exception:
+        raise ValidationError("portfolio configuration could not be loaded") from None
+    if not isinstance(payload, Mapping):
+        raise ValidationError("portfolio configuration must be a mapping")
+    return select_portfolio_mandate(payload, portfolio_id, as_of_date)
+
+
+def validate_mandate_range(
+    mandate: PortfolioMandate,
+    *,
+    start_date: date | None,
+    end_date: date,
+) -> None:
+    if start_date is not None and start_date > end_date:
+        raise ValidationError("start_date must be on or before end_date")
+    if not mandate.contains(end_date):
+        raise ValidationError("end_date is outside the selected portfolio mandate")
+    if start_date is not None and not mandate.contains(start_date):
+        raise ValidationError(
+            "requested date range crosses a portfolio mandate boundary; "
+            "split the request by mandate"
+        )
+
+
+def _record_date(record: MandateRecord) -> date:
+    value = record.get("ts_event")
+    if isinstance(value, datetime):
+        if value.tzinfo is None or value.utcoffset() is None:
+            raise ValidationError("portfolio mandate input timestamps must be aware")
+        return value.date()
+    if isinstance(value, date):
+        return value
+    if isinstance(value, str):
+        try:
+            parsed = datetime.fromisoformat(value.strip().replace("Z", "+00:00"))
+        except ValueError:
+            raise ValidationError(
+                "portfolio mandate input timestamps are invalid"
+            ) from None
+        if parsed.tzinfo is None or parsed.utcoffset() is None:
+            raise ValidationError("portfolio mandate input timestamps must be aware")
+        return parsed.date()
+    raise ValidationError("portfolio mandate input timestamps are invalid")
+
+
+def filter_records_to_mandate(
+    records: Iterable[MandateRecord],
+    mandate: PortfolioMandate,
+) -> list[MandateRecord]:
+    return [record for record in records if mandate.contains(_record_date(record))]
+
+
+def mandate_metadata(mandate: PortfolioMandate) -> dict[str, Any]:
+    return {
+        "mandate_id": mandate.mandate_id,
+        "mandate_fingerprint": mandate.fingerprint,
+        "constituent_definition_fingerprint": (
+            mandate.constituent_definition_fingerprint
+        ),
+        "effective_from": mandate.effective_from.isoformat(),
+        "effective_to": (
+            mandate.effective_to.isoformat()
+            if mandate.effective_to is not None
+            else None
+        ),
+    }

--- a/tests/unit/test_portfolio_mandates.py
+++ b/tests/unit/test_portfolio_mandates.py
@@ -1,0 +1,188 @@
+from __future__ import annotations
+
+from datetime import date, datetime, timezone
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+import yaml
+
+from src.analytics.portfolio_mandates import (
+    filter_records_to_mandate,
+    load_portfolio_mandate,
+    mandate_metadata,
+    parse_portfolio_mandates,
+    select_portfolio_mandate,
+    validate_mandate_range,
+)
+from src.analytics.portfolio_risk import parse_portfolio_definition
+from src.common.exceptions import ValidationError
+
+
+def _constituents(aapl_weight: float, msft_weight: float) -> list[dict[str, object]]:
+    return [
+        {
+            "source": "alpha_vantage",
+            "symbol": "AAPL",
+            "weight": aapl_weight,
+        },
+        {
+            "source": "alpha_vantage",
+            "symbol": "MSFT",
+            "weight": msft_weight,
+        },
+    ]
+
+
+def _multi_mandate_payload() -> dict[str, Any]:
+    return {
+        "portfolios": {
+            "us-tech": {
+                "description": "Effective-dated portfolio",
+                "mandates": [
+                    {
+                        "mandate_id": "us-tech-v1",
+                        "effective_from": "2025-01-01",
+                        "effective_to": "2026-01-01",
+                        "base_currency": "USD",
+                        "constituents": _constituents(0.5, 0.5),
+                    },
+                    {
+                        "mandate_id": "us-tech-v2",
+                        "effective_from": "2026-01-01",
+                        "effective_to": None,
+                        "base_currency": "USD",
+                        "constituents": _constituents(0.6, 0.4),
+                    },
+                ],
+            }
+        }
+    }
+
+
+def _mandate_entries(payload: dict[str, Any]) -> list[dict[str, Any]]:
+    portfolios = cast(dict[str, Any], payload["portfolios"])
+    portfolio = cast(dict[str, Any], portfolios["us-tech"])
+    return cast(list[dict[str, Any]], portfolio["mandates"])
+
+
+def test_current_portfolio_config_has_selectable_effective_mandates() -> None:
+    mandate = load_portfolio_mandate(
+        Path("config/portfolios.yaml"),
+        "us-tech-equal",
+        date(2026, 1, 26),
+    )
+
+    assert mandate.mandate_id == "us-tech-equal-v1"
+    assert mandate.effective_from == date(2020, 1, 1)
+    assert mandate.effective_to is None
+    assert mandate.contains(date(2026, 1, 26))
+    assert mandate.fingerprint.startswith("portfolio-mandate-")
+    assert mandate.constituent_definition_fingerprint.startswith("portfolio-")
+    assert mandate_metadata(mandate) == {
+        "mandate_id": "us-tech-equal-v1",
+        "mandate_fingerprint": mandate.fingerprint,
+        "constituent_definition_fingerprint": (
+            mandate.constituent_definition_fingerprint
+        ),
+        "effective_from": "2020-01-01",
+        "effective_to": None,
+    }
+
+    payload = yaml.safe_load(
+        Path("config/portfolios.yaml").read_text(encoding="utf-8")
+    )
+    legacy = parse_portfolio_definition(payload, "us-tech-equal")
+    assert legacy.base_currency == mandate.base_currency
+    assert legacy.constituents == mandate.constituents
+
+
+def test_selector_uses_inclusive_start_and_exclusive_end() -> None:
+    payload = _multi_mandate_payload()
+
+    first = select_portfolio_mandate(payload, "us-tech", date(2025, 12, 31))
+    second = select_portfolio_mandate(payload, "us-tech", date(2026, 1, 1))
+
+    assert first.mandate_id == "us-tech-v1"
+    assert second.mandate_id == "us-tech-v2"
+    assert first.fingerprint != second.fingerprint
+    assert first.constituent_definition_fingerprint != (
+        second.constituent_definition_fingerprint
+    )
+
+
+def test_mandate_identity_changes_even_when_weights_are_unchanged() -> None:
+    payload = _multi_mandate_payload()
+    _mandate_entries(payload)[1]["constituents"] = _constituents(0.5, 0.5)
+
+    first, second = parse_portfolio_mandates(payload, "us-tech")
+
+    assert (
+        first.constituent_definition_fingerprint
+        == second.constituent_definition_fingerprint
+    )
+    assert first.fingerprint != second.fingerprint
+
+
+def test_overlaps_duplicate_ids_and_uncovered_dates_fail_closed() -> None:
+    payload = _multi_mandate_payload()
+    _mandate_entries(payload)[1]["effective_from"] = "2025-12-01"
+    with pytest.raises(ValidationError, match="must not overlap"):
+        parse_portfolio_mandates(payload, "us-tech")
+
+    payload = _multi_mandate_payload()
+    _mandate_entries(payload)[1]["mandate_id"] = "us-tech-v1"
+    with pytest.raises(ValidationError, match="IDs must be unique"):
+        parse_portfolio_mandates(payload, "us-tech")
+
+    payload = _multi_mandate_payload()
+    _mandate_entries(payload)[0]["effective_to"] = "2025-06-01"
+    with pytest.raises(ValidationError, match="no unique mandate"):
+        select_portfolio_mandate(payload, "us-tech", date(2025, 8, 1))
+
+
+def test_requested_ranges_must_not_cross_mandate_boundaries() -> None:
+    mandate = select_portfolio_mandate(
+        _multi_mandate_payload(),
+        "us-tech",
+        date(2026, 3, 1),
+    )
+
+    validate_mandate_range(
+        mandate,
+        start_date=date(2026, 1, 1),
+        end_date=date(2026, 3, 1),
+    )
+    with pytest.raises(ValidationError, match="split the request"):
+        validate_mandate_range(
+            mandate,
+            start_date=date(2025, 12, 31),
+            end_date=date(2026, 3, 1),
+        )
+
+
+def test_record_filter_keeps_only_dates_owned_by_the_mandate() -> None:
+    mandate = select_portfolio_mandate(
+        _multi_mandate_payload(),
+        "us-tech",
+        date(2026, 1, 2),
+    )
+    records = [
+        {
+            "calculation_id": "before",
+            "ts_event": datetime(2025, 12, 31, tzinfo=timezone.utc),
+        },
+        {
+            "calculation_id": "inside",
+            "ts_event": "2026-01-01T00:00:00Z",
+        },
+    ]
+
+    filtered = filter_records_to_mandate(records, mandate)
+
+    assert [record["calculation_id"] for record in filtered] == ["inside"]
+    with pytest.raises(ValidationError, match="must be aware"):
+        filter_records_to_mandate(
+            [{"ts_event": datetime(2026, 1, 1)}],
+            mandate,
+        )


### PR DESCRIPTION
## Outcome

Introduce a strict temporal-governance contract for portfolio definitions before wiring it into every operator path:

```text
portfolio configuration
  -> validate all mandate histories
  -> select exactly one mandate for an as-of date
  -> reject overlap, ambiguity and uncovered dates
  -> distinguish constituent identity from mandate identity
  -> enforce single-mandate request ranges
```

Primary arc42 block: `analytics`, with a bounded configuration and documentation interface.

## Configuration

Each current demonstration portfolio now declares:

- `mandate_id`
- inclusive `effective_from`
- exclusive nullable `effective_to`
- base currency and constituents

The parser also supports a `mandates` list for future definition histories.

## Validation

The selector rejects duplicate IDs, malformed dates, invalid ranges, overlaps, non-final open-ended mandates, mixed direct/list definitions, and dates with no unique covering mandate. Gaps remain valid because a portfolio can be inactive; a calculation within a gap fails explicitly.

## Identity

`PortfolioMandate` exposes:

- `constituent_definition_fingerprint`, matching portfolio ID, currency, sources, symbols and weights;
- mandate-aware `fingerprint`, additionally binding mandate ID and effective bounds.

A formally renewed mandate is therefore distinguishable even when weights are unchanged.

## Range and record contracts

`validate_mandate_range` rejects an explicit start/end range crossing a mandate boundary. `filter_records_to_mandate` supports requests without a start date and rejects malformed or timezone-naive timestamps rather than silently accepting them.

## Compatibility boundary

The existing `parse_portfolio_definition` remains available and can still parse the direct demonstration definitions because the new temporal fields are additive. Runtime wiring is deliberately a separate PR so selector/configuration review is not mixed with orchestration changes.

## Validation evidence

GitHub Actions run `32581138415` (`ci` run 211) passed on exact head `5c0dc7ed5de06ff1c11a3d09ffd9d9e16e9f10cc`:

- Security guardrails: passed with the byte-pinned four-job CI contract unchanged.
- Python readiness: passed, including Ruff, mypy, the complete tests, dependency integrity and readiness replay.
- PostgreSQL contract: passed; the existing 65 real-engine assertions and double-load convergence remained green.
- Infrastructure validation: passed; Kubernetes rendered and Terraform format/init/validate completed without apply.

No unresolved review threads or requested changes are present.

## Scope

The branch is one commit ahead of `main` and zero behind. It changes four files with 604 additions and three deletions.

No financial formula, persisted dataset, PostgreSQL schema, deployment, provider request, credential or scheduler is changed.

## Acceptance boundary

This PR is validated and ready for squash merge as the mandate schema/selector layer.