### PR TITLE
Add portfolio risk-limit breach lifecycle views

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,7 @@ services:
       - ./sql/portfolio_schema.sql:/docker-entrypoint-initdb.d/03_portfolio_schema.sql:ro
       - ./sql/portfolio_attribution_schema.sql:/docker-entrypoint-initdb.d/04_portfolio_attribution_schema.sql:ro
       - ./sql/portfolio_risk_limits_schema.sql:/docker-entrypoint-initdb.d/05_portfolio_risk_limits_schema.sql:ro
+      - ./sql/portfolio_risk_breach_lifecycle_schema.sql:/docker-entrypoint-initdb.d/06_portfolio_risk_breach_lifecycle_schema.sql:ro
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U risk_user -d risk_platform"]
       interval: 5s

--- a/docs/portfolio-risk-breach-lifecycle.md
+++ b/docs/portfolio-risk-breach-lifecycle.md
@@ -1,0 +1,241 @@
+# Portfolio Risk-Limit Breach Lifecycle
+
+## Outcome
+
+This increment turns current portfolio risk-limit evaluations into a deterministic
+operational lifecycle without adding a second mutable state store:
+
+```text
+latest risk-limit metric evaluations
+  -> ordered metric transitions
+  -> actionable transition view
+  -> contiguous breach episodes
+  -> open-episode view
+  -> reconciliation evidence
+```
+
+The source of truth remains
+`risk_platform.latest_portfolio_risk_limit_evaluations`. Corrections to retained
+risk-limit evidence flow through the existing current-version rule and cause the
+transition and episode views to recompute.
+
+This is current operational state derived from retained evidence. It is not an
+acknowledgement workflow, notification system, case-management tool or trading
+control.
+
+## Transition Contract
+
+The view:
+
+```text
+risk_platform.portfolio_risk_limit_metric_transitions
+```
+
+orders each metric series within the full policy and analytical grain:
+
+```text
+policy_id
+policy_fingerprint
+portfolio_id
+definition_fingerprint
+risk-limit model version
+attribution model version
+weighting method
+covariance method
+correlation method
+covariance window
+annualisation basis
+metric name
+```
+
+Rows are ordered by:
+
+```text
+ts_event ASC
+ts_ingest ASC
+calculation_id ASC
+```
+
+Because the input is already the latest current evaluation for each event date
+and metric, this ordering describes the current corrected series rather than the
+raw history of superseded calculations.
+
+Transition types are:
+
+| Previous | Current | Transition |
+| --- | --- | --- |
+| none | ok | `initial_ok` |
+| none or ok | warning/critical | `opened` |
+| warning | critical | `escalated` |
+| critical | warning | `deescalated` |
+| warning/critical | ok | `resolved` |
+| all other combinations | unchanged severity | `unchanged` |
+
+The view also exposes the previous evaluation identity, previous subject key,
+integer severity rank and whether the subject changed. Subject changes matter for
+the component-concentration metric because a corrected or later attribution can
+make a different constituent the largest contributor.
+
+The focused operational subset is:
+
+```text
+risk_platform.portfolio_risk_limit_actionable_transitions
+```
+
+It contains `opened`, `escalated`, `deescalated` and `resolved` rows. No external
+message is sent from this view.
+
+## Episode Contract
+
+The view:
+
+```text
+risk_platform.portfolio_risk_limit_breach_episodes
+```
+
+creates one episode for each contiguous run of warning or critical observations
+within one metric grain.
+
+Continuity means consecutive **available evaluation observations**, not
+calendar-day adjacency. Weekends, holidays and other dates without an attribution
+snapshot do not break an episode. An `ok` evaluation closes the episode; the next
+warning or critical evaluation opens a new episode.
+
+Each episode exposes:
+
+- deterministic `episode_key`;
+- policy, definition, model, method and window grain;
+- episode sequence within that grain;
+- first breach date and last breach date;
+- first subsequent `ok` date when resolved;
+- `open` or `resolved` state;
+- warning, critical and total breach-observation counts;
+- subject-change count;
+- opening, latest-breach and peak evaluation identities;
+- opening, latest and peak subjects and observed values;
+- latest and peak breach excess; and
+- latest evidence ingest time.
+
+Peak selection is deterministic:
+
+```text
+severity rank DESC
+breach excess DESC
+observed value DESC
+event time ASC
+ingest time ASC
+calculation ID ASC
+```
+
+Critical observations therefore outrank warnings. Within the same severity, the
+largest threshold excess wins. Remaining fields provide stable tie-breaking.
+
+Current unresolved episodes are available through:
+
+```text
+risk_platform.portfolio_risk_limit_open_episodes
+```
+
+## Correction Behaviour
+
+Risk-limit evaluations are versioned by calculation ID. The current evaluation
+view selects a corrected row within its declared grain by:
+
+```text
+ts_ingest DESC
+calculation_id DESC
+```
+
+The lifecycle views operate only on that current series. A correction can
+therefore:
+
+- move an episode start;
+- remove or introduce an escalation;
+- change the peak observation;
+- change the largest constituent subject;
+- resolve an episode earlier or later; or
+- remove an episode entirely from current operational state.
+
+Superseded risk-limit evaluation rows remain in the history table. The lifecycle
+views do not delete or rewrite that evidence.
+
+## Local Operator Flow
+
+After generating and loading risk-limit evaluations, apply the lifecycle views:
+
+```bash
+docker compose exec -T postgres psql -U risk_user -d risk_platform \
+  < sql/portfolio_risk_breach_lifecycle_schema.sql
+```
+
+Inspect transitions and open episodes:
+
+```sql
+SELECT
+    policy_id,
+    portfolio_id,
+    metric_name,
+    ts_event,
+    previous_status,
+    status,
+    transition_type,
+    subject_key,
+    subject_changed
+FROM risk_platform.portfolio_risk_limit_metric_transitions
+ORDER BY policy_id, metric_name, ts_event;
+
+SELECT
+    policy_id,
+    portfolio_id,
+    metric_name,
+    episode_start,
+    last_breach_date,
+    latest_breach_status,
+    peak_status,
+    peak_subject_key,
+    peak_breach_excess
+FROM risk_platform.portfolio_risk_limit_open_episodes
+ORDER BY policy_id, metric_name, episode_start;
+```
+
+Run focused reconciliation:
+
+```bash
+docker compose exec -T postgres psql -U risk_user -d risk_platform \
+  < sql/portfolio_risk_breach_lifecycle_consistency_checks.sql
+```
+
+A newly created local PostgreSQL volume applies the lifecycle schema after the
+risk-limit schema through the read-only Docker initialization mounts.
+
+## Reconciliation
+
+The focused checks verify that:
+
+- every latest evaluation has one transition row;
+- the actionable view contains exactly the actionable transition types;
+- every `opened` transition creates one episode;
+- every `resolved` transition closes one episode;
+- the open-episode view matches unresolved episodes;
+- severity ranks and transition/status combinations are valid;
+- warning and critical counts reconcile to episode observation counts;
+- opening, latest, peak and resolution identities reference transition rows;
+- open and resolved nullability contracts are correct;
+- episode keys are unique;
+- episodes do not overlap within one metric grain; and
+- an open episode has no later current evaluation.
+
+## Boundary
+
+This increment deliberately does not add:
+
+- durable acknowledgement or ownership;
+- comments, exceptions or waivers;
+- notification delivery;
+- email, Slack, webhook or paging integration;
+- automatic escalation timers;
+- position changes or trade blocking;
+- scheduling, deployment or `terraform apply`.
+
+The next bounded increment can use the actionable transition view to create an
+idempotent notification outbox while still keeping delivery disabled.

--- a/sql/portfolio_risk_breach_lifecycle_consistency_checks.sql
+++ b/sql/portfolio_risk_breach_lifecycle_consistency_checks.sql
@@ -1,0 +1,362 @@
+-- Reconciliation checks for current portfolio risk-limit transitions and episodes.
+-- Run after sql/portfolio_risk_breach_lifecycle_schema.sql.
+
+WITH counts AS (
+    SELECT
+        (
+            SELECT COUNT(*)
+            FROM risk_platform.latest_portfolio_risk_limit_evaluations
+        ) AS latest_evaluation_rows,
+        (
+            SELECT COUNT(*)
+            FROM risk_platform.portfolio_risk_limit_metric_transitions
+        ) AS transition_rows,
+        (
+            SELECT COUNT(*)
+            FROM risk_platform.portfolio_risk_limit_actionable_transitions
+        ) AS actionable_rows,
+        (
+            SELECT COUNT(*)
+            FROM risk_platform.portfolio_risk_limit_metric_transitions
+            WHERE transition_type IN (
+                'opened',
+                'escalated',
+                'deescalated',
+                'resolved'
+            )
+        ) AS expected_actionable_rows,
+        (
+            SELECT COUNT(*)
+            FROM risk_platform.portfolio_risk_limit_breach_episodes
+        ) AS episode_rows,
+        (
+            SELECT COUNT(*)
+            FROM risk_platform.portfolio_risk_limit_metric_transitions
+            WHERE transition_type = 'opened'
+        ) AS opened_transition_rows,
+        (
+            SELECT COUNT(*)
+            FROM risk_platform.portfolio_risk_limit_breach_episodes
+            WHERE episode_status = 'resolved'
+        ) AS resolved_episode_rows,
+        (
+            SELECT COUNT(*)
+            FROM risk_platform.portfolio_risk_limit_metric_transitions
+            WHERE transition_type = 'resolved'
+        ) AS resolved_transition_rows,
+        (
+            SELECT COUNT(*)
+            FROM risk_platform.portfolio_risk_limit_open_episodes
+        ) AS open_view_rows,
+        (
+            SELECT COUNT(*)
+            FROM risk_platform.portfolio_risk_limit_breach_episodes
+            WHERE episode_status = 'open'
+        ) AS expected_open_rows
+),
+episode_order AS (
+    SELECT
+        episode.*,
+        LAG(episode_status) OVER (
+            PARTITION BY
+                policy_id,
+                policy_fingerprint,
+                portfolio_id,
+                definition_fingerprint,
+                model_version,
+                attribution_model_version,
+                weighting_method,
+                covariance_method,
+                correlation_method,
+                covariance_window,
+                annualization_days,
+                metric_name
+            ORDER BY episode_start, episode_sequence
+        ) AS previous_episode_status,
+        LAG(
+            COALESCE(resolution_date, last_breach_date)
+        ) OVER (
+            PARTITION BY
+                policy_id,
+                policy_fingerprint,
+                portfolio_id,
+                definition_fingerprint,
+                model_version,
+                attribution_model_version,
+                weighting_method,
+                covariance_method,
+                correlation_method,
+                covariance_window,
+                annualization_days,
+                metric_name
+            ORDER BY episode_start, episode_sequence
+        ) AS previous_episode_boundary
+    FROM risk_platform.portfolio_risk_limit_breach_episodes episode
+),
+integrity AS (
+    SELECT
+        (
+            SELECT COUNT(*)
+            FROM risk_platform.portfolio_risk_limit_metric_transitions
+            WHERE
+                transition_type NOT IN (
+                    'initial_ok',
+                    'opened',
+                    'escalated',
+                    'deescalated',
+                    'resolved',
+                    'unchanged'
+                )
+                OR severity_rank NOT IN (0, 1, 2)
+                OR (status = 'ok' AND severity_rank <> 0)
+                OR (status = 'warning' AND severity_rank <> 1)
+                OR (status = 'critical' AND severity_rank <> 2)
+                OR (
+                    transition_type = 'opened'
+                    AND NOT is_breach
+                )
+                OR (
+                    transition_type = 'resolved'
+                    AND (status <> 'ok' OR is_breach)
+                )
+        ) AS invalid_transition_rows,
+        (
+            SELECT COUNT(*)
+            FROM risk_platform.portfolio_risk_limit_breach_episodes
+            WHERE
+                breach_observations <= 0
+                OR breach_observations
+                    <> warning_observations + critical_observations
+                OR warning_observations < 0
+                OR critical_observations < 0
+                OR subject_change_observations < 0
+                OR opening_status NOT IN ('warning', 'critical')
+                OR latest_breach_status NOT IN ('warning', 'critical')
+                OR peak_status NOT IN ('warning', 'critical')
+                OR episode_start > last_breach_date
+                OR peak_breach_excess < 0
+                OR latest_breach_excess < 0
+        ) AS invalid_episode_counts,
+        (
+            SELECT COUNT(*)
+            FROM risk_platform.portfolio_risk_limit_breach_episodes
+            WHERE
+                (
+                    episode_status = 'open'
+                    AND (
+                        resolution_date IS NOT NULL
+                        OR resolution_evaluation_calculation_id IS NOT NULL
+                        OR resolution_calculation_ts IS NOT NULL
+                    )
+                )
+                OR (
+                    episode_status = 'resolved'
+                    AND (
+                        resolution_date IS NULL
+                        OR resolution_evaluation_calculation_id IS NULL
+                        OR resolution_calculation_ts IS NULL
+                        OR resolution_date <= last_breach_date
+                    )
+                )
+                OR episode_status NOT IN ('open', 'resolved')
+        ) AS invalid_episode_resolution_rows,
+        (
+            SELECT COUNT(*)
+            FROM risk_platform.portfolio_risk_limit_breach_episodes episode
+            LEFT JOIN
+                risk_platform.portfolio_risk_limit_metric_transitions opening
+                ON opening.calculation_id
+                    = episode.opening_evaluation_calculation_id
+            LEFT JOIN
+                risk_platform.portfolio_risk_limit_metric_transitions latest
+                ON latest.calculation_id
+                    = episode.last_breach_evaluation_calculation_id
+            LEFT JOIN
+                risk_platform.portfolio_risk_limit_metric_transitions peak
+                ON peak.calculation_id
+                    = episode.peak_evaluation_calculation_id
+            LEFT JOIN
+                risk_platform.portfolio_risk_limit_metric_transitions resolution
+                ON resolution.calculation_id
+                    = episode.resolution_evaluation_calculation_id
+            WHERE
+                opening.calculation_id IS NULL
+                OR opening.transition_type <> 'opened'
+                OR NOT opening.is_breach
+                OR latest.calculation_id IS NULL
+                OR NOT latest.is_breach
+                OR peak.calculation_id IS NULL
+                OR NOT peak.is_breach
+                OR (
+                    episode.episode_status = 'resolved'
+                    AND (
+                        resolution.calculation_id IS NULL
+                        OR resolution.transition_type <> 'resolved'
+                        OR resolution.status <> 'ok'
+                        OR resolution.is_breach
+                    )
+                )
+        ) AS invalid_episode_boundary_references,
+        (
+            SELECT COUNT(*) - COUNT(DISTINCT episode_key)
+            FROM risk_platform.portfolio_risk_limit_breach_episodes
+        ) AS duplicate_episode_keys,
+        (
+            SELECT COUNT(*)
+            FROM episode_order
+            WHERE
+                previous_episode_status = 'open'
+                OR (
+                    previous_episode_boundary IS NOT NULL
+                    AND episode_start <= previous_episode_boundary
+                )
+        ) AS overlapping_episode_rows,
+        (
+            SELECT COUNT(*)
+            FROM risk_platform.portfolio_risk_limit_open_episodes episode
+            WHERE EXISTS (
+                SELECT 1
+                FROM risk_platform.portfolio_risk_limit_metric_transitions later
+                WHERE later.policy_id = episode.policy_id
+                  AND later.policy_fingerprint = episode.policy_fingerprint
+                  AND later.portfolio_id = episode.portfolio_id
+                  AND later.definition_fingerprint
+                        = episode.definition_fingerprint
+                  AND later.model_version = episode.model_version
+                  AND later.attribution_model_version
+                        = episode.attribution_model_version
+                  AND later.weighting_method = episode.weighting_method
+                  AND later.covariance_method = episode.covariance_method
+                  AND later.correlation_method = episode.correlation_method
+                  AND later.covariance_window = episode.covariance_window
+                  AND later.annualization_days = episode.annualization_days
+                  AND later.metric_name = episode.metric_name
+                  AND later.ts_event > episode.last_breach_date
+            )
+        ) AS stale_open_episode_rows
+)
+SELECT
+    'portfolio_risk_limit_transition_rows_match_latest' AS check_name,
+    latest_evaluation_rows::TEXT AS expected,
+    transition_rows::TEXT AS actual,
+    CASE
+        WHEN latest_evaluation_rows = transition_rows THEN 'pass'
+        ELSE 'fail'
+    END AS status
+FROM counts
+
+UNION ALL
+
+SELECT
+    'portfolio_risk_limit_actionable_transition_rows_match',
+    expected_actionable_rows::TEXT,
+    actionable_rows::TEXT,
+    CASE
+        WHEN expected_actionable_rows = actionable_rows THEN 'pass'
+        ELSE 'fail'
+    END
+FROM counts
+
+UNION ALL
+
+SELECT
+    'portfolio_risk_limit_opened_transitions_match_episodes',
+    opened_transition_rows::TEXT,
+    episode_rows::TEXT,
+    CASE
+        WHEN opened_transition_rows = episode_rows THEN 'pass'
+        ELSE 'fail'
+    END
+FROM counts
+
+UNION ALL
+
+SELECT
+    'portfolio_risk_limit_resolutions_match_resolved_episodes',
+    resolved_transition_rows::TEXT,
+    resolved_episode_rows::TEXT,
+    CASE
+        WHEN resolved_transition_rows = resolved_episode_rows THEN 'pass'
+        ELSE 'fail'
+    END
+FROM counts
+
+UNION ALL
+
+SELECT
+    'portfolio_risk_limit_open_episode_view_matches',
+    expected_open_rows::TEXT,
+    open_view_rows::TEXT,
+    CASE WHEN expected_open_rows = open_view_rows THEN 'pass' ELSE 'fail' END
+FROM counts
+
+UNION ALL
+
+SELECT
+    'portfolio_risk_limit_transition_contract_valid',
+    '0',
+    invalid_transition_rows::TEXT,
+    CASE WHEN invalid_transition_rows = 0 THEN 'pass' ELSE 'fail' END
+FROM integrity
+
+UNION ALL
+
+SELECT
+    'portfolio_risk_limit_episode_counts_reconcile',
+    '0',
+    invalid_episode_counts::TEXT,
+    CASE WHEN invalid_episode_counts = 0 THEN 'pass' ELSE 'fail' END
+FROM integrity
+
+UNION ALL
+
+SELECT
+    'portfolio_risk_limit_episode_resolution_reconciles',
+    '0',
+    invalid_episode_resolution_rows::TEXT,
+    CASE
+        WHEN invalid_episode_resolution_rows = 0 THEN 'pass'
+        ELSE 'fail'
+    END
+FROM integrity
+
+UNION ALL
+
+SELECT
+    'portfolio_risk_limit_episode_boundaries_reference_transitions',
+    '0',
+    invalid_episode_boundary_references::TEXT,
+    CASE
+        WHEN invalid_episode_boundary_references = 0 THEN 'pass'
+        ELSE 'fail'
+    END
+FROM integrity
+
+UNION ALL
+
+SELECT
+    'portfolio_risk_limit_episode_keys_unique',
+    '0',
+    duplicate_episode_keys::TEXT,
+    CASE WHEN duplicate_episode_keys = 0 THEN 'pass' ELSE 'fail' END
+FROM integrity
+
+UNION ALL
+
+SELECT
+    'portfolio_risk_limit_episodes_do_not_overlap',
+    '0',
+    overlapping_episode_rows::TEXT,
+    CASE WHEN overlapping_episode_rows = 0 THEN 'pass' ELSE 'fail' END
+FROM integrity
+
+UNION ALL
+
+SELECT
+    'portfolio_risk_limit_open_episodes_are_current',
+    '0',
+    stale_open_episode_rows::TEXT,
+    CASE WHEN stale_open_episode_rows = 0 THEN 'pass' ELSE 'fail' END
+FROM integrity
+
+ORDER BY check_name;

--- a/sql/portfolio_risk_breach_lifecycle_schema.sql
+++ b/sql/portfolio_risk_breach_lifecycle_schema.sql
@@ -1,0 +1,392 @@
+-- PostgreSQL breach-lifecycle views over current portfolio risk-limit evaluations.
+-- Apply after sql/portfolio_risk_limits_schema.sql.
+
+CREATE OR REPLACE VIEW risk_platform.portfolio_risk_limit_metric_transitions AS
+WITH ordered AS (
+    SELECT
+        evaluation.*,
+        LAG(status) OVER (
+            PARTITION BY
+                policy_id,
+                policy_fingerprint,
+                portfolio_id,
+                definition_fingerprint,
+                model_version,
+                attribution_model_version,
+                weighting_method,
+                covariance_method,
+                correlation_method,
+                covariance_window,
+                annualization_days,
+                metric_name
+            ORDER BY ts_event, ts_ingest, calculation_id
+        ) AS previous_status,
+        LAG(calculation_id) OVER (
+            PARTITION BY
+                policy_id,
+                policy_fingerprint,
+                portfolio_id,
+                definition_fingerprint,
+                model_version,
+                attribution_model_version,
+                weighting_method,
+                covariance_method,
+                correlation_method,
+                covariance_window,
+                annualization_days,
+                metric_name
+            ORDER BY ts_event, ts_ingest, calculation_id
+        ) AS previous_calculation_id,
+        LAG(subject_key) OVER (
+            PARTITION BY
+                policy_id,
+                policy_fingerprint,
+                portfolio_id,
+                definition_fingerprint,
+                model_version,
+                attribution_model_version,
+                weighting_method,
+                covariance_method,
+                correlation_method,
+                covariance_window,
+                annualization_days,
+                metric_name
+            ORDER BY ts_event, ts_ingest, calculation_id
+        ) AS previous_subject_key
+    FROM risk_platform.latest_portfolio_risk_limit_evaluations evaluation
+)
+SELECT
+    ordered.*,
+    CASE
+        WHEN previous_status IS NULL AND status = 'ok' THEN 'initial_ok'
+        WHEN previous_status IS NULL AND status IN ('warning', 'critical')
+            THEN 'opened'
+        WHEN previous_status = 'ok' AND status IN ('warning', 'critical')
+            THEN 'opened'
+        WHEN previous_status = 'warning' AND status = 'critical'
+            THEN 'escalated'
+        WHEN previous_status = 'critical' AND status = 'warning'
+            THEN 'deescalated'
+        WHEN previous_status IN ('warning', 'critical') AND status = 'ok'
+            THEN 'resolved'
+        ELSE 'unchanged'
+    END AS transition_type,
+    CASE status
+        WHEN 'critical' THEN 2
+        WHEN 'warning' THEN 1
+        ELSE 0
+    END AS severity_rank,
+    (
+        previous_subject_key IS NOT NULL
+        AND previous_subject_key <> subject_key
+    ) AS subject_changed
+FROM ordered;
+
+CREATE OR REPLACE VIEW risk_platform.portfolio_risk_limit_actionable_transitions AS
+SELECT *
+FROM risk_platform.portfolio_risk_limit_metric_transitions
+WHERE transition_type IN (
+    'opened',
+    'escalated',
+    'deescalated',
+    'resolved'
+);
+
+CREATE OR REPLACE VIEW risk_platform.portfolio_risk_limit_breach_episodes AS
+WITH numbered AS (
+    SELECT
+        transition.*,
+        SUM(
+            CASE WHEN transition_type = 'opened' THEN 1 ELSE 0 END
+        ) OVER (
+            PARTITION BY
+                policy_id,
+                policy_fingerprint,
+                portfolio_id,
+                definition_fingerprint,
+                model_version,
+                attribution_model_version,
+                weighting_method,
+                covariance_method,
+                correlation_method,
+                covariance_window,
+                annualization_days,
+                metric_name
+            ORDER BY ts_event, ts_ingest, calculation_id
+            ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+        ) AS episode_sequence
+    FROM risk_platform.portfolio_risk_limit_metric_transitions transition
+),
+breach_rows AS (
+    SELECT *
+    FROM numbered
+    WHERE is_breach
+),
+rollup AS (
+    SELECT
+        policy_id,
+        policy_fingerprint,
+        portfolio_id,
+        base_currency,
+        definition_fingerprint,
+        model_version,
+        attribution_model_version,
+        weighting_method,
+        covariance_method,
+        correlation_method,
+        covariance_window,
+        annualization_days,
+        metric_name,
+        subject_type,
+        unit,
+        warning_threshold,
+        critical_threshold,
+        episode_sequence,
+        MIN(ts_event) AS episode_start,
+        MAX(ts_event) AS last_breach_date,
+        COUNT(*) AS breach_observations,
+        COUNT(*) FILTER (WHERE status = 'warning') AS warning_observations,
+        COUNT(*) FILTER (WHERE status = 'critical') AS critical_observations,
+        COUNT(*) FILTER (WHERE subject_changed) AS subject_change_observations
+    FROM breach_rows
+    GROUP BY
+        policy_id,
+        policy_fingerprint,
+        portfolio_id,
+        base_currency,
+        definition_fingerprint,
+        model_version,
+        attribution_model_version,
+        weighting_method,
+        covariance_method,
+        correlation_method,
+        covariance_window,
+        annualization_days,
+        metric_name,
+        subject_type,
+        unit,
+        warning_threshold,
+        critical_threshold,
+        episode_sequence
+),
+opening_rows AS (
+    SELECT
+        breach_rows.*,
+        ROW_NUMBER() OVER (
+            PARTITION BY
+                policy_id,
+                policy_fingerprint,
+                portfolio_id,
+                definition_fingerprint,
+                model_version,
+                attribution_model_version,
+                weighting_method,
+                covariance_method,
+                correlation_method,
+                covariance_window,
+                annualization_days,
+                metric_name,
+                episode_sequence
+            ORDER BY ts_event, ts_ingest, calculation_id
+        ) AS row_rank
+    FROM breach_rows
+),
+latest_breach_rows AS (
+    SELECT
+        breach_rows.*,
+        ROW_NUMBER() OVER (
+            PARTITION BY
+                policy_id,
+                policy_fingerprint,
+                portfolio_id,
+                definition_fingerprint,
+                model_version,
+                attribution_model_version,
+                weighting_method,
+                covariance_method,
+                correlation_method,
+                covariance_window,
+                annualization_days,
+                metric_name,
+                episode_sequence
+            ORDER BY ts_event DESC, ts_ingest DESC, calculation_id DESC
+        ) AS row_rank
+    FROM breach_rows
+),
+peak_rows AS (
+    SELECT
+        breach_rows.*,
+        ROW_NUMBER() OVER (
+            PARTITION BY
+                policy_id,
+                policy_fingerprint,
+                portfolio_id,
+                definition_fingerprint,
+                model_version,
+                attribution_model_version,
+                weighting_method,
+                covariance_method,
+                correlation_method,
+                covariance_window,
+                annualization_days,
+                metric_name,
+                episode_sequence
+            ORDER BY
+                severity_rank DESC,
+                breach_excess DESC,
+                observed_value DESC,
+                ts_event,
+                ts_ingest,
+                calculation_id
+        ) AS row_rank
+    FROM breach_rows
+),
+resolution_rows AS (
+    SELECT
+        numbered.*,
+        ROW_NUMBER() OVER (
+            PARTITION BY
+                policy_id,
+                policy_fingerprint,
+                portfolio_id,
+                definition_fingerprint,
+                model_version,
+                attribution_model_version,
+                weighting_method,
+                covariance_method,
+                correlation_method,
+                covariance_window,
+                annualization_days,
+                metric_name,
+                episode_sequence
+            ORDER BY ts_event, ts_ingest, calculation_id
+        ) AS row_rank
+    FROM numbered
+    WHERE status = 'ok' AND episode_sequence > 0
+)
+SELECT
+    (
+        rollup.policy_fingerprint
+        || '|'
+        || rollup.definition_fingerprint
+        || '|'
+        || rollup.metric_name
+        || '|'
+        || CAST(rollup.episode_start AS TEXT)
+    ) AS episode_key,
+    rollup.policy_id,
+    rollup.policy_fingerprint,
+    rollup.portfolio_id,
+    rollup.base_currency,
+    rollup.definition_fingerprint,
+    rollup.model_version,
+    rollup.attribution_model_version,
+    rollup.weighting_method,
+    rollup.covariance_method,
+    rollup.correlation_method,
+    rollup.covariance_window,
+    rollup.annualization_days,
+    rollup.metric_name,
+    rollup.subject_type,
+    rollup.unit,
+    rollup.warning_threshold,
+    rollup.critical_threshold,
+    rollup.episode_sequence,
+    rollup.episode_start,
+    rollup.last_breach_date,
+    resolution.ts_event AS resolution_date,
+    CASE
+        WHEN resolution.calculation_id IS NULL THEN 'open'
+        ELSE 'resolved'
+    END AS episode_status,
+    rollup.breach_observations,
+    rollup.warning_observations,
+    rollup.critical_observations,
+    rollup.subject_change_observations,
+    opening.status AS opening_status,
+    opening.subject_key AS opening_subject_key,
+    opening.observed_value AS opening_observed_value,
+    opening.calculation_id AS opening_evaluation_calculation_id,
+    latest.status AS latest_breach_status,
+    latest.subject_key AS latest_breach_subject_key,
+    latest.observed_value AS latest_breach_observed_value,
+    latest.breach_excess AS latest_breach_excess,
+    latest.calculation_id AS last_breach_evaluation_calculation_id,
+    peak.status AS peak_status,
+    peak.subject_key AS peak_subject_key,
+    peak.observed_value AS peak_observed_value,
+    peak.observed_signed_value AS peak_observed_signed_value,
+    peak.breach_excess AS peak_breach_excess,
+    peak.calculation_id AS peak_evaluation_calculation_id,
+    resolution.calculation_id AS resolution_evaluation_calculation_id,
+    resolution.ts_ingest AS resolution_calculation_ts,
+    CASE
+        WHEN resolution.calculation_id IS NULL THEN latest.ts_ingest
+        ELSE resolution.ts_ingest
+    END AS latest_evidence_ts
+FROM rollup
+JOIN opening_rows opening
+  ON opening.policy_id = rollup.policy_id
+ AND opening.policy_fingerprint = rollup.policy_fingerprint
+ AND opening.portfolio_id = rollup.portfolio_id
+ AND opening.definition_fingerprint = rollup.definition_fingerprint
+ AND opening.model_version = rollup.model_version
+ AND opening.attribution_model_version = rollup.attribution_model_version
+ AND opening.weighting_method = rollup.weighting_method
+ AND opening.covariance_method = rollup.covariance_method
+ AND opening.correlation_method = rollup.correlation_method
+ AND opening.covariance_window = rollup.covariance_window
+ AND opening.annualization_days = rollup.annualization_days
+ AND opening.metric_name = rollup.metric_name
+ AND opening.episode_sequence = rollup.episode_sequence
+ AND opening.row_rank = 1
+JOIN latest_breach_rows latest
+  ON latest.policy_id = rollup.policy_id
+ AND latest.policy_fingerprint = rollup.policy_fingerprint
+ AND latest.portfolio_id = rollup.portfolio_id
+ AND latest.definition_fingerprint = rollup.definition_fingerprint
+ AND latest.model_version = rollup.model_version
+ AND latest.attribution_model_version = rollup.attribution_model_version
+ AND latest.weighting_method = rollup.weighting_method
+ AND latest.covariance_method = rollup.covariance_method
+ AND latest.correlation_method = rollup.correlation_method
+ AND latest.covariance_window = rollup.covariance_window
+ AND latest.annualization_days = rollup.annualization_days
+ AND latest.metric_name = rollup.metric_name
+ AND latest.episode_sequence = rollup.episode_sequence
+ AND latest.row_rank = 1
+JOIN peak_rows peak
+  ON peak.policy_id = rollup.policy_id
+ AND peak.policy_fingerprint = rollup.policy_fingerprint
+ AND peak.portfolio_id = rollup.portfolio_id
+ AND peak.definition_fingerprint = rollup.definition_fingerprint
+ AND peak.model_version = rollup.model_version
+ AND peak.attribution_model_version = rollup.attribution_model_version
+ AND peak.weighting_method = rollup.weighting_method
+ AND peak.covariance_method = rollup.covariance_method
+ AND peak.correlation_method = rollup.correlation_method
+ AND peak.covariance_window = rollup.covariance_window
+ AND peak.annualization_days = rollup.annualization_days
+ AND peak.metric_name = rollup.metric_name
+ AND peak.episode_sequence = rollup.episode_sequence
+ AND peak.row_rank = 1
+LEFT JOIN resolution_rows resolution
+  ON resolution.policy_id = rollup.policy_id
+ AND resolution.policy_fingerprint = rollup.policy_fingerprint
+ AND resolution.portfolio_id = rollup.portfolio_id
+ AND resolution.definition_fingerprint = rollup.definition_fingerprint
+ AND resolution.model_version = rollup.model_version
+ AND resolution.attribution_model_version = rollup.attribution_model_version
+ AND resolution.weighting_method = rollup.weighting_method
+ AND resolution.covariance_method = rollup.covariance_method
+ AND resolution.correlation_method = rollup.correlation_method
+ AND resolution.covariance_window = rollup.covariance_window
+ AND resolution.annualization_days = rollup.annualization_days
+ AND resolution.metric_name = rollup.metric_name
+ AND resolution.episode_sequence = rollup.episode_sequence
+ AND resolution.row_rank = 1;
+
+CREATE OR REPLACE VIEW risk_platform.portfolio_risk_limit_open_episodes AS
+SELECT *
+FROM risk_platform.portfolio_risk_limit_breach_episodes
+WHERE episode_status = 'open';

--- a/tests/unit/test_docker_compose_contract.py
+++ b/tests/unit/test_docker_compose_contract.py
@@ -30,6 +30,7 @@ def test_local_database_seed_mounts_are_read_only_and_ordered() -> None:
         "./sql/portfolio_schema.sql:/docker-entrypoint-initdb.d/03_portfolio_schema.sql:ro",
         "./sql/portfolio_attribution_schema.sql:/docker-entrypoint-initdb.d/04_portfolio_attribution_schema.sql:ro",
         "./sql/portfolio_risk_limits_schema.sql:/docker-entrypoint-initdb.d/05_portfolio_risk_limits_schema.sql:ro",
+        "./sql/portfolio_risk_breach_lifecycle_schema.sql:/docker-entrypoint-initdb.d/06_portfolio_risk_breach_lifecycle_schema.sql:ro",
     ]
     assert services["mongo"]["volumes"] == [
         "./mongo/init:/docker-entrypoint-initdb.d:ro"

--- a/tests/unit/test_portfolio_risk_breach_lifecycle_reporting_sql_contract.py
+++ b/tests/unit/test_portfolio_risk_breach_lifecycle_reporting_sql_contract.py
@@ -1,0 +1,408 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+
+import duckdb
+
+VOLATILITY_METRIC = "portfolio_volatility_annualized"
+CONCENTRATION_METRIC = "largest_absolute_component_contribution_share"
+
+
+def _read_sql(path: str) -> str:
+    return Path(path).read_text(encoding="utf-8")
+
+
+def _extract_statement(sql: str, prefix: str) -> str:
+    start = sql.index(prefix)
+    end = sql.index(";", start) + 1
+    return sql[start:end]
+
+
+def _evaluation_row(
+    *,
+    metric_name: str,
+    day: int,
+    status: str,
+    observed_value: float,
+    subject_key: str,
+    observed_signed_value: float | None = None,
+) -> tuple[object, ...]:
+    is_volatility = metric_name == VOLATILITY_METRIC
+    warning_threshold = 0.30 if is_volatility else 0.65
+    critical_threshold = 0.45 if is_volatility else 0.80
+    is_breach = status != "ok"
+    breach_threshold = (
+        None
+        if status == "ok"
+        else critical_threshold if status == "critical" else warning_threshold
+    )
+    breach_excess = (
+        0.0
+        if breach_threshold is None
+        else observed_value - breach_threshold
+    )
+    ts_event = datetime(2026, 1, day, tzinfo=timezone.utc)
+    ts_ingest = datetime(2026, 2, 1, 12, day, tzinfo=timezone.utc)
+    return (
+        f"{metric_name}-{day}",
+        "portfolio-risk-limits-v1",
+        "us-tech-standard",
+        "risk-limit-policy-a",
+        "us-tech-equal",
+        "USD",
+        "definition-a",
+        f"attribution-{day}",
+        "portfolio-attribution-v1",
+        "constant_weight_daily_rebalanced",
+        "sample_annualized",
+        "pearson",
+        20,
+        252,
+        ts_event,
+        ts_ingest,
+        metric_name,
+        "portfolio" if is_volatility else "constituent",
+        subject_key,
+        "annualized_decimal" if is_volatility else "absolute_share",
+        observed_value,
+        (
+            observed_value
+            if observed_signed_value is None
+            else observed_signed_value
+        ),
+        warning_threshold,
+        critical_threshold,
+        status,
+        is_breach,
+        breach_threshold,
+        breach_excess,
+    )
+
+
+def _create_latest_evaluation_table(connection: duckdb.DuckDBPyConnection) -> None:
+    connection.execute("CREATE SCHEMA risk_platform")
+    connection.execute(
+        """
+        CREATE TABLE risk_platform.latest_portfolio_risk_limit_evaluations (
+            calculation_id TEXT,
+            model_version TEXT,
+            policy_id TEXT,
+            policy_fingerprint TEXT,
+            portfolio_id TEXT,
+            base_currency TEXT,
+            definition_fingerprint TEXT,
+            attribution_calculation_id TEXT,
+            attribution_model_version TEXT,
+            weighting_method TEXT,
+            covariance_method TEXT,
+            correlation_method TEXT,
+            covariance_window INTEGER,
+            annualization_days INTEGER,
+            ts_event TIMESTAMPTZ,
+            ts_ingest TIMESTAMPTZ,
+            metric_name TEXT,
+            subject_type TEXT,
+            subject_key TEXT,
+            unit TEXT,
+            observed_value DOUBLE,
+            observed_signed_value DOUBLE,
+            warning_threshold DOUBLE,
+            critical_threshold DOUBLE,
+            status TEXT,
+            is_breach BOOLEAN,
+            breach_threshold DOUBLE,
+            breach_excess DOUBLE
+        )
+        """
+    )
+
+
+def _insert_evaluation_series(connection: duckdb.DuckDBPyConnection) -> None:
+    rows = [
+        _evaluation_row(
+            metric_name=VOLATILITY_METRIC,
+            day=1,
+            status="ok",
+            observed_value=0.20,
+            subject_key="us-tech-equal",
+        ),
+        _evaluation_row(
+            metric_name=VOLATILITY_METRIC,
+            day=2,
+            status="warning",
+            observed_value=0.35,
+            subject_key="us-tech-equal",
+        ),
+        _evaluation_row(
+            metric_name=VOLATILITY_METRIC,
+            day=3,
+            status="critical",
+            observed_value=0.50,
+            subject_key="us-tech-equal",
+        ),
+        _evaluation_row(
+            metric_name=VOLATILITY_METRIC,
+            day=4,
+            status="warning",
+            observed_value=0.34,
+            subject_key="us-tech-equal",
+        ),
+        _evaluation_row(
+            metric_name=VOLATILITY_METRIC,
+            day=5,
+            status="ok",
+            observed_value=0.25,
+            subject_key="us-tech-equal",
+        ),
+        _evaluation_row(
+            metric_name=VOLATILITY_METRIC,
+            day=6,
+            status="warning",
+            observed_value=0.32,
+            subject_key="us-tech-equal",
+        ),
+        _evaluation_row(
+            metric_name=CONCENTRATION_METRIC,
+            day=1,
+            status="critical",
+            observed_value=0.90,
+            observed_signed_value=-0.90,
+            subject_key="alpha_vantage:AAPL",
+        ),
+        _evaluation_row(
+            metric_name=CONCENTRATION_METRIC,
+            day=2,
+            status="critical",
+            observed_value=0.85,
+            observed_signed_value=0.85,
+            subject_key="alpha_vantage:MSFT",
+        ),
+        _evaluation_row(
+            metric_name=CONCENTRATION_METRIC,
+            day=3,
+            status="ok",
+            observed_value=0.50,
+            observed_signed_value=0.50,
+            subject_key="alpha_vantage:MSFT",
+        ),
+        _evaluation_row(
+            metric_name=CONCENTRATION_METRIC,
+            day=4,
+            status="ok",
+            observed_value=0.40,
+            observed_signed_value=0.40,
+            subject_key="alpha_vantage:MSFT",
+        ),
+        _evaluation_row(
+            metric_name=CONCENTRATION_METRIC,
+            day=5,
+            status="warning",
+            observed_value=0.70,
+            observed_signed_value=0.70,
+            subject_key="alpha_vantage:AAPL",
+        ),
+        _evaluation_row(
+            metric_name=CONCENTRATION_METRIC,
+            day=6,
+            status="critical",
+            observed_value=0.81,
+            observed_signed_value=0.81,
+            subject_key="alpha_vantage:AAPL",
+        ),
+    ]
+    placeholders = ", ".join(["?"] * len(rows[0]))
+    connection.executemany(
+        "INSERT INTO "
+        "risk_platform.latest_portfolio_risk_limit_evaluations VALUES "
+        f"({placeholders})",
+        rows,
+    )
+
+
+def test_breach_lifecycle_schema_exposes_expected_views() -> None:
+    schema_sql = _read_sql("sql/portfolio_risk_breach_lifecycle_schema.sql")
+
+    for view_name in (
+        "portfolio_risk_limit_metric_transitions",
+        "portfolio_risk_limit_actionable_transitions",
+        "portfolio_risk_limit_breach_episodes",
+        "portfolio_risk_limit_open_episodes",
+    ):
+        assert f"CREATE OR REPLACE VIEW risk_platform.{view_name}" in schema_sql
+
+    for transition_type in (
+        "initial_ok",
+        "opened",
+        "escalated",
+        "deescalated",
+        "resolved",
+        "unchanged",
+    ):
+        assert f"'{transition_type}'" in schema_sql
+
+    assert "ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW" in schema_sql
+    assert "subject_change_observations" in schema_sql
+    assert "peak_breach_excess" in schema_sql
+
+
+def test_transition_and_episode_views_execute_deterministically() -> None:
+    schema_sql = _read_sql("sql/portfolio_risk_breach_lifecycle_schema.sql")
+    view_names = (
+        "portfolio_risk_limit_metric_transitions",
+        "portfolio_risk_limit_actionable_transitions",
+        "portfolio_risk_limit_breach_episodes",
+        "portfolio_risk_limit_open_episodes",
+    )
+
+    with duckdb.connect() as connection:
+        _create_latest_evaluation_table(connection)
+        _insert_evaluation_series(connection)
+        for view_name in view_names:
+            connection.execute(
+                _extract_statement(
+                    schema_sql,
+                    f"CREATE OR REPLACE VIEW risk_platform.{view_name} AS",
+                )
+            )
+
+        volatility_transitions = connection.execute(
+            """
+            SELECT transition_type
+            FROM risk_platform.portfolio_risk_limit_metric_transitions
+            WHERE metric_name = ?
+            ORDER BY ts_event
+            """,
+            [VOLATILITY_METRIC],
+        ).fetchall()
+        assert volatility_transitions == [
+            ("initial_ok",),
+            ("opened",),
+            ("escalated",),
+            ("deescalated",),
+            ("resolved",),
+            ("opened",),
+        ]
+
+        concentration_subject_change = connection.execute(
+            """
+            SELECT subject_changed
+            FROM risk_platform.portfolio_risk_limit_metric_transitions
+            WHERE metric_name = ? AND ts_event = ?
+            """,
+            [
+                CONCENTRATION_METRIC,
+                datetime(2026, 1, 2, tzinfo=timezone.utc),
+            ],
+        ).fetchone()
+        assert concentration_subject_change == (True,)
+
+        assert connection.execute(
+            "SELECT COUNT(*) FROM "
+            "risk_platform.portfolio_risk_limit_actionable_transitions"
+        ).fetchone() == (9,)
+
+        episodes = connection.execute(
+            """
+            SELECT
+                metric_name,
+                episode_sequence,
+                episode_status,
+                opening_status,
+                latest_breach_status,
+                peak_status,
+                breach_observations,
+                warning_observations,
+                critical_observations,
+                peak_subject_key,
+                resolution_date IS NULL
+            FROM risk_platform.portfolio_risk_limit_breach_episodes
+            ORDER BY metric_name, episode_sequence
+            """
+        ).fetchall()
+        assert episodes == [
+            (
+                CONCENTRATION_METRIC,
+                1,
+                "resolved",
+                "critical",
+                "critical",
+                "critical",
+                2,
+                0,
+                2,
+                "alpha_vantage:AAPL",
+                False,
+            ),
+            (
+                CONCENTRATION_METRIC,
+                2,
+                "open",
+                "warning",
+                "critical",
+                "critical",
+                2,
+                1,
+                1,
+                "alpha_vantage:AAPL",
+                True,
+            ),
+            (
+                VOLATILITY_METRIC,
+                1,
+                "resolved",
+                "warning",
+                "warning",
+                "critical",
+                3,
+                2,
+                1,
+                "us-tech-equal",
+                False,
+            ),
+            (
+                VOLATILITY_METRIC,
+                2,
+                "open",
+                "warning",
+                "warning",
+                "warning",
+                1,
+                1,
+                0,
+                "us-tech-equal",
+                True,
+            ),
+        ]
+        assert connection.execute(
+            "SELECT COUNT(*) FROM "
+            "risk_platform.portfolio_risk_limit_open_episodes"
+        ).fetchone() == (2,)
+
+
+def test_lifecycle_reconciliation_and_documentation_contract() -> None:
+    consistency_sql = _read_sql(
+        "sql/portfolio_risk_breach_lifecycle_consistency_checks.sql"
+    )
+    documentation = Path("docs/portfolio-risk-breach-lifecycle.md").read_text(
+        encoding="utf-8"
+    )
+
+    for check_name in (
+        "portfolio_risk_limit_transition_rows_match_latest",
+        "portfolio_risk_limit_actionable_transition_rows_match",
+        "portfolio_risk_limit_opened_transitions_match_episodes",
+        "portfolio_risk_limit_resolutions_match_resolved_episodes",
+        "portfolio_risk_limit_episode_counts_reconcile",
+        "portfolio_risk_limit_episode_resolution_reconciles",
+        "portfolio_risk_limit_episode_boundaries_reference_transitions",
+        "portfolio_risk_limit_episode_keys_unique",
+        "portfolio_risk_limit_episodes_do_not_overlap",
+        "portfolio_risk_limit_open_episodes_are_current",
+    ):
+        assert check_name in consistency_sql
+
+    assert "consecutive **available evaluation observations**" in documentation
+    assert "current corrected series" in documentation
+    assert "does not add" in documentation
+    assert "notification delivery" in documentation


### PR DESCRIPTION
## Outcome

Derive a deterministic operational lifecycle from the current portfolio risk-limit evaluation series:

```text
latest risk-limit metric evaluations
  -> ordered metric transitions
  -> actionable transition view
  -> contiguous breach episodes
  -> current open-episode view
  -> focused reconciliation
```

This is roadmap issue #64, increment 2.

## History repair

The original PR was stacked on the pre-squash PR #59 head. Since `main` subsequently received PRs #59–#62, the exact six-file lifecycle delta was reconstructed directly on current `main` rather than retaining duplicated or obsolete ancestry.

Final branch state:

- one commit ahead of `main`;
- zero commits behind;
- six changed files;
- no regression to the PostgreSQL CI, acknowledgement or mandate work already on `main`.

## Transition contract

Add:

- `risk_platform.portfolio_risk_limit_metric_transitions`;
- `risk_platform.portfolio_risk_limit_actionable_transitions`.

Each metric series is partitioned by the full policy, portfolio-definition, model, method, covariance-window, annualisation and metric grain. Rows are ordered by event time, ingest time and calculation ID.

Transitions are explicit: `initial_ok`, `opened`, `escalated`, `deescalated`, `resolved` and `unchanged`. The transition view retains previous status, previous calculation ID, previous subject, severity rank and subject-change evidence. The actionable view contains only opening, escalation, de-escalation and resolution events; it performs no delivery.

## Episode contract

Add:

- `risk_platform.portfolio_risk_limit_breach_episodes`;
- `risk_platform.portfolio_risk_limit_open_episodes`.

An episode is one contiguous run of warning or critical observations in the current corrected metric series. Continuity is based on consecutive available evaluations, not calendar-day adjacency. An `ok` evaluation resolves the episode; a later warning or critical evaluation opens a new one.

Each episode exposes deterministic identity, boundaries, resolution state, observation counts, subject changes, opening/latest/peak evidence and stable peak selection. Critical severity outranks warning; breach excess, observed value and stable time/identity fields provide deterministic tie-breaking.

Corrections remain versioned in the risk-limit history table. Because lifecycle views consume the current evaluation view, corrected evidence recomputes current transitions and episodes without deleting retained calculations.

## Reconciliation

`sql/portfolio_risk_breach_lifecycle_consistency_checks.sql` verifies transition counts, actionable rows, opened/resolved episode alignment, observation counts, state nullability, transition boundary references, unique keys, non-overlap and open-episode currency.

## Local database

Docker initializes the lifecycle schema read-only after the risk-limit schema. Existing databases can apply the new schema and checks explicitly as documented in `docs/portfolio-risk-breach-lifecycle.md`.

## Validation

GitHub Actions run `32587232031` (`ci` run 214) passed on exact reconstructed head `81601623264f7032e720d88f9e4d5fc6403c2a5d`:

- Security guardrails: passed.
- Python readiness: passed.
  - locked dependencies resolved;
  - Ruff passed;
  - mypy passed across 55 source files;
  - 497 tests passed twice through quality and readiness;
  - `pip check` passed.
- PostgreSQL contract: passed against PostgreSQL 16, including the existing seeded source-to-serving assertions after the lifecycle schema was added.
- Infrastructure validation: passed.
  - Kubernetes overlays rendered;
  - Terraform formatting, initialization and validation passed without applying infrastructure.

No unresolved review threads or requested changes are present.

## Scope

Six changed files and 1,405 additions form one SQL-serving increment. No new mutable episode table, acknowledgement, owner assignment, waiver, notification delivery, trading action, scheduler, deployment or Terraform apply is included.

## Acceptance boundary

This PR is validated and ready for squash merge as the lifecycle increment.