### PR TITLE
Add durable portfolio risk notification outbox

### DIFF
--- a/config/storage.yaml
+++ b/config/storage.yaml
@@ -18,6 +18,7 @@ storage:
       portfolio_daily_risk_summary: "portfolio_daily_risk_summary"
       portfolio_risk_attribution: "portfolio_risk_attribution"
       portfolio_risk_limit_evaluations: "portfolio_risk_limit_evaluations"
+      portfolio_risk_notification_outbox: "portfolio_risk_notification_outbox"
   format: "parquet"
   partitioning:
     granularity: "hourly"

--- a/deploy/kubernetes/base/config/storage.yaml
+++ b/deploy/kubernetes/base/config/storage.yaml
@@ -18,6 +18,7 @@ storage:
       portfolio_daily_risk_summary: "portfolio_daily_risk_summary"
       portfolio_risk_attribution: "portfolio_risk_attribution"
       portfolio_risk_limit_evaluations: "portfolio_risk_limit_evaluations"
+      portfolio_risk_notification_outbox: "portfolio_risk_notification_outbox"
   format: "parquet"
   partitioning:
     granularity: "hourly"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,7 @@ services:
       - ./sql/portfolio_attribution_schema.sql:/docker-entrypoint-initdb.d/04_portfolio_attribution_schema.sql:ro
       - ./sql/portfolio_risk_limits_schema.sql:/docker-entrypoint-initdb.d/05_portfolio_risk_limits_schema.sql:ro
       - ./sql/portfolio_risk_breach_lifecycle_schema.sql:/docker-entrypoint-initdb.d/06_portfolio_risk_breach_lifecycle_schema.sql:ro
+      - ./sql/portfolio_risk_notification_outbox_schema.sql:/docker-entrypoint-initdb.d/07_portfolio_risk_notification_outbox_schema.sql:ro
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U risk_user -d risk_platform"]
       interval: 5s

--- a/docs/portfolio-risk-notification-outbox.md
+++ b/docs/portfolio-risk-notification-outbox.md
@@ -1,0 +1,207 @@
+# Portfolio Risk Notification Outbox
+
+## Outcome
+
+This increment converts current actionable portfolio risk-limit transitions into
+durable, replay-safe notification **candidates**:
+
+```text
+current actionable risk-limit transitions
+  -> deterministic notification event identity
+  -> credential-free JSON payload
+  -> pending or suppressed disposition
+  -> content-addressed Parquet
+  -> immutable PostgreSQL outbox history
+  -> current, pending, suppressed and summary views
+```
+
+It does not deliver email, Slack, webhooks, pages or any other external message.
+The outbox is evidence for a later delivery adapter, not a claim that notification
+has occurred.
+
+## Event Contract
+
+The model version is:
+
+```text
+portfolio-risk-notification-outbox-v1
+```
+
+One event is produced for each current lifecycle transition:
+
+| Transition | Event type | Disposition |
+| --- | --- | --- |
+| `opened` | `breach_opened` | `pending` |
+| `escalated` | `breach_escalated` | `pending` |
+| `deescalated` | `breach_deescalated` | `suppressed` |
+| `resolved` | `breach_resolved` | `pending` |
+
+De-escalations are retained but deliberately suppressed with:
+
+```text
+deescalation_not_routed
+```
+
+This keeps the lifecycle observable without creating an implied production
+routing policy. A later increment can change routing through a new model version
+rather than rewriting this evidence.
+
+The deterministic event ID binds:
+
+```text
+outbox model version
+policy fingerprint
+metric name
+source evaluation calculation ID
+previous evaluation calculation ID
+transition type
+```
+
+An identical rerun therefore produces the same event ID and no duplicate
+Parquet record. Corrections to the current risk-limit series produce different
+source calculations and therefore distinguishable candidates.
+
+## Payload
+
+`payload_json` contains only reviewed operational evidence:
+
+- event and transition identity;
+- policy ID and fingerprint;
+- portfolio ID, definition fingerprint and base currency;
+- metric, subject, thresholds, status and breach excess;
+- source evaluation identities; and
+- source event and ingest timestamps.
+
+The payload does not include:
+
+- PostgreSQL DSNs;
+- provider API keys;
+- email addresses;
+- webhook URLs;
+- access tokens;
+- raw provider responses; or
+- local filesystem paths.
+
+## Local Generation
+
+Risk-limit evaluations must already be loaded into PostgreSQL and the breach
+lifecycle schema must be applied. Then generate candidates for a bounded range:
+
+```bash
+.venv/bin/python -m src.orchestration.run_portfolio_risk_notification_outbox \
+  --policy-id us-tech-standard \
+  --start-date 2026-01-01 \
+  --end-date 2026-03-31 \
+  --summary-json .demo/portfolio-risk-notification-outbox-summary.json
+```
+
+The command reads only:
+
+```text
+risk_platform.portfolio_risk_limit_actionable_transitions
+```
+
+It caps one request at 10,000 events. The summary never prints the DSN and
+records:
+
+```json
+{
+  "delivery": {
+    "performed": false,
+    "external_destinations": 0,
+    "reason": "delivery_not_implemented"
+  }
+}
+```
+
+Candidates are written to:
+
+```text
+data/curated/portfolio_risk_notification_outbox
+```
+
+Each event is published independently through the content-addressed writer.
+Partial local publication is replay-safe.
+
+## Warehouse Loading
+
+A dry run inventories Parquet without opening a PostgreSQL connection:
+
+```bash
+.venv/bin/python -m src.warehouse.portfolio_risk_notification_outbox_loader \
+  --dry-run
+```
+
+Apply the schema and load the candidates:
+
+```bash
+docker compose exec -T postgres psql -U risk_user -d risk_platform \
+  < sql/portfolio_risk_notification_outbox_schema.sql
+
+.venv/bin/python -m src.warehouse.portfolio_risk_notification_outbox_loader \
+  --dsn postgresql://risk_user:risk_password@localhost:5433/risk_platform
+```
+
+The history table is:
+
+```text
+risk_platform.portfolio_risk_notification_outbox
+```
+
+The loader uses `ON CONFLICT (event_id) DO NOTHING`. Outbox evidence is immutable;
+a replay converges without updating a previously retained event.
+
+Current and reporting views are:
+
+```text
+risk_platform.current_portfolio_risk_notification_outbox
+risk_platform.portfolio_risk_notification_pending
+risk_platform.portfolio_risk_notification_suppressed
+risk_platform.portfolio_risk_notification_outbox_summary
+```
+
+The current view joins retained outbox rows to the current actionable-transition
+view. When a corrected evaluation changes the lifecycle, superseded candidates
+remain in history but disappear from current operational views.
+
+## Bounds
+
+The PostgreSQL transition reader requires one policy and a completed end date.
+The Parquet warehouse reader retains the repository's local safety bounds:
+
+- at most 4,096 files;
+- at most 1 GB of physical input;
+- at most 250,000 rows;
+- symbolic-link rejection; and
+- unsafe-file rejection.
+
+## Reconciliation
+
+`sql/portfolio_risk_notification_outbox_consistency_checks.sql` verifies:
+
+- source and previous evaluation references;
+- current transition metadata;
+- unique event IDs;
+- pending and suppressed disposition rules;
+- payload identity;
+- one current candidate per actionable transition;
+- stale candidates excluded from current views; and
+- pending, suppressed and summary row counts.
+
+## Boundary
+
+This increment deliberately does not implement:
+
+- external delivery;
+- delivery attempts or retries;
+- channel destinations;
+- acknowledgement or ownership;
+- escalation timers;
+- personal data or recipient directories;
+- scheduling;
+- deployment; or
+- `terraform apply`.
+
+The next delivery-oriented slice would require an explicitly configured adapter,
+idempotency key, attempt history and retry/dead-letter policy. Until then,
+`pending` means eligible candidate—not sent.

--- a/sql/portfolio_risk_notification_outbox_consistency_checks.sql
+++ b/sql/portfolio_risk_notification_outbox_consistency_checks.sql
@@ -1,0 +1,325 @@
+-- Reconciliation checks for durable portfolio risk notification candidates.
+-- Run after lifecycle and notification-outbox schemas are applied and local
+-- outbox Parquet has been loaded.
+
+WITH counts AS (
+    SELECT
+        (
+            SELECT COUNT(*)
+            FROM risk_platform.portfolio_risk_notification_outbox
+        ) AS history_rows,
+        (
+            SELECT COUNT(*)
+            FROM risk_platform.current_portfolio_risk_notification_outbox
+        ) AS current_rows,
+        (
+            SELECT COUNT(*)
+            FROM risk_platform.portfolio_risk_limit_actionable_transitions
+        ) AS actionable_transition_rows,
+        (
+            SELECT COUNT(*)
+            FROM risk_platform.portfolio_risk_notification_pending
+        ) AS pending_rows,
+        (
+            SELECT COUNT(*)
+            FROM risk_platform.current_portfolio_risk_notification_outbox
+            WHERE delivery_disposition = 'pending'
+        ) AS expected_pending_rows,
+        (
+            SELECT COUNT(*)
+            FROM risk_platform.portfolio_risk_notification_suppressed
+        ) AS suppressed_rows,
+        (
+            SELECT COUNT(*)
+            FROM risk_platform.current_portfolio_risk_notification_outbox
+            WHERE delivery_disposition = 'suppressed'
+        ) AS expected_suppressed_rows,
+        (
+            SELECT COALESCE(SUM(event_count), 0)
+            FROM risk_platform.portfolio_risk_notification_outbox_summary
+        ) AS summary_event_rows
+),
+integrity AS (
+    SELECT
+        (
+            SELECT COUNT(*)
+            FROM risk_platform.portfolio_risk_notification_outbox outbox
+            LEFT JOIN
+                risk_platform.portfolio_risk_limit_evaluations evaluation
+                ON evaluation.calculation_id
+                    = outbox.source_evaluation_calculation_id
+            WHERE evaluation.calculation_id IS NULL
+        ) AS orphan_source_evaluations,
+        (
+            SELECT COUNT(*)
+            FROM risk_platform.portfolio_risk_notification_outbox outbox
+            LEFT JOIN
+                risk_platform.portfolio_risk_limit_evaluations previous
+                ON previous.calculation_id
+                    = outbox.source_previous_evaluation_calculation_id
+            WHERE
+                outbox.source_previous_evaluation_calculation_id IS NOT NULL
+                AND previous.calculation_id IS NULL
+        ) AS orphan_previous_evaluations,
+        (
+            SELECT COUNT(*)
+            FROM risk_platform.current_portfolio_risk_notification_outbox outbox
+            JOIN
+                risk_platform.portfolio_risk_limit_actionable_transitions transition
+                ON transition.calculation_id
+                    = outbox.source_evaluation_calculation_id
+               AND transition.transition_type = outbox.transition_type
+            WHERE
+                outbox.risk_limit_model_version <> transition.model_version
+                OR outbox.policy_id <> transition.policy_id
+                OR outbox.policy_fingerprint <> transition.policy_fingerprint
+                OR outbox.portfolio_id <> transition.portfolio_id
+                OR outbox.base_currency <> transition.base_currency
+                OR outbox.definition_fingerprint
+                    <> transition.definition_fingerprint
+                OR outbox.attribution_model_version
+                    <> transition.attribution_model_version
+                OR outbox.weighting_method <> transition.weighting_method
+                OR outbox.covariance_method <> transition.covariance_method
+                OR outbox.correlation_method <> transition.correlation_method
+                OR outbox.covariance_window <> transition.covariance_window
+                OR outbox.annualization_days <> transition.annualization_days
+                OR outbox.ts_event <> transition.ts_event
+                OR outbox.ts_ingest <> transition.ts_ingest
+                OR outbox.metric_name <> transition.metric_name
+                OR outbox.subject_type <> transition.subject_type
+                OR outbox.subject_key <> transition.subject_key
+                OR outbox.previous_subject_key IS DISTINCT FROM
+                    transition.previous_subject_key
+                OR outbox.subject_changed <> transition.subject_changed
+                OR outbox.unit <> transition.unit
+                OR outbox.previous_status IS DISTINCT FROM
+                    transition.previous_status
+                OR outbox.current_status <> transition.status
+                OR outbox.severity_rank <> transition.severity_rank
+                OR ABS(outbox.observed_value - transition.observed_value)
+                    > 0.0000000001
+                OR ABS(
+                    outbox.observed_signed_value
+                    - transition.observed_signed_value
+                ) > 0.0000000001
+                OR ABS(
+                    outbox.warning_threshold
+                    - transition.warning_threshold
+                ) > 0.0000000001
+                OR ABS(
+                    outbox.critical_threshold
+                    - transition.critical_threshold
+                ) > 0.0000000001
+                OR ABS(outbox.breach_excess - transition.breach_excess)
+                    > 0.0000000001
+        ) AS mismatched_transition_metadata,
+        (
+            SELECT COUNT(*) - COUNT(DISTINCT event_id)
+            FROM risk_platform.portfolio_risk_notification_outbox
+        ) AS duplicate_event_ids,
+        (
+            SELECT COUNT(*)
+            FROM risk_platform.portfolio_risk_notification_outbox
+            WHERE
+                (
+                    transition_type IN ('opened', 'escalated', 'resolved')
+                    AND (
+                        delivery_disposition <> 'pending'
+                        OR suppression_reason IS NOT NULL
+                    )
+                )
+                OR (
+                    transition_type = 'deescalated'
+                    AND (
+                        delivery_disposition <> 'suppressed'
+                        OR suppression_reason <> 'deescalation_not_routed'
+                    )
+                )
+        ) AS invalid_dispositions,
+        (
+            SELECT COUNT(*)
+            FROM risk_platform.portfolio_risk_notification_outbox
+            WHERE
+                payload_json ->> 'event_id' <> event_id
+                OR payload_json ->> 'event_type' <> event_type
+                OR payload_json ->> 'transition_type' <> transition_type
+                OR payload_json #>> '{policy,policy_id}' <> policy_id
+                OR payload_json #>> '{policy,policy_fingerprint}'
+                    <> policy_fingerprint
+                OR payload_json #>> '{portfolio,portfolio_id}'
+                    <> portfolio_id
+                OR payload_json #>> '{portfolio,definition_fingerprint}'
+                    <> definition_fingerprint
+                OR payload_json #>> '{portfolio,base_currency}'
+                    <> base_currency
+                OR payload_json #>> '{source,evaluation_calculation_id}'
+                    <> source_evaluation_calculation_id
+                OR payload_json #>> '{metric,name}' <> metric_name
+                OR payload_json #>> '{metric,subject_key}' <> subject_key
+                OR payload_json #>> '{metric,current_status}' <> current_status
+        ) AS invalid_payload_identity,
+        (
+            SELECT COUNT(*)
+            FROM risk_platform.portfolio_risk_limit_actionable_transitions transition
+            LEFT JOIN
+                risk_platform.current_portfolio_risk_notification_outbox outbox
+                ON outbox.source_evaluation_calculation_id
+                    = transition.calculation_id
+               AND outbox.transition_type = transition.transition_type
+               AND (
+                    outbox.source_previous_evaluation_calculation_id
+                        = transition.previous_calculation_id
+                    OR (
+                        outbox.source_previous_evaluation_calculation_id IS NULL
+                        AND transition.previous_calculation_id IS NULL
+                    )
+               )
+            WHERE outbox.event_id IS NULL
+        ) AS missing_current_candidates,
+        (
+            SELECT COUNT(*)
+            FROM risk_platform.current_portfolio_risk_notification_outbox outbox
+            WHERE NOT EXISTS (
+                SELECT 1
+                FROM risk_platform.portfolio_risk_limit_actionable_transitions transition
+                WHERE transition.calculation_id
+                        = outbox.source_evaluation_calculation_id
+                  AND transition.transition_type = outbox.transition_type
+                  AND (
+                        transition.previous_calculation_id
+                            = outbox.source_previous_evaluation_calculation_id
+                        OR (
+                            transition.previous_calculation_id IS NULL
+                            AND outbox.source_previous_evaluation_calculation_id
+                                IS NULL
+                        )
+                  )
+            )
+        ) AS stale_current_candidates
+)
+SELECT
+    'portfolio_notification_history_rows_present' AS check_name,
+    '>=0' AS expected,
+    history_rows::TEXT AS actual,
+    'pass' AS status
+FROM counts
+
+UNION ALL
+
+SELECT
+    'portfolio_notification_current_rows_match_actionable_transitions',
+    actionable_transition_rows::TEXT,
+    current_rows::TEXT,
+    CASE
+        WHEN actionable_transition_rows = current_rows THEN 'pass'
+        ELSE 'fail'
+    END
+FROM counts
+
+UNION ALL
+
+SELECT
+    'portfolio_notification_pending_view_matches',
+    expected_pending_rows::TEXT,
+    pending_rows::TEXT,
+    CASE WHEN expected_pending_rows = pending_rows THEN 'pass' ELSE 'fail' END
+FROM counts
+
+UNION ALL
+
+SELECT
+    'portfolio_notification_suppressed_view_matches',
+    expected_suppressed_rows::TEXT,
+    suppressed_rows::TEXT,
+    CASE
+        WHEN expected_suppressed_rows = suppressed_rows THEN 'pass'
+        ELSE 'fail'
+    END
+FROM counts
+
+UNION ALL
+
+SELECT
+    'portfolio_notification_summary_rows_reconcile',
+    current_rows::TEXT,
+    summary_event_rows::TEXT,
+    CASE WHEN current_rows = summary_event_rows THEN 'pass' ELSE 'fail' END
+FROM counts
+
+UNION ALL
+
+SELECT
+    'portfolio_notification_source_evaluations_exist',
+    '0',
+    orphan_source_evaluations::TEXT,
+    CASE WHEN orphan_source_evaluations = 0 THEN 'pass' ELSE 'fail' END
+FROM integrity
+
+UNION ALL
+
+SELECT
+    'portfolio_notification_previous_evaluations_exist',
+    '0',
+    orphan_previous_evaluations::TEXT,
+    CASE WHEN orphan_previous_evaluations = 0 THEN 'pass' ELSE 'fail' END
+FROM integrity
+
+UNION ALL
+
+SELECT
+    'portfolio_notification_transition_metadata_matches',
+    '0',
+    mismatched_transition_metadata::TEXT,
+    CASE
+        WHEN mismatched_transition_metadata = 0 THEN 'pass'
+        ELSE 'fail'
+    END
+FROM integrity
+
+UNION ALL
+
+SELECT
+    'portfolio_notification_event_ids_unique',
+    '0',
+    duplicate_event_ids::TEXT,
+    CASE WHEN duplicate_event_ids = 0 THEN 'pass' ELSE 'fail' END
+FROM integrity
+
+UNION ALL
+
+SELECT
+    'portfolio_notification_dispositions_valid',
+    '0',
+    invalid_dispositions::TEXT,
+    CASE WHEN invalid_dispositions = 0 THEN 'pass' ELSE 'fail' END
+FROM integrity
+
+UNION ALL
+
+SELECT
+    'portfolio_notification_payload_identity_matches',
+    '0',
+    invalid_payload_identity::TEXT,
+    CASE WHEN invalid_payload_identity = 0 THEN 'pass' ELSE 'fail' END
+FROM integrity
+
+UNION ALL
+
+SELECT
+    'portfolio_notification_current_candidates_complete',
+    '0',
+    missing_current_candidates::TEXT,
+    CASE WHEN missing_current_candidates = 0 THEN 'pass' ELSE 'fail' END
+FROM integrity
+
+UNION ALL
+
+SELECT
+    'portfolio_notification_current_candidates_not_stale',
+    '0',
+    stale_current_candidates::TEXT,
+    CASE WHEN stale_current_candidates = 0 THEN 'pass' ELSE 'fail' END
+FROM integrity
+
+ORDER BY check_name;

--- a/sql/portfolio_risk_notification_outbox_schema.sql
+++ b/sql/portfolio_risk_notification_outbox_schema.sql
@@ -1,0 +1,316 @@
+-- Durable notification candidates for portfolio risk-limit lifecycle transitions.
+-- Apply after sql/portfolio_risk_breach_lifecycle_schema.sql.
+-- This schema does not deliver messages to external systems.
+
+CREATE SCHEMA IF NOT EXISTS risk_platform;
+
+CREATE TABLE IF NOT EXISTS risk_platform.portfolio_risk_notification_outbox (
+    event_id TEXT PRIMARY KEY,
+    model_version TEXT NOT NULL,
+    event_type TEXT NOT NULL CHECK (
+        event_type IN (
+            'breach_opened',
+            'breach_escalated',
+            'breach_deescalated',
+            'breach_resolved'
+        )
+    ),
+    transition_type TEXT NOT NULL CHECK (
+        transition_type IN ('opened', 'escalated', 'deescalated', 'resolved')
+    ),
+    delivery_disposition TEXT NOT NULL CHECK (
+        delivery_disposition IN ('pending', 'suppressed')
+    ),
+    suppression_reason TEXT,
+    source_evaluation_calculation_id TEXT NOT NULL REFERENCES
+        risk_platform.portfolio_risk_limit_evaluations (calculation_id),
+    source_previous_evaluation_calculation_id TEXT REFERENCES
+        risk_platform.portfolio_risk_limit_evaluations (calculation_id),
+    risk_limit_model_version TEXT NOT NULL,
+    policy_id TEXT NOT NULL,
+    policy_fingerprint TEXT NOT NULL,
+    portfolio_id TEXT NOT NULL,
+    base_currency CHAR(3) NOT NULL,
+    definition_fingerprint TEXT NOT NULL,
+    attribution_model_version TEXT NOT NULL,
+    weighting_method TEXT NOT NULL,
+    covariance_method TEXT NOT NULL,
+    correlation_method TEXT NOT NULL,
+    covariance_window INTEGER NOT NULL CHECK (
+        covariance_window >= 2 AND covariance_window <= 2520
+    ),
+    annualization_days INTEGER NOT NULL CHECK (
+        annualization_days > 0 AND annualization_days <= 2520
+    ),
+    ts_event TIMESTAMPTZ NOT NULL,
+    ts_ingest TIMESTAMPTZ NOT NULL,
+    metric_name TEXT NOT NULL CHECK (
+        metric_name IN (
+            'portfolio_volatility_annualized',
+            'largest_absolute_component_contribution_share'
+        )
+    ),
+    subject_type TEXT NOT NULL CHECK (
+        subject_type IN ('portfolio', 'constituent')
+    ),
+    subject_key TEXT NOT NULL,
+    previous_subject_key TEXT,
+    subject_changed BOOLEAN NOT NULL,
+    unit TEXT NOT NULL CHECK (
+        unit IN ('annualized_decimal', 'absolute_share')
+    ),
+    previous_status TEXT CHECK (
+        previous_status IN ('ok', 'warning', 'critical')
+    ),
+    current_status TEXT NOT NULL CHECK (
+        current_status IN ('ok', 'warning', 'critical')
+    ),
+    severity_rank INTEGER NOT NULL CHECK (severity_rank IN (0, 1, 2)),
+    observed_value DOUBLE PRECISION NOT NULL,
+    observed_signed_value DOUBLE PRECISION NOT NULL,
+    warning_threshold DOUBLE PRECISION NOT NULL,
+    critical_threshold DOUBLE PRECISION NOT NULL,
+    breach_excess DOUBLE PRECISION NOT NULL,
+    payload_json JSONB NOT NULL,
+    loaded_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    CHECK (event_id <> ''),
+    CHECK (model_version <> ''),
+    CHECK (source_evaluation_calculation_id <> ''),
+    CHECK (
+        source_previous_evaluation_calculation_id IS NULL
+        OR source_previous_evaluation_calculation_id <> ''
+    ),
+    CHECK (risk_limit_model_version <> ''),
+    CHECK (policy_id <> ''),
+    CHECK (policy_fingerprint <> ''),
+    CHECK (portfolio_id <> ''),
+    CHECK (base_currency = UPPER(base_currency)),
+    CHECK (definition_fingerprint <> ''),
+    CHECK (attribution_model_version <> ''),
+    CHECK (weighting_method <> ''),
+    CHECK (covariance_method <> ''),
+    CHECK (correlation_method <> ''),
+    CHECK (subject_key <> ''),
+    CHECK (previous_subject_key IS NULL OR previous_subject_key <> ''),
+    CHECK (ts_ingest >= ts_event),
+    CHECK (
+        observed_value >= 0
+        AND observed_value < 'Infinity'::DOUBLE PRECISION
+        AND observed_value <> 'NaN'::DOUBLE PRECISION
+    ),
+    CHECK (
+        observed_signed_value > '-Infinity'::DOUBLE PRECISION
+        AND observed_signed_value < 'Infinity'::DOUBLE PRECISION
+        AND observed_signed_value <> 'NaN'::DOUBLE PRECISION
+    ),
+    CHECK (
+        warning_threshold > 0
+        AND critical_threshold > warning_threshold
+        AND critical_threshold < 'Infinity'::DOUBLE PRECISION
+    ),
+    CHECK (
+        breach_excess >= 0
+        AND breach_excess < 'Infinity'::DOUBLE PRECISION
+    ),
+    CHECK (
+        (current_status = 'ok' AND severity_rank = 0)
+        OR (current_status = 'warning' AND severity_rank = 1)
+        OR (current_status = 'critical' AND severity_rank = 2)
+    ),
+    CHECK (
+        subject_changed = (
+            previous_subject_key IS NOT NULL
+            AND previous_subject_key <> subject_key
+        )
+    ),
+    CHECK (
+        (transition_type = 'opened'
+            AND (previous_status IS NULL OR previous_status = 'ok')
+            AND current_status IN ('warning', 'critical'))
+        OR (transition_type = 'escalated'
+            AND previous_status = 'warning'
+            AND current_status = 'critical')
+        OR (transition_type = 'deescalated'
+            AND previous_status = 'critical'
+            AND current_status = 'warning')
+        OR (transition_type = 'resolved'
+            AND previous_status IN ('warning', 'critical')
+            AND current_status = 'ok')
+    ),
+    CHECK (
+        (previous_status IS NULL
+            AND source_previous_evaluation_calculation_id IS NULL)
+        OR (previous_status IS NOT NULL
+            AND source_previous_evaluation_calculation_id IS NOT NULL)
+    ),
+    CHECK (
+        (transition_type = 'opened' AND event_type = 'breach_opened')
+        OR (transition_type = 'escalated'
+            AND event_type = 'breach_escalated')
+        OR (transition_type = 'deescalated'
+            AND event_type = 'breach_deescalated')
+        OR (transition_type = 'resolved'
+            AND event_type = 'breach_resolved')
+    ),
+    CHECK (
+        (transition_type IN ('opened', 'escalated', 'resolved')
+            AND delivery_disposition = 'pending'
+            AND suppression_reason IS NULL)
+        OR (transition_type = 'deescalated'
+            AND delivery_disposition = 'suppressed'
+            AND suppression_reason = 'deescalation_not_routed')
+    ),
+    CHECK (
+        (metric_name = 'portfolio_volatility_annualized'
+            AND subject_type = 'portfolio'
+            AND subject_key = portfolio_id
+            AND unit = 'annualized_decimal'
+            AND observed_signed_value = observed_value)
+        OR (metric_name
+                = 'largest_absolute_component_contribution_share'
+            AND subject_type = 'constituent'
+            AND unit = 'absolute_share'
+            AND ABS(ABS(observed_signed_value) - observed_value)
+                <= 0.0000000001)
+    ),
+    CHECK (
+        model_version <> 'portfolio-risk-notification-outbox-v1'
+        OR (
+            risk_limit_model_version = 'portfolio-risk-limits-v1'
+            AND attribution_model_version = 'portfolio-attribution-v1'
+            AND weighting_method = 'constant_weight_daily_rebalanced'
+            AND covariance_method = 'sample_annualized'
+            AND correlation_method = 'pearson'
+        )
+    ),
+    CHECK (jsonb_typeof(payload_json) = 'object'),
+    CHECK (payload_json ->> 'event_id' = event_id),
+    CHECK (payload_json ->> 'event_type' = event_type),
+    CHECK (payload_json ->> 'transition_type' = transition_type),
+    CHECK (
+        payload_json #>> '{policy,policy_id}' = policy_id
+        AND payload_json #>> '{policy,policy_fingerprint}'
+            = policy_fingerprint
+    ),
+    CHECK (
+        payload_json #>> '{portfolio,portfolio_id}' = portfolio_id
+        AND payload_json #>> '{portfolio,definition_fingerprint}'
+            = definition_fingerprint
+        AND payload_json #>> '{portfolio,base_currency}' = base_currency
+    ),
+    CHECK (
+        payload_json #>> '{source,evaluation_calculation_id}'
+            = source_evaluation_calculation_id
+    )
+);
+
+CREATE INDEX IF NOT EXISTS idx_portfolio_notification_outbox_lookup
+    ON risk_platform.portfolio_risk_notification_outbox (
+        policy_id,
+        policy_fingerprint,
+        portfolio_id,
+        definition_fingerprint,
+        ts_event DESC,
+        metric_name,
+        transition_type,
+        loaded_at DESC,
+        event_id
+    );
+
+CREATE INDEX IF NOT EXISTS idx_portfolio_notification_outbox_pending
+    ON risk_platform.portfolio_risk_notification_outbox (
+        policy_id,
+        portfolio_id,
+        ts_event,
+        event_type
+    )
+    WHERE delivery_disposition = 'pending';
+
+CREATE OR REPLACE VIEW
+risk_platform.current_portfolio_risk_notification_outbox AS
+SELECT
+    outbox.event_id,
+    outbox.model_version,
+    outbox.event_type,
+    outbox.transition_type,
+    outbox.delivery_disposition,
+    outbox.suppression_reason,
+    outbox.source_evaluation_calculation_id,
+    outbox.source_previous_evaluation_calculation_id,
+    outbox.risk_limit_model_version,
+    outbox.policy_id,
+    outbox.policy_fingerprint,
+    outbox.portfolio_id,
+    outbox.base_currency,
+    outbox.definition_fingerprint,
+    outbox.attribution_model_version,
+    outbox.weighting_method,
+    outbox.covariance_method,
+    outbox.correlation_method,
+    outbox.covariance_window,
+    outbox.annualization_days,
+    outbox.ts_event,
+    outbox.ts_ingest,
+    outbox.metric_name,
+    outbox.subject_type,
+    outbox.subject_key,
+    outbox.previous_subject_key,
+    outbox.subject_changed,
+    outbox.unit,
+    outbox.previous_status,
+    outbox.current_status,
+    outbox.severity_rank,
+    outbox.observed_value,
+    outbox.observed_signed_value,
+    outbox.warning_threshold,
+    outbox.critical_threshold,
+    outbox.breach_excess,
+    outbox.payload_json,
+    outbox.loaded_at
+FROM risk_platform.portfolio_risk_notification_outbox outbox
+JOIN risk_platform.portfolio_risk_limit_actionable_transitions transition
+  ON transition.calculation_id
+        = outbox.source_evaluation_calculation_id
+ AND transition.transition_type = outbox.transition_type
+ AND (
+        transition.previous_calculation_id
+            = outbox.source_previous_evaluation_calculation_id
+        OR (
+            transition.previous_calculation_id IS NULL
+            AND outbox.source_previous_evaluation_calculation_id IS NULL
+        )
+    );
+
+CREATE OR REPLACE VIEW risk_platform.portfolio_risk_notification_pending AS
+SELECT *
+FROM risk_platform.current_portfolio_risk_notification_outbox
+WHERE delivery_disposition = 'pending';
+
+CREATE OR REPLACE VIEW risk_platform.portfolio_risk_notification_suppressed AS
+SELECT *
+FROM risk_platform.current_portfolio_risk_notification_outbox
+WHERE delivery_disposition = 'suppressed';
+
+CREATE OR REPLACE VIEW risk_platform.portfolio_risk_notification_outbox_summary AS
+SELECT
+    policy_id,
+    policy_fingerprint,
+    portfolio_id,
+    definition_fingerprint,
+    metric_name,
+    event_type,
+    transition_type,
+    delivery_disposition,
+    COUNT(*) AS event_count,
+    MIN(ts_event) AS first_event_time,
+    MAX(ts_event) AS last_event_time
+FROM risk_platform.current_portfolio_risk_notification_outbox
+GROUP BY
+    policy_id,
+    policy_fingerprint,
+    portfolio_id,
+    definition_fingerprint,
+    metric_name,
+    event_type,
+    transition_type,
+    delivery_disposition;

--- a/src/analytics/portfolio_risk_notification_outbox.py
+++ b/src/analytics/portfolio_risk_notification_outbox.py
@@ -1,0 +1,522 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
+from datetime import date, datetime, timezone
+from typing import Any, TypeAlias
+
+from ..common.exceptions import ValidationError
+from .portfolio_risk_limits import (
+    CONCENTRATION_METRIC,
+    MODEL_VERSION as RISK_LIMIT_MODEL_VERSION,
+    VOLATILITY_METRIC,
+)
+
+MODEL_VERSION = "portfolio-risk-notification-outbox-v1"
+MAX_NOTIFICATION_EVENTS = 10_000
+ACTIONABLE_TRANSITIONS = frozenset(
+    {"opened", "escalated", "deescalated", "resolved"}
+)
+PENDING_TRANSITIONS = frozenset({"opened", "escalated", "resolved"})
+EVENT_TYPES = {
+    "opened": "breach_opened",
+    "escalated": "breach_escalated",
+    "deescalated": "breach_deescalated",
+    "resolved": "breach_resolved",
+}
+
+TransitionInput: TypeAlias = Mapping[str, Any]
+
+
+@dataclass(frozen=True, slots=True)
+class PortfolioRiskNotificationOutput:
+    events: tuple[dict[str, Any], ...]
+    diagnostics: Mapping[str, Any]
+
+
+def _required_text(value: Any, label: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ValidationError(f"{label} must be non-empty text")
+    return value.strip()
+
+
+def _aware_utc(value: Any, label: str) -> datetime:
+    parsed: datetime | None = None
+    if isinstance(value, datetime):
+        parsed = value
+    elif isinstance(value, str):
+        try:
+            parsed = datetime.fromisoformat(value.strip().replace("Z", "+00:00"))
+        except ValueError:
+            parsed = None
+    if parsed is None or parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise ValidationError(f"{label} must be a timezone-aware timestamp")
+    return parsed.astimezone(timezone.utc)
+
+
+def _finite_number(
+    value: Any,
+    label: str,
+    *,
+    minimum: float | None = None,
+) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ValidationError(f"{label} must be a finite number")
+    parsed = float(value)
+    if not math.isfinite(parsed):
+        raise ValidationError(f"{label} must be a finite number")
+    if minimum is not None and parsed < minimum:
+        raise ValidationError(f"{label} must be at least {minimum}")
+    return parsed
+
+
+def _positive_integer(value: Any, label: str, maximum: int) -> int:
+    if type(value) is not int or not 1 <= value <= maximum:
+        raise ValidationError(
+            f"{label} must be an integer between 1 and {maximum}"
+        )
+    return value
+
+
+def _optional_text(value: Any, label: str) -> str | None:
+    if value is None:
+        return None
+    return _required_text(value, label)
+
+
+def _transition_contract(
+    previous_status: str | None,
+    current_status: str,
+    transition_type: str,
+) -> None:
+    if current_status not in {"ok", "warning", "critical"}:
+        raise ValidationError("status is invalid")
+    if previous_status is not None and previous_status not in {
+        "ok",
+        "warning",
+        "critical",
+    }:
+        raise ValidationError("previous_status is invalid")
+    valid = (
+        transition_type == "opened"
+        and previous_status in {None, "ok"}
+        and current_status in {"warning", "critical"}
+    ) or (
+        transition_type == "escalated"
+        and previous_status == "warning"
+        and current_status == "critical"
+    ) or (
+        transition_type == "deescalated"
+        and previous_status == "critical"
+        and current_status == "warning"
+    ) or (
+        transition_type == "resolved"
+        and previous_status in {"warning", "critical"}
+        and current_status == "ok"
+    )
+    if not valid:
+        raise ValidationError(
+            "transition statuses do not match transition_type"
+        )
+
+
+def _normalise_transition(candidate: TransitionInput) -> dict[str, Any] | None:
+    if not isinstance(candidate, Mapping):
+        raise ValidationError(
+            "notification input must contain transition mappings"
+        )
+    transition_type = _required_text(
+        candidate.get("transition_type"),
+        "transition_type",
+    )
+    if transition_type not in ACTIONABLE_TRANSITIONS:
+        if transition_type in {"initial_ok", "unchanged"}:
+            return None
+        raise ValidationError("transition_type is invalid")
+
+    previous_status = _optional_text(
+        candidate.get("previous_status"),
+        "previous_status",
+    )
+    current_status = _required_text(candidate.get("status"), "status")
+    _transition_contract(previous_status, current_status, transition_type)
+
+    event_ts = _aware_utc(candidate.get("ts_event"), "ts_event")
+    ingest_ts = _aware_utc(candidate.get("ts_ingest"), "ts_ingest")
+    if ingest_ts < event_ts:
+        raise ValidationError("ts_ingest must be on or after ts_event")
+
+    metric_name = _required_text(candidate.get("metric_name"), "metric_name")
+    subject_type = _required_text(
+        candidate.get("subject_type"),
+        "subject_type",
+    )
+    subject_key = _required_text(candidate.get("subject_key"), "subject_key")
+    unit = _required_text(candidate.get("unit"), "unit")
+    observed_value = _finite_number(
+        candidate.get("observed_value"),
+        "observed_value",
+        minimum=0.0,
+    )
+    observed_signed_value = _finite_number(
+        candidate.get("observed_signed_value"),
+        "observed_signed_value",
+    )
+    if metric_name == VOLATILITY_METRIC:
+        if (
+            subject_type != "portfolio"
+            or unit != "annualized_decimal"
+            or not math.isclose(
+                observed_signed_value,
+                observed_value,
+                rel_tol=0.0,
+                abs_tol=1e-12,
+            )
+        ):
+            raise ValidationError(
+                "portfolio volatility transition has invalid subject evidence"
+            )
+    elif metric_name == CONCENTRATION_METRIC:
+        if (
+            subject_type != "constituent"
+            or unit != "absolute_share"
+            or not math.isclose(
+                abs(observed_signed_value),
+                observed_value,
+                rel_tol=0.0,
+                abs_tol=1e-12,
+            )
+        ):
+            raise ValidationError(
+                "component concentration transition has invalid subject evidence"
+            )
+    else:
+        raise ValidationError("metric_name is unsupported")
+
+    warning_threshold = _finite_number(
+        candidate.get("warning_threshold"),
+        "warning_threshold",
+        minimum=0.0,
+    )
+    critical_threshold = _finite_number(
+        candidate.get("critical_threshold"),
+        "critical_threshold",
+        minimum=0.0,
+    )
+    if warning_threshold <= 0 or critical_threshold <= warning_threshold:
+        raise ValidationError(
+            "thresholds must satisfy 0 < warning < critical"
+        )
+
+    breach_excess = _finite_number(
+        candidate.get("breach_excess"),
+        "breach_excess",
+        minimum=0.0,
+    )
+    severity_rank = candidate.get("severity_rank")
+    expected_rank = {"ok": 0, "warning": 1, "critical": 2}[current_status]
+    if type(severity_rank) is not int or severity_rank != expected_rank:
+        raise ValidationError("severity_rank does not match status")
+
+    subject_changed = candidate.get("subject_changed")
+    if type(subject_changed) is not bool:
+        raise ValidationError("subject_changed must be boolean")
+    previous_subject_key = _optional_text(
+        candidate.get("previous_subject_key"),
+        "previous_subject_key",
+    )
+    if subject_changed != (
+        previous_subject_key is not None
+        and previous_subject_key != subject_key
+    ):
+        raise ValidationError(
+            "subject_changed does not match subject evidence"
+        )
+
+    covariance_window = candidate.get("covariance_window")
+    annualization_days = candidate.get("annualization_days")
+    if type(covariance_window) is not int or covariance_window < 2:
+        raise ValidationError(
+            "covariance_window must be an integer of at least 2"
+        )
+    if type(annualization_days) is not int or annualization_days < 1:
+        raise ValidationError(
+            "annualization_days must be a positive integer"
+        )
+
+    risk_limit_model_version = _required_text(
+        candidate.get("model_version"),
+        "risk-limit model_version",
+    )
+    if risk_limit_model_version != RISK_LIMIT_MODEL_VERSION:
+        raise ValidationError("risk-limit model_version is unsupported")
+
+    source_calculation_id = _required_text(
+        candidate.get("calculation_id"),
+        "source calculation_id",
+    )
+    previous_calculation_id = _optional_text(
+        candidate.get("previous_calculation_id"),
+        "previous_calculation_id",
+    )
+    if previous_status is None and previous_calculation_id is not None:
+        raise ValidationError(
+            "previous calculation requires previous_status"
+        )
+    if previous_status is not None and previous_calculation_id is None:
+        raise ValidationError(
+            "previous_status requires previous calculation"
+        )
+
+    return {
+        "source_evaluation_calculation_id": source_calculation_id,
+        "source_previous_evaluation_calculation_id": previous_calculation_id,
+        "risk_limit_model_version": risk_limit_model_version,
+        "policy_id": _required_text(candidate.get("policy_id"), "policy_id"),
+        "policy_fingerprint": _required_text(
+            candidate.get("policy_fingerprint"),
+            "policy_fingerprint",
+        ),
+        "portfolio_id": _required_text(
+            candidate.get("portfolio_id"),
+            "portfolio_id",
+        ),
+        "base_currency": _required_text(
+            candidate.get("base_currency"),
+            "base_currency",
+        ),
+        "definition_fingerprint": _required_text(
+            candidate.get("definition_fingerprint"),
+            "definition_fingerprint",
+        ),
+        "attribution_model_version": _required_text(
+            candidate.get("attribution_model_version"),
+            "attribution_model_version",
+        ),
+        "weighting_method": _required_text(
+            candidate.get("weighting_method"),
+            "weighting_method",
+        ),
+        "covariance_method": _required_text(
+            candidate.get("covariance_method"),
+            "covariance_method",
+        ),
+        "correlation_method": _required_text(
+            candidate.get("correlation_method"),
+            "correlation_method",
+        ),
+        "covariance_window": covariance_window,
+        "annualization_days": annualization_days,
+        "ts_event": event_ts,
+        "ts_ingest": ingest_ts,
+        "metric_name": metric_name,
+        "subject_type": subject_type,
+        "subject_key": subject_key,
+        "previous_subject_key": previous_subject_key,
+        "subject_changed": subject_changed,
+        "unit": unit,
+        "previous_status": previous_status,
+        "current_status": current_status,
+        "severity_rank": severity_rank,
+        "observed_value": observed_value,
+        "observed_signed_value": observed_signed_value,
+        "warning_threshold": warning_threshold,
+        "critical_threshold": critical_threshold,
+        "breach_excess": breach_excess,
+        "transition_type": transition_type,
+    }
+
+
+def _event_id(record: Mapping[str, Any]) -> str:
+    payload = {
+        "metric_name": record["metric_name"],
+        "model_version": MODEL_VERSION,
+        "policy_fingerprint": record["policy_fingerprint"],
+        "source_evaluation_calculation_id": record[
+            "source_evaluation_calculation_id"
+        ],
+        "source_previous_evaluation_calculation_id": record[
+            "source_previous_evaluation_calculation_id"
+        ],
+        "transition_type": record["transition_type"],
+    }
+    digest = hashlib.sha256(
+        json.dumps(
+            payload,
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+    ).hexdigest()[:24]
+    return f"{MODEL_VERSION}-event-{digest}"
+
+
+def _payload(record: Mapping[str, Any], event_id: str) -> str:
+    payload = {
+        "event_id": event_id,
+        "event_type": EVENT_TYPES[record["transition_type"]],
+        "transition_type": record["transition_type"],
+        "policy": {
+            "policy_id": record["policy_id"],
+            "policy_fingerprint": record["policy_fingerprint"],
+        },
+        "portfolio": {
+            "portfolio_id": record["portfolio_id"],
+            "definition_fingerprint": record["definition_fingerprint"],
+            "base_currency": record["base_currency"],
+        },
+        "metric": {
+            "name": record["metric_name"],
+            "subject_type": record["subject_type"],
+            "subject_key": record["subject_key"],
+            "previous_subject_key": record["previous_subject_key"],
+            "subject_changed": record["subject_changed"],
+            "unit": record["unit"],
+            "previous_status": record["previous_status"],
+            "current_status": record["current_status"],
+            "observed_value": record["observed_value"],
+            "observed_signed_value": record["observed_signed_value"],
+            "warning_threshold": record["warning_threshold"],
+            "critical_threshold": record["critical_threshold"],
+            "breach_excess": record["breach_excess"],
+        },
+        "source": {
+            "evaluation_calculation_id": record[
+                "source_evaluation_calculation_id"
+            ],
+            "previous_evaluation_calculation_id": record[
+                "source_previous_evaluation_calculation_id"
+            ],
+            "ts_event": record["ts_event"].isoformat(),
+            "ts_ingest": record["ts_ingest"].isoformat(),
+        },
+    }
+    return json.dumps(
+        payload,
+        sort_keys=True,
+        separators=(",", ":"),
+        allow_nan=False,
+    )
+
+
+def _event_record(record: Mapping[str, Any]) -> dict[str, Any]:
+    event_id = _event_id(record)
+    pending = record["transition_type"] in PENDING_TRANSITIONS
+    return {
+        "event_id": event_id,
+        "model_version": MODEL_VERSION,
+        "event_type": EVENT_TYPES[record["transition_type"]],
+        "transition_type": record["transition_type"],
+        "delivery_disposition": "pending" if pending else "suppressed",
+        "suppression_reason": (
+            None if pending else "deescalation_not_routed"
+        ),
+        **dict(record),
+        "payload_json": _payload(record, event_id),
+    }
+
+
+def _event_signature(event: Mapping[str, Any]) -> tuple[Any, ...]:
+    return tuple((key, event[key]) for key in sorted(event))
+
+
+def build_portfolio_risk_notification_outbox(
+    records: Iterable[TransitionInput],
+    *,
+    start_date: date | None = None,
+    end_date: date | None = None,
+    max_events: int = MAX_NOTIFICATION_EVENTS,
+) -> PortfolioRiskNotificationOutput:
+    if start_date is not None and end_date is not None and start_date > end_date:
+        raise ValidationError("start_date must be on or before end_date")
+    max_events = _positive_integer(
+        max_events,
+        "max_events",
+        MAX_NOTIFICATION_EVENTS,
+    )
+
+    events_by_id: dict[str, dict[str, Any]] = {}
+    signatures: dict[str, tuple[Any, ...]] = {}
+    matched_transitions = 0
+    skipped_non_actionable = 0
+    skipped_date_range = 0
+    for candidate in records:
+        record = _normalise_transition(candidate)
+        if record is None:
+            skipped_non_actionable += 1
+            continue
+        matched_transitions += 1
+        event_date = record["ts_event"].date()
+        if (
+            (start_date is not None and event_date < start_date)
+            or (end_date is not None and event_date > end_date)
+        ):
+            skipped_date_range += 1
+            continue
+
+        event = _event_record(record)
+        event_id = event["event_id"]
+        signature = _event_signature(event)
+        previous_signature = signatures.get(event_id)
+        if previous_signature is not None:
+            if previous_signature != signature:
+                raise ValidationError(
+                    "notification event IDs must not contain conflicting records"
+                )
+            continue
+        signatures[event_id] = signature
+        events_by_id[event_id] = event
+        if len(events_by_id) > max_events:
+            raise ValidationError(
+                "notification outbox exceeds max_events; split the date range"
+            )
+
+    if not events_by_id:
+        raise ValidationError(
+            "no actionable risk-limit transitions matched the requested range"
+        )
+
+    events = tuple(
+        sorted(
+            events_by_id.values(),
+            key=lambda item: (
+                item["ts_event"],
+                item["metric_name"],
+                item["transition_type"],
+                item["event_id"],
+            ),
+        )
+    )
+    diagnostics = {
+        "matched_actionable_transitions": matched_transitions,
+        "events_selected": len(events),
+        "events_pending": sum(
+            1
+            for event in events
+            if event["delivery_disposition"] == "pending"
+        ),
+        "events_suppressed": sum(
+            1
+            for event in events
+            if event["delivery_disposition"] == "suppressed"
+        ),
+        "skipped_non_actionable_transitions": skipped_non_actionable,
+        "skipped_outside_date_range": skipped_date_range,
+        "event_type_counts": {
+            event_type: sum(
+                1
+                for event in events
+                if event["event_type"] == event_type
+            )
+            for event_type in sorted(set(EVENT_TYPES.values()))
+        },
+        "first_event_date": events[0]["ts_event"].date().isoformat(),
+        "last_event_date": events[-1]["ts_event"].date().isoformat(),
+        "max_events": max_events,
+    }
+    return PortfolioRiskNotificationOutput(
+        events=events,
+        diagnostics=diagnostics,
+    )

--- a/src/orchestration/run_portfolio_risk_notification_outbox.py
+++ b/src/orchestration/run_portfolio_risk_notification_outbox.py
@@ -1,0 +1,390 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from collections.abc import Callable, Sequence
+from datetime import date
+from pathlib import Path
+from typing import Any
+from uuid import uuid4
+
+from ..analytics.portfolio_risk_notification_outbox import (
+    MAX_NOTIFICATION_EVENTS,
+    PortfolioRiskNotificationOutput,
+    build_portfolio_risk_notification_outbox,
+)
+from ..common.exceptions import StorageError, ValidationError
+from ..storage.s3_writer import write_records
+from ..storage.storage_config import load_storage_config, validate_storage_config
+from ..warehouse.postgres_loader import DEFAULT_POSTGRES_DSN
+
+INPUT_VIEW = "portfolio_risk_limit_actionable_transitions"
+OUTPUT_DATASET = "portfolio_risk_notification_outbox"
+
+Reader = Callable[..., list[dict[str, Any]]]
+Writer = Callable[..., int]
+StorageConfigLoader = Callable[[Path], dict[str, Any]]
+
+TRANSITION_COLUMNS = (
+    "calculation_id",
+    "model_version",
+    "policy_id",
+    "policy_fingerprint",
+    "portfolio_id",
+    "base_currency",
+    "definition_fingerprint",
+    "attribution_calculation_id",
+    "attribution_model_version",
+    "weighting_method",
+    "covariance_method",
+    "correlation_method",
+    "covariance_window",
+    "annualization_days",
+    "ts_event",
+    "ts_ingest",
+    "metric_name",
+    "subject_type",
+    "subject_key",
+    "unit",
+    "observed_value",
+    "observed_signed_value",
+    "warning_threshold",
+    "critical_threshold",
+    "status",
+    "is_breach",
+    "breach_threshold",
+    "breach_excess",
+    "previous_status",
+    "previous_calculation_id",
+    "previous_subject_key",
+    "transition_type",
+    "severity_rank",
+    "subject_changed",
+)
+
+
+def _calendar_date(value: str) -> date:
+    try:
+        parsed = date.fromisoformat(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(
+            "must be a calendar date in YYYY-MM-DD format"
+        ) from exc
+    if value != parsed.isoformat():
+        raise argparse.ArgumentTypeError(
+            "must be a calendar date in YYYY-MM-DD format"
+        )
+    return parsed
+
+
+def _max_events(value: str) -> int:
+    try:
+        parsed = int(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(
+            "max_events must be a positive integer"
+        ) from exc
+    if not 1 <= parsed <= MAX_NOTIFICATION_EVENTS:
+        raise argparse.ArgumentTypeError(
+            f"max_events must be between 1 and {MAX_NOTIFICATION_EVENTS}"
+        )
+    return parsed
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Build replay-safe notification-outbox candidates from current "
+            "portfolio risk-limit transitions without delivering messages."
+        )
+    )
+    parser.add_argument("--policy-id", required=True)
+    parser.add_argument("--start-date", type=_calendar_date)
+    parser.add_argument("--end-date", required=True, type=_calendar_date)
+    parser.add_argument(
+        "--max-events",
+        type=_max_events,
+        default=MAX_NOTIFICATION_EVENTS,
+    )
+    parser.add_argument(
+        "--dsn",
+        default=os.environ.get(
+            "WAREHOUSE_POSTGRES_DSN",
+            DEFAULT_POSTGRES_DSN,
+        ),
+    )
+    parser.add_argument(
+        "--storage-config",
+        type=Path,
+        default=Path("config/storage.yaml"),
+    )
+    parser.add_argument("--summary-json", type=Path)
+    return parser
+
+
+def _require_output_dataset(storage_config: dict[str, Any]) -> None:
+    validate_storage_config(storage_config)
+    datasets = storage_config["storage"]["curated"]["datasets"]
+    if OUTPUT_DATASET not in datasets:
+        raise StorageError(
+            "Storage configuration is missing "
+            f"'{OUTPUT_DATASET}'"
+        )
+
+
+def read_actionable_transitions(
+    *,
+    dsn: str,
+    policy_id: str,
+    start_date: date | None,
+    end_date: date,
+    max_events: int,
+    schema_name: str = "risk_platform",
+) -> list[dict[str, Any]]:
+    if not isinstance(dsn, str) or not dsn.strip():
+        raise StorageError("PostgreSQL DSN must be non-empty text")
+    if not isinstance(policy_id, str) or not policy_id.strip():
+        raise ValidationError("policy_id must be non-empty text")
+    if start_date is not None and start_date > end_date:
+        raise ValidationError("start_date must be on or before end_date")
+    if (
+        type(max_events) is not int
+        or not 1 <= max_events <= MAX_NOTIFICATION_EVENTS
+    ):
+        raise ValidationError(
+            f"max_events must be between 1 and {MAX_NOTIFICATION_EVENTS}"
+        )
+
+    try:
+        import psycopg
+        from psycopg.rows import dict_row
+    except ImportError as exc:
+        raise RuntimeError(
+            "PostgreSQL transition reading requires psycopg. "
+            "Run `make setup` first."
+        ) from exc
+
+    quoted_schema = '"' + schema_name.replace('"', '""') + '"'
+    quoted_view = '"' + INPUT_VIEW.replace('"', '""') + '"'
+    selected = ", ".join('"' + column + '"' for column in TRANSITION_COLUMNS)
+    clauses = [
+        "policy_id = %s",
+        "ts_event < (%s::date + INTERVAL '1 day')",
+    ]
+    parameters: list[Any] = [policy_id.strip(), end_date]
+    if start_date is not None:
+        clauses.append("ts_event >= %s::date")
+        parameters.append(start_date)
+    parameters.append(max_events + 1)
+    statement = (
+        f"SELECT {selected} FROM {quoted_schema}.{quoted_view} "
+        f"WHERE {' AND '.join(clauses)} "
+        "ORDER BY ts_event, metric_name, transition_type, calculation_id "
+        "LIMIT %s"
+    )
+
+    try:
+        with psycopg.connect(dsn, row_factory=dict_row) as connection:
+            with connection.cursor() as cursor:
+                cursor.execute(statement, parameters)
+                records = [dict(row) for row in cursor.fetchall()]
+    except Exception:
+        raise StorageError(
+            "Unable to read current portfolio risk-limit transitions"
+        ) from None
+
+    if len(records) > max_events:
+        raise ValidationError(
+            "notification outbox input exceeds max_events; split the date range"
+        )
+    if not records:
+        raise ValidationError(
+            "no actionable risk-limit transitions matched the requested range"
+        )
+    return records
+
+
+def _publish(
+    events: tuple[dict[str, Any], ...],
+    *,
+    storage_config: dict[str, Any],
+    writer: Writer,
+) -> int:
+    written = 0
+    for event in events:
+        try:
+            result = writer(
+                [event],
+                kind="curated",
+                dataset=OUTPUT_DATASET,
+                storage_config=storage_config,
+            )
+        except Exception:
+            raise StorageError(
+                "Portfolio notification-outbox publication failed; rerun is safe"
+            ) from None
+        if type(result) is not int or result not in {0, 1}:
+            raise StorageError(
+                "Portfolio notification-outbox publication returned an invalid result"
+            )
+        written += result
+    return written
+
+
+def run_portfolio_risk_notification_outbox(
+    *,
+    policy_id: str,
+    start_date: date | None,
+    end_date: date,
+    max_events: int,
+    dsn: str,
+    storage_config_path: Path,
+    reader: Reader | None = None,
+    writer: Writer | None = None,
+    storage_config_loader: StorageConfigLoader | None = None,
+) -> dict[str, Any]:
+    if start_date is not None and start_date > end_date:
+        raise ValidationError("start_date must be on or before end_date")
+
+    selected_storage_loader = storage_config_loader or load_storage_config
+    try:
+        storage_config = selected_storage_loader(storage_config_path)
+    except Exception:
+        raise StorageError("Storage configuration is invalid") from None
+    if not isinstance(storage_config, dict):
+        raise StorageError("Storage configuration is invalid")
+    _require_output_dataset(storage_config)
+
+    selected_reader = reader or read_actionable_transitions
+    try:
+        records = selected_reader(
+            dsn=dsn,
+            policy_id=policy_id,
+            start_date=start_date,
+            end_date=end_date,
+            max_events=max_events,
+        )
+    except (StorageError, ValidationError):
+        raise
+    except Exception:
+        raise StorageError(
+            "Unable to read current portfolio risk-limit transitions"
+        ) from None
+
+    output: PortfolioRiskNotificationOutput = (
+        build_portfolio_risk_notification_outbox(
+            records,
+            start_date=start_date,
+            end_date=end_date,
+            max_events=max_events,
+        )
+    )
+    selected_writer = writer or write_records
+    written = _publish(
+        output.events,
+        storage_config=storage_config,
+        writer=selected_writer,
+    )
+    selected = len(output.events)
+    pending = sum(
+        1
+        for event in output.events
+        if event["delivery_disposition"] == "pending"
+    )
+    suppressed = selected - pending
+    latest = output.events[-1]
+
+    return {
+        "run_id": str(uuid4()),
+        "policy_id": policy_id,
+        "selection": dict(output.diagnostics),
+        "parameters": {
+            "start_date": start_date.isoformat() if start_date else None,
+            "end_date": end_date.isoformat(),
+            "max_events": max_events,
+        },
+        "curated_output": {
+            OUTPUT_DATASET: {
+                "records_selected": selected,
+                "records_written": written,
+                "records_already_present": selected - written,
+                "pending_delivery_candidates": pending,
+                "suppressed_candidates": suppressed,
+            }
+        },
+        "delivery": {
+            "performed": False,
+            "external_destinations": 0,
+            "reason": "delivery_not_implemented",
+        },
+        "latest_event": {
+            "event_id": latest["event_id"],
+            "event_type": latest["event_type"],
+            "transition_type": latest["transition_type"],
+            "delivery_disposition": latest["delivery_disposition"],
+            "metric_name": latest["metric_name"],
+            "subject_key": latest["subject_key"],
+            "ts_event": latest["ts_event"].isoformat(),
+        },
+    }
+
+
+def _write_summary(path: Path, summary: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary_path = path.with_suffix(path.suffix + ".tmp")
+    try:
+        temporary_path.write_text(
+            json.dumps(summary, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        temporary_path.replace(path)
+    except OSError:
+        temporary_path.unlink(missing_ok=True)
+        raise StorageError(
+            "Unable to write portfolio notification-outbox summary"
+        ) from None
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    try:
+        summary = run_portfolio_risk_notification_outbox(
+            policy_id=args.policy_id,
+            start_date=args.start_date,
+            end_date=args.end_date,
+            max_events=args.max_events,
+            dsn=args.dsn,
+            storage_config_path=args.storage_config,
+        )
+        if args.summary_json is not None:
+            _write_summary(args.summary_json, summary)
+    except ValidationError:
+        print(
+            "Portfolio notification-outbox generation failed: input data "
+            "or options were invalid",
+            file=sys.stderr,
+        )
+        return 1
+    except StorageError:
+        print(
+            "Portfolio notification-outbox generation failed: local storage "
+            "or PostgreSQL operation failed; rerun is safe",
+            file=sys.stderr,
+        )
+        return 1
+    except Exception:
+        print(
+            "Portfolio notification-outbox generation failed: unexpected "
+            "local failure",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(json.dumps(summary, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/warehouse/portfolio_risk_notification_outbox_loader.py
+++ b/src/warehouse/portfolio_risk_notification_outbox_loader.py
@@ -1,0 +1,277 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+import duckdb
+import pandas as pd
+
+from src.common.exceptions import StorageError
+from src.storage.storage_config import load_storage_config, validate_storage_config
+from src.warehouse.postgres_loader import DEFAULT_POSTGRES_DSN
+
+DATASET_KEY = "portfolio_risk_notification_outbox"
+TABLE_NAME = "portfolio_risk_notification_outbox"
+MAX_INPUT_FILES = 4_096
+MAX_INPUT_BYTES = 1_000_000_000
+MAX_INPUT_ROWS = 250_000
+
+COLUMNS = (
+    "event_id",
+    "model_version",
+    "event_type",
+    "transition_type",
+    "delivery_disposition",
+    "suppression_reason",
+    "source_evaluation_calculation_id",
+    "source_previous_evaluation_calculation_id",
+    "risk_limit_model_version",
+    "policy_id",
+    "policy_fingerprint",
+    "portfolio_id",
+    "base_currency",
+    "definition_fingerprint",
+    "attribution_model_version",
+    "weighting_method",
+    "covariance_method",
+    "correlation_method",
+    "covariance_window",
+    "annualization_days",
+    "ts_event",
+    "ts_ingest",
+    "metric_name",
+    "subject_type",
+    "subject_key",
+    "previous_subject_key",
+    "subject_changed",
+    "unit",
+    "previous_status",
+    "current_status",
+    "severity_rank",
+    "observed_value",
+    "observed_signed_value",
+    "warning_threshold",
+    "critical_threshold",
+    "breach_excess",
+    "payload_json",
+)
+
+
+def _quote_identifier(value: str) -> str:
+    return '"' + value.replace('"', '""') + '"'
+
+
+def _dataset_files(storage_config: dict[str, Any]) -> list[Path]:
+    validate_storage_config(storage_config)
+    storage = storage_config["storage"]
+    datasets = storage["curated"]["datasets"]
+    if DATASET_KEY not in datasets:
+        raise StorageError(f"Storage configuration is missing '{DATASET_KEY}'")
+    curated_base = Path(storage["curated"]["base_path"])
+    dataset_path = curated_base / datasets[DATASET_KEY]
+    if curated_base.is_symlink() or dataset_path.is_symlink():
+        raise StorageError(
+            "Portfolio notification-outbox warehouse path must not be a symbolic link"
+        )
+    if not dataset_path.exists():
+        return []
+    if not dataset_path.is_dir():
+        raise StorageError(
+            "Portfolio notification-outbox warehouse path must be a directory"
+        )
+    try:
+        files = sorted(dataset_path.rglob("*.parquet"))
+    except OSError:
+        raise StorageError(
+            "Portfolio notification-outbox input could not be inventoried"
+        ) from None
+    if len(files) > MAX_INPUT_FILES:
+        raise StorageError(
+            "Portfolio notification-outbox input exceeds the file scan limit"
+        )
+
+    total_bytes = 0
+    for path in files:
+        if path.is_symlink() or not path.is_file():
+            raise StorageError(
+                "Portfolio notification-outbox input contains an unsafe file type"
+            )
+        try:
+            total_bytes += path.stat().st_size
+        except OSError:
+            raise StorageError(
+                "Portfolio notification-outbox input could not be inventoried"
+            ) from None
+        if total_bytes > MAX_INPUT_BYTES:
+            raise StorageError(
+                "Portfolio notification-outbox input exceeds the byte scan limit"
+            )
+    return files
+
+
+def _normalise_value(value: Any) -> Any:
+    if value is None:
+        return None
+    if isinstance(value, float) and pd.isna(value):
+        return None
+    if pd.isna(value) is True:
+        return None
+    if hasattr(value, "to_pydatetime"):
+        return value.to_pydatetime()
+    return value
+
+
+def collect_notification_events(
+    storage_config_path: Path = Path("config/storage.yaml"),
+) -> list[dict[str, Any]]:
+    storage_config = load_storage_config(storage_config_path)
+    files = _dataset_files(storage_config)
+    if not files:
+        return []
+
+    paths = ", ".join(
+        f"'{str(path).replace(chr(39), chr(39) * 2)}'" for path in files
+    )
+    relation = (
+        f"read_parquet([{paths}], union_by_name=true, "
+        "hive_partitioning=false)"
+    )
+    selected = ", ".join(_quote_identifier(column) for column in COLUMNS)
+    try:
+        with duckdb.connect() as connection:
+            count_row = connection.execute(
+                f"SELECT COUNT(*) FROM {relation}"
+            ).fetchone()
+            if count_row is None:
+                raise StorageError(
+                    "Portfolio notification-outbox query returned no row count"
+                )
+            if int(count_row[0]) > MAX_INPUT_ROWS:
+                raise StorageError(
+                    "Portfolio notification-outbox input exceeds the row scan limit"
+                )
+            frame = connection.execute(
+                f"SELECT {selected} FROM {relation} "
+                "ORDER BY ts_event, metric_name, transition_type, event_id"
+            ).df()
+    except StorageError:
+        raise
+    except Exception:
+        raise StorageError(
+            "Unable to read portfolio notification-outbox Parquet"
+        ) from None
+
+    records = [
+        {key: _normalise_value(value) for key, value in row.items()}
+        for row in frame.to_dict("records")
+    ]
+    for record in records:
+        payload = record["payload_json"]
+        if not isinstance(payload, str):
+            raise StorageError(
+                "Portfolio notification-outbox payload must be JSON text"
+            )
+        try:
+            parsed = json.loads(payload)
+        except (TypeError, ValueError):
+            raise StorageError(
+                "Portfolio notification-outbox payload is invalid JSON"
+            ) from None
+        if not isinstance(parsed, dict):
+            raise StorageError(
+                "Portfolio notification-outbox payload must be a JSON object"
+            )
+    return records
+
+
+def build_insert_sql(schema_name: str = "risk_platform") -> str:
+    columns = ", ".join(_quote_identifier(column) for column in COLUMNS)
+    placeholders = ", ".join(["%s"] * len(COLUMNS))
+    return (
+        f"INSERT INTO {_quote_identifier(schema_name)}."
+        f"{_quote_identifier(TABLE_NAME)} ({columns}) VALUES ({placeholders}) "
+        f"ON CONFLICT ({_quote_identifier('event_id')}) DO NOTHING"
+    )
+
+
+def load_notification_events_to_postgres(
+    *,
+    dsn: str,
+    storage_config_path: Path = Path("config/storage.yaml"),
+    schema_name: str = "risk_platform",
+    dry_run: bool = False,
+) -> int:
+    records = collect_notification_events(storage_config_path)
+    if dry_run or not records:
+        return len(records)
+    try:
+        import psycopg
+        from psycopg.types.json import Jsonb
+    except ImportError as exc:
+        raise RuntimeError(
+            "PostgreSQL loading requires psycopg. Run `make setup` first."
+        ) from exc
+
+    rows = []
+    for record in records:
+        values = []
+        for column in COLUMNS:
+            value = record[column]
+            if column == "payload_json":
+                value = Jsonb(json.loads(value))
+            values.append(value)
+        rows.append(tuple(values))
+
+    with psycopg.connect(dsn) as connection:
+        with connection.cursor() as cursor:
+            cursor.executemany(build_insert_sql(schema_name), rows)
+        connection.commit()
+    return len(records)
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Load local portfolio notification-outbox Parquet into PostgreSQL "
+            "without delivering messages."
+        )
+    )
+    parser.add_argument(
+        "--dsn",
+        default=os.environ.get(
+            "WAREHOUSE_POSTGRES_DSN",
+            DEFAULT_POSTGRES_DSN,
+        ),
+    )
+    parser.add_argument(
+        "--storage-config",
+        type=Path,
+        default=Path("config/storage.yaml"),
+    )
+    parser.add_argument("--schema", default="risk_platform")
+    parser.add_argument("--dry-run", action="store_true")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = _parse_args()
+    count = load_notification_events_to_postgres(
+        dsn=args.dsn,
+        storage_config_path=args.storage_config,
+        schema_name=args.schema,
+        dry_run=args.dry_run,
+    )
+    print(
+        "Portfolio notification-outbox warehouse load summary at "
+        f"{datetime.utcnow().isoformat()}Z"
+    )
+    print(f"{TABLE_NAME}: {count}")
+    print("external_delivery_performed: false")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/integration/test_portfolio_risk_notification_outbox_pipeline.py
+++ b/tests/integration/test_portfolio_risk_notification_outbox_pipeline.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+from datetime import date, datetime, timedelta, timezone
+from pathlib import Path
+
+from src.analytics.portfolio_risk_limits import (
+    MODEL_VERSION as RISK_LIMIT_MODEL_VERSION,
+    VOLATILITY_METRIC,
+)
+from src.orchestration.run_portfolio_risk_notification_outbox import (
+    OUTPUT_DATASET,
+    run_portfolio_risk_notification_outbox,
+)
+from src.warehouse.portfolio_risk_notification_outbox_loader import (
+    collect_notification_events,
+)
+from tests.storage_config_helpers import (
+    build_storage_config,
+    write_storage_config,
+)
+
+
+def _transitions() -> list[dict[str, object]]:
+    records: list[dict[str, object]] = []
+    for day, transition, previous, status, observed in (
+        (1, "opened", None, "warning", 0.35),
+        (2, "escalated", "warning", "critical", 0.50),
+        (3, "resolved", "critical", "ok", 0.20),
+    ):
+        ts_event = datetime(2026, 1, day, tzinfo=timezone.utc)
+        records.append(
+            {
+                "calculation_id": f"evaluation-{day}",
+                "model_version": RISK_LIMIT_MODEL_VERSION,
+                "policy_id": "us-tech-standard",
+                "policy_fingerprint": "risk-limit-policy-a",
+                "portfolio_id": "us-tech-equal",
+                "base_currency": "USD",
+                "definition_fingerprint": "definition-a",
+                "attribution_calculation_id": f"attribution-{day}",
+                "attribution_model_version": "portfolio-attribution-v1",
+                "weighting_method": "constant_weight_daily_rebalanced",
+                "covariance_method": "sample_annualized",
+                "correlation_method": "pearson",
+                "covariance_window": 20,
+                "annualization_days": 252,
+                "ts_event": ts_event,
+                "ts_ingest": ts_event + timedelta(hours=1),
+                "metric_name": VOLATILITY_METRIC,
+                "subject_type": "portfolio",
+                "subject_key": "us-tech-equal",
+                "unit": "annualized_decimal",
+                "observed_value": observed,
+                "observed_signed_value": observed,
+                "warning_threshold": 0.30,
+                "critical_threshold": 0.45,
+                "status": status,
+                "is_breach": status != "ok",
+                "breach_threshold": (
+                    None
+                    if status == "ok"
+                    else 0.30 if status == "warning"
+                    else 0.45
+                ),
+                "breach_excess": (
+                    0.0
+                    if status == "ok"
+                    else observed - (0.30 if status == "warning" else 0.45)
+                ),
+                "previous_status": previous,
+                "previous_calculation_id": (
+                    None if previous is None else f"evaluation-{day - 1}"
+                ),
+                "previous_subject_key": (
+                    None if previous is None else "us-tech-equal"
+                ),
+                "transition_type": transition,
+                "severity_rank": {
+                    "ok": 0,
+                    "warning": 1,
+                    "critical": 2,
+                }[status],
+                "subject_changed": False,
+            }
+        )
+    return records
+
+
+def test_notification_outbox_parquet_replays_and_loads(
+    tmp_path: Path,
+) -> None:
+    storage_config = build_storage_config(tmp_path)
+    storage_config_path = write_storage_config(tmp_path)
+
+    first = run_portfolio_risk_notification_outbox(
+        policy_id="us-tech-standard",
+        start_date=None,
+        end_date=date(2026, 1, 3),
+        max_events=10,
+        dsn="postgresql://unused",
+        storage_config_path=storage_config_path,
+        reader=lambda **_: _transitions(),
+        storage_config_loader=lambda _: storage_config,
+    )
+    second = run_portfolio_risk_notification_outbox(
+        policy_id="us-tech-standard",
+        start_date=None,
+        end_date=date(2026, 1, 3),
+        max_events=10,
+        dsn="postgresql://unused",
+        storage_config_path=storage_config_path,
+        reader=lambda **_: _transitions(),
+        storage_config_loader=lambda _: storage_config,
+    )
+
+    first_output = first["curated_output"][OUTPUT_DATASET]
+    second_output = second["curated_output"][OUTPUT_DATASET]
+    assert first_output["records_written"] == 3
+    assert second_output["records_written"] == 0
+    assert second_output["records_already_present"] == 3
+    assert second["delivery"]["performed"] is False
+
+    records = collect_notification_events(storage_config_path)
+    assert len(records) == 3
+    assert len({record["event_id"] for record in records}) == 3
+    assert {record["event_type"] for record in records} == {
+        "breach_opened",
+        "breach_escalated",
+        "breach_resolved",
+    }
+    assert all(
+        record["delivery_disposition"] == "pending"
+        for record in records
+    )

--- a/tests/storage_config_helpers.py
+++ b/tests/storage_config_helpers.py
@@ -18,6 +18,7 @@ CURATED_DATASETS = {
     "portfolio_daily_risk_summary": "portfolio_daily_risk_summary",
     "portfolio_risk_attribution": "portfolio_risk_attribution",
     "portfolio_risk_limit_evaluations": "portfolio_risk_limit_evaluations",
+    "portfolio_risk_notification_outbox": "portfolio_risk_notification_outbox",
 }
 
 

--- a/tests/unit/test_docker_compose_contract.py
+++ b/tests/unit/test_docker_compose_contract.py
@@ -31,6 +31,7 @@ def test_local_database_seed_mounts_are_read_only_and_ordered() -> None:
         "./sql/portfolio_attribution_schema.sql:/docker-entrypoint-initdb.d/04_portfolio_attribution_schema.sql:ro",
         "./sql/portfolio_risk_limits_schema.sql:/docker-entrypoint-initdb.d/05_portfolio_risk_limits_schema.sql:ro",
         "./sql/portfolio_risk_breach_lifecycle_schema.sql:/docker-entrypoint-initdb.d/06_portfolio_risk_breach_lifecycle_schema.sql:ro",
+        "./sql/portfolio_risk_notification_outbox_schema.sql:/docker-entrypoint-initdb.d/07_portfolio_risk_notification_outbox_schema.sql:ro",
     ]
     assert services["mongo"]["volumes"] == [
         "./mongo/init:/docker-entrypoint-initdb.d:ro"

--- a/tests/unit/test_portfolio_risk_notification_outbox.py
+++ b/tests/unit/test_portfolio_risk_notification_outbox.py
@@ -1,0 +1,223 @@
+from __future__ import annotations
+
+import json
+from datetime import date, datetime, timedelta, timezone
+
+import pytest
+
+from src.analytics.portfolio_risk_limits import (
+    CONCENTRATION_METRIC,
+    MODEL_VERSION as RISK_LIMIT_MODEL_VERSION,
+    VOLATILITY_METRIC,
+)
+from src.analytics.portfolio_risk_notification_outbox import (
+    MAX_NOTIFICATION_EVENTS,
+    MODEL_VERSION,
+    build_portfolio_risk_notification_outbox,
+)
+from src.common.exceptions import ValidationError
+
+
+def _transition(
+    day: int,
+    transition_type: str,
+    previous_status: str | None,
+    status: str,
+    *,
+    metric_name: str = VOLATILITY_METRIC,
+    subject_key: str = "us-tech-equal",
+    previous_subject_key: str | None = None,
+    calculation_id: str | None = None,
+) -> dict[str, object]:
+    event_time = datetime(2026, 1, day, tzinfo=timezone.utc)
+    is_concentration = metric_name == CONCENTRATION_METRIC
+    observed_value = (
+        0.2
+        if status == "ok"
+        else 0.35 if status == "warning" else 0.50
+    )
+    if is_concentration:
+        observed_value = (
+            0.50
+            if status == "ok"
+            else 0.70 if status == "warning" else 0.85
+        )
+    previous_calculation_id = (
+        None if previous_status is None else f"previous-{day}"
+    )
+    return {
+        "calculation_id": calculation_id or f"evaluation-{day}-{metric_name}",
+        "model_version": RISK_LIMIT_MODEL_VERSION,
+        "policy_id": "us-tech-standard",
+        "policy_fingerprint": "risk-limit-policy-a",
+        "portfolio_id": "us-tech-equal",
+        "base_currency": "USD",
+        "definition_fingerprint": "definition-a",
+        "attribution_calculation_id": f"attribution-{day}",
+        "attribution_model_version": "portfolio-attribution-v1",
+        "weighting_method": "constant_weight_daily_rebalanced",
+        "covariance_method": "sample_annualized",
+        "correlation_method": "pearson",
+        "covariance_window": 20,
+        "annualization_days": 252,
+        "ts_event": event_time,
+        "ts_ingest": event_time + timedelta(hours=1),
+        "metric_name": metric_name,
+        "subject_type": "constituent" if is_concentration else "portfolio",
+        "subject_key": subject_key,
+        "unit": "absolute_share" if is_concentration else "annualized_decimal",
+        "observed_value": observed_value,
+        "observed_signed_value": (
+            -observed_value if is_concentration else observed_value
+        ),
+        "warning_threshold": 0.65 if is_concentration else 0.30,
+        "critical_threshold": 0.80 if is_concentration else 0.45,
+        "status": status,
+        "is_breach": status != "ok",
+        "breach_threshold": (
+            None
+            if status == "ok"
+            else 0.80 if is_concentration and status == "critical"
+            else 0.65 if is_concentration
+            else 0.45 if status == "critical"
+            else 0.30
+        ),
+        "breach_excess": (
+            0.0
+            if status == "ok"
+            else observed_value
+            - (
+                0.80
+                if is_concentration and status == "critical"
+                else 0.65
+                if is_concentration
+                else 0.45
+                if status == "critical"
+                else 0.30
+            )
+        ),
+        "previous_status": previous_status,
+        "previous_calculation_id": previous_calculation_id,
+        "previous_subject_key": previous_subject_key,
+        "transition_type": transition_type,
+        "severity_rank": {"ok": 0, "warning": 1, "critical": 2}[status],
+        "subject_changed": (
+            previous_subject_key is not None
+            and previous_subject_key != subject_key
+        ),
+    }
+
+
+def test_notification_outbox_maps_actionable_transitions_and_payloads() -> None:
+    records = [
+        _transition(1, "opened", None, "warning"),
+        _transition(2, "escalated", "warning", "critical"),
+        _transition(3, "deescalated", "critical", "warning"),
+        _transition(4, "resolved", "warning", "ok"),
+    ]
+
+    output = build_portfolio_risk_notification_outbox(records)
+
+    assert [event["event_type"] for event in output.events] == [
+        "breach_opened",
+        "breach_escalated",
+        "breach_deescalated",
+        "breach_resolved",
+    ]
+    assert [event["delivery_disposition"] for event in output.events] == [
+        "pending",
+        "pending",
+        "suppressed",
+        "pending",
+    ]
+    assert output.events[2]["suppression_reason"] == "deescalation_not_routed"
+    assert output.diagnostics["events_pending"] == 3
+    assert output.diagnostics["events_suppressed"] == 1
+
+    payload = json.loads(output.events[0]["payload_json"])
+    assert payload["event_id"] == output.events[0]["event_id"]
+    assert payload["policy"]["policy_fingerprint"] == "risk-limit-policy-a"
+    assert payload["source"]["evaluation_calculation_id"].startswith(
+        "evaluation-"
+    )
+    assert "dsn" not in output.events[0]["payload_json"].lower()
+    assert output.events[0]["model_version"] == MODEL_VERSION
+
+
+def test_concentration_event_retains_signed_subject_change_evidence() -> None:
+    record = _transition(
+        2,
+        "escalated",
+        "warning",
+        "critical",
+        metric_name=CONCENTRATION_METRIC,
+        subject_key="alpha_vantage:MSFT",
+        previous_subject_key="alpha_vantage:AAPL",
+    )
+
+    event = build_portfolio_risk_notification_outbox([record]).events[0]
+
+    assert event["subject_changed"] is True
+    assert event["observed_signed_value"] < 0
+    payload = json.loads(event["payload_json"])
+    assert payload["metric"]["previous_subject_key"] == "alpha_vantage:AAPL"
+    assert payload["metric"]["subject_key"] == "alpha_vantage:MSFT"
+
+
+def test_input_order_and_identical_duplicates_do_not_change_events() -> None:
+    records = [
+        _transition(1, "opened", None, "warning"),
+        _transition(2, "escalated", "warning", "critical"),
+    ]
+
+    forward = build_portfolio_risk_notification_outbox([*records, records[0]])
+    reverse = build_portfolio_risk_notification_outbox(reversed(records))
+
+    assert forward.events == reverse.events
+
+
+def test_non_actionable_rows_and_date_filters_are_explicit() -> None:
+    unchanged = _transition(1, "opened", None, "warning")
+    unchanged["transition_type"] = "unchanged"
+    unchanged["previous_status"] = "warning"
+    unchanged["previous_calculation_id"] = "previous-1"
+    records = [
+        unchanged,
+        _transition(2, "opened", None, "warning"),
+        _transition(3, "escalated", "warning", "critical"),
+    ]
+
+    output = build_portfolio_risk_notification_outbox(
+        records,
+        start_date=date(2026, 1, 3),
+        end_date=date(2026, 1, 3),
+    )
+
+    assert len(output.events) == 1
+    assert output.events[0]["transition_type"] == "escalated"
+    assert output.diagnostics["skipped_non_actionable_transitions"] == 1
+    assert output.diagnostics["skipped_outside_date_range"] == 1
+
+
+def test_invalid_transition_contract_and_request_bound_fail_closed() -> None:
+    invalid = _transition(1, "escalated", "warning", "critical")
+    invalid["status"] = "warning"
+    invalid["severity_rank"] = 1
+    with pytest.raises(ValidationError, match="transition statuses"):
+        build_portfolio_risk_notification_outbox([invalid])
+
+    records = [
+        _transition(1, "opened", None, "warning"),
+        _transition(2, "escalated", "warning", "critical"),
+    ]
+    with pytest.raises(ValidationError, match="max_events"):
+        build_portfolio_risk_notification_outbox(
+            records,
+            max_events=1,
+        )
+
+    with pytest.raises(ValidationError, match="between 1"):
+        build_portfolio_risk_notification_outbox(
+            records,
+            max_events=MAX_NOTIFICATION_EVENTS + 1,
+        )

--- a/tests/unit/test_portfolio_risk_notification_outbox_loader.py
+++ b/tests/unit/test_portfolio_risk_notification_outbox_loader.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+from src.analytics.portfolio_risk_limits import (
+    MODEL_VERSION as RISK_LIMIT_MODEL_VERSION,
+    VOLATILITY_METRIC,
+)
+from src.analytics.portfolio_risk_notification_outbox import (
+    build_portfolio_risk_notification_outbox,
+)
+from src.common.exceptions import StorageError
+from src.storage.s3_writer import write_records
+from src.warehouse.portfolio_risk_notification_outbox_loader import (
+    DATASET_KEY,
+    build_insert_sql,
+    collect_notification_events,
+    load_notification_events_to_postgres,
+)
+from tests.storage_config_helpers import (
+    build_storage_config,
+    write_storage_config,
+)
+
+
+def _transition() -> dict[str, object]:
+    ts_event = datetime(2026, 1, 2, tzinfo=timezone.utc)
+    return {
+        "calculation_id": "evaluation-2",
+        "model_version": RISK_LIMIT_MODEL_VERSION,
+        "policy_id": "us-tech-standard",
+        "policy_fingerprint": "risk-limit-policy-a",
+        "portfolio_id": "us-tech-equal",
+        "base_currency": "USD",
+        "definition_fingerprint": "definition-a",
+        "attribution_calculation_id": "attribution-2",
+        "attribution_model_version": "portfolio-attribution-v1",
+        "weighting_method": "constant_weight_daily_rebalanced",
+        "covariance_method": "sample_annualized",
+        "correlation_method": "pearson",
+        "covariance_window": 20,
+        "annualization_days": 252,
+        "ts_event": ts_event,
+        "ts_ingest": ts_event + timedelta(hours=1),
+        "metric_name": VOLATILITY_METRIC,
+        "subject_type": "portfolio",
+        "subject_key": "us-tech-equal",
+        "unit": "annualized_decimal",
+        "observed_value": 0.35,
+        "observed_signed_value": 0.35,
+        "warning_threshold": 0.30,
+        "critical_threshold": 0.45,
+        "status": "warning",
+        "is_breach": True,
+        "breach_threshold": 0.30,
+        "breach_excess": 0.05,
+        "previous_status": "ok",
+        "previous_calculation_id": "evaluation-1",
+        "previous_subject_key": "us-tech-equal",
+        "transition_type": "opened",
+        "severity_rank": 1,
+        "subject_changed": False,
+    }
+
+
+def test_loader_collects_outbox_payload_and_uses_immutable_insert(
+    tmp_path: Path,
+) -> None:
+    storage_config = build_storage_config(tmp_path)
+    storage_config_path = write_storage_config(tmp_path)
+    event = build_portfolio_risk_notification_outbox([_transition()]).events[0]
+
+    assert write_records(
+        [event],
+        kind="curated",
+        dataset=DATASET_KEY,
+        storage_config=storage_config,
+    ) == 1
+
+    records = collect_notification_events(storage_config_path)
+
+    assert len(records) == 1
+    assert records[0]["event_id"] == event["event_id"]
+    assert records[0]["payload_json"] == event["payload_json"]
+    statement = build_insert_sql()
+    assert (
+        'INSERT INTO "risk_platform"."portfolio_risk_notification_outbox"'
+        in statement
+    )
+    assert 'ON CONFLICT ("event_id") DO NOTHING' in statement
+    assert "DO UPDATE" not in statement
+
+    assert load_notification_events_to_postgres(
+        dsn="postgresql://unused",
+        storage_config_path=storage_config_path,
+        dry_run=True,
+    ) == 1
+
+
+def test_loader_is_safe_when_dataset_is_absent(tmp_path: Path) -> None:
+    storage_config_path = write_storage_config(tmp_path)
+
+    assert collect_notification_events(storage_config_path) == []
+    assert load_notification_events_to_postgres(
+        dsn="postgresql://unused",
+        storage_config_path=storage_config_path,
+        dry_run=True,
+    ) == 0
+
+
+def test_loader_rejects_invalid_payload_json(tmp_path: Path) -> None:
+    storage_config = build_storage_config(tmp_path)
+    storage_config_path = write_storage_config(tmp_path)
+    event = dict(
+        build_portfolio_risk_notification_outbox([_transition()]).events[0]
+    )
+    event["payload_json"] = "not-json"
+
+    assert write_records(
+        [event],
+        kind="curated",
+        dataset=DATASET_KEY,
+        storage_config=storage_config,
+    ) == 1
+
+    with pytest.raises(StorageError, match="invalid JSON"):
+        collect_notification_events(storage_config_path)
+
+
+def test_loader_rejects_symbolic_link_dataset_path(tmp_path: Path) -> None:
+    storage_config = build_storage_config(tmp_path)
+    storage_config_path = write_storage_config(tmp_path)
+    curated_base = Path(storage_config["storage"]["curated"]["base_path"])
+    curated_base.mkdir(parents=True)
+    target = tmp_path / "external"
+    target.mkdir()
+    (curated_base / DATASET_KEY).symlink_to(
+        target,
+        target_is_directory=True,
+    )
+
+    with pytest.raises(StorageError, match="symbolic link"):
+        collect_notification_events(storage_config_path)

--- a/tests/unit/test_portfolio_risk_notification_outbox_reporting_sql_contract.py
+++ b/tests/unit/test_portfolio_risk_notification_outbox_reporting_sql_contract.py
@@ -1,0 +1,296 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+
+import duckdb
+
+
+def _read_sql(path: str) -> str:
+    return Path(path).read_text(encoding="utf-8")
+
+
+def _extract_statement(sql: str, prefix: str) -> str:
+    start = sql.index(prefix)
+    end = sql.index(";", start) + 1
+    return sql[start:end]
+
+
+def _create_tables(connection: duckdb.DuckDBPyConnection) -> None:
+    connection.execute("CREATE SCHEMA risk_platform")
+    connection.execute(
+        """
+        CREATE TABLE risk_platform.portfolio_risk_limit_actionable_transitions (
+            calculation_id TEXT,
+            previous_calculation_id TEXT,
+            transition_type TEXT
+        )
+        """
+    )
+    connection.execute(
+        """
+        CREATE TABLE risk_platform.portfolio_risk_notification_outbox (
+            event_id TEXT,
+            model_version TEXT,
+            event_type TEXT,
+            transition_type TEXT,
+            delivery_disposition TEXT,
+            suppression_reason TEXT,
+            source_evaluation_calculation_id TEXT,
+            source_previous_evaluation_calculation_id TEXT,
+            risk_limit_model_version TEXT,
+            policy_id TEXT,
+            policy_fingerprint TEXT,
+            portfolio_id TEXT,
+            base_currency TEXT,
+            definition_fingerprint TEXT,
+            attribution_model_version TEXT,
+            weighting_method TEXT,
+            covariance_method TEXT,
+            correlation_method TEXT,
+            covariance_window INTEGER,
+            annualization_days INTEGER,
+            ts_event TIMESTAMPTZ,
+            ts_ingest TIMESTAMPTZ,
+            metric_name TEXT,
+            subject_type TEXT,
+            subject_key TEXT,
+            previous_subject_key TEXT,
+            subject_changed BOOLEAN,
+            unit TEXT,
+            previous_status TEXT,
+            current_status TEXT,
+            severity_rank INTEGER,
+            observed_value DOUBLE,
+            observed_signed_value DOUBLE,
+            warning_threshold DOUBLE,
+            critical_threshold DOUBLE,
+            breach_excess DOUBLE,
+            payload_json TEXT,
+            loaded_at TIMESTAMPTZ
+        )
+        """
+    )
+
+
+def _outbox_row(
+    *,
+    event_id: str,
+    transition_type: str,
+    disposition: str,
+    source_id: str,
+    previous_id: str | None,
+    event_time: datetime,
+) -> tuple[object, ...]:
+    current_status = (
+        "critical"
+        if transition_type == "escalated"
+        else "warning"
+        if transition_type in {"opened", "deescalated"}
+        else "ok"
+    )
+    previous_status = (
+        None
+        if previous_id is None
+        else "warning"
+        if transition_type in {"escalated", "resolved"}
+        else "critical"
+    )
+    return (
+        event_id,
+        "portfolio-risk-notification-outbox-v1",
+        {
+            "opened": "breach_opened",
+            "escalated": "breach_escalated",
+            "deescalated": "breach_deescalated",
+            "resolved": "breach_resolved",
+        }[transition_type],
+        transition_type,
+        disposition,
+        "deescalation_not_routed" if disposition == "suppressed" else None,
+        source_id,
+        previous_id,
+        "portfolio-risk-limits-v1",
+        "us-tech-standard",
+        "risk-limit-policy-a",
+        "us-tech-equal",
+        "USD",
+        "definition-a",
+        "portfolio-attribution-v1",
+        "constant_weight_daily_rebalanced",
+        "sample_annualized",
+        "pearson",
+        20,
+        252,
+        event_time,
+        event_time,
+        "portfolio_volatility_annualized",
+        "portfolio",
+        "us-tech-equal",
+        None if previous_id is None else "us-tech-equal",
+        False,
+        "annualized_decimal",
+        previous_status,
+        current_status,
+        {"ok": 0, "warning": 1, "critical": 2}[current_status],
+        0.35,
+        0.35,
+        0.30,
+        0.45,
+        0.05 if current_status != "ok" else 0.0,
+        "{}",
+        event_time,
+    )
+
+
+def test_notification_schema_exposes_immutable_outbox_contract() -> None:
+    schema_sql = _read_sql(
+        "sql/portfolio_risk_notification_outbox_schema.sql"
+    )
+
+    assert (
+        "CREATE TABLE IF NOT EXISTS "
+        "risk_platform.portfolio_risk_notification_outbox"
+    ) in schema_sql
+    assert "event_id TEXT PRIMARY KEY" in schema_sql
+    assert "delivery_disposition IN ('pending', 'suppressed')" in schema_sql
+    assert "deescalation_not_routed" in schema_sql
+    assert "jsonb_typeof(payload_json) = 'object'" in schema_sql
+    assert (
+        "source_evaluation_calculation_id TEXT NOT NULL REFERENCES"
+        in schema_sql
+    )
+
+    for view_name in (
+        "current_portfolio_risk_notification_outbox",
+        "portfolio_risk_notification_pending",
+        "portfolio_risk_notification_suppressed",
+        "portfolio_risk_notification_outbox_summary",
+    ):
+        assert f"risk_platform.{view_name}" in schema_sql
+
+
+def test_current_pending_suppressed_and_summary_views_execute() -> None:
+    schema_sql = _read_sql(
+        "sql/portfolio_risk_notification_outbox_schema.sql"
+    )
+    view_names = (
+        "current_portfolio_risk_notification_outbox",
+        "portfolio_risk_notification_pending",
+        "portfolio_risk_notification_suppressed",
+        "portfolio_risk_notification_outbox_summary",
+    )
+
+    with duckdb.connect() as connection:
+        _create_tables(connection)
+        connection.executemany(
+            """
+            INSERT INTO risk_platform.portfolio_risk_limit_actionable_transitions
+            VALUES (?, ?, ?)
+            """,
+            [
+                ("evaluation-current", None, "opened"),
+                (
+                    "evaluation-deescalated",
+                    "evaluation-critical",
+                    "deescalated",
+                ),
+            ],
+        )
+        event_time = datetime(2026, 1, 2, tzinfo=timezone.utc)
+        connection.executemany(
+            """
+            INSERT INTO risk_platform.portfolio_risk_notification_outbox
+            VALUES (
+                ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
+                ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
+            )
+            """,
+            [
+                _outbox_row(
+                    event_id="event-current",
+                    transition_type="opened",
+                    disposition="pending",
+                    source_id="evaluation-current",
+                    previous_id=None,
+                    event_time=event_time,
+                ),
+                _outbox_row(
+                    event_id="event-stale",
+                    transition_type="opened",
+                    disposition="pending",
+                    source_id="evaluation-stale",
+                    previous_id=None,
+                    event_time=event_time,
+                ),
+                _outbox_row(
+                    event_id="event-suppressed",
+                    transition_type="deescalated",
+                    disposition="suppressed",
+                    source_id="evaluation-deescalated",
+                    previous_id="evaluation-critical",
+                    event_time=event_time,
+                ),
+            ],
+        )
+        for view_name in view_names:
+            prefix = (
+                "CREATE OR REPLACE VIEW\n"
+                "risk_platform.current_portfolio_risk_notification_outbox AS"
+                if view_name == "current_portfolio_risk_notification_outbox"
+                else f"CREATE OR REPLACE VIEW risk_platform.{view_name} AS"
+            )
+            connection.execute(_extract_statement(schema_sql, prefix))
+
+        assert connection.execute(
+            """
+            SELECT event_id
+            FROM risk_platform.current_portfolio_risk_notification_outbox
+            ORDER BY event_id
+            """
+        ).fetchall() == [
+            ("event-current",),
+            ("event-suppressed",),
+        ]
+        assert connection.execute(
+            "SELECT COUNT(*) FROM "
+            "risk_platform.portfolio_risk_notification_pending"
+        ).fetchone() == (1,)
+        assert connection.execute(
+            "SELECT COUNT(*) FROM "
+            "risk_platform.portfolio_risk_notification_suppressed"
+        ).fetchone() == (1,)
+        assert connection.execute(
+            """
+            SELECT SUM(event_count)
+            FROM risk_platform.portfolio_risk_notification_outbox_summary
+            """
+        ).fetchone() == (2,)
+
+
+def test_notification_reconciliation_and_documentation_contract() -> None:
+    consistency_sql = _read_sql(
+        "sql/portfolio_risk_notification_outbox_consistency_checks.sql"
+    )
+    documentation = _read_sql("docs/portfolio-risk-notification-outbox.md")
+
+    for check_name in (
+        "portfolio_notification_current_rows_match_actionable_transitions",
+        "portfolio_notification_pending_view_matches",
+        "portfolio_notification_suppressed_view_matches",
+        "portfolio_notification_summary_rows_reconcile",
+        "portfolio_notification_source_evaluations_exist",
+        "portfolio_notification_previous_evaluations_exist",
+        "portfolio_notification_transition_metadata_matches",
+        "portfolio_notification_event_ids_unique",
+        "portfolio_notification_dispositions_valid",
+        "portfolio_notification_payload_identity_matches",
+        "portfolio_notification_current_candidates_complete",
+        "portfolio_notification_current_candidates_not_stale",
+    ):
+        assert check_name in consistency_sql
+
+    assert "does not deliver" in documentation
+    assert '"performed": false' in documentation
+    assert "ON CONFLICT (event_id) DO NOTHING" in documentation
+    assert "`pending` means eligible candidate—not sent" in documentation

--- a/tests/unit/test_run_portfolio_risk_notification_outbox.py
+++ b/tests/unit/test_run_portfolio_risk_notification_outbox.py
@@ -1,0 +1,208 @@
+from __future__ import annotations
+
+from datetime import date, datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from src.analytics.portfolio_risk_limits import (
+    MODEL_VERSION as RISK_LIMIT_MODEL_VERSION,
+    VOLATILITY_METRIC,
+)
+from src.common.exceptions import StorageError
+from src.orchestration.run_portfolio_risk_notification_outbox import (
+    OUTPUT_DATASET,
+    run_portfolio_risk_notification_outbox,
+)
+
+
+def _transition(
+    day: int,
+    transition_type: str,
+    previous: str | None,
+    status: str,
+) -> dict[str, object]:
+    ts_event = datetime(2026, 1, day, tzinfo=timezone.utc)
+    observed = 0.2 if status == "ok" else 0.35 if status == "warning" else 0.5
+    return {
+        "calculation_id": f"evaluation-{day}",
+        "model_version": RISK_LIMIT_MODEL_VERSION,
+        "policy_id": "us-tech-standard",
+        "policy_fingerprint": "risk-limit-policy-a",
+        "portfolio_id": "us-tech-equal",
+        "base_currency": "USD",
+        "definition_fingerprint": "definition-a",
+        "attribution_calculation_id": f"attribution-{day}",
+        "attribution_model_version": "portfolio-attribution-v1",
+        "weighting_method": "constant_weight_daily_rebalanced",
+        "covariance_method": "sample_annualized",
+        "correlation_method": "pearson",
+        "covariance_window": 20,
+        "annualization_days": 252,
+        "ts_event": ts_event,
+        "ts_ingest": ts_event + timedelta(hours=1),
+        "metric_name": VOLATILITY_METRIC,
+        "subject_type": "portfolio",
+        "subject_key": "us-tech-equal",
+        "unit": "annualized_decimal",
+        "observed_value": observed,
+        "observed_signed_value": observed,
+        "warning_threshold": 0.3,
+        "critical_threshold": 0.45,
+        "status": status,
+        "is_breach": status != "ok",
+        "breach_threshold": (
+            None
+            if status == "ok"
+            else 0.3 if status == "warning" else 0.45
+        ),
+        "breach_excess": (
+            0.0
+            if status == "ok"
+            else observed - (0.3 if status == "warning" else 0.45)
+        ),
+        "previous_status": previous,
+        "previous_calculation_id": (
+            None if previous is None else f"evaluation-{day - 1}"
+        ),
+        "previous_subject_key": (
+            None if previous is None else "us-tech-equal"
+        ),
+        "transition_type": transition_type,
+        "severity_rank": {"ok": 0, "warning": 1, "critical": 2}[status],
+        "subject_changed": False,
+    }
+
+
+def _storage_config() -> dict[str, Any]:
+    return {
+        "storage": {
+            "base_dir": "unused",
+            "raw": {
+                "base_path": "unused/raw",
+                "dataset": "market_events",
+            },
+            "curated": {
+                "base_path": "unused/curated",
+                "datasets": {
+                    "portfolio_risk_limit_evaluations": (
+                        "portfolio_risk_limit_evaluations"
+                    ),
+                    OUTPUT_DATASET: OUTPUT_DATASET,
+                },
+            },
+            "format": "parquet",
+            "partitioning": {"granularity": "hourly"},
+        }
+    }
+
+
+def test_runner_publishes_candidates_without_delivery() -> None:
+    writes: list[dict[str, Any]] = []
+    records = [
+        _transition(1, "opened", None, "warning"),
+        _transition(2, "escalated", "warning", "critical"),
+        _transition(3, "resolved", "critical", "ok"),
+    ]
+
+    def reader(**kwargs: Any) -> list[dict[str, Any]]:
+        assert kwargs["policy_id"] == "us-tech-standard"
+        assert kwargs["end_date"] == date(2026, 1, 3)
+        assert kwargs["dsn"] == "postgresql://not-printed"
+        return records
+
+    def writer(
+        events: list[dict[str, Any]],
+        *,
+        dataset: str,
+        **_: Any,
+    ) -> int:
+        assert dataset == OUTPUT_DATASET
+        writes.extend(events)
+        return 1
+
+    summary = run_portfolio_risk_notification_outbox(
+        policy_id="us-tech-standard",
+        start_date=None,
+        end_date=date(2026, 1, 3),
+        max_events=10,
+        dsn="postgresql://not-printed",
+        storage_config_path=Path("unused.yaml"),
+        reader=reader,
+        writer=writer,
+        storage_config_loader=lambda _: _storage_config(),
+    )
+
+    assert summary["curated_output"][OUTPUT_DATASET]["records_written"] == 3
+    assert summary["curated_output"][OUTPUT_DATASET][
+        "pending_delivery_candidates"
+    ] == 3
+    assert summary["delivery"] == {
+        "performed": False,
+        "external_destinations": 0,
+        "reason": "delivery_not_implemented",
+    }
+    assert "postgresql" not in str(summary).lower()
+    assert len(writes) == 3
+
+
+def test_runner_reports_replay_and_suppressed_candidates() -> None:
+    records = [
+        _transition(1, "opened", None, "critical"),
+        _transition(2, "deescalated", "critical", "warning"),
+    ]
+
+    summary = run_portfolio_risk_notification_outbox(
+        policy_id="us-tech-standard",
+        start_date=None,
+        end_date=date(2026, 1, 2),
+        max_events=10,
+        dsn="postgresql://unused",
+        storage_config_path=Path("unused.yaml"),
+        reader=lambda **_: records,
+        writer=lambda *_args, **_kwargs: 0,
+        storage_config_loader=lambda _: _storage_config(),
+    )
+
+    output = summary["curated_output"][OUTPUT_DATASET]
+    assert output["records_already_present"] == 2
+    assert output["pending_delivery_candidates"] == 1
+    assert output["suppressed_candidates"] == 1
+
+
+def test_runner_requires_output_dataset() -> None:
+    config = _storage_config()
+    del config["storage"]["curated"]["datasets"][OUTPUT_DATASET]
+
+    with pytest.raises(StorageError, match=OUTPUT_DATASET):
+        run_portfolio_risk_notification_outbox(
+            policy_id="us-tech-standard",
+            start_date=None,
+            end_date=date(2026, 1, 1),
+            max_events=10,
+            dsn="postgresql://unused",
+            storage_config_path=Path("unused.yaml"),
+            reader=lambda **_: [
+                _transition(1, "opened", None, "warning")
+            ],
+            writer=lambda *_args, **_kwargs: 1,
+            storage_config_loader=lambda _: config,
+        )
+
+
+def test_runner_rejects_invalid_writer_result() -> None:
+    with pytest.raises(StorageError, match="invalid result"):
+        run_portfolio_risk_notification_outbox(
+            policy_id="us-tech-standard",
+            start_date=None,
+            end_date=date(2026, 1, 1),
+            max_events=10,
+            dsn="postgresql://unused",
+            storage_config_path=Path("unused.yaml"),
+            reader=lambda **_: [
+                _transition(1, "opened", None, "warning")
+            ],
+            writer=lambda *_args, **_kwargs: 2,
+            storage_config_loader=lambda _: _storage_config(),
+        )

--- a/tests/unit/test_storage_config.py
+++ b/tests/unit/test_storage_config.py
@@ -19,6 +19,7 @@ def test_storage_config_valid():
         "portfolio_daily_risk_summary",
         "portfolio_risk_attribution",
         "portfolio_risk_limit_evaluations",
+        "portfolio_risk_notification_outbox",
     }.issubset(storage["curated"]["datasets"])
     assert storage["partitioning"]["granularity"]
 


### PR DESCRIPTION
## Outcome

Convert current actionable portfolio risk-limit transitions into durable, replay-safe notification candidates without delivering any external message:

```text
current actionable risk-limit transitions
  -> deterministic notification event identity
  -> credential-free JSON payload
  -> pending or suppressed disposition
  -> content-addressed Parquet
  -> immutable PostgreSQL outbox history
  -> current, pending, suppressed and summary views
```

This is roadmap issue #64, increment 3.

## History and dependency

PR #65 has been squash-merged. This branch was reconstructed directly on its resulting `main` commit rather than retaining the earlier stacked history.

Final branch state:

- one commit ahead of `main`;
- zero commits behind;
- 17 changed files;
- no regression to risk limits, PostgreSQL CI, acknowledgements, effective-dated mandates or breach lifecycle serving already on `main`.

## Event contract

The model version is `portfolio-risk-notification-outbox-v1`.

| Transition | Event type | Disposition |
| --- | --- | --- |
| `opened` | `breach_opened` | `pending` |
| `escalated` | `breach_escalated` | `pending` |
| `deescalated` | `breach_deescalated` | `suppressed` |
| `resolved` | `breach_resolved` | `pending` |

De-escalations remain visible but are suppressed with `deescalation_not_routed`; this avoids inventing a production routing policy.

The deterministic event ID binds the outbox model version, policy fingerprint, metric name, source evaluation calculation ID, previous evaluation calculation ID and transition type. Identical reruns converge; corrected lifecycle evidence creates distinguishable candidates.

## Payload and safety

`payload_json` includes only reviewed operational evidence: event identity, policy and portfolio fingerprints, metric/subject/threshold/status evidence, source evaluation identities and timestamps.

It excludes DSNs, provider keys, recipients, webhook URLs, tokens, raw provider payloads and filesystem paths.

The orchestration command reads only `risk_platform.portfolio_risk_limit_actionable_transitions`, requires one policy and a completed end date, and caps a request at 10,000 events. Its summary states explicitly:

```json
{
  "delivery": {
    "performed": false,
    "external_destinations": 0,
    "reason": "delivery_not_implemented"
  }
}
```

## Storage and warehouse

Add curated dataset `portfolio_risk_notification_outbox` and a bounded loader with the existing local safety limits:

- 4,096 Parquet files;
- 1 GB physical input;
- 250,000 rows;
- symbolic-link and unsafe-file rejection.

PostgreSQL table:

- `risk_platform.portfolio_risk_notification_outbox`

The loader uses `ON CONFLICT (event_id) DO NOTHING`; retained outbox evidence is immutable rather than updated on replay.

Serving views:

- `current_portfolio_risk_notification_outbox`;
- `portfolio_risk_notification_pending`;
- `portfolio_risk_notification_suppressed`;
- `portfolio_risk_notification_outbox_summary`.

The current view joins history back to current actionable lifecycle transitions. Corrected evidence can remove a candidate from current views while preserving it in history.

## Reconciliation

`sql/portfolio_risk_notification_outbox_consistency_checks.sql` verifies source references, current transition metadata, unique event identity, disposition rules, payload identity, candidate completeness, stale-candidate exclusion and reporting counts.

## Validation

The first CI run found one test-fixture edge case: the missing-output test removed the fixture's only curated dataset, so generic storage validation fired before the intended outbox-specific assertion. The fixture now retains an unrelated valid dataset, and the branch was rebuilt as a replacement one-commit history; production behavior was not weakened.

GitHub Actions run `32587895381` (`ci` run 217) passed on exact head `1839d1314beb0ea0262c0e3351f5d6750637f4de`:

- Security guardrails: passed.
- Python readiness: passed.
  - locked dependencies resolved;
  - Ruff passed;
  - mypy passed across 58 source files;
  - 514 tests passed in both quality and readiness runs;
  - `pip check` passed;
  - demo readiness and dry-run warehouse loading passed.
- PostgreSQL contract: passed against a real PostgreSQL 16 container.
- Infrastructure validation: passed.
  - Kubernetes overlays rendered;
  - Terraform format, initialization and validation passed without applying infrastructure.

No unresolved review threads or requested changes are present.

## Scope

The branch changes 17 files with 3,050 additions and no deletions as one candidate-generation-to-serving increment.

No email, Slack, webhook, paging, recipient directory, delivery attempt, retry/dead-letter policy, acknowledgement mutation, trading action, scheduler, deployment, managed service or `terraform apply` is included.

## Acceptance boundary

This PR is validated and ready for human review. It has not been merged.