### PR TITLE
Define effective-dated risk-limit policy contract

### DIFF
--- a/config/portfolio_risk_limits.yaml
+++ b/config/portfolio_risk_limits.yaml
@@ -1,5 +1,8 @@
 policies:
   us-tech-standard:
+    policy_version_id: us-tech-standard-v1
+    effective_from: 2026-01-01
+    effective_to:
     portfolio_id: us-tech-equal
     covariance_window: 20
     annualization_days: 252

--- a/docs/portfolio-risk-limit-policy-history.md
+++ b/docs/portfolio-risk-limit-policy-history.md
@@ -1,0 +1,135 @@
+# Effective-Dated Portfolio Risk-Limit Policies
+
+## Outcome
+
+Risk-limit thresholds now have an explicit temporal-governance contract before
+they are wired into historical evaluation:
+
+```text
+risk-limit policy history
+  -> validate version IDs and effective ranges
+  -> reject overlap and ambiguity
+  -> select exactly one version for an as-of date
+  -> preserve threshold identity separately from temporal policy identity
+  -> require bounded runs to remain inside one policy version
+```
+
+The contract is implemented in
+`src/analytics/portfolio_risk_limit_policies.py`. Existing risk-limit analytics
+continue to use the current single configured policy until the separate runtime
+wiring increment is reviewed.
+
+## Configuration Shape
+
+A single direct version remains valid:
+
+```yaml
+policies:
+  us-tech-standard:
+    policy_version_id: us-tech-standard-v1
+    effective_from: 2026-01-01
+    effective_to:
+    portfolio_id: us-tech-equal
+    covariance_window: 20
+    annualization_days: 252
+    limits:
+      portfolio_volatility_annualized:
+        warning: 0.30
+        critical: 0.45
+      largest_absolute_component_contribution_share:
+        warning: 0.65
+        critical: 0.80
+```
+
+A history uses a `versions` list:
+
+```yaml
+policies:
+  us-tech-standard:
+    versions:
+      - policy_version_id: us-tech-standard-v1
+        effective_from: 2026-01-01
+        effective_to: 2026-07-01
+        portfolio_id: us-tech-equal
+        covariance_window: 20
+        annualization_days: 252
+        limits: ...
+      - policy_version_id: us-tech-standard-v2
+        effective_from: 2026-07-01
+        effective_to:
+        portfolio_id: us-tech-equal
+        covariance_window: 20
+        annualization_days: 252
+        limits: ...
+```
+
+Direct fields and a `versions` list cannot be mixed.
+
+## Date Semantics
+
+`effective_from` is inclusive. `effective_to` is exclusive and may be null only
+for the final open-ended version:
+
+```text
+v1: [2026-01-01, 2026-07-01)
+v2: [2026-07-01, infinity)
+```
+
+The parser rejects:
+
+- duplicate version IDs;
+- malformed dates or datetime values where a calendar date is required;
+- zero-length or reversed ranges;
+- overlapping versions;
+- a non-final open-ended version;
+- histories targeting different portfolio IDs; and
+- ambiguous or uncovered as-of dates during selection.
+
+Gaps are allowed because a policy may be inactive. Evaluating a date inside a
+gap fails explicitly rather than borrowing a nearby version.
+
+## Identity
+
+Each selected version exposes two fingerprints.
+
+`limit_definition_fingerprint` binds:
+
+- policy and portfolio IDs;
+- covariance window;
+- annualisation basis; and
+- warning and critical thresholds.
+
+`policy_fingerprint` additionally binds:
+
+- policy-version ID;
+- inclusive effective-from date; and
+- exclusive effective-to date.
+
+A formal policy renewal with unchanged thresholds therefore keeps the same limit
+definition identity but receives a distinct temporal policy identity. Threshold
+changes alter both identities.
+
+## Selection And Range Validation
+
+Select one version with:
+
+```python
+policy = load_effective_portfolio_risk_limit_policy(
+    Path("config/portfolio_risk_limits.yaml"),
+    "us-tech-standard",
+    as_of_date,
+)
+```
+
+A bounded operation can then call `validate_policy_range`. The current contract
+requires the explicit start and end dates to remain within one selected policy
+version. A later runtime increment will decide whether the historical evaluator
+splits a broad request into per-version segments or requires the operator to do
+so explicitly.
+
+## Boundary
+
+This increment defines and tests policy time semantics only. It does not change
+existing risk-limit calculations, stored evaluation schemas, breach lifecycle,
+notification candidates, acknowledgement state, PostgreSQL data, scheduling,
+external delivery, trading controls, credentials, deployment, or Terraform.

--- a/src/analytics/portfolio_risk_limit_policies.py
+++ b/src/analytics/portfolio_risk_limit_policies.py
@@ -1,0 +1,304 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from collections.abc import Mapping
+from dataclasses import dataclass
+from datetime import date, datetime
+from pathlib import Path
+from typing import Any, TypeAlias
+
+from ..common.config import load_yaml
+from ..common.exceptions import ValidationError
+from .portfolio_risk_limits import (
+    PortfolioRiskLimitPolicy,
+    parse_portfolio_risk_limit_policy,
+)
+
+MAX_POLICY_VERSIONS = 100
+POLICY_ID_PATTERN = re.compile(r"^[a-z0-9][a-z0-9_-]{0,63}$")
+POLICY_VERSION_ID_PATTERN = re.compile(r"^[a-z0-9][a-z0-9._-]{0,127}$")
+DIRECT_POLICY_FIELDS = frozenset(
+    {
+        "policy_version_id",
+        "effective_from",
+        "effective_to",
+        "portfolio_id",
+        "covariance_window",
+        "annualization_days",
+        "limits",
+    }
+)
+
+PolicyVersionInput: TypeAlias = Mapping[str, Any]
+
+
+@dataclass(frozen=True, slots=True)
+class EffectiveDatedPortfolioRiskLimitPolicy(PortfolioRiskLimitPolicy):
+    policy_version_id: str
+    effective_from: date
+    effective_to: date | None
+
+    @property
+    def limit_definition_fingerprint(self) -> str:
+        """Identity of thresholds and analytical parameters, excluding dates."""
+
+        base = PortfolioRiskLimitPolicy(
+            policy_id=self.policy_id,
+            portfolio_id=self.portfolio_id,
+            covariance_window=self.covariance_window,
+            annualization_days=self.annualization_days,
+            portfolio_volatility=self.portfolio_volatility,
+            component_concentration=self.component_concentration,
+        )
+        return base.fingerprint
+
+    @property
+    def fingerprint(self) -> str:
+        """Identity of one effective-dated policy version."""
+
+        payload = {
+            "effective_from": self.effective_from.isoformat(),
+            "effective_to": (
+                self.effective_to.isoformat()
+                if self.effective_to is not None
+                else None
+            ),
+            "limit_definition_fingerprint": self.limit_definition_fingerprint,
+            "policy_id": self.policy_id,
+            "policy_version_id": self.policy_version_id,
+            "portfolio_id": self.portfolio_id,
+        }
+        digest = hashlib.sha256(
+            json.dumps(payload, sort_keys=True, separators=(",", ":")).encode(
+                "utf-8"
+            )
+        ).hexdigest()[:24]
+        return f"risk-limit-policy-version-{digest}"
+
+    def contains(self, event_date: date) -> bool:
+        return self.effective_from <= event_date and (
+            self.effective_to is None or event_date < self.effective_to
+        )
+
+
+def _identifier(value: Any, label: str, pattern: re.Pattern[str]) -> str:
+    if not isinstance(value, str):
+        raise ValidationError(f"{label} must be text")
+    parsed = value.strip().lower()
+    if pattern.fullmatch(parsed) is None:
+        raise ValidationError(f"{label} has an invalid format")
+    return parsed
+
+
+def _strict_date(value: Any, label: str, *, allow_none: bool = False) -> date | None:
+    if value is None and allow_none:
+        return None
+    if isinstance(value, datetime):
+        raise ValidationError(f"{label} must be a calendar date")
+    if isinstance(value, date):
+        return value
+    if not isinstance(value, str):
+        raise ValidationError(f"{label} must be a calendar date")
+    try:
+        parsed = date.fromisoformat(value.strip())
+    except ValueError:
+        raise ValidationError(
+            f"{label} must be a calendar date in YYYY-MM-DD format"
+        ) from None
+    if value.strip() != parsed.isoformat():
+        raise ValidationError(
+            f"{label} must be a calendar date in YYYY-MM-DD format"
+        )
+    return parsed
+
+
+def _policy_candidate(
+    payload: Mapping[str, Any],
+    policy_id: str,
+) -> Mapping[str, Any]:
+    policies = payload.get("policies")
+    if not isinstance(policies, Mapping):
+        raise ValidationError(
+            "risk-limit configuration must define a policies mapping"
+        )
+    candidate = policies.get(policy_id)
+    if not isinstance(candidate, Mapping):
+        raise ValidationError(f"risk-limit policy '{policy_id}' is not configured")
+    return candidate
+
+
+def _build_policy(
+    *,
+    policy_id: str,
+    raw: PolicyVersionInput,
+) -> EffectiveDatedPortfolioRiskLimitPolicy:
+    policy_version_id = _identifier(
+        raw.get("policy_version_id"),
+        "policy_version_id",
+        POLICY_VERSION_ID_PATTERN,
+    )
+    effective_from = _strict_date(raw.get("effective_from"), "effective_from")
+    effective_to = _strict_date(
+        raw.get("effective_to"),
+        "effective_to",
+        allow_none=True,
+    )
+    if effective_from is None:  # pragma: no cover - required above.
+        raise ValidationError("effective_from is required")
+    if effective_to is not None and effective_to <= effective_from:
+        raise ValidationError("effective_to must be after effective_from")
+
+    base = parse_portfolio_risk_limit_policy(
+        {
+            "policies": {
+                policy_id: {
+                    "portfolio_id": raw.get("portfolio_id"),
+                    "covariance_window": raw.get("covariance_window"),
+                    "annualization_days": raw.get("annualization_days"),
+                    "limits": raw.get("limits"),
+                }
+            }
+        },
+        policy_id,
+    )
+    return EffectiveDatedPortfolioRiskLimitPolicy(
+        policy_id=base.policy_id,
+        portfolio_id=base.portfolio_id,
+        covariance_window=base.covariance_window,
+        annualization_days=base.annualization_days,
+        portfolio_volatility=base.portfolio_volatility,
+        component_concentration=base.component_concentration,
+        policy_version_id=policy_version_id,
+        effective_from=effective_from,
+        effective_to=effective_to,
+    )
+
+
+def parse_portfolio_risk_limit_policies(
+    payload: Mapping[str, Any],
+    policy_id: str,
+) -> tuple[EffectiveDatedPortfolioRiskLimitPolicy, ...]:
+    if not isinstance(payload, Mapping):
+        raise ValidationError("risk-limit configuration must be a mapping")
+    canonical_policy_id = _identifier(
+        policy_id,
+        "policy_id",
+        POLICY_ID_PATTERN,
+    )
+    candidate = _policy_candidate(payload, canonical_policy_id)
+    raw_versions = candidate.get("versions")
+
+    if raw_versions is None:
+        raw_entries: list[PolicyVersionInput] = [candidate]
+    else:
+        mixed_fields = sorted(DIRECT_POLICY_FIELDS.intersection(candidate))
+        if mixed_fields:
+            raise ValidationError(
+                "risk-limit policy must not mix direct and version-list fields"
+            )
+        if (
+            not isinstance(raw_versions, list)
+            or not 1 <= len(raw_versions) <= MAX_POLICY_VERSIONS
+        ):
+            raise ValidationError(
+                "risk-limit policy versions must contain between 1 and "
+                f"{MAX_POLICY_VERSIONS} entries"
+            )
+        if any(not isinstance(entry, Mapping) for entry in raw_versions):
+            raise ValidationError("each risk-limit policy version must be a mapping")
+        raw_entries = list(raw_versions)
+
+    versions = tuple(
+        sorted(
+            (
+                _build_policy(policy_id=canonical_policy_id, raw=entry)
+                for entry in raw_entries
+            ),
+            key=lambda item: (item.effective_from, item.policy_version_id),
+        )
+    )
+    version_ids = [item.policy_version_id for item in versions]
+    if len(version_ids) != len(set(version_ids)):
+        raise ValidationError("risk-limit policy version IDs must be unique")
+    if len({item.portfolio_id for item in versions}) != 1:
+        raise ValidationError(
+            "all versions of one risk-limit policy must target the same portfolio"
+        )
+
+    for previous, current in zip(versions, versions[1:], strict=False):
+        if previous.effective_to is None:
+            raise ValidationError(
+                "an open-ended risk-limit policy version must be final"
+            )
+        if current.effective_from < previous.effective_to:
+            raise ValidationError("risk-limit policy versions must not overlap")
+    return versions
+
+
+def select_portfolio_risk_limit_policy(
+    payload: Mapping[str, Any],
+    policy_id: str,
+    as_of_date: date,
+) -> EffectiveDatedPortfolioRiskLimitPolicy:
+    if isinstance(as_of_date, datetime) or not isinstance(as_of_date, date):
+        raise ValidationError("as_of_date must be a calendar date")
+    versions = parse_portfolio_risk_limit_policies(payload, policy_id)
+    matches = [version for version in versions if version.contains(as_of_date)]
+    if len(matches) != 1:
+        raise ValidationError(
+            f"risk-limit policy '{policy_id}' has no unique version for "
+            f"{as_of_date.isoformat()}"
+        )
+    return matches[0]
+
+
+def load_effective_portfolio_risk_limit_policy(
+    path: Path,
+    policy_id: str,
+    as_of_date: date,
+) -> EffectiveDatedPortfolioRiskLimitPolicy:
+    try:
+        payload = load_yaml(path)
+    except Exception:
+        raise ValidationError(
+            "risk-limit configuration could not be loaded"
+        ) from None
+    if not isinstance(payload, Mapping):
+        raise ValidationError("risk-limit configuration must be a mapping")
+    return select_portfolio_risk_limit_policy(payload, policy_id, as_of_date)
+
+
+def validate_policy_range(
+    policy: EffectiveDatedPortfolioRiskLimitPolicy,
+    *,
+    start_date: date | None,
+    end_date: date,
+) -> None:
+    if start_date is not None and start_date > end_date:
+        raise ValidationError("start_date must be on or before end_date")
+    if not policy.contains(end_date):
+        raise ValidationError("end_date is outside the selected risk-limit policy")
+    if start_date is not None and not policy.contains(start_date):
+        raise ValidationError(
+            "requested date range crosses a risk-limit policy boundary; "
+            "split the request by policy version"
+        )
+
+
+def policy_metadata(
+    policy: EffectiveDatedPortfolioRiskLimitPolicy,
+) -> dict[str, Any]:
+    return {
+        "policy_id": policy.policy_id,
+        "policy_version_id": policy.policy_version_id,
+        "policy_fingerprint": policy.fingerprint,
+        "limit_definition_fingerprint": policy.limit_definition_fingerprint,
+        "effective_from": policy.effective_from.isoformat(),
+        "effective_to": (
+            policy.effective_to.isoformat()
+            if policy.effective_to is not None
+            else None
+        ),
+    }

--- a/tests/unit/test_portfolio_risk_limit_policies.py
+++ b/tests/unit/test_portfolio_risk_limit_policies.py
@@ -1,0 +1,253 @@
+from __future__ import annotations
+
+from datetime import date, datetime
+from pathlib import Path
+
+import pytest
+import yaml
+
+from src.analytics.portfolio_risk_limit_policies import (
+    EffectiveDatedPortfolioRiskLimitPolicy,
+    load_effective_portfolio_risk_limit_policy,
+    parse_portfolio_risk_limit_policies,
+    policy_metadata,
+    select_portfolio_risk_limit_policy,
+    validate_policy_range,
+)
+from src.common.exceptions import ValidationError
+
+
+def _version(
+    version_id: str,
+    effective_from: str,
+    effective_to: str | None,
+    *,
+    volatility_warning: float = 0.30,
+    portfolio_id: str = "us-tech-equal",
+) -> dict[str, object]:
+    return {
+        "policy_version_id": version_id,
+        "effective_from": effective_from,
+        "effective_to": effective_to,
+        "portfolio_id": portfolio_id,
+        "covariance_window": 20,
+        "annualization_days": 252,
+        "limits": {
+            "portfolio_volatility_annualized": {
+                "warning": volatility_warning,
+                "critical": 0.45,
+            },
+            "largest_absolute_component_contribution_share": {
+                "warning": 0.65,
+                "critical": 0.80,
+            },
+        },
+    }
+
+
+def _history(*versions: dict[str, object]) -> dict[str, object]:
+    return {
+        "policies": {
+            "us-tech-standard": {
+                "versions": list(versions),
+            }
+        }
+    }
+
+
+def test_direct_policy_is_a_single_effective_dated_version() -> None:
+    payload = {
+        "policies": {
+            "us-tech-standard": _version(
+                "us-tech-standard-v1",
+                "2026-01-01",
+                None,
+            )
+        }
+    }
+
+    versions = parse_portfolio_risk_limit_policies(
+        payload,
+        "us-tech-standard",
+    )
+    selected = select_portfolio_risk_limit_policy(
+        payload,
+        "us-tech-standard",
+        date(2026, 8, 22),
+    )
+
+    assert len(versions) == 1
+    assert selected == versions[0]
+    assert isinstance(selected, EffectiveDatedPortfolioRiskLimitPolicy)
+    assert selected.policy_version_id == "us-tech-standard-v1"
+    assert selected.contains(date(2026, 1, 1))
+    assert selected.contains(date(2099, 1, 1))
+    assert selected.fingerprint.startswith("risk-limit-policy-version-")
+
+
+def test_policy_history_selects_inclusive_exclusive_versions() -> None:
+    payload = _history(
+        _version("us-tech-standard-v1", "2026-01-01", "2026-07-01"),
+        _version(
+            "us-tech-standard-v2",
+            "2026-07-01",
+            None,
+            volatility_warning=0.25,
+        ),
+    )
+
+    assert select_portfolio_risk_limit_policy(
+        payload,
+        "us-tech-standard",
+        date(2026, 6, 30),
+    ).policy_version_id == "us-tech-standard-v1"
+    assert select_portfolio_risk_limit_policy(
+        payload,
+        "us-tech-standard",
+        date(2026, 7, 1),
+    ).policy_version_id == "us-tech-standard-v2"
+
+
+def test_renewal_keeps_limit_identity_but_changes_temporal_identity() -> None:
+    versions = parse_portfolio_risk_limit_policies(
+        _history(
+            _version("us-tech-standard-v1", "2026-01-01", "2026-07-01"),
+            _version("us-tech-standard-v2", "2026-07-01", None),
+        ),
+        "us-tech-standard",
+    )
+
+    first, second = versions
+    assert first.limit_definition_fingerprint == second.limit_definition_fingerprint
+    assert first.fingerprint != second.fingerprint
+    assert policy_metadata(second) == {
+        "policy_id": "us-tech-standard",
+        "policy_version_id": "us-tech-standard-v2",
+        "policy_fingerprint": second.fingerprint,
+        "limit_definition_fingerprint": second.limit_definition_fingerprint,
+        "effective_from": "2026-07-01",
+        "effective_to": None,
+    }
+
+
+def test_gaps_are_valid_but_uncovered_dates_fail_selection() -> None:
+    payload = _history(
+        _version("us-tech-standard-v1", "2026-01-01", "2026-04-01"),
+        _version("us-tech-standard-v2", "2026-05-01", None),
+    )
+
+    versions = parse_portfolio_risk_limit_policies(
+        payload,
+        "us-tech-standard",
+    )
+    assert len(versions) == 2
+    with pytest.raises(ValidationError, match="no unique version"):
+        select_portfolio_risk_limit_policy(
+            payload,
+            "us-tech-standard",
+            date(2026, 4, 15),
+        )
+
+
+def test_overlaps_duplicate_ids_and_mixed_definitions_fail_closed() -> None:
+    with pytest.raises(ValidationError, match="must not overlap"):
+        parse_portfolio_risk_limit_policies(
+            _history(
+                _version("v1", "2026-01-01", "2026-08-01"),
+                _version("v2", "2026-07-01", None),
+            ),
+            "us-tech-standard",
+        )
+
+    with pytest.raises(ValidationError, match="version IDs must be unique"):
+        parse_portfolio_risk_limit_policies(
+            _history(
+                _version("same", "2026-01-01", "2026-07-01"),
+                _version("same", "2026-07-01", None),
+            ),
+            "us-tech-standard",
+        )
+
+    mixed = _history(_version("v1", "2026-01-01", None))
+    mixed["policies"]["us-tech-standard"]["portfolio_id"] = "us-tech-equal"
+    with pytest.raises(ValidationError, match="must not mix"):
+        parse_portfolio_risk_limit_policies(mixed, "us-tech-standard")
+
+
+def test_open_ended_version_must_be_final_and_portfolio_is_stable() -> None:
+    with pytest.raises(ValidationError, match="must be final"):
+        parse_portfolio_risk_limit_policies(
+            _history(
+                _version("v1", "2026-01-01", None),
+                _version("v2", "2026-07-01", None),
+            ),
+            "us-tech-standard",
+        )
+
+    with pytest.raises(ValidationError, match="same portfolio"):
+        parse_portfolio_risk_limit_policies(
+            _history(
+                _version("v1", "2026-01-01", "2026-07-01"),
+                _version(
+                    "v2",
+                    "2026-07-01",
+                    None,
+                    portfolio_id="other-portfolio",
+                ),
+            ),
+            "us-tech-standard",
+        )
+
+
+def test_policy_range_must_stay_inside_one_version() -> None:
+    policy = select_portfolio_risk_limit_policy(
+        _history(
+            _version("v1", "2026-01-01", "2026-07-01"),
+            _version("v2", "2026-07-01", None),
+        ),
+        "us-tech-standard",
+        date(2026, 6, 30),
+    )
+
+    validate_policy_range(
+        policy,
+        start_date=date(2026, 1, 1),
+        end_date=date(2026, 6, 30),
+    )
+    with pytest.raises(ValidationError, match="crosses"):
+        validate_policy_range(
+            policy,
+            start_date=date(2025, 12, 31),
+            end_date=date(2026, 6, 30),
+        )
+    with pytest.raises(ValidationError, match="outside"):
+        validate_policy_range(
+            policy,
+            start_date=None,
+            end_date=date(2026, 7, 1),
+        )
+
+
+def test_loader_and_strict_date_contract(tmp_path: Path) -> None:
+    path = tmp_path / "limits.yaml"
+    path.write_text(
+        yaml.safe_dump(
+            _history(_version("v1", "2026-01-01", None)),
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+
+    loaded = load_effective_portfolio_risk_limit_policy(
+        path,
+        "us-tech-standard",
+        date(2026, 8, 22),
+    )
+    assert loaded.policy_version_id == "v1"
+
+    invalid = _history(_version("v1", "2026-01-01", None))
+    invalid["policies"]["us-tech-standard"]["versions"][0][
+        "effective_from"
+    ] = datetime(2026, 1, 1)
+    with pytest.raises(ValidationError, match="calendar date"):
+        parse_portfolio_risk_limit_policies(invalid, "us-tech-standard")

--- a/tests/unit/test_portfolio_risk_limit_policy_contract.py
+++ b/tests/unit/test_portfolio_risk_limit_policy_contract.py
@@ -1,0 +1,30 @@
+from pathlib import Path
+
+import yaml
+
+
+def test_effective_dated_risk_limit_policy_contract_is_documented() -> None:
+    documentation = Path(
+        "docs/portfolio-risk-limit-policy-history.md"
+    ).read_text(encoding="utf-8")
+    normalized_documentation = " ".join(documentation.split())
+    configuration = yaml.safe_load(
+        Path("config/portfolio_risk_limits.yaml").read_text(encoding="utf-8")
+    )
+    policy = configuration["policies"]["us-tech-standard"]
+
+    for required in (
+        "effective_from",
+        "effective_to",
+        "policy_version_id",
+        "limit_definition_fingerprint",
+        "policy_fingerprint",
+        "inclusive",
+        "exclusive",
+        "remain within one selected policy version",
+    ):
+        assert required in normalized_documentation
+
+    assert policy["policy_version_id"] == "us-tech-standard-v1"
+    assert policy["effective_from"].isoformat() == "2026-01-01"
+    assert policy["effective_to"] is None


### PR DESCRIPTION
## Outcome

Define strict temporal governance for portfolio risk-limit policies before wiring it into historical evaluation:

```text
risk-limit policy history
  -> validate version IDs and effective ranges
  -> reject overlap and ambiguity
  -> select exactly one version for an as-of date
  -> preserve threshold identity separately from temporal policy identity
  -> require bounded requests to remain inside one version
```

Primary arc42 block: `analytics`, with a bounded configuration and documentation interface.

## Contract

Add `EffectiveDatedPortfolioRiskLimitPolicy` with `policy_version_id`, inclusive `effective_from`, exclusive nullable `effective_to`, a threshold-only `limit_definition_fingerprint`, and a temporal policy `fingerprint`.

A formal renewal with unchanged thresholds therefore retains the same limit-definition identity but receives a distinct policy-version identity.

## Configuration and validation

The demonstration policy declares its version and effective range. The parser supports either one direct version or a bounded `versions` list and rejects duplicate IDs, malformed dates, reversed ranges, overlaps, non-final open-ended versions, mixed direct/list definitions and cross-portfolio histories.

Gaps remain valid because a policy can be inactive. Selecting an uncovered date fails explicitly.

## Range boundary

`validate_policy_range` requires an explicit start/end request to remain within one selected version. Runtime selection is intentionally the next separate increment.

## Compatibility

Existing risk-limit runtime behavior is unchanged. Temporal fields are additive. No evaluation ID, Parquet schema, PostgreSQL table, lifecycle view, acknowledgement or notification contract changes in this PR.

## Validation repair

Two exact-head runs exposed documentation assertions that were sensitive to sentence wording and Markdown line wrapping. The final assertion normalizes whitespace and checks the stable semantic phrase. No production code, test coverage or validation gate was removed.

GitHub Actions run `32589143792` (`ci` run 222) passed on exact head `16cc200092a208a979ea76c204e1fe4b236b5b10`:

- Security guardrails: passed.
- Python readiness: passed.
  - Ruff passed;
  - mypy passed across 59 source files;
  - 523 tests passed twice through quality and readiness;
  - `pip check` passed;
  - readiness replay passed.
- PostgreSQL contract: passed against PostgreSQL 16.
- Infrastructure validation: passed.
  - Kubernetes overlays rendered;
  - Terraform formatting, initialization and validation passed without applying infrastructure.

No unresolved review threads or requested changes are present.

## Scope

The branch is one commit ahead of `main`, zero behind, and changes five files with 724 additions.

No risk calculation, stored dataset, database schema, provider request, credential, external delivery, scheduler, deployment or Terraform apply is included.

## Acceptance boundary

This PR is validated and ready for squash merge as the policy-time contract increment.