### PR TITLE
Wire effective-dated risk-limit policy selection

### DIFF
--- a/docs/effective-dated-risk-limit-runtime.md
+++ b/docs/effective-dated-risk-limit-runtime.md
@@ -1,0 +1,94 @@
+# Effective-Dated Risk-Limit Runtime Selection
+
+## Outcome
+
+The portfolio risk-limit runner selects the policy version valid at the requested
+end date and rejects a bounded request that crosses its temporal boundary:
+
+```text
+policy history + end date
+  -> exactly one effective-dated policy version
+  -> validate the requested range is contained by that version
+  -> evaluate current attribution snapshots
+  -> bind evaluation identity to the temporal policy fingerprint
+  -> publish and serve retained versions as before
+```
+
+This is a conservative first runtime rule. Operators split a broad historical
+request at policy boundaries rather than allowing one run to silently relabel
+observations under several threshold regimes.
+
+## Selection
+
+`run_portfolio_risk_limits` calls the effective-dated policy loader with:
+
+- the policy configuration path;
+- the policy ID; and
+- the requested inclusive end date.
+
+Selection uses inclusive `effective_from` and exclusive nullable `effective_to`.
+A gap, overlap, malformed policy history, or uncovered end date fails before
+attribution Parquet is read.
+
+## Range Boundary
+
+After selection, `validate_policy_range` checks the optional start date and the
+required end date. Both must be contained by the selected version.
+
+For example:
+
+```text
+v1: [2026-01-01, 2026-07-01)
+v2: [2026-07-01, infinity)
+```
+
+This request is valid:
+
+```text
+2026-01-01 through 2026-06-30 -> v1
+```
+
+This request is rejected and must be split:
+
+```text
+2026-06-01 through 2026-07-31 -> crosses v1/v2
+```
+
+Boundary rejection happens before local attribution input is read or output is
+written.
+
+## Versioned Evidence
+
+The existing evaluation calculation ID already binds `policy.fingerprint`.
+Because the runtime now supplies the temporal fingerprint:
+
+- a policy renewal receives new evaluation IDs even when thresholds are
+  unchanged;
+- a threshold change receives new evaluation IDs;
+- replay under one policy version converges on the same IDs; and
+- earlier Parquet and PostgreSQL evidence remains retained.
+
+No evaluation schema migration is required. The stable policy ID remains
+queryable while the policy fingerprint distinguishes versions.
+
+## Run Summary
+
+The credential-free JSON summary now includes:
+
+```text
+policy_version_id
+policy_fingerprint
+limit_definition_fingerprint
+effective_from
+effective_to
+```
+
+This makes the selected governance state visible to the operator without placing
+free text, credentials, or mutable approval state in evaluation rows.
+
+## Boundary
+
+This increment does not automatically segment one request across multiple policy
+versions. It also does not change portfolio-mandate selection, PostgreSQL schema,
+breach lifecycle, acknowledgements, notification candidates, provider access,
+scheduling, deployment, or Terraform.

--- a/docs/portfolio-risk-limit-policy-history.md
+++ b/docs/portfolio-risk-limit-policy-history.md
@@ -2,8 +2,9 @@
 
 ## Outcome
 
-Risk-limit thresholds now have an explicit temporal-governance contract before
-they are wired into historical evaluation:
+Risk-limit thresholds have an explicit temporal-governance contract and the
+historical evaluator selects one governed version before reading attribution
+data:
 
 ```text
 risk-limit policy history
@@ -12,12 +13,12 @@ risk-limit policy history
   -> select exactly one version for an as-of date
   -> preserve threshold identity separately from temporal policy identity
   -> require bounded runs to remain inside one policy version
+  -> bind evaluations to the temporal policy fingerprint
 ```
 
 The contract is implemented in
-`src/analytics/portfolio_risk_limit_policies.py`. Existing risk-limit analytics
-continue to use the current single configured policy until the separate runtime
-wiring increment is reviewed.
+`src/analytics/portfolio_risk_limit_policies.py`. Runtime selection is implemented
+in `src/orchestration/run_portfolio_risk_limits.py`.
 
 ## Configuration Shape
 
@@ -121,15 +122,18 @@ policy = load_effective_portfolio_risk_limit_policy(
 )
 ```
 
-A bounded operation can then call `validate_policy_range`. The current contract
-requires the explicit start and end dates to remain within one selected policy
-version. A later runtime increment will decide whether the historical evaluator
-splits a broad request into per-version segments or requires the operator to do
-so explicitly.
+`run_portfolio_risk_limits` uses its inclusive end date as `as_of_date`, then
+calls `validate_policy_range`. The optional start date and required end date must
+remain within one selected policy version. A request crossing a boundary is
+rejected before attribution Parquet is read and must be split by version.
+
+The resulting evaluation calculation IDs bind the temporal policy fingerprint,
+so a renewal or threshold change creates new retained evidence without changing
+the risk formulas or overwriting earlier versions.
 
 ## Boundary
 
-This increment defines and tests policy time semantics only. It does not change
-existing risk-limit calculations, stored evaluation schemas, breach lifecycle,
-notification candidates, acknowledgement state, PostgreSQL data, scheduling,
-external delivery, trading controls, credentials, deployment, or Terraform.
+This contract and runtime selection do not automatically segment one request
+across several versions. They do not change the evaluation Parquet schema,
+PostgreSQL schema, breach lifecycle, notification candidates, acknowledgement
+state, provider access, scheduling, deployment, or Terraform.

--- a/src/orchestration/run_portfolio_risk_limits.py
+++ b/src/orchestration/run_portfolio_risk_limits.py
@@ -10,11 +10,15 @@ from typing import Any
 from uuid import uuid4
 
 from ..analytics.portfolio_risk import PortfolioDefinition, load_portfolio_definition
+from ..analytics.portfolio_risk_limit_policies import (
+    EffectiveDatedPortfolioRiskLimitPolicy,
+    load_effective_portfolio_risk_limit_policy,
+    policy_metadata,
+    validate_policy_range,
+)
 from ..analytics.portfolio_risk_limits import (
     MAX_LIMIT_EVALUATIONS,
-    PortfolioRiskLimitPolicy,
     evaluate_portfolio_risk_limits,
-    load_portfolio_risk_limit_policy,
 )
 from ..common.exceptions import StorageError, ValidationError
 from ..storage.s3_writer import write_records
@@ -28,7 +32,10 @@ Reader = Callable[[Path], list[dict[str, Any]]]
 Writer = Callable[..., int]
 StorageConfigLoader = Callable[[Path], dict[str, Any]]
 DefinitionLoader = Callable[[Path, str], PortfolioDefinition]
-PolicyLoader = Callable[[Path, str], PortfolioRiskLimitPolicy]
+PolicyLoader = Callable[
+    [Path, str, date],
+    EffectiveDatedPortfolioRiskLimitPolicy,
+]
 
 
 def _calendar_date(value: str) -> date:
@@ -63,7 +70,7 @@ def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         description=(
             "Evaluate current portfolio-attribution history against a versioned "
-            "local risk-limit policy."
+            "effective-dated local risk-limit policy."
         )
     )
     parser.add_argument("--policy-id", required=True)
@@ -162,13 +169,28 @@ def run_portfolio_risk_limits(
         raise StorageError("Storage configuration is invalid")
     _require_datasets(storage_config)
 
-    selected_policy_loader = policy_loader or load_portfolio_risk_limit_policy
+    selected_policy_loader = (
+        policy_loader or load_effective_portfolio_risk_limit_policy
+    )
     try:
-        policy = selected_policy_loader(limits_config_path, policy_id)
+        policy = selected_policy_loader(
+            limits_config_path,
+            policy_id,
+            end_date,
+        )
     except ValidationError:
         raise
     except Exception:
         raise ValidationError("Portfolio risk-limit policy is invalid") from None
+    if not isinstance(policy, EffectiveDatedPortfolioRiskLimitPolicy):
+        raise ValidationError(
+            "risk-limit policy loader returned an invalid policy version"
+        )
+    validate_policy_range(
+        policy,
+        start_date=start_date,
+        end_date=end_date,
+    )
 
     selected_definition_loader = definition_loader or load_portfolio_definition
     try:
@@ -217,6 +239,7 @@ def run_portfolio_risk_limits(
         "run_id": str(uuid4()),
         "policy_id": policy.policy_id,
         "policy_fingerprint": policy.fingerprint,
+        "policy_version": policy_metadata(policy),
         "portfolio_id": policy.portfolio_id,
         "definition_fingerprint": definition.fingerprint,
         "selection": dict(output.diagnostics),

--- a/tests/integration/test_portfolio_risk_limits_pipeline.py
+++ b/tests/integration/test_portfolio_risk_limits_pipeline.py
@@ -37,6 +37,9 @@ def _limits_config(tmp_path: Path) -> Path:
         """
 policies:
   test-policy:
+    policy_version_id: test-policy-v1
+    effective_from: 2026-01-01
+    effective_to:
     portfolio_id: us-tech-equal
     covariance_window: 3
     annualization_days: 252
@@ -130,3 +133,4 @@ def test_portfolio_risk_limits_read_attribution_and_replay(tmp_path: Path) -> No
     assert second_output["records_written"] == 0
     assert second_output["records_already_present"] == 2
     assert second["latest_status"] == first["latest_status"]
+    assert second["policy_version"]["policy_version_id"] == "test-policy-v1"

--- a/tests/unit/test_effective_dated_risk_limit_runtime_contract.py
+++ b/tests/unit/test_effective_dated_risk_limit_runtime_contract.py
@@ -1,0 +1,33 @@
+from pathlib import Path
+
+
+def test_effective_dated_risk_limit_runtime_is_documented_and_wired() -> None:
+    runner = Path(
+        "src/orchestration/run_portfolio_risk_limits.py"
+    ).read_text(encoding="utf-8")
+    documentation = " ".join(
+        Path("docs/effective-dated-risk-limit-runtime.md")
+        .read_text(encoding="utf-8")
+        .split()
+    )
+
+    for required in (
+        "load_effective_portfolio_risk_limit_policy",
+        "validate_policy_range",
+        "policy_metadata",
+        "selected_policy_loader(",
+        "policy_id,",
+        "end_date,",
+        '"policy_version"',
+    ):
+        assert required in runner
+
+    for required in (
+        "selects the policy version valid at the requested end date",
+        "rejects a bounded request that crosses its temporal boundary",
+        "Boundary rejection happens before local attribution input is read",
+        "policy_version_id",
+        "limit_definition_fingerprint",
+        "does not automatically segment one request",
+    ):
+        assert required in documentation

--- a/tests/unit/test_run_portfolio_risk_limits.py
+++ b/tests/unit/test_run_portfolio_risk_limits.py
@@ -8,8 +8,11 @@ from typing import Any
 import pytest
 
 from src.analytics.portfolio_risk import parse_portfolio_definition
-from src.analytics.portfolio_risk_limits import parse_portfolio_risk_limit_policy
-from src.common.exceptions import StorageError
+from src.analytics.portfolio_risk_limit_policies import (
+    EffectiveDatedPortfolioRiskLimitPolicy,
+)
+from src.analytics.portfolio_risk_limits import RiskLimitThresholds
+from src.common.exceptions import StorageError, ValidationError
 from src.orchestration.run_portfolio_risk_limits import (
     OUTPUT_DATASET,
     run_portfolio_risk_limits,
@@ -41,28 +44,27 @@ def _definition():
     )
 
 
-def _policy():
-    return parse_portfolio_risk_limit_policy(
-        {
-            "policies": {
-                "test-policy": {
-                    "portfolio_id": "us-tech-equal",
-                    "covariance_window": 3,
-                    "annualization_days": 252,
-                    "limits": {
-                        "portfolio_volatility_annualized": {
-                            "warning": 0.30,
-                            "critical": 0.45,
-                        },
-                        "largest_absolute_component_contribution_share": {
-                            "warning": 0.65,
-                            "critical": 0.80,
-                        },
-                    },
-                }
-            }
-        },
-        "test-policy",
+def _policy(
+    *,
+    effective_from: date = date(2026, 1, 1),
+    effective_to: date | None = None,
+) -> EffectiveDatedPortfolioRiskLimitPolicy:
+    return EffectiveDatedPortfolioRiskLimitPolicy(
+        policy_id="test-policy",
+        portfolio_id="us-tech-equal",
+        covariance_window=3,
+        annualization_days=252,
+        portfolio_volatility=RiskLimitThresholds(
+            warning=0.30,
+            critical=0.45,
+        ),
+        component_concentration=RiskLimitThresholds(
+            warning=0.65,
+            critical=0.80,
+        ),
+        policy_version_id="test-policy-v1",
+        effective_from=effective_from,
+        effective_to=effective_to,
     )
 
 
@@ -127,6 +129,7 @@ def test_runner_publishes_and_summarises_limit_evaluations() -> None:
         writes.append(records[0])
         return 1
 
+    policy = _policy()
     summary = run_portfolio_risk_limits(
         policy_id="test-policy",
         limits_config_path=Path("unused-limits.yaml"),
@@ -138,7 +141,7 @@ def test_runner_publishes_and_summarises_limit_evaluations() -> None:
         writer=writer,
         storage_config_loader=lambda _: _storage_config(),
         definition_loader=lambda *_: _definition(),
-        policy_loader=lambda *_: _policy(),
+        policy_loader=lambda *_: policy,
     )
 
     assert summary["curated_output"][OUTPUT_DATASET] == {
@@ -148,7 +151,84 @@ def test_runner_publishes_and_summarises_limit_evaluations() -> None:
     }
     assert summary["latest_status"]["status"] == "critical"
     assert len(summary["latest_status"]["metrics"]) == 2
+    assert summary["policy_version"] == {
+        "policy_id": "test-policy",
+        "policy_version_id": "test-policy-v1",
+        "policy_fingerprint": policy.fingerprint,
+        "limit_definition_fingerprint": policy.limit_definition_fingerprint,
+        "effective_from": "2026-01-01",
+        "effective_to": None,
+    }
     assert len(writes) == 2
+
+
+def test_runner_passes_end_date_to_policy_loader() -> None:
+    received: list[tuple[Path, str, date]] = []
+
+    def loader(
+        path: Path,
+        policy_id: str,
+        as_of_date: date,
+    ) -> EffectiveDatedPortfolioRiskLimitPolicy:
+        received.append((path, policy_id, as_of_date))
+        return _policy()
+
+    run_portfolio_risk_limits(
+        policy_id="test-policy",
+        limits_config_path=Path("limits.yaml"),
+        portfolio_config_path=Path("portfolios.yaml"),
+        end_date=date(2026, 1, 4),
+        storage_config_path=Path("storage.yaml"),
+        reader=lambda _: _records(),
+        writer=lambda *_args, **_kwargs: 1,
+        storage_config_loader=lambda _: _storage_config(),
+        definition_loader=lambda *_: _definition(),
+        policy_loader=loader,
+    )
+
+    assert received == [(Path("limits.yaml"), "test-policy", date(2026, 1, 4))]
+
+
+def test_runner_rejects_policy_boundary_before_reading_input() -> None:
+    reader_called = False
+
+    def reader(_: Path) -> list[dict[str, object]]:
+        nonlocal reader_called
+        reader_called = True
+        return _records()
+
+    with pytest.raises(ValidationError, match="crosses"):
+        run_portfolio_risk_limits(
+            policy_id="test-policy",
+            limits_config_path=Path("unused-limits.yaml"),
+            portfolio_config_path=Path("unused-portfolios.yaml"),
+            start_date=date(2026, 1, 3),
+            end_date=date(2026, 1, 4),
+            storage_config_path=Path("unused-storage.yaml"),
+            reader=reader,
+            writer=lambda *_args, **_kwargs: 1,
+            storage_config_loader=lambda _: _storage_config(),
+            definition_loader=lambda *_: _definition(),
+            policy_loader=lambda *_: _policy(effective_from=date(2026, 1, 4)),
+        )
+
+    assert reader_called is False
+
+
+def test_runner_rejects_end_date_outside_selected_policy() -> None:
+    with pytest.raises(ValidationError, match="outside"):
+        run_portfolio_risk_limits(
+            policy_id="test-policy",
+            limits_config_path=Path("unused-limits.yaml"),
+            portfolio_config_path=Path("unused-portfolios.yaml"),
+            end_date=date(2026, 1, 4),
+            storage_config_path=Path("unused-storage.yaml"),
+            reader=lambda _: _records(),
+            writer=lambda *_args, **_kwargs: 1,
+            storage_config_loader=lambda _: _storage_config(),
+            definition_loader=lambda *_: _definition(),
+            policy_loader=lambda *_: _policy(effective_to=date(2026, 1, 4)),
+        )
 
 
 def test_runner_reports_replay_and_rejects_invalid_writer_result() -> None:
@@ -181,4 +261,20 @@ def test_runner_reports_replay_and_rejects_invalid_writer_result() -> None:
             storage_config_loader=lambda _: _storage_config(),
             definition_loader=lambda *_: _definition(),
             policy_loader=lambda *_: _policy(),
+        )
+
+
+def test_runner_rejects_invalid_policy_loader_output() -> None:
+    with pytest.raises(ValidationError, match="invalid policy version"):
+        run_portfolio_risk_limits(
+            policy_id="test-policy",
+            limits_config_path=Path("unused-limits.yaml"),
+            portfolio_config_path=Path("unused-portfolios.yaml"),
+            end_date=date(2026, 1, 4),
+            storage_config_path=Path("unused-storage.yaml"),
+            reader=lambda _: _records(),
+            writer=lambda *_args, **_kwargs: 1,
+            storage_config_loader=lambda _: _storage_config(),
+            definition_loader=lambda *_: _definition(),
+            policy_loader=lambda *_: object(),  # type: ignore[return-value]
         )


### PR DESCRIPTION
## Outcome

Wire the effective-dated policy contract into the existing risk-limit evaluator without changing its attribution reader, publication behavior or summary contract:

```text
policy history + requested end date
  -> select one effective policy version
  -> reject a request crossing that version boundary
  -> use the existing bounded attribution collector
  -> evaluate using the temporal policy fingerprint
  -> retain versioned Parquet and PostgreSQL evidence
```

Primary arc42 block: `orchestration`, with bounded interfaces to analytics policy selection and existing curated publication.

## Runtime selection

`run_portfolio_risk_limits` calls `load_effective_portfolio_risk_limit_policy` with the policy ID and requested end date. Inclusive `effective_from` and exclusive nullable `effective_to` determine the selected version.

`validate_policy_range` runs before the portfolio definition and attribution reader. The optional start date and required end date must both be contained by the selected policy version. A cross-boundary request fails before input data is read or output is written and must be split explicitly.

## Compatibility preservation

The final implementation retains:

- `collect_attribution_records` as the canonical bounded input reader;
- the complete attribution record contract, including volatility status;
- existing storage error handling and publication semantics;
- the existing `latest_status` response shape; and
- the existing maximum-evaluation CLI validation.

The run summary adds only one credential-free `policy_version` object. No Parquet or PostgreSQL schema migration is required.

## Validation repairs

Earlier exact-head runs found incorrect public import names and then showed that an over-broad runner rewrite had narrowed the canonical input and summary contracts. The final branch was rebuilt as one minimal replacement commit on current `main`, preserving those established contracts. No gate or test was bypassed.

GitHub Actions run `32589766000` (`ci` run 227) passed on exact head `034d85f9e70e2aacbfc7a1dff85235fc98c7775d`:

- Security guardrails: passed.
- Python readiness: passed.
  - Ruff passed;
  - mypy passed across 59 source files;
  - 528 tests passed twice through quality and readiness;
  - `pip check` passed;
  - readiness replay passed.
- PostgreSQL contract: passed against PostgreSQL 16, including the seeded attribution → effective-dated risk-limit → serving path.
- Infrastructure validation: passed.
  - Kubernetes overlays rendered;
  - Terraform formatting, initialization and validation passed without applying infrastructure.

No unresolved review threads or requested changes are present.

## Scope

The branch is one commit ahead of `main`, zero behind, and changes six files with 299 additions and 45 deletions.

This PR does not automatically segment requests across policy versions and does not change database schemas, lifecycle, acknowledgements, notification candidates, provider access, scheduling, deployment or Terraform apply.

## Acceptance boundary

This PR is validated and ready for squash merge as the runtime policy-selection increment.