### PR TITLE
Add governed portfolio history segment planning

### DIFF
--- a/docs/governed-portfolio-history-plan.md
+++ b/docs/governed-portfolio-history-plan.md
@@ -1,0 +1,93 @@
+# Governed Portfolio History Plan
+
+## Outcome
+
+This command turns one requested historical range into exact, deterministic segments where one portfolio mandate and one risk-limit policy version are simultaneously valid:
+
+```text
+requested inclusive date range
+  -> all configured portfolio mandates
+  -> all configured risk-limit policy versions
+  -> mandate-policy interval intersections
+  -> exact gap and overlap validation
+  -> ordered plan-only execution segments
+```
+
+The pure planner is `src/analytics/governed_portfolio_segments.py`. The operator command is `src/orchestration/plan_governed_portfolio_history.py`.
+
+## Operator command
+
+```bash
+.venv/bin/python -m src.orchestration.plan_governed_portfolio_history \
+  --portfolio-id us-tech-equal \
+  --policy-id us-tech-standard \
+  --portfolio-config config/portfolios.yaml \
+  --risk-limit-config config/portfolio_risk_limits.yaml \
+  --start-date 2026-01-01 \
+  --end-date 2026-12-31 \
+  --covariance-window 20 \
+  --summary-json .demo/governed-portfolio-history-plan.json
+```
+
+The command is plan-only. It does not acquire a lock, read analytical Parquet, execute a calculation stage, write curated data, load PostgreSQL, send a notification, acknowledge a breach, deploy infrastructure, or run `terraform apply`.
+
+## Temporal semantics
+
+Mandate and policy periods use inclusive `effective_from` and exclusive nullable `effective_to` bounds. The requested `start_date` and `end_date` are inclusive.
+
+A segment is the inclusive intersection of:
+
+```text
+requested range
+portfolio mandate period
+risk-limit policy period
+```
+
+Every calendar date in the requested range must be covered exactly once. A mandate gap, policy gap, overlap, missing period, or incompatible policy parameter fails the complete plan. The planner never silently skips an uncovered date and never chooses a newest policy as a fallback.
+
+## Compatibility rules
+
+Every intersecting policy version must match:
+
+- the requested portfolio;
+- the requested policy ID;
+- the requested covariance window; and
+- the attribution model's 252-day annualisation basis.
+
+All mandate versions must match the requested portfolio. IDs must be unique and schedules must be non-overlapping. Configuration parsers provide the primary contract; the planner repeats defensive validation for injected or programmatic callers.
+
+## Deterministic identity
+
+Each segment receives a deterministic ID binding:
+
+```text
+segment start and end
+mandate fingerprint
+policy fingerprint
+governed-portfolio-segments-v1
+```
+
+The plan ID binds the requested range and the ordered segment IDs. Reordering the source YAML entries does not change the plan. Changing a mandate, policy, date boundary, threshold fingerprint, or requested range produces a different identity.
+
+## Output evidence
+
+The JSON summary records:
+
+- deterministic plan ID;
+- requested range and calendar-day count;
+- segment count;
+- mandate and policy-version counts;
+- covariance and annualisation parameters;
+- ordered segment IDs and inclusive dates;
+- mandate metadata for each segment;
+- policy-version metadata for each segment;
+- the governed stage sequence; and
+- planned segment and stage-invocation counts.
+
+The planner caps one request at 100 segments. An unexpectedly fragmented configuration must be reviewed or split into smaller requests.
+
+## Execution boundary
+
+The existing governed portfolio cycle still requires one range to fit within one mandate and one policy version. This planner provides the exact ranges an operator or future explicitly controlled executor would pass to that cycle.
+
+Automatic multi-segment execution is intentionally separate. Before adding it, the repository needs explicit checkpointing, failure/resume semantics, per-segment review evidence, and a clear decision on whether to stop or continue after a segment failure.

--- a/src/analytics/governed_portfolio_segments.py
+++ b/src/analytics/governed_portfolio_segments.py
@@ -1,0 +1,316 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from datetime import date, datetime, timedelta
+from typing import Any
+
+from ..common.exceptions import ValidationError
+from .portfolio_mandates import MAX_MANDATES, PortfolioMandate
+from .portfolio_risk import TRADING_DAYS_PER_YEAR
+from .portfolio_risk_limit_policies import (
+    MAX_POLICY_VERSIONS,
+    EffectiveDatedPortfolioRiskLimitPolicy,
+)
+
+MODEL_VERSION = "governed-portfolio-segments-v1"
+MAX_GOVERNED_SEGMENTS = 100
+
+
+@dataclass(frozen=True, slots=True)
+class GovernedPortfolioSegment:
+    start_date: date
+    end_date: date
+    mandate: PortfolioMandate
+    policy: EffectiveDatedPortfolioRiskLimitPolicy
+
+    @property
+    def calendar_days(self) -> int:
+        return (self.end_date - self.start_date).days + 1
+
+    @property
+    def segment_id(self) -> str:
+        payload = {
+            "end_date": self.end_date.isoformat(),
+            "mandate_fingerprint": self.mandate.fingerprint,
+            "model_version": MODEL_VERSION,
+            "policy_fingerprint": self.policy.fingerprint,
+            "start_date": self.start_date.isoformat(),
+        }
+        digest = hashlib.sha256(
+            json.dumps(payload, sort_keys=True, separators=(",", ":")).encode(
+                "utf-8"
+            )
+        ).hexdigest()[:24]
+        return f"governed-segment-{digest}"
+
+
+@dataclass(frozen=True, slots=True)
+class GovernedPortfolioSegmentPlan:
+    segments: tuple[GovernedPortfolioSegment, ...]
+    diagnostics: Mapping[str, Any]
+
+
+def _calendar_date(value: Any, label: str) -> date:
+    if isinstance(value, datetime) or not isinstance(value, date):
+        raise ValidationError(f"{label} must be a calendar date")
+    return value
+
+
+def _bounded_integer(value: Any, label: str, maximum: int) -> int:
+    if type(value) is not int or not 1 <= value <= maximum:
+        raise ValidationError(
+            f"{label} must be an integer between 1 and {maximum}"
+        )
+    return value
+
+
+def _validate_mandates(
+    mandates: Sequence[PortfolioMandate],
+    *,
+    portfolio_id: str,
+) -> tuple[PortfolioMandate, ...]:
+    if (
+        isinstance(mandates, (str, bytes))
+        or not 1 <= len(mandates) <= MAX_MANDATES
+        or any(not isinstance(item, PortfolioMandate) for item in mandates)
+    ):
+        raise ValidationError(
+            "portfolio mandates must contain bounded PortfolioMandate entries"
+        )
+    ordered = tuple(
+        sorted(mandates, key=lambda item: (item.effective_from, item.mandate_id))
+    )
+    if any(item.portfolio_id != portfolio_id for item in ordered):
+        raise ValidationError(
+            "all portfolio mandates must match the requested portfolio"
+        )
+    if len({item.mandate_id for item in ordered}) != len(ordered):
+        raise ValidationError("portfolio mandate IDs must be unique")
+    for previous, current in zip(ordered, ordered[1:], strict=False):
+        if previous.effective_to is None:
+            raise ValidationError(
+                "an open-ended portfolio mandate must be the final mandate"
+            )
+        if current.effective_from < previous.effective_to:
+            raise ValidationError("portfolio mandates must not overlap")
+    return ordered
+
+
+def _validate_policies(
+    policies: Sequence[EffectiveDatedPortfolioRiskLimitPolicy],
+    *,
+    policy_id: str,
+    portfolio_id: str,
+) -> tuple[EffectiveDatedPortfolioRiskLimitPolicy, ...]:
+    if (
+        isinstance(policies, (str, bytes))
+        or not 1 <= len(policies) <= MAX_POLICY_VERSIONS
+        or any(
+            not isinstance(item, EffectiveDatedPortfolioRiskLimitPolicy)
+            for item in policies
+        )
+    ):
+        raise ValidationError(
+            "risk-limit policies must contain bounded effective-dated entries"
+        )
+    ordered = tuple(
+        sorted(
+            policies,
+            key=lambda item: (item.effective_from, item.policy_version_id),
+        )
+    )
+    if any(item.policy_id != policy_id for item in ordered):
+        raise ValidationError(
+            "all risk-limit policy versions must match the requested policy"
+        )
+    if any(item.portfolio_id != portfolio_id for item in ordered):
+        raise ValidationError(
+            "all risk-limit policy versions must match the requested portfolio"
+        )
+    if len({item.policy_version_id for item in ordered}) != len(ordered):
+        raise ValidationError("risk-limit policy version IDs must be unique")
+    for previous, current in zip(ordered, ordered[1:], strict=False):
+        if previous.effective_to is None:
+            raise ValidationError(
+                "an open-ended risk-limit policy version must be final"
+            )
+        if current.effective_from < previous.effective_to:
+            raise ValidationError("risk-limit policy versions must not overlap")
+    return ordered
+
+
+def _inclusive_end(effective_to: date | None, request_end: date) -> date:
+    if effective_to is None:
+        return request_end
+    return min(request_end, effective_to - timedelta(days=1))
+
+
+def _plan_id(
+    *,
+    portfolio_id: str,
+    policy_id: str,
+    start_date: date,
+    end_date: date,
+    segment_ids: list[str],
+) -> str:
+    payload = {
+        "end_date": end_date.isoformat(),
+        "model_version": MODEL_VERSION,
+        "policy_id": policy_id,
+        "portfolio_id": portfolio_id,
+        "segment_ids": segment_ids,
+        "start_date": start_date.isoformat(),
+    }
+    digest = hashlib.sha256(
+        json.dumps(payload, sort_keys=True, separators=(",", ":")).encode(
+            "utf-8"
+        )
+    ).hexdigest()[:24]
+    return f"governed-plan-{digest}"
+
+
+def plan_governed_portfolio_segments(
+    mandates: Sequence[PortfolioMandate],
+    policies: Sequence[EffectiveDatedPortfolioRiskLimitPolicy],
+    *,
+    portfolio_id: str,
+    policy_id: str,
+    start_date: date,
+    end_date: date,
+    covariance_window: int,
+    annualization_days: int = TRADING_DAYS_PER_YEAR,
+    max_segments: int = MAX_GOVERNED_SEGMENTS,
+) -> GovernedPortfolioSegmentPlan:
+    start_date = _calendar_date(start_date, "start_date")
+    end_date = _calendar_date(end_date, "end_date")
+    if start_date > end_date:
+        raise ValidationError("start_date must be on or before end_date")
+    if not isinstance(portfolio_id, str) or not portfolio_id.strip():
+        raise ValidationError("portfolio_id must be non-empty text")
+    if not isinstance(policy_id, str) or not policy_id.strip():
+        raise ValidationError("policy_id must be non-empty text")
+    if type(covariance_window) is not int or covariance_window < 2:
+        raise ValidationError("covariance_window must be an integer of at least 2")
+    if type(annualization_days) is not int or annualization_days <= 0:
+        raise ValidationError("annualization_days must be a positive integer")
+    max_segments = _bounded_integer(
+        max_segments,
+        "max_segments",
+        MAX_GOVERNED_SEGMENTS,
+    )
+
+    ordered_mandates = _validate_mandates(
+        mandates,
+        portfolio_id=portfolio_id,
+    )
+    ordered_policies = _validate_policies(
+        policies,
+        policy_id=policy_id,
+        portfolio_id=portfolio_id,
+    )
+
+    segments: list[GovernedPortfolioSegment] = []
+    for mandate in ordered_mandates:
+        mandate_end = _inclusive_end(mandate.effective_to, end_date)
+        for policy in ordered_policies:
+            segment_start = max(
+                start_date,
+                mandate.effective_from,
+                policy.effective_from,
+            )
+            segment_end = min(
+                end_date,
+                mandate_end,
+                _inclusive_end(policy.effective_to, end_date),
+            )
+            if segment_start > segment_end:
+                continue
+            if policy.covariance_window != covariance_window:
+                raise ValidationError(
+                    "requested covariance_window does not match policy version "
+                    f"'{policy.policy_version_id}'"
+                )
+            if policy.annualization_days != annualization_days:
+                raise ValidationError(
+                    "requested annualization_days does not match policy version "
+                    f"'{policy.policy_version_id}'"
+                )
+            segments.append(
+                GovernedPortfolioSegment(
+                    start_date=segment_start,
+                    end_date=segment_end,
+                    mandate=mandate,
+                    policy=policy,
+                )
+            )
+
+    segments.sort(
+        key=lambda item: (
+            item.start_date,
+            item.end_date,
+            item.mandate.mandate_id,
+            item.policy.policy_version_id,
+        )
+    )
+    if not segments:
+        raise ValidationError(
+            "requested range is not covered by any mandate-policy intersection"
+        )
+    if len(segments) > max_segments:
+        raise ValidationError(
+            "governed portfolio plan exceeds max_segments; split the request"
+        )
+
+    expected_start = start_date
+    for segment in segments:
+        if segment.start_date < expected_start:
+            raise ValidationError(
+                "governed portfolio segments overlap within the requested range"
+            )
+        if segment.start_date > expected_start:
+            raise ValidationError(
+                "requested range contains a mandate or policy coverage gap at "
+                f"{expected_start.isoformat()}"
+            )
+        if segment.end_date == end_date:
+            expected_start = end_date
+            break
+        expected_start = segment.end_date + timedelta(days=1)
+    if segments[-1].end_date != end_date:
+        raise ValidationError(
+            "requested range contains a mandate or policy coverage gap at "
+            f"{expected_start.isoformat()}"
+        )
+
+    segment_ids = [segment.segment_id for segment in segments]
+    diagnostics = {
+        "annualization_days": annualization_days,
+        "calendar_days": (end_date - start_date).days + 1,
+        "covariance_window": covariance_window,
+        "end_date": end_date.isoformat(),
+        "mandates_used": len(
+            {segment.mandate.fingerprint for segment in segments}
+        ),
+        "model_version": MODEL_VERSION,
+        "plan_id": _plan_id(
+            portfolio_id=portfolio_id,
+            policy_id=policy_id,
+            start_date=start_date,
+            end_date=end_date,
+            segment_ids=segment_ids,
+        ),
+        "policy_id": policy_id,
+        "policy_versions_used": len(
+            {segment.policy.fingerprint for segment in segments}
+        ),
+        "portfolio_id": portfolio_id,
+        "segment_count": len(segments),
+        "start_date": start_date.isoformat(),
+    }
+    return GovernedPortfolioSegmentPlan(
+        segments=tuple(segments),
+        diagnostics=diagnostics,
+    )

--- a/src/orchestration/plan_governed_portfolio_history.py
+++ b/src/orchestration/plan_governed_portfolio_history.py
@@ -1,0 +1,235 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections.abc import Callable, Mapping, Sequence
+from datetime import date
+from pathlib import Path
+from typing import Any
+from uuid import uuid4
+
+from ..analytics.governed_portfolio_segments import (
+    MAX_GOVERNED_SEGMENTS,
+    GovernedPortfolioSegmentPlan,
+    plan_governed_portfolio_segments,
+)
+from ..analytics.portfolio_mandates import (
+    mandate_metadata,
+    parse_portfolio_mandates,
+)
+from ..analytics.portfolio_risk import TRADING_DAYS_PER_YEAR
+from ..analytics.portfolio_risk_limit_policies import (
+    parse_portfolio_risk_limit_policies,
+    policy_metadata,
+)
+from ..common.config import load_yaml
+from ..common.exceptions import StorageError, ValidationError
+from .run_governed_portfolio_cycle import STAGES
+
+ConfigLoader = Callable[[Path], Any]
+
+
+def _calendar_date(value: str) -> date:
+    try:
+        parsed = date.fromisoformat(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(
+            "must be a calendar date in YYYY-MM-DD format"
+        ) from exc
+    if value != parsed.isoformat():
+        raise argparse.ArgumentTypeError(
+            "must be a calendar date in YYYY-MM-DD format"
+        )
+    return parsed
+
+
+def _positive_integer(value: str) -> int:
+    try:
+        parsed = int(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("must be a positive integer") from exc
+    if parsed <= 0:
+        raise argparse.ArgumentTypeError("must be a positive integer")
+    return parsed
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Plan exact mandate-policy segments for a governed historical "
+            "portfolio range without running analytical stages."
+        )
+    )
+    parser.add_argument("--portfolio-id", required=True)
+    parser.add_argument("--policy-id", required=True)
+    parser.add_argument(
+        "--portfolio-config",
+        type=Path,
+        default=Path("config/portfolios.yaml"),
+    )
+    parser.add_argument(
+        "--risk-limit-config",
+        type=Path,
+        default=Path("config/portfolio_risk_limits.yaml"),
+    )
+    parser.add_argument("--start-date", required=True, type=_calendar_date)
+    parser.add_argument("--end-date", required=True, type=_calendar_date)
+    parser.add_argument(
+        "--covariance-window",
+        type=_positive_integer,
+        default=20,
+    )
+    parser.add_argument(
+        "--max-segments",
+        type=_positive_integer,
+        default=MAX_GOVERNED_SEGMENTS,
+    )
+    parser.add_argument("--summary-json", type=Path)
+    return parser
+
+
+def _mapping(value: Any, label: str) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        raise ValidationError(f"{label} must be a mapping")
+    return value
+
+
+def _segment_records(plan: GovernedPortfolioSegmentPlan) -> list[dict[str, Any]]:
+    return [
+        {
+            "calendar_days": segment.calendar_days,
+            "end_date": segment.end_date.isoformat(),
+            "mandate": mandate_metadata(segment.mandate),
+            "policy_version": policy_metadata(segment.policy),
+            "segment_id": segment.segment_id,
+            "start_date": segment.start_date.isoformat(),
+        }
+        for segment in plan.segments
+    ]
+
+
+def plan_governed_portfolio_history(
+    *,
+    portfolio_id: str,
+    policy_id: str,
+    portfolio_config_path: Path,
+    risk_limit_config_path: Path,
+    start_date: date,
+    end_date: date,
+    covariance_window: int,
+    max_segments: int = MAX_GOVERNED_SEGMENTS,
+    config_loader: ConfigLoader | None = None,
+) -> dict[str, Any]:
+    selected_loader = config_loader or load_yaml
+    try:
+        portfolio_payload = _mapping(
+            selected_loader(portfolio_config_path),
+            "portfolio configuration",
+        )
+        policy_payload = _mapping(
+            selected_loader(risk_limit_config_path),
+            "risk-limit configuration",
+        )
+    except ValidationError:
+        raise
+    except Exception:
+        raise ValidationError(
+            "governed portfolio planning configuration could not be loaded"
+        ) from None
+
+    mandates = parse_portfolio_mandates(portfolio_payload, portfolio_id)
+    policies = parse_portfolio_risk_limit_policies(policy_payload, policy_id)
+    plan = plan_governed_portfolio_segments(
+        mandates,
+        policies,
+        portfolio_id=portfolio_id,
+        policy_id=policy_id,
+        start_date=start_date,
+        end_date=end_date,
+        covariance_window=covariance_window,
+        annualization_days=TRADING_DAYS_PER_YEAR,
+        max_segments=max_segments,
+    )
+    segments = _segment_records(plan)
+    return {
+        "execution": {
+            "performed": False,
+            "planned_segment_runs": len(segments),
+            "planned_stage_invocations": len(segments) * len(STAGES),
+            "planned_stages": list(STAGES),
+            "reason": "plan_only",
+        },
+        "parameters": {
+            "annualization_days": TRADING_DAYS_PER_YEAR,
+            "covariance_window": covariance_window,
+            "max_segments": max_segments,
+        },
+        "plan_id": plan.diagnostics["plan_id"],
+        "policy_id": policy_id,
+        "portfolio_id": portfolio_id,
+        "run_id": str(uuid4()),
+        "segments": segments,
+        "selection": dict(plan.diagnostics),
+    }
+
+
+def _write_summary(path: Path, summary: Mapping[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary_path = path.with_suffix(path.suffix + ".tmp")
+    try:
+        temporary_path.write_text(
+            json.dumps(summary, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        temporary_path.replace(path)
+    except OSError:
+        temporary_path.unlink(missing_ok=True)
+        raise StorageError(
+            "Unable to write the governed portfolio history plan"
+        ) from None
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    try:
+        summary = plan_governed_portfolio_history(
+            portfolio_id=args.portfolio_id,
+            policy_id=args.policy_id,
+            portfolio_config_path=args.portfolio_config,
+            risk_limit_config_path=args.risk_limit_config,
+            start_date=args.start_date,
+            end_date=args.end_date,
+            covariance_window=args.covariance_window,
+            max_segments=args.max_segments,
+        )
+        if args.summary_json is not None:
+            _write_summary(args.summary_json, summary)
+    except ValidationError:
+        print(
+            "Governed portfolio history planning failed: configuration, "
+            "coverage, compatibility, or options were invalid",
+            file=sys.stderr,
+        )
+        return 1
+    except StorageError:
+        print(
+            "Governed portfolio history planning failed: summary publication "
+            "failed",
+            file=sys.stderr,
+        )
+        return 1
+    except Exception:
+        print(
+            "Governed portfolio history planning failed: unexpected local "
+            "failure",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(json.dumps(summary, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/test_governed_portfolio_history_plan_architecture_contract.py
+++ b/tests/unit/test_governed_portfolio_history_plan_architecture_contract.py
@@ -1,0 +1,39 @@
+from pathlib import Path
+
+
+def test_governed_history_plan_documents_plan_only_temporal_contract() -> None:
+    source = Path(
+        "src/orchestration/plan_governed_portfolio_history.py"
+    ).read_text(encoding="utf-8")
+    analytics = Path(
+        "src/analytics/governed_portfolio_segments.py"
+    ).read_text(encoding="utf-8")
+    docs = Path("docs/governed-portfolio-history-plan.md").read_text(
+        encoding="utf-8"
+    )
+
+    for required in (
+        "plan_governed_portfolio_segments",
+        "parse_portfolio_mandates",
+        "parse_portfolio_risk_limit_policies",
+        '"performed": False',
+        '"reason": "plan_only"',
+    ):
+        assert required in source
+
+    for required in (
+        "governed-portfolio-segments-v1",
+        "coverage gap",
+        "max_segments",
+        "segment_id",
+        "plan_id",
+    ):
+        assert required in analytics
+
+    for required in (
+        "plan-only",
+        "covered exactly once",
+        "does not acquire a lock",
+        "Automatic multi-segment execution is intentionally separate",
+    ):
+        assert required in docs

--- a/tests/unit/test_governed_portfolio_segments.py
+++ b/tests/unit/test_governed_portfolio_segments.py
@@ -1,0 +1,192 @@
+from __future__ import annotations
+
+from dataclasses import replace
+from datetime import date
+
+import pytest
+
+from src.analytics.governed_portfolio_segments import (
+    MODEL_VERSION,
+    plan_governed_portfolio_segments,
+)
+from src.analytics.portfolio_mandates import parse_portfolio_mandates
+from src.analytics.portfolio_risk_limit_policies import (
+    parse_portfolio_risk_limit_policies,
+)
+from src.common.exceptions import ValidationError
+
+
+def _constituents() -> list[dict[str, object]]:
+    return [
+        {"source": "alpha_vantage", "symbol": "AAPL", "weight": 0.5},
+        {"source": "alpha_vantage", "symbol": "MSFT", "weight": 0.5},
+    ]
+
+
+def _mandates(*, gap: bool = False):
+    second_start = "2026-02-02" if gap else "2026-02-01"
+    payload = {
+        "portfolios": {
+            "us-tech-equal": {
+                "mandates": [
+                    {
+                        "mandate_id": "mandate-a",
+                        "base_currency": "USD",
+                        "effective_from": "2026-01-01",
+                        "effective_to": "2026-02-01",
+                        "constituents": _constituents(),
+                    },
+                    {
+                        "mandate_id": "mandate-b",
+                        "base_currency": "USD",
+                        "effective_from": second_start,
+                        "constituents": _constituents(),
+                    },
+                ]
+            }
+        }
+    }
+    return parse_portfolio_mandates(payload, "us-tech-equal")
+
+
+def _policies(*, second_window: int = 20, gap: bool = False):
+    second_start = "2026-01-16" if gap else "2026-01-15"
+    limits = {
+        "portfolio_volatility_annualized": {
+            "warning": 0.30,
+            "critical": 0.45,
+        },
+        "largest_absolute_component_contribution_share": {
+            "warning": 0.65,
+            "critical": 0.80,
+        },
+    }
+    payload = {
+        "policies": {
+            "us-tech-standard": {
+                "versions": [
+                    {
+                        "policy_version_id": "policy-a",
+                        "portfolio_id": "us-tech-equal",
+                        "effective_from": "2026-01-01",
+                        "effective_to": "2026-01-15",
+                        "covariance_window": 20,
+                        "annualization_days": 252,
+                        "limits": limits,
+                    },
+                    {
+                        "policy_version_id": "policy-b",
+                        "portfolio_id": "us-tech-equal",
+                        "effective_from": second_start,
+                        "covariance_window": second_window,
+                        "annualization_days": 252,
+                        "limits": limits,
+                    },
+                ]
+            }
+        }
+    }
+    return parse_portfolio_risk_limit_policies(payload, "us-tech-standard")
+
+
+def _plan(mandates=None, policies=None, **overrides):
+    kwargs = {
+        "portfolio_id": "us-tech-equal",
+        "policy_id": "us-tech-standard",
+        "start_date": date(2026, 1, 10),
+        "end_date": date(2026, 2, 10),
+        "covariance_window": 20,
+    }
+    kwargs.update(overrides)
+    return plan_governed_portfolio_segments(
+        mandates or _mandates(),
+        policies or _policies(),
+        **kwargs,
+    )
+
+
+def test_plan_intersects_every_temporal_boundary_in_order() -> None:
+    output = _plan()
+
+    assert [
+        (segment.start_date, segment.end_date)
+        for segment in output.segments
+    ] == [
+        (date(2026, 1, 10), date(2026, 1, 14)),
+        (date(2026, 1, 15), date(2026, 1, 31)),
+        (date(2026, 2, 1), date(2026, 2, 10)),
+    ]
+    assert [segment.mandate.mandate_id for segment in output.segments] == [
+        "mandate-a",
+        "mandate-a",
+        "mandate-b",
+    ]
+    assert [
+        segment.policy.policy_version_id for segment in output.segments
+    ] == ["policy-a", "policy-b", "policy-b"]
+    assert sum(segment.calendar_days for segment in output.segments) == 32
+    assert output.diagnostics["segment_count"] == 3
+    assert output.diagnostics["mandates_used"] == 2
+    assert output.diagnostics["policy_versions_used"] == 2
+    assert output.diagnostics["model_version"] == MODEL_VERSION
+
+
+def test_plan_is_deterministic_for_reordered_inputs() -> None:
+    forward = _plan()
+    reverse = _plan(
+        mandates=tuple(reversed(_mandates())),
+        policies=tuple(reversed(_policies())),
+    )
+
+    assert forward.segments == reverse.segments
+    assert forward.diagnostics == reverse.diagnostics
+    assert [item.segment_id for item in forward.segments] == [
+        item.segment_id for item in reverse.segments
+    ]
+
+
+def test_plan_rejects_mandate_and_policy_coverage_gaps() -> None:
+    with pytest.raises(ValidationError, match="coverage gap"):
+        _plan(
+            mandates=_mandates(gap=True),
+            start_date=date(2026, 1, 30),
+            end_date=date(2026, 2, 3),
+        )
+
+    with pytest.raises(ValidationError, match="coverage gap"):
+        _plan(
+            policies=_policies(gap=True),
+            start_date=date(2026, 1, 14),
+            end_date=date(2026, 1, 17),
+        )
+
+
+def test_plan_rejects_defensive_overlap_and_parameter_mismatch() -> None:
+    mandates = _mandates()
+    overlapping = (
+        mandates[0],
+        replace(mandates[1], effective_from=date(2026, 1, 20)),
+    )
+    with pytest.raises(ValidationError, match="must not overlap"):
+        _plan(mandates=overlapping)
+
+    with pytest.raises(ValidationError, match="covariance_window"):
+        _plan(policies=_policies(second_window=30))
+
+
+def test_plan_rejects_invalid_range_and_output_limit() -> None:
+    with pytest.raises(ValidationError, match="on or before"):
+        _plan(
+            start_date=date(2026, 2, 10),
+            end_date=date(2026, 1, 10),
+        )
+
+    with pytest.raises(ValidationError, match="max_segments"):
+        _plan(max_segments=2)
+
+
+def test_plan_identity_changes_with_requested_range() -> None:
+    first = _plan(end_date=date(2026, 2, 9))
+    second = _plan(end_date=date(2026, 2, 10))
+
+    assert first.diagnostics["plan_id"] != second.diagnostics["plan_id"]

--- a/tests/unit/test_plan_governed_portfolio_history.py
+++ b/tests/unit/test_plan_governed_portfolio_history.py
@@ -1,0 +1,152 @@
+from __future__ import annotations
+
+from datetime import date
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from src.common.exceptions import ValidationError
+from src.orchestration.plan_governed_portfolio_history import (
+    plan_governed_portfolio_history,
+)
+from src.orchestration.run_governed_portfolio_cycle import STAGES
+
+
+def _constituents() -> list[dict[str, object]]:
+    return [
+        {"source": "alpha_vantage", "symbol": "AAPL", "weight": 0.5},
+        {"source": "alpha_vantage", "symbol": "MSFT", "weight": 0.5},
+    ]
+
+
+def _portfolio_payload() -> dict[str, object]:
+    return {
+        "portfolios": {
+            "us-tech-equal": {
+                "mandates": [
+                    {
+                        "mandate_id": "mandate-a",
+                        "base_currency": "USD",
+                        "effective_from": "2026-01-01",
+                        "effective_to": "2026-02-01",
+                        "constituents": _constituents(),
+                    },
+                    {
+                        "mandate_id": "mandate-b",
+                        "base_currency": "USD",
+                        "effective_from": "2026-02-01",
+                        "constituents": _constituents(),
+                    },
+                ]
+            }
+        }
+    }
+
+
+def _policy_payload() -> dict[str, object]:
+    limits = {
+        "portfolio_volatility_annualized": {
+            "warning": 0.30,
+            "critical": 0.45,
+        },
+        "largest_absolute_component_contribution_share": {
+            "warning": 0.65,
+            "critical": 0.80,
+        },
+    }
+    return {
+        "policies": {
+            "us-tech-standard": {
+                "versions": [
+                    {
+                        "policy_version_id": "policy-a",
+                        "portfolio_id": "us-tech-equal",
+                        "effective_from": "2026-01-01",
+                        "effective_to": "2026-01-15",
+                        "covariance_window": 20,
+                        "annualization_days": 252,
+                        "limits": limits,
+                    },
+                    {
+                        "policy_version_id": "policy-b",
+                        "portfolio_id": "us-tech-equal",
+                        "effective_from": "2026-01-15",
+                        "covariance_window": 20,
+                        "annualization_days": 252,
+                        "limits": limits,
+                    },
+                ]
+            }
+        }
+    }
+
+
+def _loader(path: Path) -> Any:
+    if path.name == "portfolios.yaml":
+        return _portfolio_payload()
+    if path.name == "limits.yaml":
+        return _policy_payload()
+    raise AssertionError(f"unexpected path: {path}")
+
+
+def test_run_returns_plan_only_segment_evidence() -> None:
+    summary = plan_governed_portfolio_history(
+        portfolio_id="us-tech-equal",
+        policy_id="us-tech-standard",
+        portfolio_config_path=Path("portfolios.yaml"),
+        risk_limit_config_path=Path("limits.yaml"),
+        start_date=date(2026, 1, 10),
+        end_date=date(2026, 2, 10),
+        covariance_window=20,
+        max_segments=10,
+        config_loader=_loader,
+    )
+
+    assert summary["plan_id"].startswith("governed-plan-")
+    assert summary["selection"]["segment_count"] == 3
+    assert summary["execution"] == {
+        "performed": False,
+        "planned_segment_runs": 3,
+        "planned_stage_invocations": 3 * len(STAGES),
+        "planned_stages": list(STAGES),
+        "reason": "plan_only",
+    }
+    assert [segment["start_date"] for segment in summary["segments"]] == [
+        "2026-01-10",
+        "2026-01-15",
+        "2026-02-01",
+    ]
+    assert summary["segments"][0]["mandate"]["mandate_id"] == "mandate-a"
+    assert summary["segments"][1]["policy_version"][
+        "policy_version_id"
+    ] == "policy-b"
+
+
+def test_run_rejects_invalid_loader_output_and_load_failure() -> None:
+    with pytest.raises(ValidationError, match="must be a mapping"):
+        plan_governed_portfolio_history(
+            portfolio_id="us-tech-equal",
+            policy_id="us-tech-standard",
+            portfolio_config_path=Path("portfolios.yaml"),
+            risk_limit_config_path=Path("limits.yaml"),
+            start_date=date(2026, 1, 10),
+            end_date=date(2026, 1, 20),
+            covariance_window=20,
+            config_loader=lambda _: [],
+        )
+
+    def fail(_: Path) -> Any:
+        raise OSError("failed")
+
+    with pytest.raises(ValidationError, match="could not be loaded"):
+        plan_governed_portfolio_history(
+            portfolio_id="us-tech-equal",
+            policy_id="us-tech-standard",
+            portfolio_config_path=Path("portfolios.yaml"),
+            risk_limit_config_path=Path("limits.yaml"),
+            start_date=date(2026, 1, 10),
+            end_date=date(2026, 1, 20),
+            covariance_window=20,
+            config_loader=fail,
+        )


### PR DESCRIPTION
## Outcome

Add a plan-only temporal segmenter for historical governed portfolio requests:

```text
requested inclusive range
  -> all portfolio mandates
  -> all risk-limit policy versions
  -> exact mandate-policy intersections
  -> gap, overlap and compatibility validation
  -> ordered deterministic execution segments
```

Primary arc42 block: `analytics`, with a bounded orchestration interface for operator evidence.

## Contract

Every requested calendar date must be covered exactly once by one mandate and one compatible policy version. The planner fails the complete request on a mandate gap, policy gap, overlap, missing coverage, covariance-window mismatch, annualisation mismatch, duplicate identity, or excessive segment count.

Each segment ID binds its inclusive dates, mandate fingerprint, policy fingerprint, and model version. The plan ID binds the requested range and ordered segment IDs, so source configuration ordering cannot change the result.

## Plan-only boundary

The CLI loads configuration, parses all mandate and policy versions, and writes optional JSON evidence. It does not acquire a lock, read analytical Parquet, execute portfolio stages, write curated data, load PostgreSQL, send notifications, acknowledge breaches, deploy infrastructure, or run Terraform apply.

The summary exposes the planned governed stage sequence and the number of segment runs and stage invocations without performing them.

## Validation

The exact PR head passed all repository CI jobs:

- Security guardrails.
- Python readiness, including locked dependency resolution, Ruff, mypy, the complete test suite, `pip check`, and readiness replay.
- PostgreSQL 16 contract validation.
- Kubernetes rendering and Terraform format/init/validate without apply.

No unresolved review threads or requested changes are present. The branch is based directly on current `main` and is zero commits behind.

## Scope

Six new files: pure planner, CLI, two functional test files, documentation, and a documentation contract. Automatic multi-segment execution remains separate until checkpointing and failure/resume semantics are explicit.