### PR TITLE
Add disabled bounded local portfolio scheduling

### DIFF
--- a/config/local_portfolio_schedules.yaml
+++ b/config/local_portfolio_schedules.yaml
@@ -1,0 +1,14 @@
+schedules:
+  us-tech-local:
+    enabled: false
+    portfolio_id: us-tech-equal
+    policy_id: us-tech-standard
+    calendar_id: XNYS
+    maximum_catch_up_sessions: 5
+    volatility_window: 20
+    var_window: 60
+    var_confidence: 0.95
+    covariance_window: 20
+    max_snapshots: 5
+    max_evaluations: 100
+    max_notification_events: 100

--- a/docs/local-portfolio-scheduling.md
+++ b/docs/local-portfolio-scheduling.md
@@ -1,0 +1,98 @@
+# Disabled Local Portfolio Scheduling
+
+## Outcome
+
+This control provides a bounded, explicitly activated local schedule for already-landed daily market data:
+
+```text
+reviewed disabled schedule configuration
+  -> exchange-calendar session plan
+  -> bounded checkpoint catch-up
+  -> one schedule-scoped lock
+  -> daily risk and calendar freshness per constituent
+  -> governed portfolio risk, attribution, and limit evaluation
+  -> local PostgreSQL load
+  -> optional notification-outbox generation
+  -> notification-outbox load
+  -> atomic checkpoint after complete session success
+```
+
+The implementation is `src/orchestration/run_local_portfolio_schedule.py`. The default configuration is `config/local_portfolio_schedules.yaml`.
+
+## Disabled-by-default contract
+
+The committed schedule has `enabled: false`. Running the command without `--execute` always produces a plan only. Running with `--execute` while the reviewed configuration remains disabled fails before acquiring a lock or invoking a stage.
+
+Activating the local schedule therefore requires both:
+
+1. a reviewed configuration change setting `enabled: true`; and
+2. an explicit `--execute` invocation.
+
+There is no Kubernetes CronJob change, GitHub Actions schedule, system timer, daemon, background process, or cloud scheduler in this increment.
+
+## Planning and catch-up
+
+The planner uses the configured exchange calendar. On a first run with no checkpoint, it selects only the latest expected session on or before `as_of_date`. It does not backfill from calendar inception.
+
+After a successful checkpoint, it selects every expected session after the checkpoint through the latest expected session. The schedule fails rather than truncating when the selection exceeds `maximum_catch_up_sessions`. Larger backfills must be run explicitly and reviewed.
+
+A weekend or holiday as-of date selects the preceding expected trading session. The calendar coverage period is enforced.
+
+## Stage sequence
+
+For each selected session, commands execute in this fixed order:
+
+1. `run_daily_risk` for each mandate constituent;
+2. `run_market_freshness` for each mandate constituent;
+3. `run_governed_portfolio_cycle` for portfolio risk, rolling attribution, and risk-limit evaluation;
+4. local PostgreSQL warehouse loading;
+5. market-freshness loading;
+6. optional notification-outbox generation; and
+7. notification-outbox loading.
+
+The schedule supports Alpha Vantage constituents because that is the implemented daily raw source. An unsupported source fails during planning.
+
+The optional outbox wrapper treats a valid day with no actionable transition as a successful no-op. Other validation failures are not suppressed.
+
+## Checkpoint and recovery
+
+One lock named `local-schedule/<schedule_id>` spans all selected sessions. The state file is a bounded JSON document under `.scheduler/` and records:
+
+```text
+schedule ID
+schedule fingerprint
+last successful session
+state model version
+update timestamp
+```
+
+The schedule fingerprint binds all operational parameters. A changed configuration cannot silently continue from an old checkpoint; the operator must archive or reset state deliberately.
+
+Commands for one session must all succeed before the checkpoint advances. If any command fails, execution stops, the lock is released, and the last completed checkpoint remains unchanged. Deterministic underlying writes make rerunning safe.
+
+## Commands
+
+Plan without mutation:
+
+```bash
+.venv/bin/python -m src.orchestration.run_local_portfolio_schedule \
+  --schedule-id us-tech-local \
+  --as-of-date 2026-03-31 \
+  --summary-json .demo/local-schedule-plan.json
+```
+
+After a reviewed configuration change enables the schedule, execute explicitly:
+
+```bash
+.venv/bin/python -m src.orchestration.run_local_portfolio_schedule \
+  --schedule-id us-tech-local \
+  --as-of-date 2026-03-31 \
+  --execute \
+  --summary-json .demo/local-schedule-run.json
+```
+
+The PostgreSQL DSN is supplied through `WAREHOUSE_POSTGRES_DSN` or `--dsn`. It is passed to child processes through environment variables and is never included in plan or run summaries.
+
+## Safety boundary
+
+The schedule consumes local raw data. It performs no Alpha Vantage request, sends no external notification, changes no position, acknowledges no breach, creates no managed service, deploys no Kubernetes workload, and runs no `terraform apply`.

--- a/src/orchestration/run_local_portfolio_schedule.py
+++ b/src/orchestration/run_local_portfolio_schedule.py
@@ -8,7 +8,7 @@ import subprocess
 import sys
 from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
-from datetime import date, datetime, timezone
+from datetime import date, datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
 from uuid import uuid4
@@ -68,9 +68,11 @@ class LocalPortfolioSchedule:
             "volatility_window": self.volatility_window,
         }
         digest = hashlib.sha256(
-            json.dumps(payload, sort_keys=True, separators=(",", ":")).encode(
-                "utf-8"
-            )
+            json.dumps(
+                payload,
+                sort_keys=True,
+                separators=(",", ":"),
+            ).encode("utf-8")
         ).hexdigest()[:24]
         return f"local-schedule-{digest}"
 
@@ -89,10 +91,16 @@ def _required_text(value: Any, label: str) -> str:
     return parsed
 
 
-def _positive_integer(value: Any, label: str, maximum: int) -> int:
-    if type(value) is not int or not 1 <= value <= maximum:
+def _bounded_integer(
+    value: Any,
+    label: str,
+    *,
+    minimum: int,
+    maximum: int,
+) -> int:
+    if type(value) is not int or not minimum <= value <= maximum:
         raise ValidationError(
-            f"{label} must be an integer between 1 and {maximum}"
+            f"{label} must be an integer between {minimum} and {maximum}"
         )
     return value
 
@@ -124,6 +132,7 @@ def parse_local_portfolio_schedule(
         or not 0 < float(confidence) < 1
     ):
         raise ValidationError("var_confidence must be between 0 and 1")
+
     return LocalPortfolioSchedule(
         schedule_id=schedule_id,
         enabled=enabled,
@@ -136,41 +145,48 @@ def parse_local_portfolio_schedule(
             candidate.get("calendar_id"),
             "calendar_id",
         ),
-        maximum_catch_up_sessions=_positive_integer(
+        maximum_catch_up_sessions=_bounded_integer(
             candidate.get("maximum_catch_up_sessions"),
             "maximum_catch_up_sessions",
-            MAX_CATCH_UP_SESSIONS,
+            minimum=1,
+            maximum=MAX_CATCH_UP_SESSIONS,
         ),
-        volatility_window=_positive_integer(
+        volatility_window=_bounded_integer(
             candidate.get("volatility_window"),
             "volatility_window",
-            10_000,
+            minimum=2,
+            maximum=10_000,
         ),
-        var_window=_positive_integer(
+        var_window=_bounded_integer(
             candidate.get("var_window"),
             "var_window",
-            10_000,
+            minimum=2,
+            maximum=10_000,
         ),
         var_confidence=float(confidence),
-        covariance_window=_positive_integer(
+        covariance_window=_bounded_integer(
             candidate.get("covariance_window"),
             "covariance_window",
-            2_520,
+            minimum=2,
+            maximum=2_520,
         ),
-        max_snapshots=_positive_integer(
+        max_snapshots=_bounded_integer(
             candidate.get("max_snapshots"),
             "max_snapshots",
-            2_500,
+            minimum=1,
+            maximum=2_500,
         ),
-        max_evaluations=_positive_integer(
+        max_evaluations=_bounded_integer(
             candidate.get("max_evaluations"),
             "max_evaluations",
-            10_000,
+            minimum=1,
+            maximum=10_000,
         ),
-        max_notification_events=_positive_integer(
+        max_notification_events=_bounded_integer(
             candidate.get("max_notification_events"),
             "max_notification_events",
-            5_000,
+            minimum=1,
+            maximum=5_000,
         ),
     )
 
@@ -268,7 +284,7 @@ def plan_schedule_sessions(
     if checkpoint == latest_expected:
         return ()
     candidates = calendar.sessions_between(
-        checkpoint.fromordinal(checkpoint.toordinal() + 1),
+        checkpoint + timedelta(days=1),
         latest_expected,
     )
     if len(candidates) > schedule.maximum_catch_up_sessions:
@@ -314,57 +330,57 @@ def build_session_commands(
                 "local scheduling currently supports alpha_vantage constituents only"
             )
         symbol = constituent.symbol
-        commands.append(
-            (
-                python_executable,
-                "-m",
-                "src.orchestration.run_daily_risk",
-                "--symbol",
-                symbol,
-                "--start-date",
-                session,
-                "--end-date",
-                session,
-                "--vol-window",
-                str(schedule.volatility_window),
-                "--var-window",
-                str(schedule.var_window),
-                "--var-confidence",
-                str(schedule.var_confidence),
-                "--storage-config",
-                str(storage_config_path),
-                "--summary-json",
-                _summary_path(
-                    state_dir,
-                    schedule.schedule_id,
-                    session_date,
-                    f"daily-risk-{symbol}",
+        commands.extend(
+            [
+                (
+                    python_executable,
+                    "-m",
+                    "src.orchestration.run_daily_risk",
+                    "--symbol",
+                    symbol,
+                    "--start-date",
+                    session,
+                    "--end-date",
+                    session,
+                    "--vol-window",
+                    str(schedule.volatility_window),
+                    "--var-window",
+                    str(schedule.var_window),
+                    "--var-confidence",
+                    str(schedule.var_confidence),
+                    "--storage-config",
+                    str(storage_config_path),
+                    "--summary-json",
+                    _summary_path(
+                        state_dir,
+                        schedule.schedule_id,
+                        session_date,
+                        f"daily-risk-{symbol}",
+                    ),
                 ),
-            )
-        )
-        commands.append(
-            (
-                python_executable,
-                "-m",
-                "src.orchestration.run_market_freshness",
-                "--symbol",
-                symbol,
-                "--calendar-id",
-                schedule.calendar_id,
-                "--calendar-config",
-                str(calendar_config_path),
-                "--as-of-date",
-                session,
-                "--storage-config",
-                str(storage_config_path),
-                "--summary-json",
-                _summary_path(
-                    state_dir,
-                    schedule.schedule_id,
-                    session_date,
-                    f"freshness-{symbol}",
+                (
+                    python_executable,
+                    "-m",
+                    "src.orchestration.run_market_freshness",
+                    "--symbol",
+                    symbol,
+                    "--calendar-id",
+                    schedule.calendar_id,
+                    "--calendar-config",
+                    str(calendar_config_path),
+                    "--as-of-date",
+                    session,
+                    "--storage-config",
+                    str(storage_config_path),
+                    "--summary-json",
+                    _summary_path(
+                        state_dir,
+                        schedule.schedule_id,
+                        session_date,
+                        f"freshness-{symbol}",
+                    ),
                 ),
-            )
+            ]
         )
 
     commands.append(
@@ -527,6 +543,7 @@ def run_local_portfolio_schedule(
     )
     state_path = _state_path(state_dir, schedule.schedule_id)
     state = _read_state(state_path)
+    checkpoint_before = _checkpoint_date(state, schedule=schedule)
     sessions = plan_schedule_sessions(
         schedule=schedule,
         calendar=calendar,
@@ -534,7 +551,7 @@ def run_local_portfolio_schedule(
         state=state,
     )
     selected_mandate_loader = mandate_loader or load_portfolio_mandate
-    plans = []
+    plans: list[dict[str, Any]] = []
     for session_date in sessions:
         mandate = selected_mandate_loader(
             portfolio_config_path,
@@ -573,8 +590,8 @@ def run_local_portfolio_schedule(
         "selection": {
             "as_of_date": as_of_date.isoformat(),
             "checkpoint_before": (
-                _checkpoint_date(state, schedule=schedule).isoformat()
-                if state is not None
+                checkpoint_before.isoformat()
+                if checkpoint_before is not None
                 else None
             ),
             "sessions_selected": len(sessions),
@@ -619,8 +636,8 @@ def run_local_portfolio_schedule(
                 "local schedule did not acquire exactly one lock"
             )
         for session_date, plan in zip(sessions, plans, strict=True):
-            for command in plan["commands"]:
-                selected_runner(tuple(command), environment)
+            for raw_command in plan["commands"]:
+                selected_runner(tuple(raw_command), environment)
             _write_state(
                 state_path,
                 schedule=schedule,

--- a/src/orchestration/run_local_portfolio_schedule.py
+++ b/src/orchestration/run_local_portfolio_schedule.py
@@ -1,0 +1,766 @@
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import subprocess
+import sys
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass
+from datetime import date, datetime, timezone
+from pathlib import Path
+from typing import Any
+from uuid import uuid4
+
+from ..analytics.market_calendar import MarketCalendar, load_market_calendar
+from ..analytics.portfolio_mandates import (
+    PortfolioMandate,
+    load_portfolio_mandate,
+)
+from ..common.config import load_yaml
+from ..common.exceptions import OverlapError, StorageError, ValidationError
+from ..warehouse.postgres_loader import DEFAULT_POSTGRES_DSN
+from .locks import acquire_partition_locks, release_partition_locks
+
+MODEL_VERSION = "local-portfolio-schedule-v1"
+MAX_CATCH_UP_SESSIONS = 31
+MAX_STATE_BYTES = 65_536
+
+Command = tuple[str, ...]
+CommandRunner = Callable[[Command, Mapping[str, str]], None]
+MandateLoader = Callable[[Path, str, date], PortfolioMandate]
+CalendarLoader = Callable[[Path, str], MarketCalendar]
+
+
+@dataclass(frozen=True, slots=True)
+class LocalPortfolioSchedule:
+    schedule_id: str
+    enabled: bool
+    portfolio_id: str
+    policy_id: str
+    calendar_id: str
+    maximum_catch_up_sessions: int
+    volatility_window: int
+    var_window: int
+    var_confidence: float
+    covariance_window: int
+    max_snapshots: int
+    max_evaluations: int
+    max_notification_events: int
+
+    @property
+    def fingerprint(self) -> str:
+        payload = {
+            "calendar_id": self.calendar_id,
+            "covariance_window": self.covariance_window,
+            "enabled": self.enabled,
+            "max_evaluations": self.max_evaluations,
+            "max_notification_events": self.max_notification_events,
+            "max_snapshots": self.max_snapshots,
+            "maximum_catch_up_sessions": self.maximum_catch_up_sessions,
+            "model_version": MODEL_VERSION,
+            "policy_id": self.policy_id,
+            "portfolio_id": self.portfolio_id,
+            "schedule_id": self.schedule_id,
+            "var_confidence": self.var_confidence,
+            "var_window": self.var_window,
+            "volatility_window": self.volatility_window,
+        }
+        digest = hashlib.sha256(
+            json.dumps(payload, sort_keys=True, separators=(",", ":")).encode(
+                "utf-8"
+            )
+        ).hexdigest()[:24]
+        return f"local-schedule-{digest}"
+
+
+def _required_text(value: Any, label: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ValidationError(f"{label} must be non-empty text")
+    parsed = value.strip()
+    if (
+        parsed in {".", ".."}
+        or "/" in parsed
+        or "\\" in parsed
+        or any(ord(character) < 32 for character in parsed)
+    ):
+        raise ValidationError(f"{label} must be one safe text segment")
+    return parsed
+
+
+def _positive_integer(value: Any, label: str, maximum: int) -> int:
+    if type(value) is not int or not 1 <= value <= maximum:
+        raise ValidationError(
+            f"{label} must be an integer between 1 and {maximum}"
+        )
+    return value
+
+
+def parse_local_portfolio_schedule(
+    payload: Mapping[str, Any],
+    schedule_id: str,
+) -> LocalPortfolioSchedule:
+    if not isinstance(payload, Mapping):
+        raise ValidationError("local schedule configuration must be a mapping")
+    schedule_id = _required_text(schedule_id, "schedule_id")
+    schedules = payload.get("schedules")
+    if not isinstance(schedules, Mapping):
+        raise ValidationError(
+            "local schedule configuration must define a schedules mapping"
+        )
+    candidate = schedules.get(schedule_id)
+    if not isinstance(candidate, Mapping):
+        raise ValidationError(
+            f"local schedule '{schedule_id}' is not configured"
+        )
+    enabled = candidate.get("enabled")
+    if type(enabled) is not bool:
+        raise ValidationError("schedule enabled must be boolean")
+    confidence = candidate.get("var_confidence")
+    if (
+        isinstance(confidence, bool)
+        or not isinstance(confidence, (int, float))
+        or not 0 < float(confidence) < 1
+    ):
+        raise ValidationError("var_confidence must be between 0 and 1")
+    return LocalPortfolioSchedule(
+        schedule_id=schedule_id,
+        enabled=enabled,
+        portfolio_id=_required_text(
+            candidate.get("portfolio_id"),
+            "portfolio_id",
+        ),
+        policy_id=_required_text(candidate.get("policy_id"), "policy_id"),
+        calendar_id=_required_text(
+            candidate.get("calendar_id"),
+            "calendar_id",
+        ),
+        maximum_catch_up_sessions=_positive_integer(
+            candidate.get("maximum_catch_up_sessions"),
+            "maximum_catch_up_sessions",
+            MAX_CATCH_UP_SESSIONS,
+        ),
+        volatility_window=_positive_integer(
+            candidate.get("volatility_window"),
+            "volatility_window",
+            10_000,
+        ),
+        var_window=_positive_integer(
+            candidate.get("var_window"),
+            "var_window",
+            10_000,
+        ),
+        var_confidence=float(confidence),
+        covariance_window=_positive_integer(
+            candidate.get("covariance_window"),
+            "covariance_window",
+            2_520,
+        ),
+        max_snapshots=_positive_integer(
+            candidate.get("max_snapshots"),
+            "max_snapshots",
+            2_500,
+        ),
+        max_evaluations=_positive_integer(
+            candidate.get("max_evaluations"),
+            "max_evaluations",
+            10_000,
+        ),
+        max_notification_events=_positive_integer(
+            candidate.get("max_notification_events"),
+            "max_notification_events",
+            5_000,
+        ),
+    )
+
+
+def load_local_portfolio_schedule(
+    path: Path,
+    schedule_id: str,
+) -> LocalPortfolioSchedule:
+    try:
+        payload = load_yaml(path)
+    except Exception:
+        raise ValidationError(
+            "local schedule configuration could not be loaded"
+        ) from None
+    if not isinstance(payload, Mapping):
+        raise ValidationError("local schedule configuration must be a mapping")
+    return parse_local_portfolio_schedule(payload, schedule_id)
+
+
+def _state_path(state_dir: Path, schedule_id: str) -> Path:
+    return state_dir / f"{_required_text(schedule_id, 'schedule_id')}.json"
+
+
+def _read_state(path: Path) -> dict[str, Any] | None:
+    if path.is_symlink():
+        raise StorageError("local schedule state must not be a symbolic link")
+    if not path.exists():
+        return None
+    if not path.is_file():
+        raise StorageError("local schedule state must be a regular file")
+    try:
+        if path.stat().st_size > MAX_STATE_BYTES:
+            raise StorageError("local schedule state exceeds the byte limit")
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except StorageError:
+        raise
+    except (OSError, ValueError):
+        raise StorageError("local schedule state is unreadable") from None
+    if not isinstance(payload, dict):
+        raise StorageError("local schedule state must be a JSON object")
+    return payload
+
+
+def _checkpoint_date(
+    state: Mapping[str, Any] | None,
+    *,
+    schedule: LocalPortfolioSchedule,
+) -> date | None:
+    if state is None:
+        return None
+    if state.get("model_version") != MODEL_VERSION:
+        raise ValidationError("local schedule state model version is unsupported")
+    if state.get("schedule_id") != schedule.schedule_id:
+        raise ValidationError("local schedule state belongs to another schedule")
+    if state.get("schedule_fingerprint") != schedule.fingerprint:
+        raise ValidationError(
+            "local schedule configuration changed; archive or reset the state "
+            "before execution"
+        )
+    raw = state.get("last_successful_session")
+    if not isinstance(raw, str):
+        raise ValidationError(
+            "local schedule state is missing last_successful_session"
+        )
+    try:
+        parsed = date.fromisoformat(raw)
+    except ValueError:
+        raise ValidationError(
+            "local schedule checkpoint must use YYYY-MM-DD"
+        ) from None
+    if raw != parsed.isoformat():
+        raise ValidationError(
+            "local schedule checkpoint must use YYYY-MM-DD"
+        )
+    return parsed
+
+
+def plan_schedule_sessions(
+    *,
+    schedule: LocalPortfolioSchedule,
+    calendar: MarketCalendar,
+    as_of_date: date,
+    state: Mapping[str, Any] | None,
+) -> tuple[date, ...]:
+    calendar.require_covered(as_of_date)
+    latest_expected = calendar.latest_expected_session(as_of_date)
+    checkpoint = _checkpoint_date(state, schedule=schedule)
+    if checkpoint is None:
+        return (latest_expected,)
+    calendar.require_covered(checkpoint)
+    if checkpoint > latest_expected:
+        raise ValidationError(
+            "local schedule checkpoint is after the latest expected session"
+        )
+    if checkpoint == latest_expected:
+        return ()
+    candidates = calendar.sessions_between(
+        checkpoint.fromordinal(checkpoint.toordinal() + 1),
+        latest_expected,
+    )
+    if len(candidates) > schedule.maximum_catch_up_sessions:
+        raise ValidationError(
+            "local schedule catch-up exceeds maximum_catch_up_sessions; "
+            "run a bounded backfill explicitly"
+        )
+    return candidates
+
+
+def _summary_path(
+    state_dir: Path,
+    schedule_id: str,
+    session_date: date,
+    name: str,
+) -> str:
+    return str(
+        state_dir
+        / "runs"
+        / schedule_id
+        / session_date.isoformat()
+        / f"{name}.json"
+    )
+
+
+def build_session_commands(
+    *,
+    schedule: LocalPortfolioSchedule,
+    session_date: date,
+    mandate: PortfolioMandate,
+    python_executable: str,
+    portfolio_config_path: Path,
+    risk_limit_config_path: Path,
+    calendar_config_path: Path,
+    storage_config_path: Path,
+    state_dir: Path,
+) -> tuple[Command, ...]:
+    session = session_date.isoformat()
+    commands: list[Command] = []
+    for constituent in mandate.constituents:
+        if constituent.source != "alpha_vantage":
+            raise ValidationError(
+                "local scheduling currently supports alpha_vantage constituents only"
+            )
+        symbol = constituent.symbol
+        commands.append(
+            (
+                python_executable,
+                "-m",
+                "src.orchestration.run_daily_risk",
+                "--symbol",
+                symbol,
+                "--start-date",
+                session,
+                "--end-date",
+                session,
+                "--vol-window",
+                str(schedule.volatility_window),
+                "--var-window",
+                str(schedule.var_window),
+                "--var-confidence",
+                str(schedule.var_confidence),
+                "--storage-config",
+                str(storage_config_path),
+                "--summary-json",
+                _summary_path(
+                    state_dir,
+                    schedule.schedule_id,
+                    session_date,
+                    f"daily-risk-{symbol}",
+                ),
+            )
+        )
+        commands.append(
+            (
+                python_executable,
+                "-m",
+                "src.orchestration.run_market_freshness",
+                "--symbol",
+                symbol,
+                "--calendar-id",
+                schedule.calendar_id,
+                "--calendar-config",
+                str(calendar_config_path),
+                "--as-of-date",
+                session,
+                "--storage-config",
+                str(storage_config_path),
+                "--summary-json",
+                _summary_path(
+                    state_dir,
+                    schedule.schedule_id,
+                    session_date,
+                    f"freshness-{symbol}",
+                ),
+            )
+        )
+
+    commands.append(
+        (
+            python_executable,
+            "-m",
+            "src.orchestration.run_governed_portfolio_cycle",
+            "--portfolio-id",
+            schedule.portfolio_id,
+            "--policy-id",
+            schedule.policy_id,
+            "--portfolio-config",
+            str(portfolio_config_path),
+            "--risk-limit-config",
+            str(risk_limit_config_path),
+            "--start-date",
+            session,
+            "--end-date",
+            session,
+            "--vol-window",
+            str(schedule.volatility_window),
+            "--var-window",
+            str(schedule.var_window),
+            "--var-confidence",
+            str(schedule.var_confidence),
+            "--covariance-window",
+            str(schedule.covariance_window),
+            "--max-snapshots",
+            str(schedule.max_snapshots),
+            "--max-evaluations",
+            str(schedule.max_evaluations),
+            "--storage-config",
+            str(storage_config_path),
+            "--lock-base-dir",
+            str(state_dir),
+            "--summary-json",
+            _summary_path(
+                state_dir,
+                schedule.schedule_id,
+                session_date,
+                "governed-cycle",
+            ),
+        )
+    )
+    commands.extend(
+        [
+            ("make", "portfolio-risk-limits-warehouse-load"),
+            (
+                python_executable,
+                "-m",
+                "src.warehouse.market_freshness_loader",
+                "--storage-config",
+                str(storage_config_path),
+            ),
+            (
+                python_executable,
+                "-m",
+                "src.orchestration.run_optional_portfolio_risk_notification_outbox",
+                "--policy-id",
+                schedule.policy_id,
+                "--start-date",
+                session,
+                "--end-date",
+                session,
+                "--max-events",
+                str(schedule.max_notification_events),
+                "--storage-config",
+                str(storage_config_path),
+                "--summary-json",
+                _summary_path(
+                    state_dir,
+                    schedule.schedule_id,
+                    session_date,
+                    "notification-outbox",
+                ),
+            ),
+            (
+                python_executable,
+                "-m",
+                "src.warehouse.portfolio_risk_notification_outbox_loader",
+                "--storage-config",
+                str(storage_config_path),
+            ),
+        ]
+    )
+    return tuple(commands)
+
+
+def _default_command_runner(
+    command: Command,
+    environment: Mapping[str, str],
+) -> None:
+    merged_environment = dict(os.environ)
+    merged_environment.update(environment)
+    try:
+        subprocess.run(
+            list(command),
+            check=True,
+            env=merged_environment,
+        )
+    except (OSError, subprocess.CalledProcessError):
+        raise StorageError(
+            "local portfolio schedule command failed; checkpoint was not advanced"
+        ) from None
+
+
+def _write_state(
+    path: Path,
+    *,
+    schedule: LocalPortfolioSchedule,
+    session_date: date,
+) -> None:
+    if path.is_symlink():
+        raise StorageError("local schedule state must not be a symbolic link")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_suffix(".json.tmp")
+    payload = {
+        "last_successful_session": session_date.isoformat(),
+        "model_version": MODEL_VERSION,
+        "schedule_fingerprint": schedule.fingerprint,
+        "schedule_id": schedule.schedule_id,
+        "updated_at": datetime.now(timezone.utc).isoformat(),
+    }
+    try:
+        temporary.write_text(
+            json.dumps(payload, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        temporary.replace(path)
+    except OSError:
+        temporary.unlink(missing_ok=True)
+        raise StorageError("unable to update local schedule checkpoint") from None
+
+
+def run_local_portfolio_schedule(
+    *,
+    schedule_id: str,
+    as_of_date: date,
+    schedule_config_path: Path,
+    calendar_config_path: Path,
+    portfolio_config_path: Path,
+    risk_limit_config_path: Path,
+    storage_config_path: Path,
+    state_dir: Path,
+    dsn: str,
+    execute: bool = False,
+    python_executable: str = sys.executable,
+    command_runner: CommandRunner | None = None,
+    mandate_loader: MandateLoader | None = None,
+    calendar_loader: CalendarLoader | None = None,
+) -> dict[str, Any]:
+    schedule = load_local_portfolio_schedule(
+        schedule_config_path,
+        schedule_id,
+    )
+    selected_calendar_loader = calendar_loader or load_market_calendar
+    calendar = selected_calendar_loader(
+        calendar_config_path,
+        schedule.calendar_id,
+    )
+    state_path = _state_path(state_dir, schedule.schedule_id)
+    state = _read_state(state_path)
+    sessions = plan_schedule_sessions(
+        schedule=schedule,
+        calendar=calendar,
+        as_of_date=as_of_date,
+        state=state,
+    )
+    selected_mandate_loader = mandate_loader or load_portfolio_mandate
+    plans = []
+    for session_date in sessions:
+        mandate = selected_mandate_loader(
+            portfolio_config_path,
+            schedule.portfolio_id,
+            session_date,
+        )
+        commands = build_session_commands(
+            schedule=schedule,
+            session_date=session_date,
+            mandate=mandate,
+            python_executable=python_executable,
+            portfolio_config_path=portfolio_config_path,
+            risk_limit_config_path=risk_limit_config_path,
+            calendar_config_path=calendar_config_path,
+            storage_config_path=storage_config_path,
+            state_dir=state_dir,
+        )
+        plans.append(
+            {
+                "session_date": session_date.isoformat(),
+                "mandate_id": mandate.mandate_id,
+                "mandate_fingerprint": mandate.fingerprint,
+                "commands": [list(command) for command in commands],
+            }
+        )
+
+    summary: dict[str, Any] = {
+        "run_id": str(uuid4()),
+        "schedule_id": schedule.schedule_id,
+        "schedule_fingerprint": schedule.fingerprint,
+        "enabled": schedule.enabled,
+        "calendar": {
+            "calendar_id": calendar.calendar_id,
+            "calendar_fingerprint": calendar.fingerprint,
+        },
+        "selection": {
+            "as_of_date": as_of_date.isoformat(),
+            "checkpoint_before": (
+                _checkpoint_date(state, schedule=schedule).isoformat()
+                if state is not None
+                else None
+            ),
+            "sessions_selected": len(sessions),
+            "session_dates": [value.isoformat() for value in sessions],
+        },
+        "plans": plans,
+        "execution": {
+            "requested": execute,
+            "performed": False,
+            "completed_sessions": [],
+        },
+        "provider_request_performed": False,
+        "external_delivery_performed": False,
+        "cloud_schedule_activated": False,
+    }
+    if not execute or not sessions:
+        return summary
+    if not schedule.enabled:
+        raise ValidationError(
+            "local schedule is disabled; enable it in reviewed configuration "
+            "before execution"
+        )
+    if not isinstance(dsn, str) or not dsn.strip():
+        raise ValidationError("PostgreSQL DSN must be non-empty text")
+
+    selected_runner = command_runner or _default_command_runner
+    environment = {
+        "LOCAL_POSTGRES_DSN": dsn,
+        "WAREHOUSE_POSTGRES_DSN": dsn,
+    }
+    lock_paths: list[Path] = []
+    completed: list[str] = []
+    try:
+        lock_paths = acquire_partition_locks(
+            state_dir,
+            [f"local-schedule/{schedule.schedule_id}"],
+            summary["run_id"],
+            stale_after_seconds=21_600,
+        )
+        if len(lock_paths) != 1:
+            raise StorageError(
+                "local schedule did not acquire exactly one lock"
+            )
+        for session_date, plan in zip(sessions, plans, strict=True):
+            for command in plan["commands"]:
+                selected_runner(tuple(command), environment)
+            _write_state(
+                state_path,
+                schedule=schedule,
+                session_date=session_date,
+            )
+            completed.append(session_date.isoformat())
+    finally:
+        if lock_paths:
+            release_partition_locks(lock_paths)
+
+    summary["execution"] = {
+        "requested": True,
+        "performed": True,
+        "completed_sessions": completed,
+        "checkpoint_after": completed[-1],
+    }
+    return summary
+
+
+def _calendar_date(value: str) -> date:
+    try:
+        parsed = date.fromisoformat(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(
+            "must be a calendar date in YYYY-MM-DD format"
+        ) from exc
+    if value != parsed.isoformat():
+        raise argparse.ArgumentTypeError(
+            "must be a calendar date in YYYY-MM-DD format"
+        )
+    return parsed
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Plan or explicitly execute a bounded local portfolio schedule."
+        )
+    )
+    parser.add_argument("--schedule-id", required=True)
+    parser.add_argument("--as-of-date", required=True, type=_calendar_date)
+    parser.add_argument(
+        "--schedule-config",
+        type=Path,
+        default=Path("config/local_portfolio_schedules.yaml"),
+    )
+    parser.add_argument(
+        "--calendar-config",
+        type=Path,
+        default=Path("config/market_calendars.yaml"),
+    )
+    parser.add_argument(
+        "--portfolio-config",
+        type=Path,
+        default=Path("config/portfolios.yaml"),
+    )
+    parser.add_argument(
+        "--risk-limit-config",
+        type=Path,
+        default=Path("config/portfolio_risk_limits.yaml"),
+    )
+    parser.add_argument(
+        "--storage-config",
+        type=Path,
+        default=Path("config/storage.yaml"),
+    )
+    parser.add_argument("--state-dir", type=Path, default=Path(".scheduler"))
+    parser.add_argument(
+        "--dsn",
+        default=os.environ.get(
+            "WAREHOUSE_POSTGRES_DSN",
+            DEFAULT_POSTGRES_DSN,
+        ),
+    )
+    parser.add_argument("--execute", action="store_true")
+    parser.add_argument("--summary-json", type=Path)
+    return parser
+
+
+def _write_summary(path: Path, summary: Mapping[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_suffix(path.suffix + ".tmp")
+    try:
+        temporary.write_text(
+            json.dumps(summary, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        temporary.replace(path)
+    except OSError:
+        temporary.unlink(missing_ok=True)
+        raise StorageError("unable to write local schedule summary") from None
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    try:
+        summary = run_local_portfolio_schedule(
+            schedule_id=args.schedule_id,
+            as_of_date=args.as_of_date,
+            schedule_config_path=args.schedule_config,
+            calendar_config_path=args.calendar_config,
+            portfolio_config_path=args.portfolio_config,
+            risk_limit_config_path=args.risk_limit_config,
+            storage_config_path=args.storage_config,
+            state_dir=args.state_dir,
+            dsn=args.dsn,
+            execute=args.execute,
+        )
+        if args.summary_json is not None:
+            _write_summary(args.summary_json, summary)
+    except ValidationError:
+        print(
+            "Local portfolio schedule failed: configuration, checkpoint, "
+            "calendar, or options were invalid",
+            file=sys.stderr,
+        )
+        return 1
+    except OverlapError:
+        print(
+            "Local portfolio schedule failed: another schedule run owns the lock",
+            file=sys.stderr,
+        )
+        return 1
+    except StorageError:
+        print(
+            "Local portfolio schedule failed: a local stage failed; the last "
+            "completed checkpoint is unchanged",
+            file=sys.stderr,
+        )
+        return 1
+    except Exception:
+        print(
+            "Local portfolio schedule failed: unexpected local failure",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(json.dumps(summary, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/orchestration/run_optional_portfolio_risk_notification_outbox.py
+++ b/src/orchestration/run_optional_portfolio_risk_notification_outbox.py
@@ -1,0 +1,157 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from collections.abc import Sequence
+from datetime import date
+from pathlib import Path
+from typing import Any
+from uuid import uuid4
+
+from ..analytics.portfolio_risk_notification_outbox import MAX_NOTIFICATION_EVENTS
+from ..common.exceptions import StorageError, ValidationError
+from ..warehouse.postgres_loader import DEFAULT_POSTGRES_DSN
+from .run_portfolio_risk_notification_outbox import (
+    _calendar_date,
+    _max_events,
+    _write_summary,
+    read_actionable_transitions,
+    run_portfolio_risk_notification_outbox,
+)
+
+NO_TRANSITIONS_MESSAGE = (
+    "no actionable risk-limit transitions matched the requested range"
+)
+
+
+def run_optional_portfolio_risk_notification_outbox(
+    *,
+    policy_id: str,
+    start_date: date | None,
+    end_date: date,
+    max_events: int,
+    dsn: str,
+    storage_config_path: Path,
+) -> dict[str, Any]:
+    try:
+        records = read_actionable_transitions(
+            dsn=dsn,
+            policy_id=policy_id,
+            start_date=start_date,
+            end_date=end_date,
+            max_events=max_events,
+        )
+    except ValidationError as exc:
+        if str(exc) != NO_TRANSITIONS_MESSAGE:
+            raise
+        return {
+            "run_id": str(uuid4()),
+            "policy_id": policy_id,
+            "selection": {
+                "start_date": start_date.isoformat() if start_date else None,
+                "end_date": end_date.isoformat(),
+                "actionable_transitions": 0,
+            },
+            "parameters": {"max_events": max_events},
+            "curated_output": {
+                "portfolio_risk_notification_outbox": {
+                    "records_selected": 0,
+                    "records_written": 0,
+                    "records_already_present": 0,
+                    "pending_delivery_candidates": 0,
+                    "suppressed_candidates": 0,
+                }
+            },
+            "delivery": {
+                "performed": False,
+                "external_destinations": 0,
+                "reason": "no_actionable_transitions",
+            },
+            "latest_event": None,
+        }
+
+    return run_portfolio_risk_notification_outbox(
+        policy_id=policy_id,
+        start_date=start_date,
+        end_date=end_date,
+        max_events=max_events,
+        dsn=dsn,
+        storage_config_path=storage_config_path,
+        reader=lambda **_: records,
+    )
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Build notification-outbox evidence when actionable transitions "
+            "exist and otherwise return a successful no-op summary."
+        )
+    )
+    parser.add_argument("--policy-id", required=True)
+    parser.add_argument("--start-date", type=_calendar_date)
+    parser.add_argument("--end-date", required=True, type=_calendar_date)
+    parser.add_argument(
+        "--max-events",
+        type=_max_events,
+        default=MAX_NOTIFICATION_EVENTS,
+    )
+    parser.add_argument(
+        "--dsn",
+        default=os.environ.get(
+            "WAREHOUSE_POSTGRES_DSN",
+            DEFAULT_POSTGRES_DSN,
+        ),
+    )
+    parser.add_argument(
+        "--storage-config",
+        type=Path,
+        default=Path("config/storage.yaml"),
+    )
+    parser.add_argument("--summary-json", type=Path)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    try:
+        summary = run_optional_portfolio_risk_notification_outbox(
+            policy_id=args.policy_id,
+            start_date=args.start_date,
+            end_date=args.end_date,
+            max_events=args.max_events,
+            dsn=args.dsn,
+            storage_config_path=args.storage_config,
+        )
+        if args.summary_json is not None:
+            _write_summary(args.summary_json, summary)
+    except ValidationError:
+        print(
+            "Optional notification-outbox generation failed: input data or "
+            "options were invalid",
+            file=sys.stderr,
+        )
+        return 1
+    except StorageError:
+        print(
+            "Optional notification-outbox generation failed: local storage or "
+            "PostgreSQL operation failed; rerun is safe",
+            file=sys.stderr,
+        )
+        return 1
+    except Exception:
+        print(
+            "Optional notification-outbox generation failed: unexpected local "
+            "failure",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(json.dumps(summary, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/test_local_portfolio_schedule.py
+++ b/tests/unit/test_local_portfolio_schedule.py
@@ -1,0 +1,293 @@
+from __future__ import annotations
+
+import json
+from datetime import date
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+from src.analytics.market_calendar import parse_market_calendar
+from src.analytics.portfolio_mandates import select_portfolio_mandate
+from src.common.exceptions import StorageError, ValidationError
+from src.orchestration.run_local_portfolio_schedule import (
+    MODEL_VERSION,
+    build_session_commands,
+    parse_local_portfolio_schedule,
+    plan_schedule_sessions,
+    run_local_portfolio_schedule,
+)
+
+
+def _schedule_payload(*, enabled: bool = False, maximum: int = 5):
+    return {
+        "schedules": {
+            "us-tech-local": {
+                "enabled": enabled,
+                "portfolio_id": "us-tech-equal",
+                "policy_id": "us-tech-standard",
+                "calendar_id": "XNYS",
+                "maximum_catch_up_sessions": maximum,
+                "volatility_window": 20,
+                "var_window": 60,
+                "var_confidence": 0.95,
+                "covariance_window": 20,
+                "max_snapshots": 5,
+                "max_evaluations": 100,
+                "max_notification_events": 100,
+            }
+        }
+    }
+
+
+def _schedule(*, enabled: bool = False, maximum: int = 5):
+    return parse_local_portfolio_schedule(
+        _schedule_payload(enabled=enabled, maximum=maximum),
+        "us-tech-local",
+    )
+
+
+def _calendar():
+    return parse_market_calendar(
+        {
+            "calendars": {
+                "XNYS": {
+                    "timezone": "America/New_York",
+                    "valid_from": "2026-01-01",
+                    "valid_to": "2027-01-01",
+                    "session_weekdays": [0, 1, 2, 3, 4],
+                    "regular_close_time": "16:00",
+                    "holidays": ["2026-01-01", "2026-01-19"],
+                    "early_closes": {},
+                }
+            }
+        },
+        "XNYS",
+    )
+
+
+def _mandate():
+    return select_portfolio_mandate(
+        {
+            "portfolios": {
+                "us-tech-equal": {
+                    "mandates": [
+                        {
+                            "mandate_id": "us-tech-2026",
+                            "base_currency": "USD",
+                            "effective_from": "2026-01-01",
+                            "effective_to": "2027-01-01",
+                            "constituents": [
+                                {
+                                    "source": "alpha_vantage",
+                                    "symbol": "AAPL",
+                                    "weight": 0.5,
+                                },
+                                {
+                                    "source": "alpha_vantage",
+                                    "symbol": "MSFT",
+                                    "weight": 0.5,
+                                },
+                            ],
+                        }
+                    ]
+                }
+            }
+        },
+        "us-tech-equal",
+        date(2026, 1, 9),
+    )
+
+
+def _write_schedule(tmp_path: Path, *, enabled: bool, maximum: int = 5) -> Path:
+    path = tmp_path / "schedule.yaml"
+    path.write_text(
+        yaml.safe_dump(
+            _schedule_payload(enabled=enabled, maximum=maximum),
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+    return path
+
+
+def test_initial_plan_uses_latest_expected_session_on_weekend() -> None:
+    sessions = plan_schedule_sessions(
+        schedule=_schedule(),
+        calendar=_calendar(),
+        as_of_date=date(2026, 1, 10),
+        state=None,
+    )
+    assert sessions == (date(2026, 1, 9),)
+
+
+def test_checkpoint_plans_bounded_sessions_and_rejects_excess() -> None:
+    schedule = _schedule(maximum=3)
+    state = {
+        "model_version": MODEL_VERSION,
+        "schedule_id": schedule.schedule_id,
+        "schedule_fingerprint": schedule.fingerprint,
+        "last_successful_session": "2026-01-06",
+    }
+    assert plan_schedule_sessions(
+        schedule=schedule,
+        calendar=_calendar(),
+        as_of_date=date(2026, 1, 9),
+        state=state,
+    ) == (
+        date(2026, 1, 7),
+        date(2026, 1, 8),
+        date(2026, 1, 9),
+    )
+
+    with pytest.raises(ValidationError, match="catch-up"):
+        plan_schedule_sessions(
+            schedule=_schedule(maximum=2),
+            calendar=_calendar(),
+            as_of_date=date(2026, 1, 9),
+            state={
+                **state,
+                "schedule_fingerprint": _schedule(maximum=2).fingerprint,
+            },
+        )
+
+
+def test_command_plan_uses_current_cli_contracts_without_secrets() -> None:
+    commands = build_session_commands(
+        schedule=_schedule(enabled=True),
+        session_date=date(2026, 1, 9),
+        mandate=_mandate(),
+        python_executable="python",
+        portfolio_config_path=Path("portfolios.yaml"),
+        risk_limit_config_path=Path("limits.yaml"),
+        calendar_config_path=Path("calendar.yaml"),
+        storage_config_path=Path("storage.yaml"),
+        state_dir=Path(".scheduler"),
+    )
+    flattened = "\n".join(" ".join(command) for command in commands)
+
+    assert flattened.count("src.orchestration.run_daily_risk") == 2
+    assert flattened.count("src.orchestration.run_market_freshness") == 2
+    assert "src.orchestration.run_governed_portfolio_cycle" in flattened
+    assert "--risk-limit-config limits.yaml" in flattened
+    assert "portfolio-risk-limits-warehouse-load" in flattened
+    assert "run_optional_portfolio_risk_notification_outbox" in flattened
+    assert "portfolio_risk_notification_outbox_loader" in flattened
+    assert "postgresql://" not in flattened
+
+
+def test_dry_run_does_not_execute_or_create_state(tmp_path: Path) -> None:
+    calls: list[tuple[str, ...]] = []
+    summary = run_local_portfolio_schedule(
+        schedule_id="us-tech-local",
+        as_of_date=date(2026, 1, 10),
+        schedule_config_path=_write_schedule(tmp_path, enabled=False),
+        calendar_config_path=Path("calendar.yaml"),
+        portfolio_config_path=Path("portfolios.yaml"),
+        risk_limit_config_path=Path("limits.yaml"),
+        storage_config_path=Path("storage.yaml"),
+        state_dir=tmp_path / "state",
+        dsn="not-used",
+        execute=False,
+        python_executable="python",
+        command_runner=lambda command, _: calls.append(command),
+        mandate_loader=lambda *_: _mandate(),
+        calendar_loader=lambda *_: _calendar(),
+    )
+
+    assert calls == []
+    assert summary["execution"]["performed"] is False
+    assert summary["selection"]["session_dates"] == ["2026-01-09"]
+    assert not (tmp_path / "state" / "us-tech-local.json").exists()
+
+
+def test_disabled_schedule_refuses_execution_before_commands(tmp_path: Path) -> None:
+    calls: list[tuple[str, ...]] = []
+    with pytest.raises(ValidationError, match="disabled"):
+        run_local_portfolio_schedule(
+            schedule_id="us-tech-local",
+            as_of_date=date(2026, 1, 10),
+            schedule_config_path=_write_schedule(tmp_path, enabled=False),
+            calendar_config_path=Path("calendar.yaml"),
+            portfolio_config_path=Path("portfolios.yaml"),
+            risk_limit_config_path=Path("limits.yaml"),
+            storage_config_path=Path("storage.yaml"),
+            state_dir=tmp_path / "state",
+            dsn="dsn",
+            execute=True,
+            python_executable="python",
+            command_runner=lambda command, _: calls.append(command),
+            mandate_loader=lambda *_: _mandate(),
+            calendar_loader=lambda *_: _calendar(),
+        )
+    assert calls == []
+
+
+def test_successful_execution_checkpoints_after_complete_session(tmp_path: Path) -> None:
+    calls: list[tuple[str, ...]] = []
+    environments: list[dict[str, str]] = []
+
+    def runner(command: tuple[str, ...], environment: Any) -> None:
+        calls.append(command)
+        environments.append(dict(environment))
+
+    summary = run_local_portfolio_schedule(
+        schedule_id="us-tech-local",
+        as_of_date=date(2026, 1, 10),
+        schedule_config_path=_write_schedule(tmp_path, enabled=True),
+        calendar_config_path=Path("calendar.yaml"),
+        portfolio_config_path=Path("portfolios.yaml"),
+        risk_limit_config_path=Path("limits.yaml"),
+        storage_config_path=Path("storage.yaml"),
+        state_dir=tmp_path / "state",
+        dsn="postgresql://secret-value",
+        execute=True,
+        python_executable="python",
+        command_runner=runner,
+        mandate_loader=lambda *_: _mandate(),
+        calendar_loader=lambda *_: _calendar(),
+    )
+
+    state = json.loads(
+        (tmp_path / "state" / "us-tech-local.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    assert state["last_successful_session"] == "2026-01-09"
+    assert summary["execution"]["completed_sessions"] == ["2026-01-09"]
+    assert len(calls) == 9
+    assert all(
+        environment["WAREHOUSE_POSTGRES_DSN"] == "postgresql://secret-value"
+        for environment in environments
+    )
+    assert "postgresql://secret-value" not in json.dumps(summary)
+
+
+def test_failed_command_does_not_advance_checkpoint(tmp_path: Path) -> None:
+    calls = 0
+
+    def fail_after_first(command: tuple[str, ...], environment: Any) -> None:
+        nonlocal calls
+        calls += 1
+        if calls == 2:
+            raise StorageError("failed")
+
+    with pytest.raises(StorageError, match="failed"):
+        run_local_portfolio_schedule(
+            schedule_id="us-tech-local",
+            as_of_date=date(2026, 1, 10),
+            schedule_config_path=_write_schedule(tmp_path, enabled=True),
+            calendar_config_path=Path("calendar.yaml"),
+            portfolio_config_path=Path("portfolios.yaml"),
+            risk_limit_config_path=Path("limits.yaml"),
+            storage_config_path=Path("storage.yaml"),
+            state_dir=tmp_path / "state",
+            dsn="dsn",
+            execute=True,
+            python_executable="python",
+            command_runner=fail_after_first,
+            mandate_loader=lambda *_: _mandate(),
+            calendar_loader=lambda *_: _calendar(),
+        )
+    assert not (tmp_path / "state" / "us-tech-local.json").exists()

--- a/tests/unit/test_local_portfolio_schedule_architecture_contract.py
+++ b/tests/unit/test_local_portfolio_schedule_architecture_contract.py
@@ -1,0 +1,42 @@
+from pathlib import Path
+
+
+def test_local_scheduler_documents_disabled_checkpointed_execution() -> None:
+    source = Path(
+        "src/orchestration/run_local_portfolio_schedule.py"
+    ).read_text(encoding="utf-8")
+    optional = Path(
+        "src/orchestration/run_optional_portfolio_risk_notification_outbox.py"
+    ).read_text(encoding="utf-8")
+    docs = Path("docs/local-portfolio-scheduling.md").read_text(
+        encoding="utf-8"
+    )
+    config = Path("config/local_portfolio_schedules.yaml").read_text(
+        encoding="utf-8"
+    )
+
+    for required in (
+        "maximum_catch_up_sessions",
+        "local-schedule/",
+        "schedule_fingerprint",
+        "last_successful_session",
+        "run_market_freshness",
+        "run_governed_portfolio_cycle",
+        "portfolio-risk-limits-warehouse-load",
+        "run_optional_portfolio_risk_notification_outbox",
+        "portfolio_risk_notification_outbox_loader",
+        "provider_request_performed",
+        "cloud_schedule_activated",
+    ):
+        assert required in source
+
+    assert "no_actionable_transitions" in optional
+    assert "enabled: false" in config
+    for required in (
+        "Disabled-by-default",
+        "checkpoint advances",
+        "maximum_catch_up_sessions",
+        "no Kubernetes CronJob",
+        "never included in plan or run summaries",
+    ):
+        assert required.lower() in docs.lower()

--- a/tests/unit/test_optional_portfolio_risk_notification_outbox.py
+++ b/tests/unit/test_optional_portfolio_risk_notification_outbox.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+from datetime import date
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+import src.orchestration.run_optional_portfolio_risk_notification_outbox as optional
+from src.common.exceptions import ValidationError
+
+
+def test_optional_outbox_returns_successful_noop_when_no_transition(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def no_records(**_: Any) -> list[dict[str, Any]]:
+        raise ValidationError(optional.NO_TRANSITIONS_MESSAGE)
+
+    monkeypatch.setattr(optional, "read_actionable_transitions", no_records)
+    summary = optional.run_optional_portfolio_risk_notification_outbox(
+        policy_id="us-tech-standard",
+        start_date=date(2026, 1, 9),
+        end_date=date(2026, 1, 9),
+        max_events=100,
+        dsn="dsn",
+        storage_config_path=Path("storage.yaml"),
+    )
+
+    assert summary["selection"]["actionable_transitions"] == 0
+    assert summary["delivery"] == {
+        "performed": False,
+        "external_destinations": 0,
+        "reason": "no_actionable_transitions",
+    }
+    assert summary["latest_event"] is None
+
+
+def test_optional_outbox_reuses_preloaded_records(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    records = [{"calculation_id": "transition-1"}]
+    received: list[list[dict[str, Any]]] = []
+
+    monkeypatch.setattr(
+        optional,
+        "read_actionable_transitions",
+        lambda **_: records,
+    )
+
+    def run_outbox(**kwargs: Any) -> dict[str, Any]:
+        received.append(kwargs["reader"]())
+        return {"ok": True}
+
+    monkeypatch.setattr(
+        optional,
+        "run_portfolio_risk_notification_outbox",
+        run_outbox,
+    )
+    assert optional.run_optional_portfolio_risk_notification_outbox(
+        policy_id="us-tech-standard",
+        start_date=None,
+        end_date=date(2026, 1, 9),
+        max_events=100,
+        dsn="dsn",
+        storage_config_path=Path("storage.yaml"),
+    ) == {"ok": True}
+    assert received == [records]
+
+
+def test_optional_outbox_does_not_suppress_other_validation_errors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def invalid(**_: Any) -> list[dict[str, Any]]:
+        raise ValidationError("different failure")
+
+    monkeypatch.setattr(optional, "read_actionable_transitions", invalid)
+    with pytest.raises(ValidationError, match="different failure"):
+        optional.run_optional_portfolio_risk_notification_outbox(
+            policy_id="us-tech-standard",
+            start_date=None,
+            end_date=date(2026, 1, 9),
+            max_events=100,
+            dsn="dsn",
+            storage_config_path=Path("storage.yaml"),
+        )


### PR DESCRIPTION
## Outcome

Add an explicitly activated local schedule over already-landed daily market data:

```text
reviewed disabled configuration
  -> exchange-session planning
  -> bounded checkpoint catch-up
  -> one schedule lock
  -> daily risk and market freshness per constituent
  -> governed portfolio risk, attribution, and limits
  -> local warehouse load
  -> optional notification outbox
  -> atomic session checkpoint
```

Primary arc42 block: `orchestration`, with bounded interfaces to calendar, mandate, warehouse, notification, and lock contracts.

## Safety controls

The committed schedule is disabled. Normal invocation is plan-only. Execution requires both a reviewed `enabled: true` configuration and explicit `--execute`. There is no Kubernetes CronJob, GitHub schedule, daemon, timer, background process, cloud scheduler, provider call, external notification delivery, position mutation, deployment, or Terraform apply.

## Catch-up and recovery

The first run selects only the latest expected exchange session. Later runs select sessions after the checkpoint, capped by `maximum_catch_up_sessions`; oversized catch-up fails rather than truncating.

One `local-schedule/<schedule_id>` lock spans execution. The bounded JSON state binds the schedule fingerprint and advances only after every command for a session succeeds. Configuration changes cannot silently reuse old state. A failure stops downstream commands and leaves the last completed checkpoint unchanged.

## Stage contract

Each session runs daily risk and exchange-calendar freshness for every Alpha Vantage mandate constituent, the governed portfolio cycle, local PostgreSQL loading, optional notification-outbox generation, and outbox loading. The optional wrapper treats the valid absence of actionable transitions as a successful no-op while preserving all other failures.

DSNs are passed only through child-process environment variables and never appear in plan or run summaries.

## Validation and repair

The first exact-head run exposed one nullable checkpoint expression that runtime validation already made safe. The scheduler now computes the parsed checkpoint once and narrows it explicitly before rendering the plan; window bounds were also aligned with downstream minimums.

GitHub Actions run `32607932750` (`ci` run 240) passed on exact head `0ea3326cebee9df1431675c0caa8524a3a86e11f`:

- Security guardrails: passed.
- Python readiness: passed.
  - Ruff passed;
  - mypy passed across 67 source files;
  - 572 tests passed;
  - `pip check` and readiness replay passed.
- PostgreSQL contract: passed against PostgreSQL 16.
- Infrastructure validation: passed without deployment or Terraform apply.

No unresolved review threads or requested changes are present.

## Boundary

The schedule consumes local raw data. It performs no Alpha Vantage request, sends no external notification, changes no position, acknowledges no breach, creates no managed service, deploys no Kubernetes workload, and runs no Terraform apply.