### PR TITLE
Add manual webhook notification delivery

### DIFF
--- a/config/notification_delivery.yaml
+++ b/config/notification_delivery.yaml
@@ -1,0 +1,8 @@
+delivery:
+  webhook:
+    enabled: false
+    endpoint_env: RISK_NOTIFICATION_WEBHOOK_URL
+    timeout_seconds: 5
+    max_batch_events: 25
+    max_attempts_per_event: 3
+    initial_backoff_seconds: 1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,7 @@ services:
       - ./sql/portfolio_risk_breach_lifecycle_schema.sql:/docker-entrypoint-initdb.d/06_portfolio_risk_breach_lifecycle_schema.sql:ro
       - ./sql/portfolio_risk_notification_outbox_schema.sql:/docker-entrypoint-initdb.d/07_portfolio_risk_notification_outbox_schema.sql:ro
       - ./sql/market_freshness_schema.sql:/docker-entrypoint-initdb.d/08_market_freshness_schema.sql:ro
+      - ./sql/portfolio_risk_notification_delivery_schema.sql:/docker-entrypoint-initdb.d/09_portfolio_risk_notification_delivery_schema.sql:ro
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U risk_user -d risk_platform"]
       interval: 5s

--- a/docs/manual-webhook-delivery.md
+++ b/docs/manual-webhook-delivery.md
@@ -1,0 +1,100 @@
+# Manual Webhook Notification Delivery
+
+## Outcome
+
+This adapter delivers current pending portfolio risk notifications to one explicitly configured HTTPS webhook while retaining append-only attempt evidence:
+
+```text
+current pending notification outbox
+  -> exclude an already succeeded event
+  -> bounded manual batch
+  -> HTTPS POST with stable Idempotency-Key
+  -> bounded retry and exponential backoff
+  -> append-only PostgreSQL delivery attempt
+  -> pending or succeeded operational views
+```
+
+The implementation is `src/orchestration/deliver_portfolio_risk_notifications.py`. The committed configuration is `config/notification_delivery.yaml`.
+
+## Disabled-by-default activation
+
+The committed webhook configuration has `enabled: false` and contains no endpoint or recipient. Normal invocation is plan-only. External delivery requires both:
+
+1. a reviewed configuration change setting `enabled: true`; and
+2. an explicit `--execute` invocation with `RISK_NOTIFICATION_WEBHOOK_URL` set locally.
+
+The endpoint must be HTTPS and may not contain embedded credentials or a URL fragment. Only the endpoint host is recorded in evidence. The full URL and environment value are not written to summaries or the database.
+
+## Idempotency and retries
+
+Every request uses the notification `event_id` as the `Idempotency-Key`. Retries of the same event therefore carry the same remote deduplication identity.
+
+Attempt identity binds:
+
+```text
+notification event ID
+webhook channel
+attempt number
+portfolio-risk-webhook-delivery-v1
+```
+
+Attempts are append-only and numbered from one. A successful attempt prevents the event from being selected again. A failed attempt may be retried until `max_attempts_per_event` is reached. Backoff begins at `initial_backoff_seconds`, doubles after each failure, and is capped at 60 seconds.
+
+There remains an unavoidable failure window in which the remote receiver accepts a request but local attempt persistence fails. The stable `Idempotency-Key` is the control for that ambiguity; receivers must deduplicate it.
+
+## Evidence boundary
+
+Each attempt stores:
+
+- attempt and notification IDs;
+- attempt number and timestamp;
+- outcome;
+- HTTP status or bounded error code;
+- endpoint host;
+- payload SHA-256; and
+- idempotency key.
+
+Response bodies, endpoint paths, credentials, headers containing secrets, and arbitrary exception messages are never stored.
+
+## Operator commands
+
+Plan the current batch without network activity:
+
+```bash
+.venv/bin/python -m src.orchestration.deliver_portfolio_risk_notifications \
+  --summary-json .demo/webhook-delivery-plan.json
+```
+
+After reviewing and enabling the configuration:
+
+```bash
+export RISK_NOTIFICATION_WEBHOOK_URL='https://alerts.example.com/risk'
+
+.venv/bin/python -m src.orchestration.deliver_portfolio_risk_notifications \
+  --execute \
+  --summary-json .demo/webhook-delivery-run.json
+```
+
+The PostgreSQL DSN comes from `WAREHOUSE_POSTGRES_DSN` or `--dsn`. It is not included in summaries.
+
+## PostgreSQL serving
+
+The append-only table is:
+
+```text
+risk_platform.portfolio_risk_notification_delivery_attempts
+```
+
+Operational views are:
+
+```text
+risk_platform.portfolio_risk_notification_delivery_status
+risk_platform.portfolio_risk_notification_delivery_pending
+risk_platform.portfolio_risk_notification_delivery_succeeded
+```
+
+The source outbox remains immutable. Delivery status is derived from attempts rather than written back to notification records.
+
+## Boundary
+
+This adapter does not schedule itself, discover recipients, create webhook endpoints, rotate secrets, acknowledge or resolve breaches, mutate analytical evidence, block trading, deploy infrastructure, or run `terraform apply`. CI uses fake transports and performs no network request.

--- a/sql/portfolio_risk_notification_delivery_consistency_checks.sql
+++ b/sql/portfolio_risk_notification_delivery_consistency_checks.sql
@@ -1,0 +1,170 @@
+-- Reconciliation checks for append-only notification delivery attempts.
+
+WITH counts AS (
+    SELECT
+        (SELECT COUNT(*)
+         FROM risk_platform.portfolio_risk_notification_delivery_attempts)
+            AS attempt_rows,
+        (SELECT COUNT(*)
+         FROM risk_platform.portfolio_risk_notification_delivery_status)
+            AS status_rows,
+        (SELECT COUNT(*)
+         FROM risk_platform.portfolio_risk_notification_delivery_pending)
+            AS pending_rows,
+        (SELECT COUNT(*)
+         FROM risk_platform.portfolio_risk_notification_delivery_succeeded)
+            AS succeeded_rows
+),
+integrity AS (
+    SELECT
+        (
+            SELECT COUNT(*)
+            FROM risk_platform.portfolio_risk_notification_delivery_attempts attempt
+            LEFT JOIN risk_platform.portfolio_risk_notification_outbox outbox
+              ON outbox.event_id = attempt.event_id
+            WHERE outbox.event_id IS NULL
+        ) AS orphan_attempts,
+        (
+            SELECT COUNT(*)
+            FROM risk_platform.portfolio_risk_notification_delivery_attempts
+            WHERE idempotency_key <> event_id
+               OR payload_sha256 !~ '^[0-9a-f]{64}$'
+               OR endpoint_host = ''
+        ) AS invalid_identity_rows,
+        (
+            SELECT COUNT(*)
+            FROM risk_platform.portfolio_risk_notification_delivery_attempts
+            WHERE
+                (outcome = 'succeeded'
+                    AND (http_status NOT BETWEEN 200 AND 299
+                         OR error_code IS NOT NULL))
+                OR
+                (outcome = 'failed' AND error_code IS NULL)
+        ) AS invalid_outcome_rows,
+        (
+            SELECT COUNT(*)
+            FROM (
+                SELECT event_id, channel, attempt_number
+                FROM risk_platform.portfolio_risk_notification_delivery_attempts
+                GROUP BY event_id, channel, attempt_number
+                HAVING COUNT(*) > 1
+            ) duplicated
+        ) AS duplicate_attempt_numbers,
+        (
+            SELECT COUNT(*)
+            FROM (
+                SELECT event_id, channel
+                FROM risk_platform.portfolio_risk_notification_delivery_attempts
+                WHERE outcome = 'succeeded'
+                GROUP BY event_id, channel
+                HAVING COUNT(*) > 1
+            ) duplicated
+        ) AS duplicate_successes,
+        (
+            SELECT COUNT(*)
+            FROM (
+                SELECT
+                    event_id,
+                    channel,
+                    COUNT(*) AS attempt_count,
+                    MAX(attempt_number) AS max_attempt_number
+                FROM risk_platform.portfolio_risk_notification_delivery_attempts
+                GROUP BY event_id, channel
+            ) numbered
+            WHERE attempt_count <> max_attempt_number
+        ) AS non_contiguous_attempts,
+        (
+            SELECT COUNT(*)
+            FROM risk_platform.portfolio_risk_notification_delivery_status status
+            WHERE status.delivered <> EXISTS (
+                SELECT 1
+                FROM risk_platform.portfolio_risk_notification_delivery_attempts attempt
+                WHERE attempt.event_id = status.event_id
+                  AND attempt.channel = 'webhook'
+                  AND attempt.outcome = 'succeeded'
+            )
+        ) AS invalid_delivery_status
+)
+SELECT
+    'notification_delivery_attempts_reference_outbox' AS check_name,
+    '0' AS expected,
+    orphan_attempts::TEXT AS actual,
+    CASE WHEN orphan_attempts = 0 THEN 'pass' ELSE 'fail' END AS status
+FROM integrity
+
+UNION ALL
+
+SELECT
+    'notification_delivery_identity_valid',
+    '0',
+    invalid_identity_rows::TEXT,
+    CASE WHEN invalid_identity_rows = 0 THEN 'pass' ELSE 'fail' END
+FROM integrity
+
+UNION ALL
+
+SELECT
+    'notification_delivery_outcomes_valid',
+    '0',
+    invalid_outcome_rows::TEXT,
+    CASE WHEN invalid_outcome_rows = 0 THEN 'pass' ELSE 'fail' END
+FROM integrity
+
+UNION ALL
+
+SELECT
+    'notification_delivery_attempt_numbers_unique',
+    '0',
+    duplicate_attempt_numbers::TEXT,
+    CASE WHEN duplicate_attempt_numbers = 0 THEN 'pass' ELSE 'fail' END
+FROM integrity
+
+UNION ALL
+
+SELECT
+    'notification_delivery_success_unique',
+    '0',
+    duplicate_successes::TEXT,
+    CASE WHEN duplicate_successes = 0 THEN 'pass' ELSE 'fail' END
+FROM integrity
+
+UNION ALL
+
+SELECT
+    'notification_delivery_attempt_numbers_contiguous',
+    '0',
+    non_contiguous_attempts::TEXT,
+    CASE WHEN non_contiguous_attempts = 0 THEN 'pass' ELSE 'fail' END
+FROM integrity
+
+UNION ALL
+
+SELECT
+    'notification_delivery_status_matches_attempts',
+    '0',
+    invalid_delivery_status::TEXT,
+    CASE WHEN invalid_delivery_status = 0 THEN 'pass' ELSE 'fail' END
+FROM integrity
+
+UNION ALL
+
+SELECT
+    'notification_delivery_status_partitions_current_outbox',
+    status_rows::TEXT,
+    (pending_rows + succeeded_rows)::TEXT,
+    CASE
+        WHEN status_rows = pending_rows + succeeded_rows THEN 'pass'
+        ELSE 'fail'
+    END
+FROM counts
+
+UNION ALL
+
+SELECT
+    'notification_delivery_attempt_count_nonnegative',
+    '0',
+    CASE WHEN attempt_rows >= 0 THEN '0' ELSE '1' END,
+    CASE WHEN attempt_rows >= 0 THEN 'pass' ELSE 'fail' END
+FROM counts
+
+ORDER BY check_name;

--- a/sql/portfolio_risk_notification_delivery_schema.sql
+++ b/sql/portfolio_risk_notification_delivery_schema.sql
@@ -1,0 +1,124 @@
+-- Append-only delivery-attempt evidence for portfolio risk notifications.
+-- Apply after sql/portfolio_risk_notification_outbox_schema.sql.
+
+CREATE SCHEMA IF NOT EXISTS risk_platform;
+
+CREATE TABLE IF NOT EXISTS
+risk_platform.portfolio_risk_notification_delivery_attempts (
+    attempt_id TEXT PRIMARY KEY,
+    model_version TEXT NOT NULL,
+    event_id TEXT NOT NULL REFERENCES
+        risk_platform.portfolio_risk_notification_outbox (event_id),
+    channel TEXT NOT NULL CHECK (channel = 'webhook'),
+    attempt_number INTEGER NOT NULL CHECK (
+        attempt_number >= 1 AND attempt_number <= 10
+    ),
+    idempotency_key TEXT NOT NULL,
+    attempted_at TIMESTAMPTZ NOT NULL,
+    outcome TEXT NOT NULL CHECK (outcome IN ('succeeded', 'failed')),
+    http_status INTEGER CHECK (http_status BETWEEN 100 AND 599),
+    error_code TEXT,
+    endpoint_host TEXT NOT NULL,
+    payload_sha256 TEXT NOT NULL,
+    loaded_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    UNIQUE (event_id, channel, attempt_number),
+    CHECK (attempt_id <> ''),
+    CHECK (model_version <> ''),
+    CHECK (event_id <> ''),
+    CHECK (idempotency_key = event_id),
+    CHECK (endpoint_host <> ''),
+    CHECK (payload_sha256 ~ '^[0-9a-f]{64}$'),
+    CHECK (
+        (outcome = 'succeeded'
+            AND http_status BETWEEN 200 AND 299
+            AND error_code IS NULL)
+        OR
+        (outcome = 'failed'
+            AND error_code IS NOT NULL)
+    ),
+    CHECK (
+        model_version <> 'portfolio-risk-webhook-delivery-v1'
+        OR channel = 'webhook'
+    )
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS
+idx_portfolio_notification_delivery_one_success
+    ON risk_platform.portfolio_risk_notification_delivery_attempts (
+        event_id,
+        channel
+    )
+    WHERE outcome = 'succeeded';
+
+CREATE INDEX IF NOT EXISTS idx_portfolio_notification_delivery_history
+    ON risk_platform.portfolio_risk_notification_delivery_attempts (
+        event_id,
+        channel,
+        attempt_number DESC,
+        attempted_at DESC
+    );
+
+CREATE OR REPLACE VIEW
+risk_platform.portfolio_risk_notification_delivery_status AS
+SELECT
+    pending.event_id,
+    pending.event_type,
+    pending.transition_type,
+    pending.policy_id,
+    pending.policy_fingerprint,
+    pending.portfolio_id,
+    pending.definition_fingerprint,
+    pending.metric_name,
+    pending.subject_key,
+    pending.current_status,
+    pending.ts_event,
+    COUNT(attempt.attempt_id) AS attempt_count,
+    COUNT(attempt.attempt_id) FILTER (
+        WHERE attempt.outcome = 'failed'
+    ) AS failed_attempt_count,
+    BOOL_OR(attempt.outcome = 'succeeded') AS delivered,
+    MAX(attempt.attempted_at) AS last_attempted_at,
+    MAX(attempt.http_status) FILTER (
+        WHERE attempt.attempt_number = (
+            SELECT MAX(latest.attempt_number)
+            FROM risk_platform.portfolio_risk_notification_delivery_attempts latest
+            WHERE latest.event_id = pending.event_id
+              AND latest.channel = 'webhook'
+        )
+    ) AS last_http_status,
+    MAX(attempt.error_code) FILTER (
+        WHERE attempt.attempt_number = (
+            SELECT MAX(latest.attempt_number)
+            FROM risk_platform.portfolio_risk_notification_delivery_attempts latest
+            WHERE latest.event_id = pending.event_id
+              AND latest.channel = 'webhook'
+        )
+    ) AS last_error_code
+FROM risk_platform.portfolio_risk_notification_pending pending
+LEFT JOIN risk_platform.portfolio_risk_notification_delivery_attempts attempt
+  ON attempt.event_id = pending.event_id
+ AND attempt.channel = 'webhook'
+GROUP BY
+    pending.event_id,
+    pending.event_type,
+    pending.transition_type,
+    pending.policy_id,
+    pending.policy_fingerprint,
+    pending.portfolio_id,
+    pending.definition_fingerprint,
+    pending.metric_name,
+    pending.subject_key,
+    pending.current_status,
+    pending.ts_event;
+
+CREATE OR REPLACE VIEW
+risk_platform.portfolio_risk_notification_delivery_pending AS
+SELECT *
+FROM risk_platform.portfolio_risk_notification_delivery_status
+WHERE NOT delivered;
+
+CREATE OR REPLACE VIEW
+risk_platform.portfolio_risk_notification_delivery_succeeded AS
+SELECT *
+FROM risk_platform.portfolio_risk_notification_delivery_status
+WHERE delivered;

--- a/sql/portfolio_risk_notification_delivery_schema.sql
+++ b/sql/portfolio_risk_notification_delivery_schema.sql
@@ -76,7 +76,10 @@ SELECT
     COUNT(attempt.attempt_id) FILTER (
         WHERE attempt.outcome = 'failed'
     ) AS failed_attempt_count,
-    BOOL_OR(attempt.outcome = 'succeeded') AS delivered,
+    COALESCE(
+        BOOL_OR(attempt.outcome = 'succeeded'),
+        FALSE
+    ) AS delivered,
     MAX(attempt.attempted_at) AS last_attempted_at,
     MAX(attempt.http_status) FILTER (
         WHERE attempt.attempt_number = (

--- a/src/orchestration/deliver_portfolio_risk_notifications.py
+++ b/src/orchestration/deliver_portfolio_risk_notifications.py
@@ -1,0 +1,578 @@
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import sys
+import time as time_module
+import urllib.error
+import urllib.request
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlparse
+from uuid import uuid4
+
+from ..common.config import load_yaml
+from ..common.exceptions import StorageError, ValidationError
+from ..warehouse.postgres_loader import DEFAULT_POSTGRES_DSN
+
+MODEL_VERSION = "portfolio-risk-webhook-delivery-v1"
+CHANNEL = "webhook"
+MAX_BATCH_EVENTS = 100
+MAX_ATTEMPTS_PER_EVENT = 10
+MAX_TIMEOUT_SECONDS = 30
+MAX_BACKOFF_SECONDS = 60
+
+CandidateReader = Callable[..., list[dict[str, Any]]]
+AttemptWriter = Callable[[Mapping[str, Any]], None]
+Transport = Callable[[str, bytes, Mapping[str, str], float], int]
+Sleeper = Callable[[float], None]
+
+
+class DeliveryTransportError(RuntimeError):
+    pass
+
+
+@dataclass(frozen=True, slots=True)
+class WebhookDeliveryConfig:
+    enabled: bool
+    endpoint_env: str
+    timeout_seconds: int
+    max_batch_events: int
+    max_attempts_per_event: int
+    initial_backoff_seconds: int
+
+    @property
+    def fingerprint(self) -> str:
+        payload = {
+            "channel": CHANNEL,
+            "enabled": self.enabled,
+            "endpoint_env": self.endpoint_env,
+            "initial_backoff_seconds": self.initial_backoff_seconds,
+            "max_attempts_per_event": self.max_attempts_per_event,
+            "max_batch_events": self.max_batch_events,
+            "model_version": MODEL_VERSION,
+            "timeout_seconds": self.timeout_seconds,
+        }
+        digest = hashlib.sha256(
+            json.dumps(payload, sort_keys=True, separators=(",", ":")).encode(
+                "utf-8"
+            )
+        ).hexdigest()[:24]
+        return f"webhook-delivery-{digest}"
+
+
+def _required_text(value: Any, label: str, maximum: int = 128) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ValidationError(f"{label} must be non-empty text")
+    parsed = value.strip()
+    if len(parsed) > maximum or any(ord(character) < 32 for character in parsed):
+        raise ValidationError(f"{label} is invalid")
+    return parsed
+
+
+def _bounded_integer(value: Any, label: str, maximum: int) -> int:
+    if type(value) is not int or not 1 <= value <= maximum:
+        raise ValidationError(
+            f"{label} must be an integer between 1 and {maximum}"
+        )
+    return value
+
+
+def parse_webhook_delivery_config(
+    payload: Mapping[str, Any],
+) -> WebhookDeliveryConfig:
+    if not isinstance(payload, Mapping):
+        raise ValidationError("notification delivery configuration must be a mapping")
+    delivery = payload.get("delivery")
+    if not isinstance(delivery, Mapping):
+        raise ValidationError("notification delivery configuration is missing delivery")
+    webhook = delivery.get("webhook")
+    if not isinstance(webhook, Mapping):
+        raise ValidationError("notification delivery configuration is missing webhook")
+    enabled = webhook.get("enabled")
+    if type(enabled) is not bool:
+        raise ValidationError("webhook enabled must be boolean")
+    return WebhookDeliveryConfig(
+        enabled=enabled,
+        endpoint_env=_required_text(webhook.get("endpoint_env"), "endpoint_env"),
+        timeout_seconds=_bounded_integer(
+            webhook.get("timeout_seconds"),
+            "timeout_seconds",
+            MAX_TIMEOUT_SECONDS,
+        ),
+        max_batch_events=_bounded_integer(
+            webhook.get("max_batch_events"),
+            "max_batch_events",
+            MAX_BATCH_EVENTS,
+        ),
+        max_attempts_per_event=_bounded_integer(
+            webhook.get("max_attempts_per_event"),
+            "max_attempts_per_event",
+            MAX_ATTEMPTS_PER_EVENT,
+        ),
+        initial_backoff_seconds=_bounded_integer(
+            webhook.get("initial_backoff_seconds"),
+            "initial_backoff_seconds",
+            MAX_BACKOFF_SECONDS,
+        ),
+    )
+
+
+def load_webhook_delivery_config(path: Path) -> WebhookDeliveryConfig:
+    try:
+        payload = load_yaml(path)
+    except Exception:
+        raise ValidationError(
+            "notification delivery configuration could not be loaded"
+        ) from None
+    if not isinstance(payload, Mapping):
+        raise ValidationError("notification delivery configuration must be a mapping")
+    return parse_webhook_delivery_config(payload)
+
+
+def _endpoint(value: str) -> tuple[str, str]:
+    endpoint = _required_text(value, "webhook endpoint", maximum=2_048)
+    parsed = urlparse(endpoint)
+    if (
+        parsed.scheme != "https"
+        or not parsed.hostname
+        or parsed.username is not None
+        or parsed.password is not None
+        or parsed.fragment
+    ):
+        raise ValidationError(
+            "webhook endpoint must be an HTTPS URL without credentials or fragment"
+        )
+    return endpoint, parsed.hostname.lower()
+
+
+def read_pending_delivery_candidates(
+    *,
+    dsn: str,
+    max_events: int,
+    schema_name: str = "risk_platform",
+) -> list[dict[str, Any]]:
+    if not isinstance(dsn, str) or not dsn.strip():
+        raise ValidationError("PostgreSQL DSN must be non-empty text")
+    max_events = _bounded_integer(max_events, "max_events", MAX_BATCH_EVENTS)
+    try:
+        import psycopg
+        from psycopg.rows import dict_row
+    except ImportError as exc:
+        raise RuntimeError(
+            "PostgreSQL delivery reading requires psycopg. Run `make setup` first."
+        ) from exc
+
+    schema = '"' + schema_name.replace('"', '""') + '"'
+    statement = f"""
+        SELECT
+            pending.event_id,
+            pending.event_type,
+            pending.transition_type,
+            pending.policy_id,
+            pending.policy_fingerprint,
+            pending.portfolio_id,
+            pending.definition_fingerprint,
+            pending.metric_name,
+            pending.subject_type,
+            pending.subject_key,
+            pending.current_status,
+            pending.ts_event,
+            pending.payload_json,
+            COALESCE(MAX(attempt.attempt_number), 0) AS attempts_so_far
+        FROM {schema}.portfolio_risk_notification_pending pending
+        LEFT JOIN {schema}.portfolio_risk_notification_delivery_attempts attempt
+          ON attempt.event_id = pending.event_id
+         AND attempt.channel = %s
+        WHERE NOT EXISTS (
+            SELECT 1
+            FROM {schema}.portfolio_risk_notification_delivery_attempts success
+            WHERE success.event_id = pending.event_id
+              AND success.channel = %s
+              AND success.outcome = 'succeeded'
+        )
+        GROUP BY
+            pending.event_id,
+            pending.event_type,
+            pending.transition_type,
+            pending.policy_id,
+            pending.policy_fingerprint,
+            pending.portfolio_id,
+            pending.definition_fingerprint,
+            pending.metric_name,
+            pending.subject_type,
+            pending.subject_key,
+            pending.current_status,
+            pending.ts_event,
+            pending.payload_json
+        ORDER BY pending.ts_event, pending.event_id
+        LIMIT %s
+    """
+    try:
+        with psycopg.connect(dsn, row_factory=dict_row) as connection:
+            with connection.cursor() as cursor:
+                cursor.execute(statement, [CHANNEL, CHANNEL, max_events + 1])
+                records = [dict(row) for row in cursor.fetchall()]
+    except Exception:
+        raise StorageError(
+            "Unable to read pending notification delivery candidates"
+        ) from None
+    if len(records) > max_events:
+        raise ValidationError(
+            "pending notification delivery exceeds max_events; reduce the batch"
+        )
+    return records
+
+
+def _attempt_id(event_id: str, attempt_number: int) -> str:
+    payload = {
+        "attempt_number": attempt_number,
+        "channel": CHANNEL,
+        "event_id": event_id,
+        "model_version": MODEL_VERSION,
+    }
+    digest = hashlib.sha256(
+        json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    ).hexdigest()[:24]
+    return f"{MODEL_VERSION}-attempt-{digest}"
+
+
+def _canonical_payload(candidate: Mapping[str, Any]) -> bytes:
+    raw_payload = candidate.get("payload_json")
+    if isinstance(raw_payload, str):
+        try:
+            raw_payload = json.loads(raw_payload)
+        except ValueError:
+            raise ValidationError("notification payload_json is invalid") from None
+    if not isinstance(raw_payload, Mapping):
+        raise ValidationError("notification payload_json must be an object")
+    ts_event = candidate.get("ts_event")
+    if not isinstance(ts_event, datetime) or ts_event.tzinfo is None:
+        raise ValidationError("notification ts_event must be timezone-aware")
+    envelope = {
+        "event_id": _required_text(candidate.get("event_id"), "event_id", 512),
+        "event_type": _required_text(candidate.get("event_type"), "event_type"),
+        "metric_name": _required_text(candidate.get("metric_name"), "metric_name"),
+        "payload": dict(raw_payload),
+        "policy_id": _required_text(candidate.get("policy_id"), "policy_id"),
+        "portfolio_id": _required_text(
+            candidate.get("portfolio_id"),
+            "portfolio_id",
+        ),
+        "status": _required_text(candidate.get("current_status"), "current_status"),
+        "subject_key": _required_text(
+            candidate.get("subject_key"),
+            "subject_key",
+            512,
+        ),
+        "ts_event": ts_event.astimezone(timezone.utc).isoformat(),
+    }
+    return json.dumps(
+        envelope,
+        sort_keys=True,
+        separators=(",", ":"),
+        allow_nan=False,
+    ).encode("utf-8")
+
+
+def _default_transport(
+    endpoint: str,
+    payload: bytes,
+    headers: Mapping[str, str],
+    timeout_seconds: float,
+) -> int:
+    request = urllib.request.Request(
+        endpoint,
+        data=payload,
+        headers=dict(headers),
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=timeout_seconds) as response:
+            return int(response.status)
+    except urllib.error.HTTPError as exc:
+        return int(exc.code)
+    except (urllib.error.URLError, TimeoutError, OSError):
+        raise DeliveryTransportError("network_error") from None
+
+
+def write_delivery_attempt(
+    attempt: Mapping[str, Any],
+    *,
+    dsn: str,
+    schema_name: str = "risk_platform",
+) -> None:
+    try:
+        import psycopg
+    except ImportError as exc:
+        raise RuntimeError(
+            "PostgreSQL attempt writing requires psycopg. Run `make setup` first."
+        ) from exc
+    schema = '"' + schema_name.replace('"', '""') + '"'
+    columns = (
+        "attempt_id",
+        "model_version",
+        "event_id",
+        "channel",
+        "attempt_number",
+        "idempotency_key",
+        "attempted_at",
+        "outcome",
+        "http_status",
+        "error_code",
+        "endpoint_host",
+        "payload_sha256",
+    )
+    quoted = ", ".join('"' + column + '"' for column in columns)
+    placeholders = ", ".join(["%s"] * len(columns))
+    statement = (
+        f"INSERT INTO {schema}.portfolio_risk_notification_delivery_attempts "
+        f"({quoted}) VALUES ({placeholders}) "
+        "ON CONFLICT (attempt_id) DO NOTHING"
+    )
+    values = tuple(attempt[column] for column in columns)
+    try:
+        with psycopg.connect(dsn) as connection:
+            with connection.cursor() as cursor:
+                cursor.execute(statement, values)
+            connection.commit()
+    except Exception:
+        raise StorageError("Unable to persist notification delivery attempt") from None
+
+
+def deliver_portfolio_risk_notifications(
+    *,
+    config_path: Path,
+    dsn: str,
+    execute: bool = False,
+    environment: Mapping[str, str] | None = None,
+    reader: CandidateReader | None = None,
+    attempt_writer: AttemptWriter | None = None,
+    transport: Transport | None = None,
+    sleeper: Sleeper | None = None,
+) -> dict[str, Any]:
+    config = load_webhook_delivery_config(config_path)
+    selected_environment = environment or os.environ
+    raw_endpoint = selected_environment.get(config.endpoint_env)
+    endpoint_host = None
+    endpoint_value = None
+    if raw_endpoint:
+        endpoint_value, endpoint_host = _endpoint(raw_endpoint)
+    if execute:
+        if not config.enabled:
+            raise ValidationError(
+                "webhook delivery is disabled in reviewed configuration"
+            )
+        if endpoint_value is None or endpoint_host is None:
+            raise ValidationError(
+                f"webhook endpoint environment variable {config.endpoint_env} is not set"
+            )
+
+    selected_reader = reader or read_pending_delivery_candidates
+    candidates = selected_reader(
+        dsn=dsn,
+        max_events=config.max_batch_events,
+    )
+    plan = [
+        {
+            "attempts_so_far": int(candidate.get("attempts_so_far", 0)),
+            "event_id": candidate.get("event_id"),
+            "event_type": candidate.get("event_type"),
+            "metric_name": candidate.get("metric_name"),
+            "status": candidate.get("current_status"),
+        }
+        for candidate in candidates
+    ]
+    summary: dict[str, Any] = {
+        "run_id": str(uuid4()),
+        "config_fingerprint": config.fingerprint,
+        "channel": CHANNEL,
+        "endpoint": {
+            "configured": endpoint_host is not None,
+            "host": endpoint_host,
+        },
+        "selection": {
+            "candidates_selected": len(candidates),
+            "max_batch_events": config.max_batch_events,
+        },
+        "plan": plan,
+        "execution": {
+            "requested": execute,
+            "performed": False,
+            "succeeded": 0,
+            "failed": 0,
+            "exhausted": 0,
+            "attempts_recorded": 0,
+        },
+        "response_bodies_recorded": False,
+    }
+    if not execute or not candidates:
+        return summary
+
+    selected_transport = transport or _default_transport
+    selected_sleeper = sleeper or time_module.sleep
+    selected_writer = attempt_writer or (
+        lambda attempt: write_delivery_attempt(attempt, dsn=dsn)
+    )
+    succeeded = 0
+    failed = 0
+    exhausted = 0
+    attempts_recorded = 0
+
+    for candidate in candidates:
+        event_id = _required_text(candidate.get("event_id"), "event_id", 512)
+        attempts_so_far = candidate.get("attempts_so_far", 0)
+        if type(attempts_so_far) is not int or attempts_so_far < 0:
+            raise ValidationError("attempts_so_far must be a non-negative integer")
+        if attempts_so_far >= config.max_attempts_per_event:
+            exhausted += 1
+            continue
+        payload = _canonical_payload(candidate)
+        payload_sha256 = hashlib.sha256(payload).hexdigest()
+        event_succeeded = False
+        for attempt_number in range(
+            attempts_so_far + 1,
+            config.max_attempts_per_event + 1,
+        ):
+            attempted_at = datetime.now(timezone.utc)
+            outcome = "failed"
+            http_status: int | None = None
+            error_code: str | None = None
+            try:
+                http_status = selected_transport(
+                    endpoint_value,
+                    payload,
+                    {
+                        "Content-Type": "application/json",
+                        "Idempotency-Key": event_id,
+                        "User-Agent": "financial-risk-data-platform/1",
+                    },
+                    float(config.timeout_seconds),
+                )
+                if 200 <= http_status < 300:
+                    outcome = "succeeded"
+                else:
+                    error_code = f"http_{http_status}"
+            except DeliveryTransportError as exc:
+                error_code = str(exc)
+            attempt = {
+                "attempt_id": _attempt_id(event_id, attempt_number),
+                "model_version": MODEL_VERSION,
+                "event_id": event_id,
+                "channel": CHANNEL,
+                "attempt_number": attempt_number,
+                "idempotency_key": event_id,
+                "attempted_at": attempted_at,
+                "outcome": outcome,
+                "http_status": http_status,
+                "error_code": error_code,
+                "endpoint_host": endpoint_host,
+                "payload_sha256": payload_sha256,
+            }
+            selected_writer(attempt)
+            attempts_recorded += 1
+            if outcome == "succeeded":
+                succeeded += 1
+                event_succeeded = True
+                break
+            if attempt_number < config.max_attempts_per_event:
+                delay = min(
+                    config.initial_backoff_seconds
+                    * (2 ** (attempt_number - attempts_so_far - 1)),
+                    MAX_BACKOFF_SECONDS,
+                )
+                selected_sleeper(float(delay))
+        if not event_succeeded:
+            failed += 1
+
+    summary["execution"] = {
+        "requested": True,
+        "performed": True,
+        "succeeded": succeeded,
+        "failed": failed,
+        "exhausted": exhausted,
+        "attempts_recorded": attempts_recorded,
+    }
+    return summary
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Plan or manually deliver pending portfolio risk notifications to "
+            "one explicitly configured HTTPS webhook."
+        )
+    )
+    parser.add_argument(
+        "--config",
+        type=Path,
+        default=Path("config/notification_delivery.yaml"),
+    )
+    parser.add_argument(
+        "--dsn",
+        default=os.environ.get(
+            "WAREHOUSE_POSTGRES_DSN",
+            DEFAULT_POSTGRES_DSN,
+        ),
+    )
+    parser.add_argument("--execute", action="store_true")
+    parser.add_argument("--summary-json", type=Path)
+    return parser
+
+
+def _write_summary(path: Path, summary: Mapping[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_suffix(path.suffix + ".tmp")
+    try:
+        temporary.write_text(
+            json.dumps(summary, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        temporary.replace(path)
+    except OSError:
+        temporary.unlink(missing_ok=True)
+        raise StorageError("Unable to write webhook delivery summary") from None
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    try:
+        summary = deliver_portfolio_risk_notifications(
+            config_path=args.config,
+            dsn=args.dsn,
+            execute=args.execute,
+        )
+        if args.summary_json is not None:
+            _write_summary(args.summary_json, summary)
+    except ValidationError:
+        print(
+            "Webhook delivery failed: configuration, endpoint, candidate, or "
+            "options were invalid",
+            file=sys.stderr,
+        )
+        return 1
+    except StorageError:
+        print(
+            "Webhook delivery failed: PostgreSQL or attempt persistence failed; "
+            "remote receivers should deduplicate by Idempotency-Key",
+            file=sys.stderr,
+        )
+        return 1
+    except Exception:
+        print(
+            "Webhook delivery failed: unexpected local failure",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(json.dumps(summary, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/orchestration/deliver_portfolio_risk_notifications.py
+++ b/src/orchestration/deliver_portfolio_risk_notifications.py
@@ -359,8 +359,8 @@ def deliver_portfolio_risk_notifications(
     config = load_webhook_delivery_config(config_path)
     selected_environment = environment or os.environ
     raw_endpoint = selected_environment.get(config.endpoint_env)
-    endpoint_host = None
-    endpoint_value = None
+    endpoint_host: str | None = None
+    endpoint_value: str | None = None
     if raw_endpoint:
         endpoint_value, endpoint_host = _endpoint(raw_endpoint)
     if execute:
@@ -413,6 +413,8 @@ def deliver_portfolio_risk_notifications(
     }
     if not execute or not candidates:
         return summary
+    if endpoint_value is None or endpoint_host is None:
+        raise ValidationError("webhook endpoint was not resolved for execution")
 
     selected_transport = transport or _default_transport
     selected_sleeper = sleeper or time_module.sleep

--- a/tests/unit/test_docker_compose_contract.py
+++ b/tests/unit/test_docker_compose_contract.py
@@ -33,6 +33,7 @@ def test_local_database_seed_mounts_are_read_only_and_ordered() -> None:
         "./sql/portfolio_risk_breach_lifecycle_schema.sql:/docker-entrypoint-initdb.d/06_portfolio_risk_breach_lifecycle_schema.sql:ro",
         "./sql/portfolio_risk_notification_outbox_schema.sql:/docker-entrypoint-initdb.d/07_portfolio_risk_notification_outbox_schema.sql:ro",
         "./sql/market_freshness_schema.sql:/docker-entrypoint-initdb.d/08_market_freshness_schema.sql:ro",
+        "./sql/portfolio_risk_notification_delivery_schema.sql:/docker-entrypoint-initdb.d/09_portfolio_risk_notification_delivery_schema.sql:ro",
     ]
     assert services["mongo"]["volumes"] == [
         "./mongo/init:/docker-entrypoint-initdb.d:ro"

--- a/tests/unit/test_manual_webhook_delivery_architecture_contract.py
+++ b/tests/unit/test_manual_webhook_delivery_architecture_contract.py
@@ -1,0 +1,37 @@
+from pathlib import Path
+
+
+def test_manual_webhook_delivery_is_disabled_secret_safe_and_manual() -> None:
+    source = Path(
+        "src/orchestration/deliver_portfolio_risk_notifications.py"
+    ).read_text(encoding="utf-8")
+    docs = Path("docs/manual-webhook-delivery.md").read_text(
+        encoding="utf-8"
+    )
+    config = Path("config/notification_delivery.yaml").read_text(
+        encoding="utf-8"
+    )
+
+    assert "enabled: false" in config
+    assert "RISK_NOTIFICATION_WEBHOOK_URL" in config
+    assert "https://" not in config
+
+    for required in (
+        "Idempotency-Key",
+        "--execute",
+        "response_bodies_recorded",
+        "max_attempts_per_event",
+        "initial_backoff_seconds",
+        "portfolio_risk_notification_delivery_attempts",
+    ):
+        assert required in source
+
+    for required in (
+        "Disabled-by-default",
+        "append-only",
+        "Idempotency-Key",
+        "Response bodies",
+        "CI uses fake transports",
+        "does not schedule itself",
+    ):
+        assert required.lower() in docs.lower()

--- a/tests/unit/test_portfolio_risk_notification_delivery_sql_contract.py
+++ b/tests/unit/test_portfolio_risk_notification_delivery_sql_contract.py
@@ -1,0 +1,41 @@
+from pathlib import Path
+
+
+def test_delivery_schema_is_append_only_and_status_is_derived() -> None:
+    sql = Path(
+        "sql/portfolio_risk_notification_delivery_schema.sql"
+    ).read_text(encoding="utf-8")
+
+    for required in (
+        "portfolio_risk_notification_delivery_attempts",
+        "UNIQUE (event_id, channel, attempt_number)",
+        "idx_portfolio_notification_delivery_one_success",
+        "portfolio_risk_notification_delivery_status",
+        "portfolio_risk_notification_delivery_pending",
+        "portfolio_risk_notification_delivery_succeeded",
+        "COALESCE(",
+        "BOOL_OR(attempt.outcome = 'succeeded')",
+        "idempotency_key = event_id",
+        "payload_sha256 ~ '^[0-9a-f]{64}$'",
+    ):
+        assert required in sql
+
+    assert "UPDATE risk_platform.portfolio_risk_notification_outbox" not in sql
+
+
+def test_delivery_reconciliation_covers_identity_attempts_and_status() -> None:
+    sql = Path(
+        "sql/portfolio_risk_notification_delivery_consistency_checks.sql"
+    ).read_text(encoding="utf-8")
+
+    for required in (
+        "notification_delivery_attempts_reference_outbox",
+        "notification_delivery_identity_valid",
+        "notification_delivery_outcomes_valid",
+        "notification_delivery_attempt_numbers_unique",
+        "notification_delivery_success_unique",
+        "notification_delivery_attempt_numbers_contiguous",
+        "notification_delivery_status_matches_attempts",
+        "notification_delivery_status_partitions_current_outbox",
+    ):
+        assert required in sql

--- a/tests/unit/test_portfolio_risk_webhook_delivery.py
+++ b/tests/unit/test_portfolio_risk_webhook_delivery.py
@@ -1,0 +1,245 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+from src.common.exceptions import ValidationError
+from src.orchestration.deliver_portfolio_risk_notifications import (
+    DeliveryTransportError,
+    deliver_portfolio_risk_notifications,
+    parse_webhook_delivery_config,
+)
+
+
+def _config_payload(*, enabled: bool = False, attempts: int = 3):
+    return {
+        "delivery": {
+            "webhook": {
+                "enabled": enabled,
+                "endpoint_env": "RISK_NOTIFICATION_WEBHOOK_URL",
+                "timeout_seconds": 5,
+                "max_batch_events": 25,
+                "max_attempts_per_event": attempts,
+                "initial_backoff_seconds": 1,
+            }
+        }
+    }
+
+
+def _write_config(tmp_path: Path, *, enabled: bool, attempts: int = 3) -> Path:
+    path = tmp_path / "delivery.yaml"
+    path.write_text(
+        yaml.safe_dump(
+            _config_payload(enabled=enabled, attempts=attempts),
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+    return path
+
+
+def _candidate(*, attempts_so_far: int = 0) -> dict[str, Any]:
+    return {
+        "event_id": "event-1",
+        "event_type": "breach_opened",
+        "transition_type": "opened",
+        "policy_id": "us-tech-standard",
+        "policy_fingerprint": "policy-1",
+        "portfolio_id": "us-tech-equal",
+        "definition_fingerprint": "definition-1",
+        "metric_name": "portfolio_volatility_annualized",
+        "subject_type": "portfolio",
+        "subject_key": "us-tech-equal",
+        "current_status": "critical",
+        "ts_event": datetime(2026, 1, 9, tzinfo=timezone.utc),
+        "payload_json": {"event_id": "event-1", "severity": "critical"},
+        "attempts_so_far": attempts_so_far,
+    }
+
+
+def test_delivery_config_is_disabled_and_fingerprinted_deterministically() -> None:
+    first = parse_webhook_delivery_config(_config_payload())
+    second = parse_webhook_delivery_config(_config_payload())
+
+    assert first.enabled is False
+    assert first.fingerprint == second.fingerprint
+
+
+def test_plan_only_reads_candidates_without_transport_or_attempt_writes(
+    tmp_path: Path,
+) -> None:
+    transports: list[bytes] = []
+    attempts: list[dict[str, Any]] = []
+    summary = deliver_portfolio_risk_notifications(
+        config_path=_write_config(tmp_path, enabled=False),
+        dsn="dsn",
+        execute=False,
+        environment={},
+        reader=lambda **_: [_candidate()],
+        transport=lambda endpoint, payload, headers, timeout: (
+            transports.append(payload) or 204
+        ),
+        attempt_writer=lambda attempt: attempts.append(dict(attempt)),
+    )
+
+    assert transports == []
+    assert attempts == []
+    assert summary["execution"]["performed"] is False
+    assert summary["endpoint"] == {"configured": False, "host": None}
+    assert "dsn" not in json.dumps(summary)
+
+
+def test_execute_requires_reviewed_enablement_before_reading_candidates(
+    tmp_path: Path,
+) -> None:
+    reads = 0
+
+    def reader(**_: Any) -> list[dict[str, Any]]:
+        nonlocal reads
+        reads += 1
+        return [_candidate()]
+
+    with pytest.raises(ValidationError, match="disabled"):
+        deliver_portfolio_risk_notifications(
+            config_path=_write_config(tmp_path, enabled=False),
+            dsn="dsn",
+            execute=True,
+            environment={
+                "RISK_NOTIFICATION_WEBHOOK_URL": "https://alerts.example.test/risk"
+            },
+            reader=reader,
+        )
+    assert reads == 0
+
+
+def test_failed_attempt_retries_then_succeeds_with_same_idempotency_key(
+    tmp_path: Path,
+) -> None:
+    statuses = iter([503, 204])
+    calls: list[dict[str, Any]] = []
+    attempts: list[dict[str, Any]] = []
+    sleeps: list[float] = []
+
+    def transport(
+        endpoint: str,
+        payload: bytes,
+        headers: Any,
+        timeout: float,
+    ) -> int:
+        calls.append(
+            {
+                "endpoint": endpoint,
+                "payload": json.loads(payload),
+                "headers": dict(headers),
+                "timeout": timeout,
+            }
+        )
+        return next(statuses)
+
+    summary = deliver_portfolio_risk_notifications(
+        config_path=_write_config(tmp_path, enabled=True),
+        dsn="dsn",
+        execute=True,
+        environment={
+            "RISK_NOTIFICATION_WEBHOOK_URL": "https://alerts.example.test/risk"
+        },
+        reader=lambda **_: [_candidate()],
+        attempt_writer=lambda attempt: attempts.append(dict(attempt)),
+        transport=transport,
+        sleeper=sleeps.append,
+    )
+
+    assert [attempt["outcome"] for attempt in attempts] == [
+        "failed",
+        "succeeded",
+    ]
+    assert [attempt["attempt_number"] for attempt in attempts] == [1, 2]
+    assert all(
+        call["headers"]["Idempotency-Key"] == "event-1" for call in calls
+    )
+    assert calls[0]["payload"]["event_id"] == "event-1"
+    assert sleeps == [1.0]
+    assert summary["execution"] == {
+        "requested": True,
+        "performed": True,
+        "succeeded": 1,
+        "failed": 0,
+        "exhausted": 0,
+        "attempts_recorded": 2,
+    }
+    assert "https://alerts.example.test/risk" not in json.dumps(summary)
+    assert summary["endpoint"]["host"] == "alerts.example.test"
+
+
+def test_network_failure_is_recorded_without_error_message_or_response_body(
+    tmp_path: Path,
+) -> None:
+    attempts: list[dict[str, Any]] = []
+
+    def transport(*_: Any) -> int:
+        raise DeliveryTransportError("network_error")
+
+    summary = deliver_portfolio_risk_notifications(
+        config_path=_write_config(tmp_path, enabled=True, attempts=1),
+        dsn="dsn",
+        execute=True,
+        environment={
+            "RISK_NOTIFICATION_WEBHOOK_URL": "https://alerts.example.test/risk"
+        },
+        reader=lambda **_: [_candidate()],
+        attempt_writer=lambda attempt: attempts.append(dict(attempt)),
+        transport=transport,
+        sleeper=lambda _: None,
+    )
+
+    assert attempts[0]["error_code"] == "network_error"
+    assert attempts[0]["http_status"] is None
+    assert summary["response_bodies_recorded"] is False
+    assert summary["execution"]["failed"] == 1
+
+
+def test_exhausted_candidate_is_not_sent_again(tmp_path: Path) -> None:
+    calls = 0
+
+    def transport(*_: Any) -> int:
+        nonlocal calls
+        calls += 1
+        return 204
+
+    summary = deliver_portfolio_risk_notifications(
+        config_path=_write_config(tmp_path, enabled=True, attempts=3),
+        dsn="dsn",
+        execute=True,
+        environment={
+            "RISK_NOTIFICATION_WEBHOOK_URL": "https://alerts.example.test/risk"
+        },
+        reader=lambda **_: [_candidate(attempts_so_far=3)],
+        attempt_writer=lambda _: None,
+        transport=transport,
+    )
+
+    assert calls == 0
+    assert summary["execution"]["exhausted"] == 1
+
+
+def test_endpoint_must_be_https_without_embedded_credentials(
+    tmp_path: Path,
+) -> None:
+    for endpoint in (
+        "http://alerts.example.test/risk",
+        "https://user:password@alerts.example.test/risk",
+        "https://alerts.example.test/risk#secret",
+    ):
+        with pytest.raises(ValidationError, match="HTTPS"):
+            deliver_portfolio_risk_notifications(
+                config_path=_write_config(tmp_path, enabled=True),
+                dsn="dsn",
+                execute=True,
+                environment={"RISK_NOTIFICATION_WEBHOOK_URL": endpoint},
+                reader=lambda **_: [_candidate()],
+            )


### PR DESCRIPTION
## Outcome

Add a manually activated HTTPS webhook adapter for current pending portfolio risk notifications:

```text
current pending notification outbox
  -> exclude an already succeeded event
  -> bounded manual batch
  -> stable Idempotency-Key
  -> bounded retry and exponential backoff
  -> append-only delivery attempts
  -> pending and succeeded operational views
```

Primary arc42 block: `orchestration`, with a PostgreSQL evidence boundary.

## Activation and secrets

The committed configuration is disabled and contains no endpoint. Normal invocation is plan-only. Network delivery requires both a reviewed `enabled: true` change and explicit `--execute` with `RISK_NOTIFICATION_WEBHOOK_URL` set locally.

Only HTTPS endpoints without embedded credentials or fragments are accepted. The full URL, path, DSN, response body, and arbitrary exception messages are never stored or included in summaries. Evidence records only the endpoint host, HTTP status or bounded error code, and payload SHA-256.

## Idempotency and retry

Every delivery uses the notification event ID as `Idempotency-Key`. Append-only attempt IDs bind event, channel, attempt number, and model version. A successful attempt removes the event from future candidate selection. Failed attempts retry with bounded exponential backoff until the configured total attempt limit is reached.

The stable idempotency key controls the unavoidable crash window where a remote receiver accepts a request but local attempt persistence fails.

## PostgreSQL serving

Add `portfolio_risk_notification_delivery_attempts` plus derived status, pending, and succeeded views. The source outbox remains immutable; delivery state is derived from attempts. Reconciliation verifies outbox references, identities, outcome semantics, contiguous attempt numbers, unique successes, and status partitioning.

## Validation

Focused tests cover disabled execution, plan-only behavior, endpoint validation, secret-free summaries, retry then success, stable idempotency headers, network-failure evidence, exhausted attempts, SQL contracts, Docker schema order, and documentation drift. CI uses fake transports and performs no network request.

Fresh GitHub Actions must pass security, Python readiness, PostgreSQL contract, and infrastructure validation on the exact head before merge.

## Boundary

The adapter does not schedule itself, discover recipients, provision endpoints, rotate secrets, acknowledge breaches, mutate analytical evidence, block trading, deploy infrastructure, or run Terraform apply.