### PR TITLE
Add disabled immutable S3 replication

### DIFF
--- a/config/object_storage.yaml
+++ b/config/object_storage.yaml
@@ -1,0 +1,9 @@
+object_storage:
+  s3:
+    enabled: false
+    bucket_env: RISK_PLATFORM_S3_BUCKET
+    region_env: AWS_REGION
+    prefix: financial-risk-data-platform
+    server_side_encryption: AES256
+    maximum_files: 4096
+    maximum_bytes: 1000000000

--- a/docs/durable-s3-replication.md
+++ b/docs/durable-s3-replication.md
@@ -1,0 +1,125 @@
+# Disabled Durable S3 Replication
+
+## Outcome
+
+This adapter copies already-published local raw and curated Parquet into an existing S3 bucket without changing the local analytical contracts:
+
+```text
+configured local raw and curated paths
+  -> bounded regular-file inventory
+  -> SHA-256 and deterministic object keys
+  -> plan-only manifest by default
+  -> explicit immutable S3 upload
+  -> metadata verification
+  -> replay or conflict refusal
+```
+
+The implementation is `src/storage/s3_replication.py`. The committed configuration is `config/object_storage.yaml`.
+
+## Disabled-by-default activation
+
+The committed S3 configuration has `enabled: false` and contains no bucket name, account, credential, or endpoint. Normal invocation builds a plan only and does not construct or call an S3 client.
+
+Execution requires all of:
+
+1. a reviewed configuration change setting `enabled: true`;
+2. an existing bucket supplied through `RISK_PLATFORM_S3_BUCKET`;
+3. an AWS region supplied through `AWS_REGION`;
+4. locally configured AWS credentials or workload identity; and
+5. an explicit `--execute` invocation.
+
+The adapter does not create a bucket, alter bucket policy, add lifecycle rules, change encryption settings, provision IAM, deploy infrastructure, or run `terraform apply`.
+
+## Immutable key contract
+
+Object keys preserve the local path below `storage.base_dir`:
+
+```text
+<prefix>/<raw or curated relative path>
+```
+
+For example:
+
+```text
+financial-risk-data-platform/curated/daily_returns/year=2026/.../batch.parquet
+```
+
+Each upload stores user metadata containing:
+
+```text
+sha256
+relative-path
+model-version
+```
+
+and requests S3-managed `AES256` server-side encryption.
+
+Before uploading, the adapter performs `HeadObject`:
+
+- missing object: upload, then verify metadata and content length;
+- matching size, SHA-256, and relative path: count as already present;
+- existing but non-matching object: fail and never overwrite.
+
+This contract makes reruns convergent while keeping object-key conflicts visible. It does not depend on ETag semantics, which can differ for multipart or encrypted uploads.
+
+## Inventory bounds
+
+The adapter inventories only `*.parquet` beneath the configured raw and curated base paths. It rejects symbolic-link bases, directories, and files; paths outside `storage.base_dir`; and unsafe relative paths.
+
+The committed bounds are:
+
+```text
+4,096 files
+1 GB total local input
+```
+
+A request exceeding either limit fails before any remote operation. Hashing streams files in 1 MB chunks.
+
+## Evidence and redaction
+
+The plan or execution summary includes:
+
+- configuration and manifest fingerprints;
+- selected file and byte counts;
+- object keys, relative paths, sizes, and SHA-256 values;
+- uploaded and already-present counts;
+- encryption and prefix; and
+- a one-way fingerprint showing whether a bucket was configured.
+
+The bucket name, AWS credentials, session tokens, account identifiers, and endpoint configuration are not written to the summary.
+
+## Commands
+
+Plan without installing an S3 client or making a cloud request:
+
+```bash
+.venv/bin/python -m src.storage.s3_replication \
+  --summary-json .demo/s3-replication-plan.json
+```
+
+Install the optional client only on an operator environment:
+
+```bash
+.venv/bin/python -m pip install -e '.[s3]'
+```
+
+After reviewing and enabling the configuration:
+
+```bash
+export RISK_PLATFORM_S3_BUCKET='existing-private-bucket'
+export AWS_REGION='eu-west-2'
+
+.venv/bin/python -m src.storage.s3_replication \
+  --execute \
+  --summary-json .demo/s3-replication-run.json
+```
+
+## Retention and recovery boundary
+
+This increment provides durable replication, not lifecycle ownership. No object is deleted or replaced. Retention periods, legal holds, object lock, archival classes, cross-region replication, disaster-recovery objectives, and restore testing require explicit later decisions tied to the target environment.
+
+Local Parquet remains the immediate source for existing commands. Reading analytics directly from S3 and transactional lakehouse semantics are separate changes.
+
+## CI boundary
+
+CI uses fake clients and plan-only behavior. It creates no AWS resource, makes no S3 call, uploads no object, and applies no infrastructure.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,9 @@ dev = [
   "mypy>=1.10",
   "types-PyYAML>=6.0",
 ]
+s3 = [
+  "boto3>=1.35,<2",
+]
 
 [tool.ruff]
 line-length = 100

--- a/src/storage/s3_replication.py
+++ b/src/storage/s3_replication.py
@@ -1,0 +1,501 @@
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import sys
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Protocol
+from uuid import uuid4
+
+from ..common.config import load_yaml
+from ..common.exceptions import StorageError, ValidationError
+from .storage_config import load_storage_config, validate_storage_config
+
+MODEL_VERSION = "s3-replication-v1"
+MAX_CONFIGURED_FILES = 10_000
+MAX_CONFIGURED_BYTES = 10_000_000_000
+MAX_PLAN_PREVIEW = 100
+CHUNK_SIZE = 1024 * 1024
+S3_BUCKET_PATTERN = re.compile(r"^[a-z0-9][a-z0-9.-]{1,61}[a-z0-9]$")
+
+
+class S3Client(Protocol):
+    def head_object(self, **kwargs: Any) -> Mapping[str, Any]: ...
+
+    def put_object(self, **kwargs: Any) -> Mapping[str, Any]: ...
+
+
+@dataclass(frozen=True, slots=True)
+class S3ReplicationConfig:
+    enabled: bool
+    bucket_env: str
+    region_env: str
+    prefix: str
+    server_side_encryption: str
+    maximum_files: int
+    maximum_bytes: int
+
+    @property
+    def fingerprint(self) -> str:
+        payload = {
+            "bucket_env": self.bucket_env,
+            "enabled": self.enabled,
+            "maximum_bytes": self.maximum_bytes,
+            "maximum_files": self.maximum_files,
+            "model_version": MODEL_VERSION,
+            "prefix": self.prefix,
+            "region_env": self.region_env,
+            "server_side_encryption": self.server_side_encryption,
+        }
+        digest = hashlib.sha256(
+            json.dumps(payload, sort_keys=True, separators=(",", ":")).encode(
+                "utf-8"
+            )
+        ).hexdigest()[:24]
+        return f"s3-replication-config-{digest}"
+
+
+@dataclass(frozen=True, slots=True)
+class LocalObject:
+    path: Path
+    relative_path: str
+    object_key: str
+    size_bytes: int
+    sha256: str
+
+    def evidence(self) -> dict[str, Any]:
+        return {
+            "object_key": self.object_key,
+            "relative_path": self.relative_path,
+            "sha256": self.sha256,
+            "size_bytes": self.size_bytes,
+        }
+
+
+def _required_text(value: Any, label: str, maximum: int = 256) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ValidationError(f"{label} must be non-empty text")
+    parsed = value.strip()
+    if len(parsed) > maximum or any(ord(character) < 32 for character in parsed):
+        raise ValidationError(f"{label} is invalid")
+    return parsed
+
+
+def _bounded_integer(value: Any, label: str, maximum: int) -> int:
+    if type(value) is not int or not 1 <= value <= maximum:
+        raise ValidationError(
+            f"{label} must be an integer between 1 and {maximum}"
+        )
+    return value
+
+
+def _prefix(value: Any) -> str:
+    parsed = _required_text(value, "prefix", maximum=512).strip("/")
+    segments = parsed.split("/")
+    if any(segment in {"", ".", ".."} for segment in segments):
+        raise ValidationError("prefix must contain safe non-empty path segments")
+    return "/".join(segments)
+
+
+def parse_s3_replication_config(
+    payload: Mapping[str, Any],
+) -> S3ReplicationConfig:
+    if not isinstance(payload, Mapping):
+        raise ValidationError("object-storage configuration must be a mapping")
+    object_storage = payload.get("object_storage")
+    if not isinstance(object_storage, Mapping):
+        raise ValidationError("object-storage configuration is missing object_storage")
+    candidate = object_storage.get("s3")
+    if not isinstance(candidate, Mapping):
+        raise ValidationError("object-storage configuration is missing s3")
+    enabled = candidate.get("enabled")
+    if type(enabled) is not bool:
+        raise ValidationError("s3 enabled must be boolean")
+    encryption = _required_text(
+        candidate.get("server_side_encryption"),
+        "server_side_encryption",
+    )
+    if encryption != "AES256":
+        raise ValidationError(
+            "this replication contract supports AES256 server-side encryption only"
+        )
+    return S3ReplicationConfig(
+        enabled=enabled,
+        bucket_env=_required_text(candidate.get("bucket_env"), "bucket_env"),
+        region_env=_required_text(candidate.get("region_env"), "region_env"),
+        prefix=_prefix(candidate.get("prefix")),
+        server_side_encryption=encryption,
+        maximum_files=_bounded_integer(
+            candidate.get("maximum_files"),
+            "maximum_files",
+            MAX_CONFIGURED_FILES,
+        ),
+        maximum_bytes=_bounded_integer(
+            candidate.get("maximum_bytes"),
+            "maximum_bytes",
+            MAX_CONFIGURED_BYTES,
+        ),
+    )
+
+
+def load_s3_replication_config(path: Path) -> S3ReplicationConfig:
+    try:
+        payload = load_yaml(path)
+    except Exception:
+        raise ValidationError(
+            "object-storage configuration could not be loaded"
+        ) from None
+    if not isinstance(payload, Mapping):
+        raise ValidationError("object-storage configuration must be a mapping")
+    return parse_s3_replication_config(payload)
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    try:
+        with path.open("rb") as handle:
+            while chunk := handle.read(CHUNK_SIZE):
+                digest.update(chunk)
+    except OSError:
+        raise StorageError("unable to hash local Parquet input") from None
+    return digest.hexdigest()
+
+
+def _ensure_safe_file(path: Path, base: Path) -> None:
+    if path.is_symlink() or not path.is_file():
+        raise StorageError("S3 replication input contains an unsafe file type")
+    current = path.parent
+    while current != base:
+        if current.is_symlink():
+            raise StorageError(
+                "S3 replication input contains a symbolic-link directory"
+            )
+        if current == current.parent:
+            raise StorageError("S3 replication input escaped its configured base")
+        current = current.parent
+    if base.is_symlink() or not base.is_dir():
+        raise StorageError("S3 replication base must be a regular directory")
+
+
+def inventory_local_parquet(
+    *,
+    storage_config_path: Path,
+    replication_config: S3ReplicationConfig,
+) -> tuple[LocalObject, ...]:
+    storage_config = load_storage_config(storage_config_path)
+    validate_storage_config(storage_config)
+    storage = storage_config["storage"]
+    base_dir = Path(storage["base_dir"])
+    if base_dir.is_symlink():
+        raise StorageError("storage base_dir must not be a symbolic link")
+
+    configured_bases = (
+        Path(storage["raw"]["base_path"]),
+        Path(storage["curated"]["base_path"]),
+    )
+    files: list[Path] = []
+    for configured_base in configured_bases:
+        if not configured_base.exists():
+            continue
+        if configured_base.is_symlink() or not configured_base.is_dir():
+            raise StorageError(
+                "configured replication source must be a regular directory"
+            )
+        try:
+            files.extend(sorted(configured_base.rglob("*.parquet")))
+        except OSError:
+            raise StorageError(
+                "unable to inventory local Parquet for S3 replication"
+            ) from None
+
+    unique_files = sorted(set(files), key=lambda item: item.as_posix())
+    if len(unique_files) > replication_config.maximum_files:
+        raise StorageError("S3 replication input exceeds the file limit")
+
+    objects: list[LocalObject] = []
+    total_bytes = 0
+    for path in unique_files:
+        containing_base = next(
+            (
+                candidate
+                for candidate in configured_bases
+                if path == candidate or candidate in path.parents
+            ),
+            None,
+        )
+        if containing_base is None:
+            raise StorageError("S3 replication input escaped configured storage")
+        _ensure_safe_file(path, containing_base)
+        try:
+            size_bytes = path.stat().st_size
+            relative = path.relative_to(base_dir).as_posix()
+        except (OSError, ValueError):
+            raise StorageError(
+                "S3 replication input is outside storage base_dir"
+            ) from None
+        if relative.startswith("../") or relative in {"", ".", ".."}:
+            raise StorageError("S3 replication relative path is unsafe")
+        total_bytes += size_bytes
+        if total_bytes > replication_config.maximum_bytes:
+            raise StorageError("S3 replication input exceeds the byte limit")
+        objects.append(
+            LocalObject(
+                path=path,
+                relative_path=relative,
+                object_key=f"{replication_config.prefix}/{relative}",
+                size_bytes=size_bytes,
+                sha256=_sha256(path),
+            )
+        )
+    return tuple(objects)
+
+
+def _manifest_fingerprint(objects: Sequence[LocalObject]) -> str:
+    payload = [item.evidence() for item in objects]
+    return hashlib.sha256(
+        json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    ).hexdigest()
+
+
+def _bucket(value: str) -> str:
+    parsed = _required_text(value, "S3 bucket", maximum=63)
+    if not S3_BUCKET_PATTERN.fullmatch(parsed) or ".." in parsed:
+        raise ValidationError("S3 bucket name is invalid")
+    return parsed
+
+
+def _missing_object(exc: Exception) -> bool:
+    response = getattr(exc, "response", None)
+    if not isinstance(response, Mapping):
+        return False
+    error = response.get("Error")
+    if not isinstance(error, Mapping):
+        return False
+    return str(error.get("Code")) in {"404", "NoSuchKey", "NotFound"}
+
+
+def _head(client: S3Client, bucket: str, item: LocalObject) -> Mapping[str, Any] | None:
+    try:
+        return client.head_object(Bucket=bucket, Key=item.object_key)
+    except Exception as exc:
+        if _missing_object(exc):
+            return None
+        raise StorageError("unable to inspect durable S3 object") from None
+
+
+def _matches_remote(head: Mapping[str, Any], item: LocalObject) -> bool:
+    metadata = head.get("Metadata")
+    if not isinstance(metadata, Mapping):
+        return False
+    try:
+        content_length = int(head.get("ContentLength"))
+    except (TypeError, ValueError):
+        return False
+    return (
+        content_length == item.size_bytes
+        and str(metadata.get("sha256")) == item.sha256
+        and str(metadata.get("relative-path")) == item.relative_path
+    )
+
+
+def _build_client(region: str) -> S3Client:
+    try:
+        import boto3
+    except ImportError as exc:
+        raise RuntimeError(
+            "S3 execution requires the optional dependency. "
+            "Install with `python -m pip install -e '.[s3]'`."
+        ) from exc
+    return boto3.client("s3", region_name=region)
+
+
+def replicate_local_parquet_to_s3(
+    *,
+    replication_config_path: Path,
+    storage_config_path: Path,
+    execute: bool = False,
+    environment: Mapping[str, str] | None = None,
+    client: S3Client | None = None,
+) -> dict[str, Any]:
+    config = load_s3_replication_config(replication_config_path)
+    objects = inventory_local_parquet(
+        storage_config_path=storage_config_path,
+        replication_config=config,
+    )
+    total_bytes = sum(item.size_bytes for item in objects)
+    manifest_fingerprint = _manifest_fingerprint(objects)
+    selected_environment = environment or os.environ
+    bucket_value = selected_environment.get(config.bucket_env)
+    region_value = selected_environment.get(config.region_env)
+    bucket_fingerprint = (
+        hashlib.sha256(bucket_value.encode("utf-8")).hexdigest()[:12]
+        if bucket_value
+        else None
+    )
+    summary: dict[str, Any] = {
+        "run_id": str(uuid4()),
+        "model_version": MODEL_VERSION,
+        "config_fingerprint": config.fingerprint,
+        "manifest_fingerprint": manifest_fingerprint,
+        "selection": {
+            "files_selected": len(objects),
+            "bytes_selected": total_bytes,
+            "maximum_files": config.maximum_files,
+            "maximum_bytes": config.maximum_bytes,
+        },
+        "destination": {
+            "bucket_configured": bucket_value is not None,
+            "bucket_fingerprint": bucket_fingerprint,
+            "prefix": config.prefix,
+            "region_configured": region_value is not None,
+            "server_side_encryption": config.server_side_encryption,
+        },
+        "plan_preview": [
+            item.evidence() for item in objects[:MAX_PLAN_PREVIEW]
+        ],
+        "plan_preview_truncated": len(objects) > MAX_PLAN_PREVIEW,
+        "execution": {
+            "requested": execute,
+            "performed": False,
+            "uploaded": 0,
+            "already_present": 0,
+        },
+        "bucket_created": False,
+        "objects_deleted": 0,
+        "infrastructure_applied": False,
+    }
+    if not execute or not objects:
+        return summary
+    if not config.enabled:
+        raise ValidationError(
+            "S3 replication is disabled in reviewed configuration"
+        )
+    if bucket_value is None:
+        raise ValidationError(
+            f"S3 bucket environment variable {config.bucket_env} is not set"
+        )
+    if region_value is None or not region_value.strip():
+        raise ValidationError(
+            f"AWS region environment variable {config.region_env} is not set"
+        )
+    bucket = _bucket(bucket_value)
+    selected_client = client or _build_client(region_value.strip())
+
+    uploaded = 0
+    already_present = 0
+    for item in objects:
+        existing = _head(selected_client, bucket, item)
+        if existing is not None:
+            if _matches_remote(existing, item):
+                already_present += 1
+                continue
+            raise StorageError(
+                f"durable object conflict for key {item.object_key}; overwrite is forbidden"
+            )
+        try:
+            with item.path.open("rb") as body:
+                selected_client.put_object(
+                    Bucket=bucket,
+                    Key=item.object_key,
+                    Body=body,
+                    ContentLength=item.size_bytes,
+                    ContentType="application/vnd.apache.parquet",
+                    Metadata={
+                        "sha256": item.sha256,
+                        "relative-path": item.relative_path,
+                        "model-version": MODEL_VERSION,
+                    },
+                    ServerSideEncryption=config.server_side_encryption,
+                )
+        except OSError:
+            raise StorageError("unable to read local object for S3 replication") from None
+        except Exception:
+            raise StorageError("unable to upload durable S3 object") from None
+        verified = _head(selected_client, bucket, item)
+        if verified is None or not _matches_remote(verified, item):
+            raise StorageError("uploaded S3 object failed metadata verification")
+        uploaded += 1
+
+    summary["execution"] = {
+        "requested": True,
+        "performed": True,
+        "uploaded": uploaded,
+        "already_present": already_present,
+    }
+    return summary
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Plan or explicitly replicate immutable local Parquet into an "
+            "existing S3 bucket without overwriting conflicts."
+        )
+    )
+    parser.add_argument(
+        "--config",
+        type=Path,
+        default=Path("config/object_storage.yaml"),
+    )
+    parser.add_argument(
+        "--storage-config",
+        type=Path,
+        default=Path("config/storage.yaml"),
+    )
+    parser.add_argument("--execute", action="store_true")
+    parser.add_argument("--summary-json", type=Path)
+    return parser
+
+
+def _write_summary(path: Path, summary: Mapping[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_suffix(path.suffix + ".tmp")
+    try:
+        temporary.write_text(
+            json.dumps(summary, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        temporary.replace(path)
+    except OSError:
+        temporary.unlink(missing_ok=True)
+        raise StorageError("unable to write S3 replication summary") from None
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    try:
+        summary = replicate_local_parquet_to_s3(
+            replication_config_path=args.config,
+            storage_config_path=args.storage_config,
+            execute=args.execute,
+        )
+        if args.summary_json is not None:
+            _write_summary(args.summary_json, summary)
+    except ValidationError:
+        print(
+            "S3 replication failed: configuration, destination, or options were invalid",
+            file=sys.stderr,
+        )
+        return 1
+    except StorageError:
+        print(
+            "S3 replication failed: local inventory, remote inspection, upload, "
+            "or verification failed; conflicts were not overwritten",
+            file=sys.stderr,
+        )
+        return 1
+    except Exception:
+        print("S3 replication failed: unexpected local failure", file=sys.stderr)
+        return 1
+
+    print(json.dumps(summary, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/storage/s3_replication.py
+++ b/src/storage/s3_replication.py
@@ -279,7 +279,11 @@ def _missing_object(exc: Exception) -> bool:
     return str(error.get("Code")) in {"404", "NoSuchKey", "NotFound"}
 
 
-def _head(client: S3Client, bucket: str, item: LocalObject) -> Mapping[str, Any] | None:
+def _head(
+    client: S3Client,
+    bucket: str,
+    item: LocalObject,
+) -> Mapping[str, Any] | None:
     try:
         return client.head_object(Bucket=bucket, Key=item.object_key)
     except Exception as exc:
@@ -292,9 +296,15 @@ def _matches_remote(head: Mapping[str, Any], item: LocalObject) -> bool:
     metadata = head.get("Metadata")
     if not isinstance(metadata, Mapping):
         return False
+    raw_content_length = head.get("ContentLength")
+    if isinstance(raw_content_length, bool) or not isinstance(
+        raw_content_length,
+        (int, str),
+    ):
+        return False
     try:
-        content_length = int(head.get("ContentLength"))
-    except (TypeError, ValueError):
+        content_length = int(raw_content_length)
+    except ValueError:
         return False
     return (
         content_length == item.size_bytes

--- a/tests/unit/test_durable_s3_replication_architecture_contract.py
+++ b/tests/unit/test_durable_s3_replication_architecture_contract.py
@@ -1,0 +1,37 @@
+from pathlib import Path
+
+
+def test_s3_replication_is_disabled_immutable_and_secret_safe() -> None:
+    source = Path("src/storage/s3_replication.py").read_text(encoding="utf-8")
+    docs = Path("docs/durable-s3-replication.md").read_text(
+        encoding="utf-8"
+    )
+    config = Path("config/object_storage.yaml").read_text(encoding="utf-8")
+    pyproject = Path("pyproject.toml").read_text(encoding="utf-8")
+
+    assert "enabled: false" in config
+    assert "RISK_PLATFORM_S3_BUCKET" in config
+    assert "AWS_REGION" in config
+    assert "boto3>=1.35,<2" in pyproject
+
+    for required in (
+        "head_object",
+        "put_object",
+        "overwrite is forbidden",
+        "ServerSideEncryption",
+        "bucket_fingerprint",
+        '"bucket_created": False',
+        '"objects_deleted": 0',
+        '"infrastructure_applied": False',
+    ):
+        assert required in source
+
+    for required in (
+        "Disabled-by-default",
+        "does not create a bucket",
+        "fail and never overwrite",
+        "bucket name",
+        "CI uses fake clients",
+        "no object is deleted or replaced",
+    ):
+        assert required.lower() in docs.lower()

--- a/tests/unit/test_s3_replication.py
+++ b/tests/unit/test_s3_replication.py
@@ -1,0 +1,380 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+from src.common.exceptions import StorageError, ValidationError
+from src.storage.s3_replication import (
+    MODEL_VERSION,
+    inventory_local_parquet,
+    parse_s3_replication_config,
+    replicate_local_parquet_to_s3,
+)
+from tests.storage_config_helpers import build_storage_config
+
+
+class MissingObject(Exception):
+    response = {"Error": {"Code": "404"}}
+
+
+class FakeS3Client:
+    def __init__(self) -> None:
+        self.objects: dict[tuple[str, str], dict[str, Any]] = {}
+        self.put_calls: list[dict[str, Any]] = []
+        self.head_calls: list[tuple[str, str]] = []
+
+    def head_object(self, **kwargs: Any) -> dict[str, Any]:
+        key = (kwargs["Bucket"], kwargs["Key"])
+        self.head_calls.append(key)
+        if key not in self.objects:
+            raise MissingObject()
+        return dict(self.objects[key])
+
+    def put_object(self, **kwargs: Any) -> dict[str, Any]:
+        body = kwargs["Body"]
+        content = body.read()
+        call = {
+            key: value
+            for key, value in kwargs.items()
+            if key != "Body"
+        }
+        self.put_calls.append(call)
+        self.objects[(kwargs["Bucket"], kwargs["Key"])] = {
+            "ContentLength": len(content),
+            "Metadata": dict(kwargs["Metadata"]),
+            "ServerSideEncryption": kwargs["ServerSideEncryption"],
+        }
+        return {"ETag": "fake"}
+
+
+def _replication_payload(*, enabled: bool = False, maximum_files: int = 4096):
+    return {
+        "object_storage": {
+            "s3": {
+                "enabled": enabled,
+                "bucket_env": "RISK_PLATFORM_S3_BUCKET",
+                "region_env": "AWS_REGION",
+                "prefix": "financial-risk-data-platform",
+                "server_side_encryption": "AES256",
+                "maximum_files": maximum_files,
+                "maximum_bytes": 1_000_000_000,
+            }
+        }
+    }
+
+
+def _write_configs(
+    tmp_path: Path,
+    *,
+    enabled: bool = False,
+    maximum_files: int = 4096,
+) -> tuple[Path, Path, dict[str, Any]]:
+    storage = build_storage_config(tmp_path)
+    storage_path = tmp_path / "storage.yaml"
+    storage_path.write_text(
+        yaml.safe_dump(storage, sort_keys=False),
+        encoding="utf-8",
+    )
+    replication_path = tmp_path / "object-storage.yaml"
+    replication_path.write_text(
+        yaml.safe_dump(
+            _replication_payload(
+                enabled=enabled,
+                maximum_files=maximum_files,
+            ),
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+    return replication_path, storage_path, storage
+
+
+def _write_parquet_like_file(
+    storage: dict[str, Any],
+    *,
+    kind: str,
+    dataset: str,
+    name: str,
+    content: bytes,
+) -> Path:
+    if kind == "raw":
+        base = Path(storage["storage"]["raw"]["base_path"])
+    else:
+        base = Path(storage["storage"]["curated"]["base_path"])
+    path = base / dataset / name
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(content)
+    return path
+
+
+def test_config_and_inventory_are_deterministic_and_bounded(tmp_path: Path) -> None:
+    replication_path, storage_path, storage = _write_configs(tmp_path)
+    raw = _write_parquet_like_file(
+        storage,
+        kind="raw",
+        dataset="market_events",
+        name="raw.parquet",
+        content=b"raw",
+    )
+    curated = _write_parquet_like_file(
+        storage,
+        kind="curated",
+        dataset="daily_returns",
+        name="curated.parquet",
+        content=b"curated",
+    )
+    config = parse_s3_replication_config(_replication_payload())
+
+    first = inventory_local_parquet(
+        storage_config_path=storage_path,
+        replication_config=config,
+    )
+    second = inventory_local_parquet(
+        storage_config_path=storage_path,
+        replication_config=config,
+    )
+
+    assert first == second
+    assert [item.relative_path for item in first] == [
+        raw.relative_to(tmp_path).as_posix(),
+        curated.relative_to(tmp_path).as_posix(),
+    ]
+    assert all(item.object_key.startswith(config.prefix + "/") for item in first)
+    assert first[0].sha256 == hashlib.sha256(b"raw").hexdigest()
+    assert replication_path.exists()
+
+
+def test_plan_only_never_constructs_or_calls_s3_client(tmp_path: Path) -> None:
+    replication_path, storage_path, storage = _write_configs(tmp_path)
+    _write_parquet_like_file(
+        storage,
+        kind="curated",
+        dataset="daily_returns",
+        name="one.parquet",
+        content=b"one",
+    )
+
+    class FailClient:
+        def head_object(self, **kwargs: Any) -> dict[str, Any]:
+            raise AssertionError("dry run must not call S3")
+
+        def put_object(self, **kwargs: Any) -> dict[str, Any]:
+            raise AssertionError("dry run must not call S3")
+
+    summary = replicate_local_parquet_to_s3(
+        replication_config_path=replication_path,
+        storage_config_path=storage_path,
+        execute=False,
+        environment={},
+        client=FailClient(),
+    )
+
+    assert summary["execution"]["performed"] is False
+    assert summary["selection"]["files_selected"] == 1
+    assert summary["bucket_created"] is False
+    assert summary["objects_deleted"] == 0
+    assert summary["infrastructure_applied"] is False
+
+
+def test_disabled_execution_fails_before_remote_calls(tmp_path: Path) -> None:
+    replication_path, storage_path, storage = _write_configs(tmp_path)
+    _write_parquet_like_file(
+        storage,
+        kind="curated",
+        dataset="daily_returns",
+        name="one.parquet",
+        content=b"one",
+    )
+    client = FakeS3Client()
+
+    with pytest.raises(ValidationError, match="disabled"):
+        replicate_local_parquet_to_s3(
+            replication_config_path=replication_path,
+            storage_config_path=storage_path,
+            execute=True,
+            environment={
+                "RISK_PLATFORM_S3_BUCKET": "risk-platform-example",
+                "AWS_REGION": "eu-west-2",
+            },
+            client=client,
+        )
+    assert client.head_calls == []
+    assert client.put_calls == []
+
+
+def test_upload_verifies_metadata_and_redacts_bucket_name(tmp_path: Path) -> None:
+    replication_path, storage_path, storage = _write_configs(
+        tmp_path,
+        enabled=True,
+    )
+    _write_parquet_like_file(
+        storage,
+        kind="curated",
+        dataset="daily_returns",
+        name="one.parquet",
+        content=b"one",
+    )
+    client = FakeS3Client()
+    summary = replicate_local_parquet_to_s3(
+        replication_config_path=replication_path,
+        storage_config_path=storage_path,
+        execute=True,
+        environment={
+            "RISK_PLATFORM_S3_BUCKET": "risk-platform-example",
+            "AWS_REGION": "eu-west-2",
+        },
+        client=client,
+    )
+
+    assert summary["execution"] == {
+        "requested": True,
+        "performed": True,
+        "uploaded": 1,
+        "already_present": 0,
+    }
+    assert client.put_calls[0]["ServerSideEncryption"] == "AES256"
+    assert client.put_calls[0]["Metadata"]["model-version"] == MODEL_VERSION
+    serialized = json.dumps(summary)
+    assert "risk-platform-example" not in serialized
+    assert summary["destination"]["bucket_fingerprint"] is not None
+
+
+def test_matching_remote_object_is_replay_and_conflict_is_not_overwritten(
+    tmp_path: Path,
+) -> None:
+    replication_path, storage_path, storage = _write_configs(
+        tmp_path,
+        enabled=True,
+    )
+    _write_parquet_like_file(
+        storage,
+        kind="curated",
+        dataset="daily_returns",
+        name="one.parquet",
+        content=b"one",
+    )
+    environment = {
+        "RISK_PLATFORM_S3_BUCKET": "risk-platform-example",
+        "AWS_REGION": "eu-west-2",
+    }
+    client = FakeS3Client()
+    first = replicate_local_parquet_to_s3(
+        replication_config_path=replication_path,
+        storage_config_path=storage_path,
+        execute=True,
+        environment=environment,
+        client=client,
+    )
+    second = replicate_local_parquet_to_s3(
+        replication_config_path=replication_path,
+        storage_config_path=storage_path,
+        execute=True,
+        environment=environment,
+        client=client,
+    )
+    assert first["execution"]["uploaded"] == 1
+    assert second["execution"] == {
+        "requested": True,
+        "performed": True,
+        "uploaded": 0,
+        "already_present": 1,
+    }
+    assert len(client.put_calls) == 1
+
+    key = next(iter(client.objects))
+    client.objects[key]["Metadata"]["sha256"] = "different"
+    with pytest.raises(StorageError, match="overwrite is forbidden"):
+        replicate_local_parquet_to_s3(
+            replication_config_path=replication_path,
+            storage_config_path=storage_path,
+            execute=True,
+            environment=environment,
+            client=client,
+        )
+    assert len(client.put_calls) == 1
+
+
+def test_inventory_rejects_symlinks_and_file_limit(tmp_path: Path) -> None:
+    replication_path, storage_path, storage = _write_configs(
+        tmp_path,
+        maximum_files=1,
+    )
+    _write_parquet_like_file(
+        storage,
+        kind="curated",
+        dataset="daily_returns",
+        name="one.parquet",
+        content=b"one",
+    )
+    _write_parquet_like_file(
+        storage,
+        kind="curated",
+        dataset="daily_returns",
+        name="two.parquet",
+        content=b"two",
+    )
+    config = parse_s3_replication_config(
+        _replication_payload(maximum_files=1)
+    )
+    with pytest.raises(StorageError, match="file limit"):
+        inventory_local_parquet(
+            storage_config_path=storage_path,
+            replication_config=config,
+        )
+
+    target = tmp_path / "target.parquet"
+    target.write_bytes(b"target")
+    symlink = (
+        Path(storage["storage"]["curated"]["base_path"])
+        / "daily_returns"
+        / "linked.parquet"
+    )
+    symlink.unlink(missing_ok=True)
+    symlink.symlink_to(target)
+    config = parse_s3_replication_config(_replication_payload())
+    with pytest.raises(StorageError, match="unsafe file type"):
+        inventory_local_parquet(
+            storage_config_path=storage_path,
+            replication_config=config,
+        )
+    assert replication_path.exists()
+
+
+def test_invalid_bucket_and_destination_requirements_fail_closed(
+    tmp_path: Path,
+) -> None:
+    replication_path, storage_path, storage = _write_configs(
+        tmp_path,
+        enabled=True,
+    )
+    _write_parquet_like_file(
+        storage,
+        kind="curated",
+        dataset="daily_returns",
+        name="one.parquet",
+        content=b"one",
+    )
+    for environment, pattern in (
+        ({"AWS_REGION": "eu-west-2"}, "bucket environment"),
+        ({"RISK_PLATFORM_S3_BUCKET": "risk-platform-example"}, "region environment"),
+        (
+            {
+                "RISK_PLATFORM_S3_BUCKET": "Invalid_Bucket",
+                "AWS_REGION": "eu-west-2",
+            },
+            "bucket name",
+        ),
+    ):
+        with pytest.raises(ValidationError, match=pattern):
+            replicate_local_parquet_to_s3(
+                replication_config_path=replication_path,
+                storage_config_path=storage_path,
+                execute=True,
+                environment=environment,
+                client=FakeS3Client(),
+            )

--- a/tests/unit/test_s3_replication.py
+++ b/tests/unit/test_s3_replication.py
@@ -140,12 +140,17 @@ def test_config_and_inventory_are_deterministic_and_bounded(tmp_path: Path) -> N
     )
 
     assert first == second
-    assert [item.relative_path for item in first] == [
-        raw.relative_to(tmp_path).as_posix(),
-        curated.relative_to(tmp_path).as_posix(),
-    ]
+    assert [item.relative_path for item in first] == sorted(
+        [
+            raw.relative_to(tmp_path).as_posix(),
+            curated.relative_to(tmp_path).as_posix(),
+        ]
+    )
     assert all(item.object_key.startswith(config.prefix + "/") for item in first)
-    assert first[0].sha256 == hashlib.sha256(b"raw").hexdigest()
+    hashes = {item.relative_path: item.sha256 for item in first}
+    assert hashes[raw.relative_to(tmp_path).as_posix()] == hashlib.sha256(
+        b"raw"
+    ).hexdigest()
     assert replication_path.exists()
 
 
@@ -361,7 +366,10 @@ def test_invalid_bucket_and_destination_requirements_fail_closed(
     )
     for environment, pattern in (
         ({"AWS_REGION": "eu-west-2"}, "bucket environment"),
-        ({"RISK_PLATFORM_S3_BUCKET": "risk-platform-example"}, "region environment"),
+        (
+            {"RISK_PLATFORM_S3_BUCKET": "risk-platform-example"},
+            "region environment",
+        ),
         (
             {
                 "RISK_PLATFORM_S3_BUCKET": "Invalid_Bucket",


### PR DESCRIPTION
## Superseded by storage foundation #85

Closed without merge after PR #85 was validated and squash-merged as the canonical immutable S3 adapter.

This draft implemented a separate bulk-replication client on an older base. Keeping both would duplicate destination validation, hashing, replay verification, encryption and overwrite-refusal logic. The next replication increment should be rebuilt on current `main` as a thin bounded inventory/orchestration layer that delegates every object write and verification to the merged #85 adapter.

No cloud request or infrastructure mutation was performed while closing this draft.