### PR TITLE
Add risk-limit decision lifecycle serving

### DIFF
--- a/docs/portfolio-risk-limit-decisions.md
+++ b/docs/portfolio-risk-limit-decisions.md
@@ -1,0 +1,117 @@
+# Portfolio Risk-Limit Decision Serving
+
+## Outcome
+
+Append-only operator decisions are loaded into PostgreSQL without changing the analytical evaluation or notification that prompted them:
+
+```text
+portfolio_risk_limit_decisions Parquet
+  -> bounded calculation-ID load
+  -> immutable decision history
+  -> latest decision per notification
+  -> open / acknowledged / resolved / waived lifecycle views
+  -> lifecycle reconciliation
+```
+
+The loader is `src/warehouse/portfolio_risk_limit_decisions_loader.py`. The schema is `sql/portfolio_risk_limit_decisions_schema.sql`.
+
+## Apply and load
+
+Apply the schema after the notification serving schema:
+
+```bash
+docker compose exec -T postgres psql -U risk_user -d risk_platform \
+  < sql/portfolio_risk_limit_decisions_schema.sql
+```
+
+Inspect the bounded batch without opening a database connection:
+
+```bash
+.venv/bin/python -m src.warehouse.portfolio_risk_limit_decisions_loader \
+  --dry-run
+```
+
+Load the decisions:
+
+```bash
+.venv/bin/python -m src.warehouse.portfolio_risk_limit_decisions_loader \
+  --dsn postgresql://risk_user:risk_password@localhost:5433/risk_platform
+```
+
+Run reconciliation:
+
+```bash
+docker compose exec -T postgres psql -U risk_user -d risk_platform \
+  < sql/portfolio_risk_limit_decisions_consistency_checks.sql
+```
+
+## Append-only history
+
+The base table is:
+
+```text
+risk_platform.portfolio_risk_limit_decisions
+```
+
+`decision_id` is the primary and loader conflict key. An identical retry converges on one row. A later acknowledgement, resolution, or waiver remains a separate decision record with its own identity.
+
+The complete source record is retained as JSONB alongside the minimal queryable decision fields. The loader performs no threshold calculation and does not rewrite notification evidence.
+
+## Current decision
+
+```text
+risk_platform.latest_portfolio_risk_limit_decisions
+```
+
+The current decision for one notification is chosen using:
+
+```text
+decided_at DESC
+decision_id DESC
+```
+
+This is a serving interpretation over immutable records, not a mutable status column.
+
+## Lifecycle views
+
+The lifecycle view joins current notification intent to the latest decision:
+
+```text
+risk_platform.portfolio_risk_limit_breach_lifecycle
+```
+
+The resulting states are:
+
+| State | Meaning | Operationally closed |
+| --- | --- | --- |
+| `open` | No decision has been recorded | No |
+| `acknowledged` | Seen and under investigation | No |
+| `resolved` | Operator records that the condition was addressed | Yes |
+| `waived` | Operator explicitly accepts the breach with a reason | Yes |
+
+Convenience views are:
+
+```text
+risk_platform.open_portfolio_risk_limit_breaches
+risk_platform.acknowledged_portfolio_risk_limit_breaches
+risk_platform.resolved_portfolio_risk_limit_breaches
+risk_platform.waived_portfolio_risk_limit_breaches
+risk_platform.portfolio_risk_limit_decision_summary
+```
+
+Only notifications that remain current after stale-breach suppression enter the lifecycle. A corrected risk-limit evaluation that becomes `ok` therefore removes the old notification from current operational views while preserving all historical notification and decision records.
+
+## Safety bounds
+
+The loader:
+
+- reads only the configured `portfolio_risk_limit_decisions` dataset;
+- rejects symbolic-link paths and unsafe file types;
+- caps input at 4,096 files, 1 GB, and 250,000 rows;
+- requires timezone-aware decision and ingest timestamps;
+- permits only `acknowledged`, `resolved`, and `waived`; and
+- converts only the canonical source record to JSONB.
+
+## Boundary
+
+This serving contract does not authenticate the actor, require a second approver, send messages, mutate notification state, block trading, schedule work, deploy infrastructure, or run `terraform apply`. Those remain separate governance and delivery decisions.

--- a/sql/portfolio_risk_limit_decisions_consistency_checks.sql
+++ b/sql/portfolio_risk_limit_decisions_consistency_checks.sql
@@ -1,0 +1,200 @@
+-- Reconciliation for append-only risk-limit decision serving.
+-- Run after notification and decision schemas and warehouse loads.
+
+WITH counts AS (
+    SELECT
+        (
+            SELECT COUNT(*)
+            FROM risk_platform.current_portfolio_risk_limit_notifications
+        ) AS current_notification_rows,
+        (
+            SELECT COUNT(*)
+            FROM risk_platform.portfolio_risk_limit_breach_lifecycle
+        ) AS lifecycle_rows,
+        (
+            SELECT COUNT(*)
+            FROM risk_platform.open_portfolio_risk_limit_breaches
+        ) AS open_rows,
+        (
+            SELECT COUNT(*)
+            FROM risk_platform.acknowledged_portfolio_risk_limit_breaches
+        ) AS acknowledged_rows,
+        (
+            SELECT COUNT(*)
+            FROM risk_platform.resolved_portfolio_risk_limit_breaches
+        ) AS resolved_rows,
+        (
+            SELECT COUNT(*)
+            FROM risk_platform.waived_portfolio_risk_limit_breaches
+        ) AS waived_rows
+), integrity AS (
+    SELECT
+        (
+            SELECT COUNT(*)
+            FROM risk_platform.portfolio_risk_limit_decisions decision_record
+            LEFT JOIN risk_platform.portfolio_risk_limit_notifications notification
+                ON notification.notification_id = decision_record.notification_id
+            WHERE notification.notification_id IS NULL
+        ) AS orphan_decisions,
+        (
+            SELECT COUNT(*)
+            FROM (
+                SELECT decision_id
+                FROM risk_platform.portfolio_risk_limit_decisions
+                GROUP BY decision_id
+                HAVING COUNT(*) > 1
+            ) duplicate
+        ) AS duplicate_decision_ids,
+        (
+            SELECT COUNT(*)
+            FROM (
+                SELECT notification_id
+                FROM risk_platform.latest_portfolio_risk_limit_decisions
+                GROUP BY notification_id
+                HAVING COUNT(*) > 1
+            ) duplicate
+        ) AS duplicate_latest_notification_rows,
+        (
+            SELECT COUNT(*)
+            FROM risk_platform.latest_portfolio_risk_limit_decisions latest
+            WHERE EXISTS (
+                SELECT 1
+                FROM risk_platform.portfolio_risk_limit_decisions candidate
+                WHERE candidate.notification_id = latest.notification_id
+                  AND (
+                    candidate.decided_at,
+                    candidate.decision_id
+                  ) > (
+                    latest.decided_at,
+                    latest.decision_id
+                  )
+            )
+        ) AS stale_latest_decisions,
+        (
+            SELECT COUNT(*)
+            FROM risk_platform.portfolio_risk_limit_decisions
+            WHERE ts_ingest < decided_at
+               OR decision NOT IN ('acknowledged', 'resolved', 'waived')
+               OR actor = ''
+               OR reason = ''
+               OR jsonb_typeof(record_json) <> 'object'
+        ) AS invalid_decision_contract_rows,
+        (
+            SELECT COUNT(*)
+            FROM risk_platform.portfolio_risk_limit_breach_lifecycle lifecycle
+            WHERE lifecycle_status NOT IN (
+                    'open', 'acknowledged', 'resolved', 'waived'
+                )
+               OR requires_operator_decision
+                    <> (latest_decision_id IS NULL)
+               OR operationally_closed
+                    <> (lifecycle_status IN ('resolved', 'waived'))
+               OR (
+                    latest_decision_id IS NULL
+                    AND lifecycle_status <> 'open'
+                )
+               OR (
+                    latest_decision = 'acknowledged'
+                    AND lifecycle_status <> 'acknowledged'
+                )
+               OR (
+                    latest_decision = 'resolved'
+                    AND lifecycle_status <> 'resolved'
+                )
+               OR (
+                    latest_decision = 'waived'
+                    AND lifecycle_status <> 'waived'
+                )
+        ) AS invalid_lifecycle_rows
+)
+SELECT
+    check_name,
+    expected,
+    actual,
+    status
+FROM (
+    SELECT
+        'risk_limit_decisions_reference_notifications' AS check_name,
+        '0' AS expected,
+        orphan_decisions::TEXT AS actual,
+        CASE WHEN orphan_decisions = 0 THEN 'pass' ELSE 'fail' END AS status
+    FROM integrity
+
+    UNION ALL
+
+    SELECT
+        'risk_limit_decision_ids_unique',
+        '0',
+        duplicate_decision_ids::TEXT,
+        CASE WHEN duplicate_decision_ids = 0 THEN 'pass' ELSE 'fail' END
+    FROM integrity
+
+    UNION ALL
+
+    SELECT
+        'latest_decision_notification_grain_unique',
+        '0',
+        duplicate_latest_notification_rows::TEXT,
+        CASE
+            WHEN duplicate_latest_notification_rows = 0 THEN 'pass'
+            ELSE 'fail'
+        END
+    FROM integrity
+
+    UNION ALL
+
+    SELECT
+        'latest_decision_selects_current_version',
+        '0',
+        stale_latest_decisions::TEXT,
+        CASE WHEN stale_latest_decisions = 0 THEN 'pass' ELSE 'fail' END
+    FROM integrity
+
+    UNION ALL
+
+    SELECT
+        'risk_limit_decision_contract_valid',
+        '0',
+        invalid_decision_contract_rows::TEXT,
+        CASE
+            WHEN invalid_decision_contract_rows = 0 THEN 'pass'
+            ELSE 'fail'
+        END
+    FROM integrity
+
+    UNION ALL
+
+    SELECT
+        'risk_limit_decision_lifecycle_valid',
+        '0',
+        invalid_lifecycle_rows::TEXT,
+        CASE WHEN invalid_lifecycle_rows = 0 THEN 'pass' ELSE 'fail' END
+    FROM integrity
+
+    UNION ALL
+
+    SELECT
+        'decision_lifecycle_rows_match_current_notifications',
+        current_notification_rows::TEXT,
+        lifecycle_rows::TEXT,
+        CASE
+            WHEN current_notification_rows = lifecycle_rows THEN 'pass'
+            ELSE 'fail'
+        END
+    FROM counts
+
+    UNION ALL
+
+    SELECT
+        'decision_lifecycle_partitions_current_notifications',
+        current_notification_rows::TEXT,
+        (open_rows + acknowledged_rows + resolved_rows + waived_rows)::TEXT,
+        CASE
+            WHEN current_notification_rows =
+                open_rows + acknowledged_rows + resolved_rows + waived_rows
+            THEN 'pass'
+            ELSE 'fail'
+        END
+    FROM counts
+) checks
+ORDER BY check_name;

--- a/sql/portfolio_risk_limit_decisions_schema.sql
+++ b/sql/portfolio_risk_limit_decisions_schema.sql
@@ -1,0 +1,114 @@
+-- Append-only operator decision serving for deterministic risk-limit notifications.
+-- Apply after sql/portfolio_risk_limit_notifications_schema.sql.
+
+CREATE SCHEMA IF NOT EXISTS risk_platform;
+
+CREATE TABLE IF NOT EXISTS risk_platform.portfolio_risk_limit_decisions (
+    decision_id TEXT PRIMARY KEY,
+    model_version TEXT NOT NULL,
+    notification_id TEXT NOT NULL REFERENCES
+        risk_platform.portfolio_risk_limit_notifications (notification_id),
+    decision TEXT NOT NULL CHECK (
+        decision IN ('acknowledged', 'resolved', 'waived')
+    ),
+    actor TEXT NOT NULL CHECK (
+        actor <> '' AND char_length(actor) <= 128
+    ),
+    reason TEXT NOT NULL CHECK (
+        reason <> '' AND char_length(reason) <= 1000
+    ),
+    decided_at TIMESTAMPTZ NOT NULL,
+    ts_ingest TIMESTAMPTZ NOT NULL,
+    record_json JSONB NOT NULL CHECK (jsonb_typeof(record_json) = 'object'),
+    loaded_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    CHECK (decision_id <> ''),
+    CHECK (model_version <> ''),
+    CHECK (notification_id <> ''),
+    CHECK (ts_ingest >= decided_at)
+);
+
+CREATE INDEX IF NOT EXISTS idx_risk_limit_decision_notification_order
+    ON risk_platform.portfolio_risk_limit_decisions (
+        notification_id,
+        decided_at DESC,
+        decision_id DESC
+    );
+
+CREATE INDEX IF NOT EXISTS idx_risk_limit_decision_type_order
+    ON risk_platform.portfolio_risk_limit_decisions (
+        decision,
+        decided_at DESC
+    );
+
+CREATE OR REPLACE VIEW risk_platform.latest_portfolio_risk_limit_decisions AS
+SELECT
+    decision_id,
+    model_version,
+    notification_id,
+    decision,
+    actor,
+    reason,
+    decided_at,
+    ts_ingest,
+    record_json
+FROM (
+    SELECT
+        decision_record.*,
+        ROW_NUMBER() OVER (
+            PARTITION BY notification_id
+            ORDER BY decided_at DESC, decision_id DESC
+        ) AS version_rank
+    FROM risk_platform.portfolio_risk_limit_decisions decision_record
+) ranked
+WHERE version_rank = 1;
+
+CREATE OR REPLACE VIEW risk_platform.portfolio_risk_limit_breach_lifecycle AS
+SELECT
+    notification.*,
+    decision_record.decision_id AS latest_decision_id,
+    decision_record.model_version AS latest_decision_model_version,
+    decision_record.decision AS latest_decision,
+    decision_record.actor AS latest_decision_actor,
+    decision_record.reason AS latest_decision_reason,
+    decision_record.decided_at AS latest_decided_at,
+    CASE
+        WHEN decision_record.decision = 'resolved' THEN 'resolved'
+        WHEN decision_record.decision = 'waived' THEN 'waived'
+        WHEN decision_record.decision = 'acknowledged' THEN 'acknowledged'
+        ELSE 'open'
+    END AS lifecycle_status,
+    decision_record.decision IS NULL AS requires_operator_decision,
+    decision_record.decision IN ('resolved', 'waived') AS operationally_closed
+FROM risk_platform.current_portfolio_risk_limit_notifications notification
+LEFT JOIN risk_platform.latest_portfolio_risk_limit_decisions decision_record
+    ON decision_record.notification_id = notification.notification_id;
+
+CREATE OR REPLACE VIEW risk_platform.open_portfolio_risk_limit_breaches AS
+SELECT *
+FROM risk_platform.portfolio_risk_limit_breach_lifecycle
+WHERE lifecycle_status = 'open';
+
+CREATE OR REPLACE VIEW risk_platform.acknowledged_portfolio_risk_limit_breaches AS
+SELECT *
+FROM risk_platform.portfolio_risk_limit_breach_lifecycle
+WHERE lifecycle_status = 'acknowledged';
+
+CREATE OR REPLACE VIEW risk_platform.resolved_portfolio_risk_limit_breaches AS
+SELECT *
+FROM risk_platform.portfolio_risk_limit_breach_lifecycle
+WHERE lifecycle_status = 'resolved';
+
+CREATE OR REPLACE VIEW risk_platform.waived_portfolio_risk_limit_breaches AS
+SELECT *
+FROM risk_platform.portfolio_risk_limit_breach_lifecycle
+WHERE lifecycle_status = 'waived';
+
+CREATE OR REPLACE VIEW risk_platform.portfolio_risk_limit_decision_summary AS
+SELECT
+    lifecycle_status,
+    COUNT(*) AS notification_count,
+    COUNT(*) FILTER (WHERE requires_operator_decision) AS undecided_count,
+    COUNT(*) FILTER (WHERE operationally_closed) AS closed_count,
+    MAX(latest_decided_at) AS latest_decided_at
+FROM risk_platform.portfolio_risk_limit_breach_lifecycle
+GROUP BY lifecycle_status;

--- a/tests/unit/test_portfolio_risk_limit_decision_serving_contract.py
+++ b/tests/unit/test_portfolio_risk_limit_decision_serving_contract.py
@@ -1,0 +1,43 @@
+from pathlib import Path
+
+
+def test_decision_schema_preserves_history_and_derives_lifecycle() -> None:
+    sql = Path("sql/portfolio_risk_limit_decisions_schema.sql").read_text(
+        encoding="utf-8"
+    )
+
+    for required in (
+        "portfolio_risk_limit_decisions",
+        "latest_portfolio_risk_limit_decisions",
+        "portfolio_risk_limit_breach_lifecycle",
+        "open_portfolio_risk_limit_breaches",
+        "acknowledged_portfolio_risk_limit_breaches",
+        "resolved_portfolio_risk_limit_breaches",
+        "waived_portfolio_risk_limit_breaches",
+        "portfolio_risk_limit_decision_summary",
+        "PARTITION BY notification_id",
+        "ORDER BY decided_at DESC, decision_id DESC",
+        "current_portfolio_risk_limit_notifications",
+    ):
+        assert required in sql
+
+    assert "UPDATE risk_platform.portfolio_risk_limit_notifications" not in sql
+    assert "DELETE FROM risk_platform.portfolio_risk_limit_notifications" not in sql
+
+
+def test_decision_consistency_checks_cover_lifecycle_invariants() -> None:
+    sql = Path(
+        "sql/portfolio_risk_limit_decisions_consistency_checks.sql"
+    ).read_text(encoding="utf-8")
+
+    for check_name in (
+        "risk_limit_decisions_reference_notifications",
+        "risk_limit_decision_ids_unique",
+        "latest_decision_notification_grain_unique",
+        "latest_decision_selects_current_version",
+        "risk_limit_decision_contract_valid",
+        "risk_limit_decision_lifecycle_valid",
+        "decision_lifecycle_rows_match_current_notifications",
+        "decision_lifecycle_partitions_current_notifications",
+    ):
+        assert check_name in sql

--- a/tests/unit/test_portfolio_risk_limit_decisions_loader.py
+++ b/tests/unit/test_portfolio_risk_limit_decisions_loader.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+import yaml
+
+from src.common.exceptions import StorageError
+from src.storage.s3_writer import write_records
+from src.warehouse.portfolio_risk_limit_decisions_loader import (
+    DATASET_KEY,
+    build_upsert_sql,
+    collect_decision_records,
+)
+
+
+def _storage(tmp_path: Path) -> tuple[dict, Path]:
+    config = {
+        "storage": {
+            "base_dir": str(tmp_path),
+            "raw": {
+                "base_path": str(tmp_path / "raw"),
+                "dataset": "market_events",
+            },
+            "curated": {
+                "base_path": str(tmp_path / "curated"),
+                "datasets": {DATASET_KEY: DATASET_KEY},
+            },
+            "format": "parquet",
+            "partitioning": {"granularity": "hourly"},
+        }
+    }
+    path = tmp_path / "storage.yaml"
+    path.write_text(yaml.safe_dump(config), encoding="utf-8")
+    return config, path
+
+
+def _decision(**overrides: object) -> dict[str, object]:
+    decided_at = datetime(2026, 8, 22, 14, tzinfo=timezone.utc)
+    record: dict[str, object] = {
+        "decision_id": "decision-1",
+        "model_version": "portfolio-risk-limit-decisions-v1",
+        "notification_id": "notification-1",
+        "decision": "acknowledged",
+        "actor": "alex@example.com",
+        "reason": "Investigating the breach",
+        "decided_at": decided_at,
+        "ts_ingest": decided_at + timedelta(minutes=1),
+        "metric_name": "portfolio_volatility_annualized",
+        "status": "critical",
+    }
+    record.update(overrides)
+    return record
+
+
+def test_collect_decisions_returns_zero_when_dataset_is_absent(
+    tmp_path: Path,
+) -> None:
+    _, path = _storage(tmp_path)
+
+    assert collect_decision_records(path) == []
+
+
+def test_collect_decisions_retains_minimal_columns_and_full_json(
+    tmp_path: Path,
+) -> None:
+    config, path = _storage(tmp_path)
+    assert write_records(
+        [_decision()],
+        kind="curated",
+        dataset=DATASET_KEY,
+        storage_config=config,
+    ) == 1
+
+    records = collect_decision_records(path)
+
+    assert len(records) == 1
+    record = records[0]
+    assert record["decision_id"] == "decision-1"
+    assert record["notification_id"] == "notification-1"
+    assert record["decision"] == "acknowledged"
+    assert record["record_json"]["metric_name"] == (
+        "portfolio_volatility_annualized"
+    )
+    assert record["record_json"]["decided_at"].endswith("+00:00")
+
+
+def test_collect_decisions_accepts_calculation_id_as_legacy_identity(
+    tmp_path: Path,
+) -> None:
+    config, path = _storage(tmp_path)
+    decision = _decision()
+    decision["calculation_id"] = decision.pop("decision_id")
+    assert write_records(
+        [decision],
+        kind="curated",
+        dataset=DATASET_KEY,
+        storage_config=config,
+    ) == 1
+
+    assert collect_decision_records(path)[0]["decision_id"] == "decision-1"
+
+
+def test_collect_decisions_rejects_invalid_contract(
+    tmp_path: Path,
+) -> None:
+    config, path = _storage(tmp_path)
+    invalid = _decision(decision="closed")
+    assert write_records(
+        [invalid],
+        kind="curated",
+        dataset=DATASET_KEY,
+        storage_config=config,
+    ) == 1
+
+    with pytest.raises(StorageError, match="unsupported decision"):
+        collect_decision_records(path)
+
+
+def test_collect_decisions_rejects_symbolic_link_dataset(
+    tmp_path: Path,
+) -> None:
+    _, path = _storage(tmp_path)
+    target = tmp_path / "real"
+    target.mkdir()
+    dataset = tmp_path / "curated" / DATASET_KEY
+    dataset.parent.mkdir(parents=True)
+    try:
+        dataset.symlink_to(target, target_is_directory=True)
+    except OSError:
+        pytest.skip("symbolic links are unavailable")
+
+    with pytest.raises(StorageError, match="symbolic link"):
+        collect_decision_records(path)
+
+
+def test_upsert_uses_decision_identity_and_jsonb_record() -> None:
+    sql = build_upsert_sql()
+
+    assert 'INSERT INTO "risk_platform"."portfolio_risk_limit_decisions"' in sql
+    assert 'ON CONFLICT ("decision_id")' in sql
+    assert '"record_json" = EXCLUDED."record_json"' in sql
+    assert "loaded_at = now()" in sql


### PR DESCRIPTION
## Closed: incompatible parallel lifecycle model

This draft is closed without merge after review against current `main`.

The branch does not contain the loader its tests import, but that is not the only gap: the repository has no configured `portfolio_risk_limit_decisions` curated dataset or producer on `main`. It already has an append-only acknowledgement contract and current breach/lifecycle serving. This draft introduces a second, incompatible decision vocabulary (`acknowledged`, `resolved`, `waived`) over notification records, which would split operator state across two models without a migration or authoritative precedence rule.

A future lifecycle extension should build on the existing acknowledgement and breach-lifecycle contracts, with one explicit state machine and compatibility plan, rather than repair this isolated serving layer. The failed CI evidence is retained in the closed PR.