### PR TITLE
Add exchange-calendar freshness semantics

### DIFF
--- a/docs/market-calendar-freshness.md
+++ b/docs/market-calendar-freshness.md
@@ -1,0 +1,78 @@
+# Exchange-Calendar Freshness
+
+## Outcome
+
+Daily freshness is evaluated against an explicit market calendar rather than calendar-day gaps:
+
+```text
+local daily-return observation dates
+  -> configured instrument-to-calendar mapping
+  -> exchange timezone, close time, grace period, weekends and holidays
+  -> expected latest completed trading session
+  -> current or stale evidence
+  -> missing-session and non-session observation evidence
+```
+
+The calendar model is `src/analytics/market_calendar_freshness.py`. The bounded local runner is `src/orchestration/run_market_freshness.py`.
+
+## Operator command
+
+```bash
+.venv/bin/python -m src.orchestration.run_market_freshness \
+  --source alpha_vantage \
+  --symbol IBM \
+  --as-of 2026-01-08T22:00:00Z \
+  --summary-json .demo/market-freshness-IBM.json
+```
+
+The command reads existing `daily_returns` Parquet and makes no provider request.
+
+## Calendar contract
+
+`config/market_calendars.yaml` maps a source-and-symbol key to a calendar ID. A calendar defines:
+
+```text
+timezone
+local close time
+post-close grace period
+weekend weekday numbers
+explicit holiday dates
+```
+
+The bundled XNAS entry is a small demonstration configuration, not a claim to be a complete authoritative exchange holiday feed. An operational deployment must manage and review the full exchange calendar as versioned reference data.
+
+## Expected session
+
+The expected latest observation is the most recent completed trading session.
+
+- On a weekend or configured holiday, the expected session is the previous trading session.
+- During a trading day but before local close plus the grace period, the expected session remains the previous session.
+- After close plus grace, the current session becomes expected.
+
+This prevents weekends, holidays, and an incomplete current trading day from being reported as missing data.
+
+## Evidence
+
+The summary records:
+
+```text
+calendar ID
+UTC and exchange-local as-of timestamps
+expected latest session
+latest observed date
+current or stale status
+stale trading-session count
+missing trading-session dates
+observed non-session dates
+observed session count
+```
+
+A weekend-dated or holiday-dated source observation is not silently discarded. It remains explicit `observed_non_session_dates` evidence for review.
+
+## Bounds
+
+The reader accepts only local `daily_returns` Parquet, rejects symbolic links and unsafe file types, and caps input at 4,096 files, 1 GB, and 250,000 rows. Calendar evaluation caps one span at twenty years and missing-session evidence at 2,500 dates.
+
+## Boundary
+
+This increment does not automatically download exchange calendars, call Alpha Vantage, schedule ingestion, send alerts, change portfolio calculations, deploy infrastructure, or run `terraform apply`. Calendar maintenance and any external reference-data adapter remain explicit future changes.

--- a/src/analytics/market_calendar_freshness.py
+++ b/src/analytics/market_calendar_freshness.py
@@ -1,0 +1,327 @@
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import dataclass
+from datetime import date, datetime, time, timedelta, timezone
+from pathlib import Path
+from typing import Any
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+from ..common.config import load_yaml
+from ..common.exceptions import ValidationError
+
+MAX_CALENDAR_SPAN_DAYS = 20 * 366
+MAX_MISSING_SESSIONS = 2_500
+
+
+@dataclass(frozen=True, slots=True)
+class MarketCalendar:
+    calendar_id: str
+    timezone_name: str
+    close_time: time
+    grace_minutes: int
+    weekend_days: frozenset[int]
+    holidays: frozenset[date]
+
+    @property
+    def timezone(self) -> ZoneInfo:
+        try:
+            return ZoneInfo(self.timezone_name)
+        except ZoneInfoNotFoundError:
+            raise ValidationError(
+                f"calendar '{self.calendar_id}' has an unknown timezone"
+            ) from None
+
+    def classify(self, value: date) -> str:
+        if value.weekday() in self.weekend_days:
+            return "weekend"
+        if value in self.holidays:
+            return "holiday"
+        return "trading_session"
+
+    def is_session(self, value: date) -> bool:
+        return self.classify(value) == "trading_session"
+
+
+@dataclass(frozen=True, slots=True)
+class MarketFreshnessEvaluation:
+    calendar_id: str
+    source: str
+    symbol: str
+    as_of_utc: datetime
+    as_of_local: datetime
+    expected_latest_session: date
+    latest_observation_date: date
+    status: str
+    stale_session_count: int
+    missing_session_dates: tuple[date, ...]
+    observed_session_count: int
+    observed_non_session_dates: tuple[date, ...]
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "as_of_local": self.as_of_local.isoformat(),
+            "as_of_utc": self.as_of_utc.isoformat(),
+            "calendar_id": self.calendar_id,
+            "expected_latest_session": self.expected_latest_session.isoformat(),
+            "latest_observation_date": self.latest_observation_date.isoformat(),
+            "missing_session_count": len(self.missing_session_dates),
+            "missing_session_dates": [
+                value.isoformat() for value in self.missing_session_dates
+            ],
+            "observed_non_session_dates": [
+                value.isoformat() for value in self.observed_non_session_dates
+            ],
+            "observed_session_count": self.observed_session_count,
+            "source": self.source,
+            "stale_session_count": self.stale_session_count,
+            "status": self.status,
+            "symbol": self.symbol,
+        }
+
+
+def _required_text(value: Any, label: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ValidationError(f"{label} must be non-empty text")
+    return value.strip()
+
+
+def _clock(value: Any, label: str) -> time:
+    if not isinstance(value, str):
+        raise ValidationError(f"{label} must use HH:MM")
+    try:
+        parsed = time.fromisoformat(value.strip())
+    except ValueError:
+        raise ValidationError(f"{label} must use HH:MM") from None
+    if parsed.second or parsed.microsecond or parsed.tzinfo is not None:
+        raise ValidationError(f"{label} must use local HH:MM without seconds")
+    return parsed
+
+
+def _calendar_date(value: Any, label: str) -> date:
+    if type(value) is date:
+        return value
+    if not isinstance(value, str):
+        raise ValidationError(f"{label} must use YYYY-MM-DD")
+    try:
+        parsed = date.fromisoformat(value.strip())
+    except ValueError:
+        raise ValidationError(f"{label} must use YYYY-MM-DD") from None
+    if value.strip() != parsed.isoformat():
+        raise ValidationError(f"{label} must use YYYY-MM-DD")
+    return parsed
+
+
+def parse_market_calendar(
+    payload: Mapping[str, Any],
+    calendar_id: str,
+) -> MarketCalendar:
+    calendars = payload.get("calendars")
+    if not isinstance(calendars, Mapping):
+        raise ValidationError("market-calendar configuration must define calendars")
+    candidate = calendars.get(calendar_id)
+    if not isinstance(candidate, Mapping):
+        raise ValidationError(f"calendar '{calendar_id}' is not configured")
+
+    timezone_name = _required_text(
+        candidate.get("timezone"),
+        f"calendar {calendar_id}.timezone",
+    )
+    try:
+        ZoneInfo(timezone_name)
+    except ZoneInfoNotFoundError:
+        raise ValidationError(
+            f"calendar '{calendar_id}' has an unknown timezone"
+        ) from None
+
+    grace_minutes = candidate.get("grace_minutes", 0)
+    if type(grace_minutes) is not int or not 0 <= grace_minutes <= 24 * 60:
+        raise ValidationError("grace_minutes must be an integer from 0 to 1440")
+
+    weekend_raw = candidate.get("weekend_days", [5, 6])
+    if (
+        not isinstance(weekend_raw, Sequence)
+        or isinstance(weekend_raw, (str, bytes))
+        or not weekend_raw
+        or any(type(value) is not int or not 0 <= value <= 6 for value in weekend_raw)
+    ):
+        raise ValidationError("weekend_days must contain weekday integers 0 to 6")
+    weekend_days = frozenset(weekend_raw)
+
+    holidays_raw = candidate.get("holidays", [])
+    if not isinstance(holidays_raw, Sequence) or isinstance(
+        holidays_raw, (str, bytes)
+    ):
+        raise ValidationError("holidays must be a sequence of calendar dates")
+    holidays = frozenset(
+        _calendar_date(value, f"calendar {calendar_id}.holiday")
+        for value in holidays_raw
+    )
+    if any(value.weekday() in weekend_days for value in holidays):
+        raise ValidationError("configured holidays must not duplicate weekend dates")
+
+    return MarketCalendar(
+        calendar_id=_required_text(calendar_id, "calendar_id"),
+        timezone_name=timezone_name,
+        close_time=_clock(
+            candidate.get("close_time"),
+            f"calendar {calendar_id}.close_time",
+        ),
+        grace_minutes=grace_minutes,
+        weekend_days=weekend_days,
+        holidays=holidays,
+    )
+
+
+def load_market_calendar(path: Path, calendar_id: str) -> MarketCalendar:
+    try:
+        payload = load_yaml(path)
+    except Exception:
+        raise ValidationError(
+            "market-calendar configuration could not be loaded"
+        ) from None
+    if not isinstance(payload, Mapping):
+        raise ValidationError("market-calendar configuration must be a mapping")
+    return parse_market_calendar(payload, calendar_id)
+
+
+def resolve_instrument_calendar(
+    payload: Mapping[str, Any],
+    *,
+    source: str,
+    symbol: str,
+) -> str:
+    instruments = payload.get("instruments")
+    if not isinstance(instruments, Mapping):
+        raise ValidationError("market-calendar configuration must define instruments")
+    key = f"{_required_text(source, 'source')}:{_required_text(symbol, 'symbol').upper()}"
+    calendar_id = instruments.get(key)
+    return _required_text(calendar_id, f"calendar mapping for {key}")
+
+
+def load_instrument_calendar(
+    path: Path,
+    *,
+    source: str,
+    symbol: str,
+) -> MarketCalendar:
+    try:
+        payload = load_yaml(path)
+    except Exception:
+        raise ValidationError(
+            "market-calendar configuration could not be loaded"
+        ) from None
+    if not isinstance(payload, Mapping):
+        raise ValidationError("market-calendar configuration must be a mapping")
+    calendar_id = resolve_instrument_calendar(
+        payload,
+        source=source,
+        symbol=symbol,
+    )
+    return parse_market_calendar(payload, calendar_id)
+
+
+def _previous_session(calendar: MarketCalendar, candidate: date) -> date:
+    for offset in range(1, MAX_CALENDAR_SPAN_DAYS + 1):
+        value = candidate - timedelta(days=offset)
+        if calendar.is_session(value):
+            return value
+    raise ValidationError("market calendar has no previous session within the bound")
+
+
+def expected_latest_session(
+    calendar: MarketCalendar,
+    *,
+    as_of: datetime,
+) -> tuple[date, datetime]:
+    if as_of.tzinfo is None or as_of.utcoffset() is None:
+        raise ValidationError("as_of must be timezone-aware")
+    as_of_utc = as_of.astimezone(timezone.utc)
+    local = as_of_utc.astimezone(calendar.timezone)
+    local_date = local.date()
+
+    if not calendar.is_session(local_date):
+        return _previous_session(calendar, local_date), local
+
+    close = datetime.combine(
+        local_date,
+        calendar.close_time,
+        tzinfo=calendar.timezone,
+    ) + timedelta(minutes=calendar.grace_minutes)
+    if local >= close:
+        return local_date, local
+    return _previous_session(calendar, local_date), local
+
+
+def _session_dates(
+    calendar: MarketCalendar,
+    start: date,
+    end: date,
+) -> tuple[date, ...]:
+    if start > end:
+        return ()
+    span = (end - start).days + 1
+    if span > MAX_CALENDAR_SPAN_DAYS:
+        raise ValidationError("market freshness date span exceeds the safety bound")
+    return tuple(
+        start + timedelta(days=offset)
+        for offset in range(span)
+        if calendar.is_session(start + timedelta(days=offset))
+    )
+
+
+def evaluate_market_freshness(
+    observed_dates: Iterable[date],
+    *,
+    source: str,
+    symbol: str,
+    calendar: MarketCalendar,
+    as_of: datetime,
+    max_missing_sessions: int = MAX_MISSING_SESSIONS,
+) -> MarketFreshnessEvaluation:
+    if type(max_missing_sessions) is not int or not 0 <= max_missing_sessions <= MAX_MISSING_SESSIONS:
+        raise ValidationError(
+            f"max_missing_sessions must be between 0 and {MAX_MISSING_SESSIONS}"
+        )
+    source = _required_text(source, "source")
+    symbol = _required_text(symbol, "symbol").upper()
+    materialized = tuple(observed_dates)
+    if not materialized or any(type(value) is not date for value in materialized):
+        raise ValidationError("observed_dates must contain calendar dates")
+    unique = tuple(sorted(set(materialized)))
+
+    expected, local = expected_latest_session(calendar, as_of=as_of)
+    future = [value for value in unique if value > expected]
+    if future:
+        raise ValidationError(
+            "observed dates contain a session after the expected latest session"
+        )
+
+    latest = unique[-1]
+    non_sessions = tuple(
+        value for value in unique if not calendar.is_session(value)
+    )
+    observed_sessions = {value for value in unique if calendar.is_session(value)}
+    sessions = _session_dates(calendar, unique[0], expected)
+    missing = tuple(value for value in sessions if value not in observed_sessions)
+    if len(missing) > max_missing_sessions:
+        raise ValidationError(
+            "market freshness missing-session evidence exceeds the request bound"
+        )
+    stale_sessions = sum(1 for value in sessions if value > latest)
+    status = "current" if latest == expected else "stale"
+
+    return MarketFreshnessEvaluation(
+        calendar_id=calendar.calendar_id,
+        source=source,
+        symbol=symbol,
+        as_of_utc=as_of.astimezone(timezone.utc),
+        as_of_local=local,
+        expected_latest_session=expected,
+        latest_observation_date=latest,
+        status=status,
+        stale_session_count=stale_sessions,
+        missing_session_dates=missing,
+        observed_session_count=len(observed_sessions),
+        observed_non_session_dates=non_sessions,
+    )

--- a/tests/unit/test_market_calendar_freshness.py
+++ b/tests/unit/test_market_calendar_freshness.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+from datetime import date, datetime, timezone
+
+import pytest
+
+from src.analytics.market_calendar_freshness import (
+    MarketCalendar,
+    evaluate_market_freshness,
+    expected_latest_session,
+    parse_market_calendar,
+)
+from src.common.exceptions import ValidationError
+
+
+def _calendar() -> MarketCalendar:
+    return parse_market_calendar(
+        {
+            "calendars": {
+                "TEST": {
+                    "timezone": "America/New_York",
+                    "close_time": "16:00",
+                    "grace_minutes": 30,
+                    "weekend_days": [5, 6],
+                    "holidays": ["2026-01-01"],
+                }
+            }
+        },
+        "TEST",
+    )
+
+
+def test_classifies_sessions_weekends_and_holidays() -> None:
+    calendar = _calendar()
+
+    assert calendar.classify(date(2026, 1, 1)) == "holiday"
+    assert calendar.classify(date(2026, 1, 3)) == "weekend"
+    assert calendar.classify(date(2026, 1, 2)) == "trading_session"
+
+
+def test_expected_session_waits_for_close_and_grace() -> None:
+    calendar = _calendar()
+
+    before_close, local_before = expected_latest_session(
+        calendar,
+        as_of=datetime(2026, 1, 5, 20, 0, tzinfo=timezone.utc),
+    )
+    after_grace, local_after = expected_latest_session(
+        calendar,
+        as_of=datetime(2026, 1, 5, 21, 31, tzinfo=timezone.utc),
+    )
+
+    assert before_close == date(2026, 1, 2)
+    assert local_before.hour == 15
+    assert after_grace == date(2026, 1, 5)
+    assert local_after.hour == 16
+
+
+def test_weekend_and_holiday_resolve_to_previous_session() -> None:
+    calendar = _calendar()
+
+    weekend, _ = expected_latest_session(
+        calendar,
+        as_of=datetime(2026, 1, 4, 18, tzinfo=timezone.utc),
+    )
+    holiday, _ = expected_latest_session(
+        calendar,
+        as_of=datetime(2026, 1, 1, 18, tzinfo=timezone.utc),
+    )
+
+    assert weekend == date(2026, 1, 2)
+    assert holiday == date(2025, 12, 31)
+
+
+def test_evaluation_distinguishes_stale_and_missing_sessions() -> None:
+    output = evaluate_market_freshness(
+        [date(2026, 1, 2), date(2026, 1, 5), date(2026, 1, 7)],
+        source="alpha_vantage",
+        symbol="aapl",
+        calendar=_calendar(),
+        as_of=datetime(2026, 1, 8, 22, tzinfo=timezone.utc),
+    )
+
+    assert output.status == "stale"
+    assert output.expected_latest_session == date(2026, 1, 8)
+    assert output.latest_observation_date == date(2026, 1, 7)
+    assert output.stale_session_count == 1
+    assert output.missing_session_dates == (
+        date(2026, 1, 6),
+        date(2026, 1, 8),
+    )
+    assert output.symbol == "AAPL"
+
+
+def test_current_evaluation_does_not_treat_weekend_as_missing() -> None:
+    output = evaluate_market_freshness(
+        [date(2026, 1, 2), date(2026, 1, 5)],
+        source="alpha_vantage",
+        symbol="IBM",
+        calendar=_calendar(),
+        as_of=datetime(2026, 1, 5, 22, tzinfo=timezone.utc),
+    )
+
+    assert output.status == "current"
+    assert output.stale_session_count == 0
+    assert output.missing_session_dates == ()
+
+
+def test_non_session_observations_remain_explicit_evidence() -> None:
+    output = evaluate_market_freshness(
+        [date(2026, 1, 2), date(2026, 1, 3), date(2026, 1, 5)],
+        source="alpha_vantage",
+        symbol="IBM",
+        calendar=_calendar(),
+        as_of=datetime(2026, 1, 5, 22, tzinfo=timezone.utc),
+    )
+
+    assert output.observed_non_session_dates == (date(2026, 1, 3),)
+
+
+def test_invalid_calendars_and_future_observations_fail_closed() -> None:
+    with pytest.raises(ValidationError, match="unknown timezone"):
+        parse_market_calendar(
+            {
+                "calendars": {
+                    "BAD": {
+                        "timezone": "Not/AZone",
+                        "close_time": "16:00",
+                    }
+                }
+            },
+            "BAD",
+        )
+
+    with pytest.raises(ValidationError, match="after the expected"):
+        evaluate_market_freshness(
+            [date(2026, 1, 6)],
+            source="alpha_vantage",
+            symbol="IBM",
+            calendar=_calendar(),
+            as_of=datetime(2026, 1, 5, 22, tzinfo=timezone.utc),
+        )
+
+
+def test_missing_evidence_limit_fails_before_returning_partial_output() -> None:
+    with pytest.raises(ValidationError, match="exceeds the request bound"):
+        evaluate_market_freshness(
+            [date(2026, 1, 2)],
+            source="alpha_vantage",
+            symbol="IBM",
+            calendar=_calendar(),
+            as_of=datetime(2026, 1, 8, 22, tzinfo=timezone.utc),
+            max_missing_sessions=1,
+        )


### PR DESCRIPTION
## Superseded

Closed without merge because merged PR #77 already provides the repository's exchange-calendar-aware market freshness contract, including reviewed XNYS session semantics, deterministic Parquet evidence, PostgreSQL current/exception views, reconciliation, bounded local input and a provider-free operator path.

Retaining this alternative implementation would create two competing freshness grains and operator commands over different source datasets. Any further freshness work should extend the contract already on `main` rather than merge this parallel draft.