### PR TITLE
Add explicit risk-limit webhook delivery

### DIFF
--- a/docs/risk-limit-webhook-delivery.md
+++ b/docs/risk-limit-webhook-delivery.md
@@ -1,0 +1,100 @@
+# Explicit Risk-Limit Webhook Delivery
+
+## Outcome
+
+Current pending risk-limit notification intent can be delivered through one explicitly configured webhook adapter:
+
+```text
+PostgreSQL pending notification view
+  -> disabled adapter configuration
+  -> explicit runtime enable flag
+  -> endpoint and authorization from environment
+  -> stable Idempotency-Key
+  -> bounded retry and backoff
+  -> sanitized append-only local attempt records
+```
+
+The transport is `src/delivery/risk_limit_webhook.py`. The operator runner is `src/orchestration/run_risk_limit_webhook_delivery.py`.
+
+## Two enable gates
+
+The bundled configuration contains:
+
+```yaml
+enabled: false
+```
+
+The runner also requires:
+
+```text
+--enable-external-delivery
+```
+
+Both gates must be enabled. A runtime flag cannot override a disabled configuration. Normal CI, readiness checks, and local development therefore make no external request.
+
+## Secret-safe configuration
+
+The configuration stores environment-variable names, never endpoint or authorization values:
+
+```text
+RISK_LIMIT_WEBHOOK_URL
+RISK_LIMIT_WEBHOOK_AUTHORIZATION
+```
+
+The run summary records only those variable names. Endpoint and authorization values are not written to summaries or attempt files. There is no default endpoint or recipient.
+
+## Explicit invocation
+
+After reviewing and enabling `config/notification_delivery.yaml`:
+
+```bash
+export RISK_LIMIT_WEBHOOK_URL='https://receiver.example/risk-limit'
+export RISK_LIMIT_WEBHOOK_AUTHORIZATION='Bearer resolved-at-runtime'
+
+.venv/bin/python -m src.orchestration.run_risk_limit_webhook_delivery \
+  --adapter-id risk-limit-webhook \
+  --enable-external-delivery \
+  --summary-json .demo/risk-limit-webhook-delivery.json
+```
+
+The runner reads only:
+
+```text
+risk_platform.pending_portfolio_risk_limit_notifications
+```
+
+Historical or corrected stale breaches excluded by the current pending view are not delivered.
+
+## Idempotency and retries
+
+Every request uses the notification deduplication identity as the HTTP `Idempotency-Key`. The receiver should honour that key so a network timeout after server-side acceptance cannot create a duplicate external message.
+
+Attempt identity binds:
+
+```text
+adapter ID
+notification ID
+attempt number
+```
+
+Attempt files contain only:
+
+```text
+attempt identity and number
+notification and deduplication identity
+attempted-at timestamp
+HTTP status or sanitized error class
+result status
+```
+
+They do not contain the endpoint, authorization value, request payload, or response body.
+
+Retryable responses are HTTP 408, 425, 429, and 5xx plus transport timeouts/errors. Other 4xx responses are permanent failures. Backoff is exponential and bounded by configuration. A delivered or permanently failed notification is not sent again on an identical rerun.
+
+## Bounds
+
+Configuration caps attempts at ten and one invocation at 1,000 notifications, with a lower default of 100. Attempt history is capped at 100,000 files. Delivery is one-shot; no background worker or resident retry process is started.
+
+## Boundary
+
+This adapter does not discover recipients, manage credentials, acknowledge or resolve a breach, mutate notification rows, guarantee receiver behaviour, schedule itself, deploy infrastructure, or run `terraform apply`. Production use requires review of the receiver's authentication, idempotency, retention, availability, and incident procedures.

--- a/src/delivery/__init__.py
+++ b/src/delivery/__init__.py
@@ -1,0 +1,1 @@
+"""Explicit, disabled-by-default external delivery adapters."""

--- a/src/delivery/risk_limit_webhook.py
+++ b/src/delivery/risk_limit_webhook.py
@@ -1,0 +1,431 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import time as time_module
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+from urllib.error import HTTPError
+from urllib.request import Request, urlopen
+
+from ..common.config import load_yaml
+from ..common.exceptions import StorageError, ValidationError
+
+MAX_ATTEMPT_FILES = 100_000
+MAX_NOTIFICATIONS_PER_RUN = 1_000
+
+
+@dataclass(frozen=True, slots=True)
+class WebhookDeliveryConfig:
+    adapter_id: str
+    enabled: bool
+    endpoint_env: str
+    authorization_env: str | None
+    timeout_seconds: int
+    max_attempts: int
+    initial_backoff_seconds: int
+    max_backoff_seconds: int
+    max_notifications_per_run: int
+
+
+@dataclass(frozen=True, slots=True)
+class WebhookResponse:
+    status_code: int
+
+
+Transport = Callable[..., WebhookResponse]
+Sleeper = Callable[[float], None]
+Clock = Callable[[], datetime]
+
+
+def _required_text(value: Any, label: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ValidationError(f"{label} must be non-empty text")
+    return value.strip()
+
+
+def _bounded_integer(
+    value: Any,
+    label: str,
+    *,
+    minimum: int = 1,
+    maximum: int,
+) -> int:
+    if type(value) is not int or not minimum <= value <= maximum:
+        raise ValidationError(
+            f"{label} must be an integer between {minimum} and {maximum}"
+        )
+    return value
+
+
+def parse_webhook_delivery_config(
+    payload: Mapping[str, Any],
+    adapter_id: str,
+) -> WebhookDeliveryConfig:
+    adapters = payload.get("adapters")
+    if not isinstance(adapters, Mapping):
+        raise ValidationError("delivery configuration must define adapters")
+    candidate = adapters.get(adapter_id)
+    if not isinstance(candidate, Mapping):
+        raise ValidationError(f"delivery adapter '{adapter_id}' is not configured")
+    enabled = candidate.get("enabled")
+    if type(enabled) is not bool:
+        raise ValidationError("delivery adapter enabled must be true or false")
+    if candidate.get("adapter_type") != "webhook":
+        raise ValidationError("only the webhook adapter type is supported")
+
+    authorization_raw = candidate.get("authorization_env")
+    authorization_env = (
+        None
+        if authorization_raw in {None, ""}
+        else _required_text(authorization_raw, "authorization_env")
+    )
+    return WebhookDeliveryConfig(
+        adapter_id=_required_text(adapter_id, "adapter_id"),
+        enabled=enabled,
+        endpoint_env=_required_text(candidate.get("endpoint_env"), "endpoint_env"),
+        authorization_env=authorization_env,
+        timeout_seconds=_bounded_integer(
+            candidate.get("timeout_seconds"),
+            "timeout_seconds",
+            maximum=120,
+        ),
+        max_attempts=_bounded_integer(
+            candidate.get("max_attempts"),
+            "max_attempts",
+            maximum=10,
+        ),
+        initial_backoff_seconds=_bounded_integer(
+            candidate.get("initial_backoff_seconds"),
+            "initial_backoff_seconds",
+            minimum=0,
+            maximum=300,
+        ),
+        max_backoff_seconds=_bounded_integer(
+            candidate.get("max_backoff_seconds"),
+            "max_backoff_seconds",
+            minimum=0,
+            maximum=3600,
+        ),
+        max_notifications_per_run=_bounded_integer(
+            candidate.get("max_notifications_per_run"),
+            "max_notifications_per_run",
+            maximum=MAX_NOTIFICATIONS_PER_RUN,
+        ),
+    )
+
+
+def load_webhook_delivery_config(
+    path: Path,
+    adapter_id: str,
+) -> WebhookDeliveryConfig:
+    try:
+        payload = load_yaml(path)
+    except Exception:
+        raise ValidationError("delivery configuration could not be loaded") from None
+    if not isinstance(payload, Mapping):
+        raise ValidationError("delivery configuration must be a mapping")
+    return parse_webhook_delivery_config(payload, adapter_id)
+
+
+def default_webhook_transport(
+    *,
+    endpoint: str,
+    headers: Mapping[str, str],
+    body: bytes,
+    timeout_seconds: int,
+) -> WebhookResponse:
+    request = Request(
+        endpoint,
+        data=body,
+        headers=dict(headers),
+        method="POST",
+    )
+    try:
+        with urlopen(request, timeout=timeout_seconds) as response:  # noqa: S310
+            return WebhookResponse(status_code=int(response.status))
+    except HTTPError as exc:
+        return WebhookResponse(status_code=int(exc.code))
+
+
+def _status_for_http(status_code: int) -> str:
+    if 200 <= status_code <= 299:
+        return "delivered"
+    if status_code in {408, 425, 429} or 500 <= status_code <= 599:
+        return "retryable_failure"
+    return "permanent_failure"
+
+
+def _aware_now(clock: Clock) -> datetime:
+    value = clock()
+    if value.tzinfo is None or value.utcoffset() is None:
+        raise StorageError("delivery attempt clock must be timezone-aware")
+    return value.astimezone(timezone.utc)
+
+
+def _required_notification_text(
+    notification: Mapping[str, Any],
+    field: str,
+) -> str:
+    value = notification.get(field)
+    if not isinstance(value, str) or not value.strip():
+        raise ValidationError(f"notification {field} must be non-empty text")
+    return value.strip()
+
+
+def _payload(notification: Mapping[str, Any]) -> Mapping[str, Any]:
+    value = notification.get("payload_json")
+    if isinstance(value, str):
+        try:
+            value = json.loads(value)
+        except ValueError:
+            raise ValidationError("notification payload_json is invalid") from None
+    if value is None:
+        return {
+            key: item
+            for key, item in notification.items()
+            if key not in {"authorization", "endpoint", "secret"}
+        }
+    if not isinstance(value, Mapping):
+        raise ValidationError("notification payload_json must be an object")
+    return value
+
+
+def _stable_path_segment(value: str) -> str:
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()[:32]
+
+
+def _attempt_id(
+    *,
+    adapter_id: str,
+    notification_id: str,
+    attempt_number: int,
+) -> str:
+    payload = {
+        "adapter_id": adapter_id,
+        "attempt_number": attempt_number,
+        "notification_id": notification_id,
+    }
+    digest = hashlib.sha256(
+        json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    ).hexdigest()[:24]
+    return f"risk-limit-delivery-attempt-{digest}"
+
+
+def _attempt_directory(
+    attempts_dir: Path,
+    *,
+    adapter_id: str,
+    notification_id: str,
+) -> Path:
+    if attempts_dir.is_symlink():
+        raise StorageError("delivery attempt directory must not be a symbolic link")
+    return (
+        attempts_dir
+        / _stable_path_segment(adapter_id)
+        / _stable_path_segment(notification_id)
+    )
+
+
+def _read_attempts(path: Path) -> list[dict[str, Any]]:
+    if not path.exists():
+        return []
+    if path.is_symlink() or not path.is_dir():
+        raise StorageError("delivery attempt path must be a regular directory")
+    try:
+        files = sorted(path.glob("attempt-*.json"))
+    except OSError:
+        raise StorageError("delivery attempts could not be inventoried") from None
+    if len(files) > MAX_ATTEMPT_FILES:
+        raise StorageError("delivery attempt history exceeds the file bound")
+    attempts: list[dict[str, Any]] = []
+    for file_path in files:
+        if file_path.is_symlink() or not file_path.is_file():
+            raise StorageError("delivery attempt history contains an unsafe file")
+        try:
+            value = json.loads(file_path.read_text(encoding="utf-8"))
+        except (OSError, ValueError):
+            raise StorageError("delivery attempt history is invalid") from None
+        if not isinstance(value, dict):
+            raise StorageError("delivery attempt history is invalid")
+        attempts.append(value)
+    attempts.sort(key=lambda item: int(item.get("attempt_number", -1)))
+    return attempts
+
+
+def _write_attempt(path: Path, attempt: Mapping[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if path.parent.is_symlink():
+        raise StorageError("delivery attempt path must not be a symbolic link")
+    temporary = path.with_suffix(path.suffix + ".tmp")
+    try:
+        temporary.write_text(
+            json.dumps(attempt, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        temporary.replace(path)
+    except OSError:
+        temporary.unlink(missing_ok=True)
+        raise StorageError("delivery attempt could not be persisted") from None
+
+
+def _backoff_seconds(config: WebhookDeliveryConfig, attempt_number: int) -> int:
+    return min(
+        config.max_backoff_seconds,
+        config.initial_backoff_seconds * (2 ** max(0, attempt_number - 1)),
+    )
+
+
+def deliver_risk_limit_notifications(
+    notifications: Sequence[Mapping[str, Any]],
+    *,
+    config: WebhookDeliveryConfig,
+    attempts_dir: Path,
+    endpoint: str,
+    authorization: str | None,
+    transport: Transport | None = None,
+    sleeper: Sleeper = time_module.sleep,
+    clock: Clock = lambda: datetime.now(timezone.utc),
+) -> dict[str, Any]:
+    if not config.enabled:
+        raise ValidationError("delivery adapter is disabled")
+    endpoint = _required_text(endpoint, "webhook endpoint")
+    if not endpoint.startswith(("https://", "http://")):
+        raise ValidationError("webhook endpoint must use HTTP or HTTPS")
+    if len(notifications) > config.max_notifications_per_run:
+        raise ValidationError("notification selection exceeds the configured bound")
+    if len(notifications) > MAX_NOTIFICATIONS_PER_RUN:
+        raise ValidationError("notification selection exceeds the hard bound")
+
+    selected_transport = transport or default_webhook_transport
+    counts = {
+        "delivered": 0,
+        "permanent_failure": 0,
+        "retryable_failure": 0,
+        "skipped_terminal": 0,
+        "attempts_written": 0,
+    }
+    notification_results: list[dict[str, Any]] = []
+
+    for notification in notifications:
+        notification_id = _required_notification_text(
+            notification,
+            "notification_id",
+        )
+        deduplication_id = notification.get("deduplication_id", notification_id)
+        if not isinstance(deduplication_id, str) or not deduplication_id.strip():
+            raise ValidationError(
+                "notification deduplication_id must be non-empty text"
+            )
+        history_path = _attempt_directory(
+            attempts_dir,
+            adapter_id=config.adapter_id,
+            notification_id=notification_id,
+        )
+        history = _read_attempts(history_path)
+        terminal = next(
+            (
+                item
+                for item in reversed(history)
+                if item.get("status") in {"delivered", "permanent_failure"}
+            ),
+            None,
+        )
+        if terminal is not None:
+            counts["skipped_terminal"] += 1
+            notification_results.append(
+                {
+                    "notification_id": notification_id,
+                    "status": "skipped_terminal",
+                    "terminal_attempt_id": terminal.get("attempt_id"),
+                }
+            )
+            continue
+
+        starting_attempt = len(history) + 1
+        final_status = "retryable_failure"
+        final_attempt_id: str | None = None
+        for attempt_number in range(starting_attempt, config.max_attempts + 1):
+            attempted_at = _aware_now(clock)
+            headers = {
+                "Content-Type": "application/json",
+                "Idempotency-Key": deduplication_id.strip(),
+                "User-Agent": "financial-risk-data-platform/1",
+            }
+            if authorization is not None:
+                headers["Authorization"] = authorization
+            body = json.dumps(
+                {
+                    "notification_id": notification_id,
+                    "payload": _payload(notification),
+                },
+                sort_keys=True,
+                separators=(",", ":"),
+                default=str,
+            ).encode("utf-8")
+
+            http_status: int | None = None
+            error_class: str | None = None
+            try:
+                response = selected_transport(
+                    endpoint=endpoint,
+                    headers=headers,
+                    body=body,
+                    timeout_seconds=config.timeout_seconds,
+                )
+                http_status = int(response.status_code)
+                final_status = _status_for_http(http_status)
+            except (OSError, TimeoutError):
+                final_status = "retryable_failure"
+                error_class = "transport_error"
+            except Exception:
+                final_status = "permanent_failure"
+                error_class = "unexpected_transport_error"
+
+            attempt_id = _attempt_id(
+                adapter_id=config.adapter_id,
+                notification_id=notification_id,
+                attempt_number=attempt_number,
+            )
+            final_attempt_id = attempt_id
+            attempt = {
+                "adapter_id": config.adapter_id,
+                "attempt_id": attempt_id,
+                "attempt_number": attempt_number,
+                "attempted_at": attempted_at.isoformat(),
+                "deduplication_id": deduplication_id.strip(),
+                "error_class": error_class,
+                "http_status": http_status,
+                "notification_id": notification_id,
+                "status": final_status,
+            }
+            _write_attempt(
+                history_path / f"attempt-{attempt_number:02d}.json",
+                attempt,
+            )
+            counts["attempts_written"] += 1
+
+            if final_status in {"delivered", "permanent_failure"}:
+                break
+            if attempt_number < config.max_attempts:
+                sleeper(float(_backoff_seconds(config, attempt_number)))
+
+        counts[final_status] += 1
+        notification_results.append(
+            {
+                "final_attempt_id": final_attempt_id,
+                "notification_id": notification_id,
+                "status": final_status,
+            }
+        )
+
+    return {
+        "adapter_id": config.adapter_id,
+        "counts": counts,
+        "delivery_performed": True,
+        "notifications_selected": len(notifications),
+        "results": notification_results,
+    }

--- a/src/orchestration/run_risk_limit_webhook_delivery.py
+++ b/src/orchestration/run_risk_limit_webhook_delivery.py
@@ -1,0 +1,266 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from collections.abc import Callable, Mapping, Sequence
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+from uuid import uuid4
+
+from ..common.exceptions import StorageError, ValidationError
+from ..delivery.risk_limit_webhook import (
+    WebhookDeliveryConfig,
+    deliver_risk_limit_notifications,
+    load_webhook_delivery_config,
+)
+
+DEFAULT_POSTGRES_DSN = (
+    "postgresql://risk_user:risk_password@localhost:5433/risk_platform"
+)
+
+NotificationReader = Callable[..., list[dict[str, Any]]]
+ConfigLoader = Callable[[Path, str], WebhookDeliveryConfig]
+
+
+def collect_pending_notifications(
+    *,
+    dsn: str,
+    limit: int,
+) -> list[dict[str, Any]]:
+    if type(limit) is not int or limit <= 0:
+        raise ValidationError("notification limit must be a positive integer")
+    try:
+        import psycopg
+    except ImportError as exc:
+        raise RuntimeError(
+            "PostgreSQL notification delivery requires psycopg. Run `make setup`."
+        ) from exc
+
+    query = """
+        SELECT to_jsonb(pending) AS notification
+        FROM risk_platform.pending_portfolio_risk_limit_notifications pending
+        ORDER BY notification_id
+        LIMIT %s
+    """
+    try:
+        with psycopg.connect(dsn) as connection:
+            with connection.cursor() as cursor:
+                cursor.execute(query, (limit,))
+                rows = cursor.fetchall()
+    except Exception:
+        raise StorageError(
+            "Unable to read pending risk-limit notifications from PostgreSQL"
+        ) from None
+
+    notifications: list[dict[str, Any]] = []
+    for row in rows:
+        value = row[0]
+        if isinstance(value, str):
+            try:
+                value = json.loads(value)
+            except ValueError:
+                raise StorageError(
+                    "Pending notification payload from PostgreSQL is invalid"
+                ) from None
+        if not isinstance(value, Mapping):
+            raise StorageError(
+                "Pending notification payload from PostgreSQL is invalid"
+            )
+        notifications.append(dict(value))
+    return notifications
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Explicitly deliver current pending risk-limit notification intent "
+            "through a disabled-by-default webhook adapter."
+        )
+    )
+    parser.add_argument("--adapter-id", required=True)
+    parser.add_argument(
+        "--delivery-config",
+        type=Path,
+        default=Path("config/notification_delivery.yaml"),
+    )
+    parser.add_argument(
+        "--dsn",
+        default=os.environ.get(
+            "WAREHOUSE_POSTGRES_DSN",
+            DEFAULT_POSTGRES_DSN,
+        ),
+    )
+    parser.add_argument(
+        "--attempts-dir",
+        type=Path,
+        default=Path(".delivery/attempts"),
+    )
+    parser.add_argument("--enable-external-delivery", action="store_true")
+    parser.add_argument("--summary-json", type=Path)
+    return parser
+
+
+def _environment_value(
+    environment: Mapping[str, str],
+    name: str,
+    *,
+    required: bool,
+) -> str | None:
+    value = environment.get(name)
+    if value is None or not value.strip():
+        if required:
+            raise ValidationError(
+                f"required delivery environment variable '{name}' is not set"
+            )
+        return None
+    return value.strip()
+
+
+def run_risk_limit_webhook_delivery(
+    *,
+    adapter_id: str,
+    delivery_config_path: Path,
+    dsn: str,
+    attempts_dir: Path,
+    enable_external_delivery: bool = False,
+    environment: Mapping[str, str] | None = None,
+    config_loader: ConfigLoader | None = None,
+    notification_reader: NotificationReader | None = None,
+    deliverer: Callable[..., dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    selected_config_loader = config_loader or load_webhook_delivery_config
+    try:
+        config = selected_config_loader(delivery_config_path, adapter_id)
+    except ValidationError:
+        raise
+    except Exception:
+        raise ValidationError("delivery configuration is invalid") from None
+
+    base = {
+        "run_id": str(uuid4()),
+        "adapter_id": config.adapter_id,
+        "adapter_enabled": config.enabled,
+        "explicit_enable_flag": enable_external_delivery,
+        "endpoint_environment_variable": config.endpoint_env,
+        "authorization_environment_variable": config.authorization_env,
+        "secrets_recorded": False,
+    }
+    if not enable_external_delivery:
+        return {
+            **base,
+            "delivery": {
+                "performed": False,
+                "reason": "explicit_enable_flag_required",
+            },
+        }
+    if not config.enabled:
+        return {
+            **base,
+            "delivery": {
+                "performed": False,
+                "reason": "adapter_disabled_in_configuration",
+            },
+        }
+
+    selected_environment = environment if environment is not None else os.environ
+    endpoint = _environment_value(
+        selected_environment,
+        config.endpoint_env,
+        required=True,
+    )
+    authorization = (
+        _environment_value(
+            selected_environment,
+            config.authorization_env,
+            required=True,
+        )
+        if config.authorization_env is not None
+        else None
+    )
+    if endpoint is None:
+        raise ValidationError("webhook endpoint is missing")
+
+    selected_reader = notification_reader or collect_pending_notifications
+    notifications = selected_reader(
+        dsn=dsn,
+        limit=config.max_notifications_per_run,
+    )
+    if not notifications:
+        return {
+            **base,
+            "delivery": {
+                "performed": False,
+                "reason": "nothing_pending",
+                "notifications_selected": 0,
+            },
+        }
+
+    selected_deliverer = deliverer or deliver_risk_limit_notifications
+    result = selected_deliverer(
+        notifications,
+        config=config,
+        attempts_dir=attempts_dir,
+        endpoint=endpoint,
+        authorization=authorization,
+    )
+    if not isinstance(result, dict):
+        raise StorageError("webhook deliverer returned invalid evidence")
+    return {
+        **base,
+        "delivery": result,
+    }
+
+
+def _write_summary(path: Path, summary: Mapping[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_suffix(path.suffix + ".tmp")
+    try:
+        temporary.write_text(
+            json.dumps(summary, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        temporary.replace(path)
+    except OSError:
+        temporary.unlink(missing_ok=True)
+        raise StorageError("Unable to write webhook delivery summary") from None
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    try:
+        summary = run_risk_limit_webhook_delivery(
+            adapter_id=args.adapter_id,
+            delivery_config_path=args.delivery_config,
+            dsn=args.dsn,
+            attempts_dir=args.attempts_dir,
+            enable_external_delivery=args.enable_external_delivery,
+        )
+        if args.summary_json is not None:
+            _write_summary(args.summary_json, summary)
+    except ValidationError:
+        print(
+            "Webhook delivery failed: explicit configuration, environment, or "
+            "notification input was invalid",
+            file=sys.stderr,
+        )
+        return 1
+    except StorageError:
+        print(
+            "Webhook delivery failed: pending-notification read or attempt "
+            "persistence failed",
+            file=sys.stderr,
+        )
+        return 1
+    except Exception:
+        print("Webhook delivery failed: unexpected local failure", file=sys.stderr)
+        return 1
+
+    print(json.dumps(summary, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/test_risk_limit_webhook.py
+++ b/tests/unit/test_risk_limit_webhook.py
@@ -1,0 +1,209 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from src.common.exceptions import ValidationError
+from src.delivery.risk_limit_webhook import (
+    WebhookDeliveryConfig,
+    WebhookResponse,
+    deliver_risk_limit_notifications,
+    parse_webhook_delivery_config,
+)
+
+
+def _config(**overrides: Any) -> WebhookDeliveryConfig:
+    values: dict[str, Any] = {
+        "adapter_id": "risk-webhook",
+        "enabled": True,
+        "endpoint_env": "ENDPOINT",
+        "authorization_env": "AUTH",
+        "timeout_seconds": 5,
+        "max_attempts": 3,
+        "initial_backoff_seconds": 2,
+        "max_backoff_seconds": 10,
+        "max_notifications_per_run": 10,
+    }
+    values.update(overrides)
+    return WebhookDeliveryConfig(**values)
+
+
+def _notification() -> dict[str, object]:
+    return {
+        "notification_id": "notification-1",
+        "deduplication_id": "dedupe-1",
+        "payload_json": {
+            "policy_id": "us-tech-standard",
+            "status": "critical",
+        },
+    }
+
+
+def test_config_is_disabled_by_default_and_secret_referenced() -> None:
+    parsed = parse_webhook_delivery_config(
+        {
+            "adapters": {
+                "risk-webhook": {
+                    "enabled": False,
+                    "adapter_type": "webhook",
+                    "endpoint_env": "ENDPOINT",
+                    "authorization_env": "AUTH",
+                    "timeout_seconds": 10,
+                    "max_attempts": 3,
+                    "initial_backoff_seconds": 2,
+                    "max_backoff_seconds": 30,
+                    "max_notifications_per_run": 100,
+                }
+            }
+        },
+        "risk-webhook",
+    )
+
+    assert parsed.enabled is False
+    assert parsed.endpoint_env == "ENDPOINT"
+    assert parsed.authorization_env == "AUTH"
+
+
+def test_success_writes_one_secret_free_attempt(tmp_path: Path) -> None:
+    calls: list[dict[str, Any]] = []
+
+    def transport(**kwargs: Any) -> WebhookResponse:
+        calls.append(kwargs)
+        return WebhookResponse(status_code=202)
+
+    result = deliver_risk_limit_notifications(
+        [_notification()],
+        config=_config(),
+        attempts_dir=tmp_path,
+        endpoint="https://example.invalid/risk",
+        authorization="Bearer top-secret",
+        transport=transport,
+        sleeper=lambda _: None,
+        clock=lambda: datetime(2026, 8, 22, 12, tzinfo=timezone.utc),
+    )
+
+    assert result["counts"]["delivered"] == 1
+    assert result["counts"]["attempts_written"] == 1
+    assert calls[0]["headers"]["Idempotency-Key"] == "dedupe-1"
+    assert calls[0]["headers"]["Authorization"] == "Bearer top-secret"
+    attempt_files = list(tmp_path.rglob("attempt-*.json"))
+    assert len(attempt_files) == 1
+    attempt_text = attempt_files[0].read_text(encoding="utf-8")
+    assert "top-secret" not in attempt_text
+    assert "example.invalid" not in attempt_text
+
+
+def test_retryable_failure_uses_same_idempotency_key_then_succeeds(
+    tmp_path: Path,
+) -> None:
+    statuses = iter([500, 429, 204])
+    keys: list[str] = []
+    sleeps: list[float] = []
+
+    def transport(**kwargs: Any) -> WebhookResponse:
+        keys.append(kwargs["headers"]["Idempotency-Key"])
+        return WebhookResponse(status_code=next(statuses))
+
+    result = deliver_risk_limit_notifications(
+        [_notification()],
+        config=_config(),
+        attempts_dir=tmp_path,
+        endpoint="https://example.invalid/risk",
+        authorization=None,
+        transport=transport,
+        sleeper=sleeps.append,
+        clock=lambda: datetime(2026, 8, 22, 12, tzinfo=timezone.utc),
+    )
+
+    assert result["counts"]["delivered"] == 1
+    assert result["counts"]["attempts_written"] == 3
+    assert keys == ["dedupe-1", "dedupe-1", "dedupe-1"]
+    assert sleeps == [2.0, 4.0]
+
+
+def test_permanent_failure_is_not_retried(tmp_path: Path) -> None:
+    calls = 0
+
+    def transport(**_kwargs: Any) -> WebhookResponse:
+        nonlocal calls
+        calls += 1
+        return WebhookResponse(status_code=400)
+
+    result = deliver_risk_limit_notifications(
+        [_notification()],
+        config=_config(),
+        attempts_dir=tmp_path,
+        endpoint="https://example.invalid/risk",
+        authorization=None,
+        transport=transport,
+        sleeper=lambda _: pytest.fail("permanent failure must not sleep"),
+        clock=lambda: datetime(2026, 8, 22, 12, tzinfo=timezone.utc),
+    )
+
+    assert calls == 1
+    assert result["counts"]["permanent_failure"] == 1
+
+
+def test_identical_rerun_skips_existing_terminal_attempt(tmp_path: Path) -> None:
+    kwargs = {
+        "config": _config(),
+        "attempts_dir": tmp_path,
+        "endpoint": "https://example.invalid/risk",
+        "authorization": None,
+        "transport": lambda **_: WebhookResponse(status_code=200),
+        "sleeper": lambda _: None,
+        "clock": lambda: datetime(2026, 8, 22, 12, tzinfo=timezone.utc),
+    }
+    first = deliver_risk_limit_notifications([_notification()], **kwargs)
+    second = deliver_risk_limit_notifications([_notification()], **kwargs)
+
+    assert first["counts"]["delivered"] == 1
+    assert second["counts"]["skipped_terminal"] == 1
+    assert second["counts"]["attempts_written"] == 0
+    assert len(list(tmp_path.rglob("attempt-*.json"))) == 1
+
+
+def test_disabled_adapter_and_oversized_selection_fail_closed(
+    tmp_path: Path,
+) -> None:
+    with pytest.raises(ValidationError, match="disabled"):
+        deliver_risk_limit_notifications(
+            [_notification()],
+            config=_config(enabled=False),
+            attempts_dir=tmp_path,
+            endpoint="https://example.invalid/risk",
+            authorization=None,
+        )
+
+    with pytest.raises(ValidationError, match="configured bound"):
+        deliver_risk_limit_notifications(
+            [_notification(), {**_notification(), "notification_id": "n-2"}],
+            config=_config(max_notifications_per_run=1),
+            attempts_dir=tmp_path,
+            endpoint="https://example.invalid/risk",
+            authorization=None,
+        )
+
+
+def test_attempt_json_is_valid_and_contains_no_payload(tmp_path: Path) -> None:
+    deliver_risk_limit_notifications(
+        [_notification()],
+        config=_config(),
+        attempts_dir=tmp_path,
+        endpoint="https://example.invalid/risk",
+        authorization=None,
+        transport=lambda **_: WebhookResponse(status_code=200),
+        sleeper=lambda _: None,
+        clock=lambda: datetime(2026, 8, 22, 12, tzinfo=timezone.utc),
+    )
+    attempt = json.loads(
+        next(tmp_path.rglob("attempt-*.json")).read_text(encoding="utf-8")
+    )
+
+    assert attempt["notification_id"] == "notification-1"
+    assert attempt["status"] == "delivered"
+    assert "payload" not in attempt

--- a/tests/unit/test_run_risk_limit_webhook_delivery.py
+++ b/tests/unit/test_run_risk_limit_webhook_delivery.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from src.common.exceptions import ValidationError
+from src.delivery.risk_limit_webhook import WebhookDeliveryConfig
+from src.orchestration.run_risk_limit_webhook_delivery import (
+    run_risk_limit_webhook_delivery,
+)
+
+
+def _config(*, enabled: bool) -> WebhookDeliveryConfig:
+    return WebhookDeliveryConfig(
+        adapter_id="risk-webhook",
+        enabled=enabled,
+        endpoint_env="ENDPOINT",
+        authorization_env="AUTH",
+        timeout_seconds=5,
+        max_attempts=3,
+        initial_backoff_seconds=1,
+        max_backoff_seconds=4,
+        max_notifications_per_run=10,
+    )
+
+
+def test_missing_explicit_flag_returns_without_reading_notifications() -> None:
+    def fail(**_kwargs: Any) -> list[dict[str, Any]]:
+        raise AssertionError("notification reader must not be called")
+
+    summary = run_risk_limit_webhook_delivery(
+        adapter_id="risk-webhook",
+        delivery_config_path=Path("delivery.yaml"),
+        dsn="unused",
+        attempts_dir=Path("attempts"),
+        config_loader=lambda *_: _config(enabled=True),
+        notification_reader=fail,
+    )
+
+    assert summary["delivery"] == {
+        "performed": False,
+        "reason": "explicit_enable_flag_required",
+    }
+    assert summary["secrets_recorded"] is False
+
+
+def test_disabled_configuration_cannot_be_overridden_by_flag() -> None:
+    summary = run_risk_limit_webhook_delivery(
+        adapter_id="risk-webhook",
+        delivery_config_path=Path("delivery.yaml"),
+        dsn="unused",
+        attempts_dir=Path("attempts"),
+        enable_external_delivery=True,
+        config_loader=lambda *_: _config(enabled=False),
+    )
+
+    assert summary["delivery"]["reason"] == (
+        "adapter_disabled_in_configuration"
+    )
+
+
+def test_enabled_run_resolves_secret_environment_without_recording_values() -> None:
+    calls: list[dict[str, Any]] = []
+
+    def deliverer(notifications: Any, **kwargs: Any) -> dict[str, Any]:
+        calls.append({"notifications": notifications, **kwargs})
+        return {
+            "delivery_performed": True,
+            "notifications_selected": 1,
+        }
+
+    summary = run_risk_limit_webhook_delivery(
+        adapter_id="risk-webhook",
+        delivery_config_path=Path("delivery.yaml"),
+        dsn="postgresql://example",
+        attempts_dir=Path("attempts"),
+        enable_external_delivery=True,
+        environment={
+            "ENDPOINT": "https://example.invalid/hook",
+            "AUTH": "Bearer secret-value",
+        },
+        config_loader=lambda *_: _config(enabled=True),
+        notification_reader=lambda **kwargs: [
+            {"notification_id": "notification-1"}
+        ],
+        deliverer=deliverer,
+    )
+
+    assert calls[0]["endpoint"] == "https://example.invalid/hook"
+    assert calls[0]["authorization"] == "Bearer secret-value"
+    assert "secret-value" not in str(summary)
+    assert "example.invalid" not in str(summary)
+    assert summary["delivery"]["delivery_performed"] is True
+
+
+def test_missing_required_environment_fails_before_database_read() -> None:
+    reader_called = False
+
+    def reader(**_kwargs: Any) -> list[dict[str, Any]]:
+        nonlocal reader_called
+        reader_called = True
+        return []
+
+    with pytest.raises(ValidationError, match="ENDPOINT"):
+        run_risk_limit_webhook_delivery(
+            adapter_id="risk-webhook",
+            delivery_config_path=Path("delivery.yaml"),
+            dsn="unused",
+            attempts_dir=Path("attempts"),
+            enable_external_delivery=True,
+            environment={"AUTH": "Bearer secret"},
+            config_loader=lambda *_: _config(enabled=True),
+            notification_reader=reader,
+        )
+
+    assert reader_called is False
+
+
+def test_nothing_pending_performs_no_delivery() -> None:
+    summary = run_risk_limit_webhook_delivery(
+        adapter_id="risk-webhook",
+        delivery_config_path=Path("delivery.yaml"),
+        dsn="unused",
+        attempts_dir=Path("attempts"),
+        enable_external_delivery=True,
+        environment={
+            "ENDPOINT": "https://example.invalid/hook",
+            "AUTH": "Bearer secret",
+        },
+        config_loader=lambda *_: _config(enabled=True),
+        notification_reader=lambda **_: [],
+        deliverer=lambda *_args, **_kwargs: pytest.fail(
+            "deliverer must not be called"
+        ),
+    )
+
+    assert summary["delivery"] == {
+        "performed": False,
+        "reason": "nothing_pending",
+        "notifications_selected": 0,
+    }


### PR DESCRIPTION
## Superseded

Closed without merge because merged PR #79 already provides the repository's manually activated HTTPS notification delivery contract: current pending outbox selection, stable idempotency keys, bounded retry/backoff, sanitized append-only attempt evidence, succeeded/pending PostgreSQL views and secret-safe summaries.

Merging this parallel adapter would create a second terminal-state and attempt-evidence model. Further delivery work should extend the implementation already on `main`.