### PR TITLE
Add disabled immutable S3 storage adapter

### DIFF
--- a/boto3.pyi
+++ b/boto3.pyi
@@ -1,0 +1,4 @@
+from typing import Any
+
+
+def client(service_name: str, *, region_name: str) -> Any: ...

--- a/config/durable_storage.yaml
+++ b/config/durable_storage.yaml
@@ -1,0 +1,11 @@
+stores:
+  primary-s3:
+    enabled: false
+    adapter_type: s3
+    bucket_env: RISK_PLATFORM_DURABLE_BUCKET
+    region_env: AWS_REGION
+    prefix: financial-risk-data-platform
+    server_side_encryption: AES256
+    kms_key_env: null
+    max_object_bytes: 100000000
+    max_list_objects: 1000

--- a/docs/durable-s3-storage.md
+++ b/docs/durable-s3-storage.md
@@ -1,0 +1,96 @@
+# Disabled Immutable S3 Storage
+
+## Outcome
+
+One local artifact can be published to a content-addressed S3 key through an explicitly enabled adapter:
+
+```text
+regular local file
+  -> bounded read
+  -> SHA-256 content identity
+  -> deterministic immutable object key
+  -> conditional S3 PutObject
+  -> checksum and server-side encryption
+  -> written or verified-already-present evidence
+```
+
+The adapter is `src/storage/durable_s3.py`. The operator command is `src/orchestration/publish_durable_artifact.py`.
+
+## Disabled default
+
+`config/durable_storage.yaml` contains:
+
+```yaml
+enabled: false
+```
+
+Publication also requires:
+
+```text
+--enable-durable-write
+```
+
+Both gates must be enabled. Normal CI, readiness checks, and local development perform no S3 request.
+
+## Runtime configuration
+
+The repository stores environment-variable names rather than a bucket, KMS key, or credentials:
+
+```text
+RISK_PLATFORM_DURABLE_BUCKET
+AWS_REGION
+optional configured KMS key environment variable
+```
+
+The boto3 client uses the normal AWS credential chain of the enabled runtime. Static credentials are not accepted by the adapter and are not written to configuration or summaries.
+
+## Immutable identity
+
+Object keys use:
+
+```text
+<prefix>/<dataset>/sha256=<first-two-hex>/<full-sha256>.<extension>
+```
+
+The write sends:
+
+```text
+If-None-Match: *
+ChecksumSHA256
+sha256 metadata
+server-side encryption
+```
+
+A precondition failure is treated as replay only after `HeadObject` confirms both the stored SHA-256 metadata and content length. A key collision or mismatched existing object fails closed.
+
+The adapter exposes no overwrite or delete operation.
+
+## Explicit publication
+
+After reviewing and enabling the store:
+
+```bash
+export RISK_PLATFORM_DURABLE_BUCKET='reviewed-private-bucket'
+export AWS_REGION='eu-west-2'
+
+.venv/bin/python -m src.orchestration.publish_durable_artifact \
+  --store-id primary-s3 \
+  --dataset portfolio-risk-attribution \
+  --file data/curated/portfolio_risk_attribution/example.parquet \
+  --enable-durable-write \
+  --summary-json .demo/durable-publication.json
+```
+
+The enabled runtime must provide boto3. The import is deliberately lazy so disabled validation and normal CI do not require AWS SDK installation or credentials.
+
+## Inventory
+
+`inventory_immutable_objects` lists only the configured prefix and dataset. Pagination is bounded by `max_list_objects`, with a hard maximum of 10,000. Any returned key outside the requested prefix fails the inventory.
+
+## Bounds
+
+The bundled store caps one object at 100 MB and one inventory at 1,000 objects. Code-level hard limits are 5 GB and 10,000 objects. Local input must be a non-empty regular file, must not be a symbolic link, and must not change size while being read.
+
+## Boundary
+
+This increment does not create a bucket, KMS key, IAM role, lifecycle rule, replication policy, retention lock, inventory schedule, or credential. It does not migrate existing local datasets automatically, activate cloud storage by default, deploy infrastructure, or run `terraform apply`. Those require explicit infrastructure and operating decisions.

--- a/src/orchestration/publish_durable_artifact.py
+++ b/src/orchestration/publish_durable_artifact.py
@@ -1,0 +1,238 @@
+from __future__ import annotations
+
+import argparse
+import json
+import mimetypes
+import os
+import sys
+from collections.abc import Callable, Mapping, Sequence
+from pathlib import Path
+from typing import Any
+from uuid import uuid4
+
+from ..common.exceptions import StorageError, ValidationError
+from ..storage.durable_s3 import (
+    DurableS3Config,
+    create_boto3_s3_client,
+    load_durable_s3_config,
+    put_immutable_object,
+)
+
+ConfigLoader = Callable[[Path, str], DurableS3Config]
+ClientFactory = Callable[..., Any]
+Publisher = Callable[..., dict[str, Any]]
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Explicitly publish one local artifact to disabled-by-default, "
+            "content-addressed S3 storage."
+        )
+    )
+    parser.add_argument("--store-id", required=True)
+    parser.add_argument("--dataset", required=True)
+    parser.add_argument("--file", required=True, type=Path)
+    parser.add_argument("--content-type")
+    parser.add_argument(
+        "--durable-config",
+        type=Path,
+        default=Path("config/durable_storage.yaml"),
+    )
+    parser.add_argument("--enable-durable-write", action="store_true")
+    parser.add_argument("--summary-json", type=Path)
+    return parser
+
+
+def _environment_value(
+    environment: Mapping[str, str],
+    name: str,
+    *,
+    required: bool,
+) -> str | None:
+    value = environment.get(name)
+    if value is None or not value.strip():
+        if required:
+            raise ValidationError(
+                f"required durable-storage environment variable '{name}' is not set"
+            )
+        return None
+    return value.strip()
+
+
+def _read_artifact(path: Path, *, maximum: int) -> bytes:
+    if path.is_symlink() or not path.is_file():
+        raise StorageError("durable artifact must be a regular non-symbolic-link file")
+    try:
+        size = path.stat().st_size
+    except OSError:
+        raise StorageError("durable artifact could not be inventoried") from None
+    if size <= 0:
+        raise ValidationError("durable artifact must not be empty")
+    if size > maximum:
+        raise ValidationError("durable artifact exceeds max_object_bytes")
+    try:
+        payload = path.read_bytes()
+    except OSError:
+        raise StorageError("durable artifact could not be read") from None
+    if len(payload) != size:
+        raise StorageError("durable artifact changed while it was being read")
+    return payload
+
+
+def publish_durable_artifact(
+    *,
+    store_id: str,
+    dataset: str,
+    file_path: Path,
+    durable_config_path: Path,
+    enable_durable_write: bool = False,
+    content_type: str | None = None,
+    environment: Mapping[str, str] | None = None,
+    config_loader: ConfigLoader | None = None,
+    client_factory: ClientFactory | None = None,
+    publisher: Publisher | None = None,
+) -> dict[str, Any]:
+    selected_loader = config_loader or load_durable_s3_config
+    try:
+        config = selected_loader(durable_config_path, store_id)
+    except ValidationError:
+        raise
+    except Exception:
+        raise ValidationError("durable-storage configuration is invalid") from None
+
+    base = {
+        "run_id": str(uuid4()),
+        "store_id": config.store_id,
+        "store_enabled": config.enabled,
+        "explicit_enable_flag": enable_durable_write,
+        "bucket_environment_variable": config.bucket_env,
+        "region_environment_variable": config.region_env,
+        "kms_key_environment_variable": config.kms_key_env,
+        "credentials_recorded": False,
+    }
+    if not enable_durable_write:
+        return {
+            **base,
+            "publication": {
+                "performed": False,
+                "reason": "explicit_enable_flag_required",
+            },
+        }
+    if not config.enabled:
+        return {
+            **base,
+            "publication": {
+                "performed": False,
+                "reason": "store_disabled_in_configuration",
+            },
+        }
+
+    selected_environment = environment if environment is not None else os.environ
+    bucket = _environment_value(
+        selected_environment,
+        config.bucket_env,
+        required=True,
+    )
+    region = _environment_value(
+        selected_environment,
+        config.region_env,
+        required=True,
+    )
+    kms_key_id = (
+        _environment_value(
+            selected_environment,
+            config.kms_key_env,
+            required=True,
+        )
+        if config.kms_key_env is not None
+        else None
+    )
+    if bucket is None or region is None:
+        raise ValidationError("durable S3 bucket or region is missing")
+
+    payload = _read_artifact(file_path, maximum=config.max_object_bytes)
+    extension = file_path.suffix.lstrip(".") or "bin"
+    resolved_content_type = content_type or mimetypes.guess_type(file_path.name)[0]
+    if resolved_content_type is None:
+        resolved_content_type = "application/octet-stream"
+
+    selected_factory = client_factory or create_boto3_s3_client
+    client = selected_factory(region_name=region)
+    selected_publisher = publisher or put_immutable_object
+    result = selected_publisher(
+        client,
+        config=config,
+        bucket=bucket,
+        dataset=dataset,
+        payload=payload,
+        extension=extension,
+        content_type=resolved_content_type,
+        kms_key_id=kms_key_id,
+    )
+    if not isinstance(result, dict):
+        raise StorageError("durable S3 publisher returned invalid evidence")
+    safe_result = {
+        key: value
+        for key, value in result.items()
+        if key not in {"bucket", "credentials", "kms_key_id", "region"}
+    }
+    return {
+        **base,
+        "publication": {
+            "performed": True,
+            **safe_result,
+        },
+    }
+
+
+def _write_summary(path: Path, summary: Mapping[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_suffix(path.suffix + ".tmp")
+    try:
+        temporary.write_text(
+            json.dumps(summary, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        temporary.replace(path)
+    except OSError:
+        temporary.unlink(missing_ok=True)
+        raise StorageError("Unable to write durable publication summary") from None
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    try:
+        summary = publish_durable_artifact(
+            store_id=args.store_id,
+            dataset=args.dataset,
+            file_path=args.file,
+            durable_config_path=args.durable_config,
+            enable_durable_write=args.enable_durable_write,
+            content_type=args.content_type,
+        )
+        if args.summary_json is not None:
+            _write_summary(args.summary_json, summary)
+    except ValidationError:
+        print(
+            "Durable publication failed: configuration, environment, artifact, "
+            "or options were invalid",
+            file=sys.stderr,
+        )
+        return 1
+    except StorageError:
+        print(
+            "Durable publication failed: bounded local read or S3 operation failed",
+            file=sys.stderr,
+        )
+        return 1
+    except Exception:
+        print("Durable publication failed: unexpected local failure", file=sys.stderr)
+        return 1
+
+    print(json.dumps(summary, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/storage/durable_s3.py
+++ b/src/storage/durable_s3.py
@@ -1,0 +1,364 @@
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+from collections.abc import Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from ..common.config import load_yaml
+from ..common.exceptions import StorageError, ValidationError
+
+MAX_OBJECT_BYTES = 5_000_000_000
+MAX_LIST_OBJECTS = 10_000
+
+
+@dataclass(frozen=True, slots=True)
+class DurableS3Config:
+    store_id: str
+    enabled: bool
+    bucket_env: str
+    region_env: str
+    prefix: str
+    server_side_encryption: str
+    kms_key_env: str | None
+    max_object_bytes: int
+    max_list_objects: int
+
+
+def _required_text(value: Any, label: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ValidationError(f"{label} must be non-empty text")
+    return value.strip()
+
+
+def _bounded_integer(value: Any, label: str, maximum: int) -> int:
+    if type(value) is not int or not 1 <= value <= maximum:
+        raise ValidationError(
+            f"{label} must be an integer between 1 and {maximum}"
+        )
+    return value
+
+
+def _safe_path(value: Any, label: str) -> str:
+    text = _required_text(value, label).strip("/")
+    segments = text.split("/")
+    if not segments or any(
+        segment in {"", ".", ".."}
+        or "\\" in segment
+        or any(ord(character) < 32 for character in segment)
+        for segment in segments
+    ):
+        raise ValidationError(f"{label} must contain safe path segments")
+    return "/".join(segments)
+
+
+def _safe_dataset(value: Any) -> str:
+    text = _required_text(value, "dataset")
+    if (
+        text in {".", ".."}
+        or "/" in text
+        or "\\" in text
+        or any(ord(character) < 32 for character in text)
+    ):
+        raise ValidationError("dataset must be one safe path segment")
+    return text
+
+
+def parse_durable_s3_config(
+    payload: Mapping[str, Any],
+    store_id: str,
+) -> DurableS3Config:
+    stores = payload.get("stores")
+    if not isinstance(stores, Mapping):
+        raise ValidationError("durable-storage configuration must define stores")
+    candidate = stores.get(store_id)
+    if not isinstance(candidate, Mapping):
+        raise ValidationError(f"durable store '{store_id}' is not configured")
+    enabled = candidate.get("enabled")
+    if type(enabled) is not bool:
+        raise ValidationError("durable store enabled must be true or false")
+    if candidate.get("adapter_type") != "s3":
+        raise ValidationError("only the s3 durable adapter type is supported")
+
+    encryption = _required_text(
+        candidate.get("server_side_encryption"),
+        "server_side_encryption",
+    )
+    if encryption not in {"AES256", "aws:kms"}:
+        raise ValidationError(
+            "server_side_encryption must be AES256 or aws:kms"
+        )
+    kms_raw = candidate.get("kms_key_env")
+    kms_key_env = (
+        None
+        if kms_raw is None or kms_raw == ""
+        else _required_text(kms_raw, "kms_key_env")
+    )
+    if encryption == "aws:kms" and kms_key_env is None:
+        raise ValidationError("aws:kms storage requires kms_key_env")
+    if encryption == "AES256" and kms_key_env is not None:
+        raise ValidationError("AES256 storage must not configure kms_key_env")
+
+    return DurableS3Config(
+        store_id=_required_text(store_id, "store_id"),
+        enabled=enabled,
+        bucket_env=_required_text(candidate.get("bucket_env"), "bucket_env"),
+        region_env=_required_text(candidate.get("region_env"), "region_env"),
+        prefix=_safe_path(candidate.get("prefix"), "prefix"),
+        server_side_encryption=encryption,
+        kms_key_env=kms_key_env,
+        max_object_bytes=_bounded_integer(
+            candidate.get("max_object_bytes"),
+            "max_object_bytes",
+            MAX_OBJECT_BYTES,
+        ),
+        max_list_objects=_bounded_integer(
+            candidate.get("max_list_objects"),
+            "max_list_objects",
+            MAX_LIST_OBJECTS,
+        ),
+    )
+
+
+def load_durable_s3_config(path: Path, store_id: str) -> DurableS3Config:
+    try:
+        payload = load_yaml(path)
+    except Exception:
+        raise ValidationError(
+            "durable-storage configuration could not be loaded"
+        ) from None
+    if not isinstance(payload, Mapping):
+        raise ValidationError("durable-storage configuration must be a mapping")
+    return parse_durable_s3_config(payload, store_id)
+
+
+def content_sha256(payload: bytes) -> str:
+    if not isinstance(payload, bytes):
+        raise ValidationError("durable object payload must be bytes")
+    return hashlib.sha256(payload).hexdigest()
+
+
+def immutable_object_key(
+    config: DurableS3Config,
+    *,
+    dataset: str,
+    payload: bytes,
+    extension: str,
+) -> str:
+    dataset = _safe_dataset(dataset)
+    extension = _required_text(extension, "extension").lstrip(".")
+    if not extension.isalnum() or len(extension) > 16:
+        raise ValidationError("extension must be short alphanumeric text")
+    digest = content_sha256(payload)
+    return (
+        f"{config.prefix}/{dataset}/sha256={digest[:2]}/"
+        f"{digest}.{extension}"
+    )
+
+
+def _already_exists(exc: Exception) -> bool:
+    response = getattr(exc, "response", None)
+    if not isinstance(response, Mapping):
+        return False
+    error = response.get("Error")
+    metadata = response.get("ResponseMetadata")
+    code = error.get("Code") if isinstance(error, Mapping) else None
+    status = (
+        metadata.get("HTTPStatusCode")
+        if isinstance(metadata, Mapping)
+        else None
+    )
+    return code in {"PreconditionFailed", "412"} or status == 412
+
+
+def _verify_existing_object(
+    client: Any,
+    *,
+    bucket: str,
+    key: str,
+    digest: str,
+    payload_length: int,
+) -> None:
+    try:
+        response = client.head_object(Bucket=bucket, Key=key)
+    except Exception:
+        raise StorageError(
+            "Unable to verify an existing durable object"
+        ) from None
+    metadata = response.get("Metadata")
+    stored_digest = (
+        metadata.get("sha256") if isinstance(metadata, Mapping) else None
+    )
+    if stored_digest != digest or response.get("ContentLength") != payload_length:
+        raise StorageError(
+            "Existing durable object does not match the immutable content identity"
+        )
+
+
+def put_immutable_object(
+    client: Any,
+    *,
+    config: DurableS3Config,
+    bucket: str,
+    dataset: str,
+    payload: bytes,
+    extension: str,
+    content_type: str,
+    kms_key_id: str | None = None,
+) -> dict[str, Any]:
+    if not config.enabled:
+        raise ValidationError("durable S3 store is disabled")
+    bucket = _required_text(bucket, "bucket")
+    content_type = _required_text(content_type, "content_type")
+    if not isinstance(payload, bytes) or not payload:
+        raise ValidationError("durable object payload must be non-empty bytes")
+    if len(payload) > config.max_object_bytes:
+        raise ValidationError("durable object exceeds max_object_bytes")
+    if config.server_side_encryption == "aws:kms":
+        kms_key_id = _required_text(kms_key_id, "kms_key_id")
+    elif kms_key_id is not None:
+        raise ValidationError("kms_key_id is invalid for AES256 storage")
+
+    digest = content_sha256(payload)
+    key = immutable_object_key(
+        config,
+        dataset=dataset,
+        payload=payload,
+        extension=extension,
+    )
+    checksum = base64.b64encode(bytes.fromhex(digest)).decode("ascii")
+    request: dict[str, Any] = {
+        "Body": payload,
+        "Bucket": bucket,
+        "ChecksumSHA256": checksum,
+        "ContentType": content_type,
+        "IfNoneMatch": "*",
+        "Key": key,
+        "Metadata": {
+            "sha256": digest,
+            "storage-contract": "immutable-content-addressed-v1",
+        },
+        "ServerSideEncryption": config.server_side_encryption,
+    }
+    if kms_key_id is not None:
+        request["SSEKMSKeyId"] = kms_key_id
+
+    try:
+        response = client.put_object(**request)
+    except Exception as exc:
+        if not _already_exists(exc):
+            raise StorageError("Durable S3 object publication failed") from None
+        _verify_existing_object(
+            client,
+            bucket=bucket,
+            key=key,
+            digest=digest,
+            payload_length=len(payload),
+        )
+        return {
+            "bucket_configured": True,
+            "content_length": len(payload),
+            "etag": None,
+            "key": key,
+            "sha256": digest,
+            "status": "already_present",
+        }
+
+    return {
+        "bucket_configured": True,
+        "content_length": len(payload),
+        "etag": response.get("ETag"),
+        "key": key,
+        "sha256": digest,
+        "status": "written",
+    }
+
+
+def inventory_immutable_objects(
+    client: Any,
+    *,
+    config: DurableS3Config,
+    bucket: str,
+    dataset: str,
+) -> tuple[dict[str, Any], ...]:
+    if not config.enabled:
+        raise ValidationError("durable S3 store is disabled")
+    bucket = _required_text(bucket, "bucket")
+    dataset = _safe_dataset(dataset)
+    prefix = f"{config.prefix}/{dataset}/"
+    token: str | None = None
+    objects: list[dict[str, Any]] = []
+
+    while True:
+        request: dict[str, Any] = {
+            "Bucket": bucket,
+            "MaxKeys": min(1000, config.max_list_objects),
+            "Prefix": prefix,
+        }
+        if token is not None:
+            request["ContinuationToken"] = token
+        try:
+            response = client.list_objects_v2(**request)
+        except Exception:
+            raise StorageError("Durable S3 inventory failed") from None
+        contents = response.get("Contents", [])
+        if not isinstance(contents, list):
+            raise StorageError("Durable S3 inventory returned invalid contents")
+        for item in contents:
+            if not isinstance(item, Mapping):
+                raise StorageError(
+                    "Durable S3 inventory returned an invalid object"
+                )
+            key = item.get("Key")
+            if not isinstance(key, str) or not key.startswith(prefix):
+                raise StorageError(
+                    "Durable S3 inventory escaped the configured prefix"
+                )
+            objects.append(
+                {
+                    "etag": item.get("ETag"),
+                    "key": key,
+                    "last_modified": item.get("LastModified"),
+                    "size": item.get("Size"),
+                }
+            )
+            if len(objects) > config.max_list_objects:
+                raise StorageError(
+                    "Durable S3 inventory exceeds max_list_objects"
+                )
+        if not response.get("IsTruncated"):
+            break
+        next_token = response.get("NextContinuationToken")
+        if not isinstance(next_token, str) or not next_token:
+            raise StorageError(
+                "Durable S3 inventory is truncated without a continuation token"
+            )
+        token = next_token
+
+    return tuple(objects)
+
+
+def create_boto3_s3_client(*, region_name: str) -> Any:
+    region_name = _required_text(region_name, "region_name")
+    try:
+        import boto3
+    except ImportError as exc:
+        raise RuntimeError(
+            "Durable S3 storage requires boto3 in the enabled runtime."
+        ) from exc
+    return boto3.client("s3", region_name=region_name)
+
+
+def canonical_json_payload(value: Mapping[str, Any]) -> bytes:
+    if not isinstance(value, Mapping):
+        raise ValidationError("canonical JSON payload must be a mapping")
+    return json.dumps(
+        value,
+        default=str,
+        sort_keys=True,
+        separators=(",", ":"),
+        allow_nan=False,
+    ).encode("utf-8")

--- a/tests/unit/test_durable_s3.py
+++ b/tests/unit/test_durable_s3.py
@@ -1,0 +1,281 @@
+from __future__ import annotations
+
+from dataclasses import replace
+from datetime import datetime, timezone
+from typing import Any
+
+import pytest
+
+from src.common.exceptions import StorageError, ValidationError
+from src.storage.durable_s3 import (
+    DurableS3Config,
+    immutable_object_key,
+    inventory_immutable_objects,
+    parse_durable_s3_config,
+    put_immutable_object,
+)
+
+
+class PreconditionFailed(Exception):
+    def __init__(self) -> None:
+        self.response = {
+            "Error": {"Code": "PreconditionFailed"},
+            "ResponseMetadata": {"HTTPStatusCode": 412},
+        }
+
+
+class FakeClient:
+    def __init__(self) -> None:
+        self.put_calls: list[dict[str, Any]] = []
+        self.head_response: dict[str, Any] | None = None
+        self.raise_precondition = False
+        self.list_responses: list[dict[str, Any]] = []
+
+    def put_object(self, **kwargs: Any) -> dict[str, Any]:
+        self.put_calls.append(kwargs)
+        if self.raise_precondition:
+            raise PreconditionFailed()
+        return {"ETag": '"etag-1"'}
+
+    def head_object(self, **_kwargs: Any) -> dict[str, Any]:
+        assert self.head_response is not None
+        return self.head_response
+
+    def list_objects_v2(self, **_kwargs: Any) -> dict[str, Any]:
+        return self.list_responses.pop(0)
+
+
+def _config(**overrides: Any) -> DurableS3Config:
+    values: dict[str, Any] = {
+        "store_id": "primary",
+        "enabled": True,
+        "bucket_env": "BUCKET",
+        "region_env": "REGION",
+        "prefix": "risk-platform",
+        "server_side_encryption": "AES256",
+        "kms_key_env": None,
+        "max_object_bytes": 1_000_000,
+        "max_list_objects": 10,
+    }
+    values.update(overrides)
+    return DurableS3Config(**values)
+
+
+def test_config_is_disabled_and_contains_no_bucket_or_credentials() -> None:
+    parsed = parse_durable_s3_config(
+        {
+            "stores": {
+                "primary": {
+                    "enabled": False,
+                    "adapter_type": "s3",
+                    "bucket_env": "BUCKET",
+                    "region_env": "REGION",
+                    "prefix": "risk-platform",
+                    "server_side_encryption": "AES256",
+                    "kms_key_env": None,
+                    "max_object_bytes": 1000,
+                    "max_list_objects": 10,
+                }
+            }
+        },
+        "primary",
+    )
+
+    assert parsed.enabled is False
+    assert parsed.bucket_env == "BUCKET"
+    assert parsed.region_env == "REGION"
+
+
+def test_object_key_is_content_addressed_and_deterministic() -> None:
+    first = immutable_object_key(
+        _config(),
+        dataset="daily-risk",
+        payload=b"same-content",
+        extension="json",
+    )
+    second = immutable_object_key(
+        _config(),
+        dataset="daily-risk",
+        payload=b"same-content",
+        extension="json",
+    )
+    changed = immutable_object_key(
+        _config(),
+        dataset="daily-risk",
+        payload=b"changed-content",
+        extension="json",
+    )
+
+    assert first == second
+    assert first != changed
+    assert first.startswith("risk-platform/daily-risk/sha256=")
+
+
+def test_put_uses_conditional_write_checksum_and_encryption() -> None:
+    client = FakeClient()
+
+    result = put_immutable_object(
+        client,
+        config=_config(),
+        bucket="bucket-name",
+        dataset="daily-risk",
+        payload=b"payload",
+        extension="json",
+        content_type="application/json",
+    )
+
+    assert result["status"] == "written"
+    request = client.put_calls[0]
+    assert request["IfNoneMatch"] == "*"
+    assert request["ServerSideEncryption"] == "AES256"
+    assert request["ChecksumSHA256"]
+    assert request["Metadata"]["sha256"] == result["sha256"]
+    assert request["Bucket"] == "bucket-name"
+
+
+def test_existing_matching_object_is_replay_safe() -> None:
+    client = FakeClient()
+    client.raise_precondition = True
+    expected = put_immutable_object
+    payload = b"payload"
+    from src.storage.durable_s3 import content_sha256
+
+    digest = content_sha256(payload)
+    client.head_response = {
+        "ContentLength": len(payload),
+        "Metadata": {"sha256": digest},
+    }
+
+    result = expected(
+        client,
+        config=_config(),
+        bucket="bucket-name",
+        dataset="daily-risk",
+        payload=payload,
+        extension="json",
+        content_type="application/json",
+    )
+
+    assert result["status"] == "already_present"
+    assert result["sha256"] == digest
+
+
+def test_existing_identity_mismatch_fails_closed() -> None:
+    client = FakeClient()
+    client.raise_precondition = True
+    client.head_response = {
+        "ContentLength": 7,
+        "Metadata": {"sha256": "different"},
+    }
+
+    with pytest.raises(StorageError, match="does not match"):
+        put_immutable_object(
+            client,
+            config=_config(),
+            bucket="bucket-name",
+            dataset="daily-risk",
+            payload=b"payload",
+            extension="json",
+            content_type="application/json",
+        )
+
+
+def test_kms_configuration_requires_key_and_passes_it_to_s3() -> None:
+    client = FakeClient()
+    config = replace(
+        _config(),
+        server_side_encryption="aws:kms",
+        kms_key_env="KMS_KEY",
+    )
+
+    with pytest.raises(ValidationError, match="kms_key_id"):
+        put_immutable_object(
+            client,
+            config=config,
+            bucket="bucket-name",
+            dataset="daily-risk",
+            payload=b"payload",
+            extension="json",
+            content_type="application/json",
+        )
+
+    put_immutable_object(
+        client,
+        config=config,
+        bucket="bucket-name",
+        dataset="daily-risk",
+        payload=b"payload",
+        extension="json",
+        content_type="application/json",
+        kms_key_id="alias/risk-platform",
+    )
+    assert client.put_calls[-1]["SSEKMSKeyId"] == "alias/risk-platform"
+
+
+def test_inventory_is_prefix_bounded_and_paginated() -> None:
+    client = FakeClient()
+    client.list_responses = [
+        {
+            "Contents": [
+                {
+                    "Key": "risk-platform/daily-risk/a.json",
+                    "Size": 10,
+                    "ETag": "a",
+                    "LastModified": datetime(2026, 1, 1, tzinfo=timezone.utc),
+                }
+            ],
+            "IsTruncated": True,
+            "NextContinuationToken": "next",
+        },
+        {
+            "Contents": [
+                {
+                    "Key": "risk-platform/daily-risk/b.json",
+                    "Size": 20,
+                    "ETag": "b",
+                    "LastModified": datetime(2026, 1, 2, tzinfo=timezone.utc),
+                }
+            ],
+            "IsTruncated": False,
+        },
+    ]
+
+    inventory = inventory_immutable_objects(
+        client,
+        config=_config(),
+        bucket="bucket-name",
+        dataset="daily-risk",
+    )
+
+    assert [item["key"] for item in inventory] == [
+        "risk-platform/daily-risk/a.json",
+        "risk-platform/daily-risk/b.json",
+    ]
+
+
+def test_disabled_and_oversized_writes_fail_before_client_use() -> None:
+    client = FakeClient()
+
+    with pytest.raises(ValidationError, match="disabled"):
+        put_immutable_object(
+            client,
+            config=_config(enabled=False),
+            bucket="bucket-name",
+            dataset="daily-risk",
+            payload=b"payload",
+            extension="json",
+            content_type="application/json",
+        )
+
+    with pytest.raises(ValidationError, match="max_object_bytes"):
+        put_immutable_object(
+            client,
+            config=_config(max_object_bytes=2),
+            bucket="bucket-name",
+            dataset="daily-risk",
+            payload=b"payload",
+            extension="json",
+            content_type="application/json",
+        )
+
+    assert client.put_calls == []

--- a/tests/unit/test_publish_durable_artifact.py
+++ b/tests/unit/test_publish_durable_artifact.py
@@ -1,0 +1,160 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from src.common.exceptions import StorageError, ValidationError
+from src.orchestration.publish_durable_artifact import publish_durable_artifact
+from src.storage.durable_s3 import DurableS3Config
+
+
+def _config(*, enabled: bool) -> DurableS3Config:
+    return DurableS3Config(
+        store_id="primary",
+        enabled=enabled,
+        bucket_env="BUCKET",
+        region_env="REGION",
+        prefix="risk-platform",
+        server_side_encryption="AES256",
+        kms_key_env=None,
+        max_object_bytes=1_000_000,
+        max_list_objects=100,
+    )
+
+
+def test_missing_explicit_flag_returns_without_reading_file(
+    tmp_path: Path,
+) -> None:
+    missing = tmp_path / "missing.json"
+
+    summary = publish_durable_artifact(
+        store_id="primary",
+        dataset="daily-risk",
+        file_path=missing,
+        durable_config_path=Path("durable.yaml"),
+        config_loader=lambda *_: _config(enabled=True),
+    )
+
+    assert summary["publication"] == {
+        "performed": False,
+        "reason": "explicit_enable_flag_required",
+    }
+    assert summary["credentials_recorded"] is False
+
+
+def test_disabled_configuration_cannot_be_overridden(tmp_path: Path) -> None:
+    artifact = tmp_path / "artifact.json"
+    artifact.write_text("{}", encoding="utf-8")
+
+    summary = publish_durable_artifact(
+        store_id="primary",
+        dataset="daily-risk",
+        file_path=artifact,
+        durable_config_path=Path("durable.yaml"),
+        enable_durable_write=True,
+        config_loader=lambda *_: _config(enabled=False),
+    )
+
+    assert summary["publication"]["reason"] == (
+        "store_disabled_in_configuration"
+    )
+
+
+def test_enabled_publication_resolves_environment_without_recording_values(
+    tmp_path: Path,
+) -> None:
+    artifact = tmp_path / "artifact.json"
+    artifact.write_text('{"value":1}', encoding="utf-8")
+    calls: list[dict[str, Any]] = []
+    client = object()
+
+    def publisher(selected_client: object, **kwargs: Any) -> dict[str, Any]:
+        calls.append({"client": selected_client, **kwargs})
+        return {
+            "status": "written",
+            "key": "risk-platform/daily-risk/sha256=aa/value.json",
+            "sha256": "a" * 64,
+            "content_length": 11,
+            "bucket_configured": True,
+        }
+
+    summary = publish_durable_artifact(
+        store_id="primary",
+        dataset="daily-risk",
+        file_path=artifact,
+        durable_config_path=Path("durable.yaml"),
+        enable_durable_write=True,
+        environment={"BUCKET": "private-bucket", "REGION": "eu-west-2"},
+        config_loader=lambda *_: _config(enabled=True),
+        client_factory=lambda **kwargs: client,
+        publisher=publisher,
+    )
+
+    assert calls[0]["client"] is client
+    assert calls[0]["bucket"] == "private-bucket"
+    assert calls[0]["payload"] == b'{"value":1}'
+    assert calls[0]["content_type"] == "application/json"
+    assert "private-bucket" not in str(summary)
+    assert "eu-west-2" not in str(summary)
+    assert summary["publication"]["status"] == "written"
+
+
+def test_missing_environment_fails_before_client_creation(tmp_path: Path) -> None:
+    artifact = tmp_path / "artifact.json"
+    artifact.write_text("{}", encoding="utf-8")
+    client_created = False
+
+    def client_factory(**_kwargs: Any) -> object:
+        nonlocal client_created
+        client_created = True
+        return object()
+
+    with pytest.raises(ValidationError, match="BUCKET"):
+        publish_durable_artifact(
+            store_id="primary",
+            dataset="daily-risk",
+            file_path=artifact,
+            durable_config_path=Path("durable.yaml"),
+            enable_durable_write=True,
+            environment={"REGION": "eu-west-2"},
+            config_loader=lambda *_: _config(enabled=True),
+            client_factory=client_factory,
+        )
+
+    assert client_created is False
+
+
+def test_symbolic_link_and_empty_artifacts_fail_closed(tmp_path: Path) -> None:
+    target = tmp_path / "target.json"
+    target.write_text("{}", encoding="utf-8")
+    link = tmp_path / "link.json"
+    try:
+        link.symlink_to(target)
+    except OSError:
+        pytest.skip("symbolic links are unavailable")
+
+    with pytest.raises(StorageError, match="non-symbolic-link"):
+        publish_durable_artifact(
+            store_id="primary",
+            dataset="daily-risk",
+            file_path=link,
+            durable_config_path=Path("durable.yaml"),
+            enable_durable_write=True,
+            environment={"BUCKET": "bucket", "REGION": "eu-west-2"},
+            config_loader=lambda *_: _config(enabled=True),
+        )
+
+    empty = tmp_path / "empty.json"
+    empty.write_bytes(b"")
+    with pytest.raises(ValidationError, match="must not be empty"):
+        publish_durable_artifact(
+            store_id="primary",
+            dataset="daily-risk",
+            file_path=empty,
+            durable_config_path=Path("durable.yaml"),
+            enable_durable_write=True,
+            environment={"BUCKET": "bucket", "REGION": "eu-west-2"},
+            config_loader=lambda *_: _config(enabled=True),
+        )


### PR DESCRIPTION
## Outcome

Add an explicit, disabled-by-default durable object-storage adapter:

```text
regular local artifact
  -> bounded read
  -> SHA-256 content identity
  -> deterministic immutable S3 key
  -> conditional PutObject with checksum and encryption
  -> written or verified-already-present evidence
```

Primary arc42 block: `storage`.

## Safety and replay

The bundled store is disabled and contains no bucket, KMS key or credential. Both reviewed enabled configuration and `--enable-durable-write` are required. Bucket, region and optional KMS key are resolved only from named environment variables. boto3 is imported lazily and uses the runtime's normal AWS credential chain.

Keys are content-addressed. Writes use `IfNoneMatch='*'`, `ChecksumSHA256`, SHA-256 metadata and configured server-side encryption. A precondition failure is accepted as replay only after HeadObject verifies digest metadata and content length. The adapter exposes no overwrite or delete operation.

## Bounds

Local files must be non-empty regular files and not symbolic links. Configuration and code cap object size and inventory count. Inventory is restricted to the configured prefix and dataset and fails if S3 returns an escaping key.

## Validation

GitHub Actions run `32609561736` (`ci` run 251) passed on exact head `424ec363b8299c86e8825ebeed03a3d9131a42ac`:

- Security guardrails: passed.
- Python readiness: passed, including locked dependencies, Ruff, mypy, the complete test suite, dependency integrity and readiness replay.
- PostgreSQL contract: passed against PostgreSQL 16.
- Infrastructure validation: passed without deployment or Terraform apply.

Focused tests cover disabled configuration, deterministic keys, conditional writes, checksums, AES256 and KMS parameters, verified replay, mismatch failure, prefix-bounded pagination, explicit runtime gates, missing environment, secret-safe summaries and unsafe local files. No unresolved review threads or requested changes are present.

## Boundary

This PR does not create or configure AWS resources, credentials, IAM, lifecycle, replication, Object Lock, migration, scheduling, deployment or Terraform apply.

## Acceptance boundary

Validated and ready for squash merge as the storage-adapter foundation.