### PR TITLE
Add bounded durable dataset replication

### DIFF
--- a/docs/durable-s3-replication.md
+++ b/docs/durable-s3-replication.md
@@ -1,0 +1,200 @@
+# Bounded Durable Dataset Replication
+
+## Outcome
+
+This increment adds a thin orchestration layer over the immutable S3 adapter that
+is already implemented in `src/storage/durable_s3.py`.
+
+```text
+configured local raw and curated Parquet
+  -> bounded regular-file inventory
+  -> deterministic content hashes and object keys
+  -> stable replication manifest
+  -> plan-only evidence by default
+  -> explicit dual-gated immutable S3 publication
+```
+
+The runner is:
+
+```text
+src/orchestration/replicate_durable_datasets.py
+```
+
+It does not introduce another S3 client or another object identity. Every object
+write and replay verification delegates to `put_immutable_object`.
+
+## Plan First
+
+The default command does not resolve AWS environment values, create an S3 client,
+or perform a network call:
+
+```bash
+.venv/bin/python -m src.orchestration.replicate_durable_datasets \
+  --store-id primary-s3 \
+  --dataset daily_returns \
+  --dataset portfolio_risk_attribution \
+  --summary-json .demo/durable-replication-plan.json
+```
+
+With no `--dataset` arguments, the runner inventories every configured raw and
+curated dataset that currently exists locally.
+
+A plan reports:
+
+- selected local artifact count and bytes;
+- local dataset and relative Parquet path;
+- durable dataset name;
+- SHA-256 content identity;
+- deterministic immutable object key;
+- deterministic manifest ID and manifest object key; and
+- only the names of environment variables that an enabled execution would use.
+
+Bucket, region, KMS-key and credential values are never included in the summary.
+
+## Explicit Execution Gate
+
+Publication requires both:
+
+1. `enabled: true` for the selected store in
+   `config/durable_storage.yaml`; and
+2. the explicit `--enable-durable-write` command flag.
+
+For example:
+
+```bash
+export RISK_PLATFORM_DURABLE_BUCKET='configured-outside-git'
+export AWS_REGION='eu-west-2'
+
+.venv/bin/python -m src.orchestration.replicate_durable_datasets \
+  --store-id primary-s3 \
+  --dataset daily_returns \
+  --max-files 1000 \
+  --max-total-bytes 1000000000 \
+  --enable-durable-write \
+  --summary-json .demo/durable-replication-result.json
+```
+
+The bundled configuration remains disabled and contains no bucket, key,
+credential or account identifier.
+
+## Local Inventory Contract
+
+The runner derives paths only from `config/storage.yaml`.
+
+Raw Parquet is grouped under:
+
+```text
+raw-<configured raw dataset>
+```
+
+Curated Parquet is grouped under:
+
+```text
+curated-<configured curated dataset key>
+```
+
+The inventory:
+
+- includes only `*.parquet`;
+- is sorted by durable dataset, relative path and content hash;
+- rejects symbolic-link base paths, dataset paths and files;
+- rejects non-regular files;
+- rejects empty files;
+- rejects objects above the durable store's `max_object_bytes`;
+- rejects unconfigured dataset selectors;
+- applies an explicit file cap;
+- applies an explicit total-byte cap; and
+- verifies that a file's size is unchanged while it is read.
+
+The requested file cap cannot exceed either the hard 10,000-file bound or the
+selected durable store's `max_list_objects`. The hard total-byte bound is 100 GB;
+the default request bound is 1 GB.
+
+## Immutable Publication
+
+For each planned file, execution calls the existing adapter with:
+
+```text
+dataset
+payload
+extension
+content type
+configured encryption controls
+```
+
+The adapter owns:
+
+- the SHA-256 object identity;
+- content-addressed object keys;
+- `If-None-Match: *`;
+- S3 checksum submission;
+- server-side encryption;
+- matching-object replay verification; and
+- overwrite refusal.
+
+Before each call, the runner rereads the local file and verifies the planned
+length and SHA-256 digest. A file changed after planning fails before that object
+is submitted.
+
+Partial execution is replay-safe. Successfully written objects remain immutable;
+rerunning verifies or writes the remaining content.
+
+## Replication Manifest
+
+After every selected artifact has either been written or verified as already
+present, the runner publishes one canonical JSON manifest under:
+
+```text
+replication-manifests
+```
+
+The manifest contract is `durable-dataset-replication-v1` and contains only stable evidence:
+
+- contract version;
+- store ID;
+- local dataset;
+- durable dataset;
+- relative source path;
+- content length;
+- SHA-256 digest; and
+- immutable object key.
+
+It contains no run timestamp, random run ID, bucket, region, KMS key or
+credential. The manifest ID is a SHA-256-derived identity over its ordered
+entries. Repeating the same local state therefore converges on the same manifest
+object. A changed file, selected dataset or path creates a distinguishable
+manifest.
+
+The manifest is published last. Its presence means every referenced object
+completed the immutable adapter contract for that execution.
+
+## Failure And Replay Semantics
+
+| Condition | Behaviour |
+| --- | --- |
+| No local artifacts match | Return `no_artifacts`; make no client |
+| Explicit flag absent | Return the complete plan; make no client |
+| Store disabled | Return the complete plan; make no client |
+| Required environment missing | Fail before client creation |
+| Local file changes after planning | Fail before publishing that object |
+| Existing matching object | Report `already_present` |
+| Existing identity mismatch | Fail closed through the adapter |
+| Artifact publication fails | Stop; do not publish the manifest |
+| Manifest publication fails | Artifact objects remain safe; rerun converges |
+
+## Boundary
+
+This increment does not:
+
+- create an S3 bucket, KMS key, IAM role or credential;
+- activate the bundled store;
+- upload anything in CI;
+- preserve a mutable partition hierarchy in object keys;
+- delete or overwrite remote objects;
+- restore objects to local storage;
+- schedule replication;
+- deploy infrastructure; or
+- run `terraform apply`.
+
+The source partition path is retained in the immutable manifest. Object keys stay
+content-addressed rather than becoming mutable copies of local paths.

--- a/src/orchestration/replicate_durable_datasets.py
+++ b/src/orchestration/replicate_durable_datasets.py
@@ -1,0 +1,570 @@
+from __future__ import annotations
+
+import argparse
+import json
+import mimetypes
+import os
+import sys
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+from uuid import uuid4
+
+from ..common.exceptions import StorageError, ValidationError
+from ..storage.durable_s3 import (
+    DurableS3Config,
+    canonical_json_payload,
+    content_sha256,
+    create_boto3_s3_client,
+    immutable_object_key,
+    load_durable_s3_config,
+    put_immutable_object,
+)
+from ..storage.storage_config import load_storage_config, validate_storage_config
+
+MAX_REPLICATION_FILES = 10_000
+MAX_REPLICATION_BYTES = 100_000_000_000
+DEFAULT_MAX_REPLICATION_BYTES = 1_000_000_000
+MANIFEST_DATASET = "replication-manifests"
+
+ConfigLoader = Callable[[Path, str], DurableS3Config]
+StorageConfigLoader = Callable[[Path], dict[str, Any]]
+ClientFactory = Callable[..., Any]
+Publisher = Callable[..., dict[str, Any]]
+
+
+@dataclass(frozen=True, slots=True)
+class LocalReplicationArtifact:
+    dataset: str
+    remote_dataset: str
+    path: Path
+    relative_path: str
+    content_length: int
+    sha256: str
+    object_key: str
+    extension: str
+    content_type: str
+
+
+def _bounded_integer(value: int, label: str, maximum: int) -> int:
+    if type(value) is not int or not 1 <= value <= maximum:
+        raise ValidationError(f"{label} must be an integer between 1 and {maximum}")
+    return value
+
+
+def _environment_value(
+    environment: Mapping[str, str],
+    name: str,
+    *,
+    required: bool,
+) -> str | None:
+    value = environment.get(name)
+    if value is None or not value.strip():
+        if required:
+            raise ValidationError(
+                f"required durable-storage environment variable '{name}' is not set"
+            )
+        return None
+    return value.strip()
+
+
+def _safe_remote_dataset(kind: str, dataset: str) -> str:
+    candidate = f"{kind}-{dataset}"
+    if (
+        candidate in {"", ".", ".."}
+        or "/" in candidate
+        or "\\" in candidate
+        or any(ord(character) < 32 for character in candidate)
+    ):
+        raise ValidationError("storage dataset names must form a safe remote dataset")
+    return candidate
+
+
+def _configured_dataset_paths(
+    storage_config: dict[str, Any],
+) -> tuple[tuple[str, str, Path], ...]:
+    validate_storage_config(storage_config)
+    storage = storage_config["storage"]
+    raw = storage["raw"]
+    curated = storage["curated"]
+
+    configured: list[tuple[str, str, Path]] = [
+        (
+            "raw",
+            str(raw["dataset"]),
+            Path(raw["base_path"]) / str(raw["dataset"]),
+        )
+    ]
+    datasets = curated["datasets"]
+    if not isinstance(datasets, Mapping):
+        raise StorageError("curated datasets configuration is invalid")
+    for dataset_key in sorted(datasets):
+        dataset_name = datasets[dataset_key]
+        if not isinstance(dataset_key, str) or not isinstance(dataset_name, str):
+            raise StorageError("curated datasets configuration is invalid")
+        configured.append(
+            (
+                "curated",
+                dataset_key,
+                Path(curated["base_path"]) / dataset_name,
+            )
+        )
+    return tuple(configured)
+
+
+def _read_regular_file(path: Path, *, expected_size: int) -> bytes:
+    try:
+        payload = path.read_bytes()
+    except OSError:
+        raise StorageError("replication artifact could not be read") from None
+    if len(payload) != expected_size:
+        raise StorageError("replication artifact changed while it was being read")
+    return payload
+
+
+def inventory_local_replication_artifacts(
+    *,
+    storage_config: dict[str, Any],
+    durable_config: DurableS3Config,
+    selected_datasets: Sequence[str] | None = None,
+    max_files: int | None = None,
+    max_total_bytes: int = DEFAULT_MAX_REPLICATION_BYTES,
+) -> tuple[LocalReplicationArtifact, ...]:
+    requested_max_files = (
+        durable_config.max_list_objects if max_files is None else max_files
+    )
+    requested_max_files = _bounded_integer(
+        requested_max_files,
+        "max_files",
+        min(MAX_REPLICATION_FILES, durable_config.max_list_objects),
+    )
+    max_total_bytes = _bounded_integer(
+        max_total_bytes,
+        "max_total_bytes",
+        MAX_REPLICATION_BYTES,
+    )
+
+    selected = set(selected_datasets or ())
+    configured = _configured_dataset_paths(storage_config)
+    configured_names = {dataset for _, dataset, _ in configured}
+    unknown = sorted(selected - configured_names)
+    if unknown:
+        raise ValidationError(
+            "selected datasets are not configured: " + ", ".join(unknown)
+        )
+
+    artifacts: list[LocalReplicationArtifact] = []
+    total_bytes = 0
+    for kind, dataset, dataset_path in configured:
+        if selected and dataset not in selected:
+            continue
+        base_path = dataset_path.parent
+        if base_path.is_symlink() or dataset_path.is_symlink():
+            raise StorageError("replication dataset path must not be a symbolic link")
+        if not dataset_path.exists():
+            continue
+        if not dataset_path.is_dir():
+            raise StorageError("replication dataset path must be a directory")
+        try:
+            files = sorted(dataset_path.rglob("*.parquet"))
+        except OSError:
+            raise StorageError("replication dataset could not be inventoried") from None
+
+        remote_dataset = _safe_remote_dataset(kind, dataset)
+        for path in files:
+            if path.is_symlink() or not path.is_file():
+                raise StorageError(
+                    "replication dataset contains an unsafe local file type"
+                )
+            try:
+                size = path.stat().st_size
+            except OSError:
+                raise StorageError(
+                    "replication artifact could not be inventoried"
+                ) from None
+            if size <= 0:
+                raise ValidationError("replication artifacts must not be empty")
+            if size > durable_config.max_object_bytes:
+                raise ValidationError(
+                    "replication artifact exceeds durable max_object_bytes"
+                )
+            total_bytes += size
+            if total_bytes > max_total_bytes:
+                raise ValidationError("replication plan exceeds max_total_bytes")
+            if len(artifacts) >= requested_max_files:
+                raise ValidationError("replication plan exceeds max_files")
+
+            payload = _read_regular_file(path, expected_size=size)
+            digest = content_sha256(payload)
+            extension = path.suffix.lstrip(".") or "bin"
+            object_key = immutable_object_key(
+                durable_config,
+                dataset=remote_dataset,
+                payload=payload,
+                extension=extension,
+            )
+            relative_path = path.relative_to(dataset_path).as_posix()
+            content_type = (
+                "application/vnd.apache.parquet"
+                if extension == "parquet"
+                else mimetypes.guess_type(path.name)[0]
+                or "application/octet-stream"
+            )
+            artifacts.append(
+                LocalReplicationArtifact(
+                    dataset=dataset,
+                    remote_dataset=remote_dataset,
+                    path=path,
+                    relative_path=relative_path,
+                    content_length=size,
+                    sha256=digest,
+                    object_key=object_key,
+                    extension=extension,
+                    content_type=content_type,
+                )
+            )
+
+    return tuple(
+        sorted(
+            artifacts,
+            key=lambda artifact: (
+                artifact.remote_dataset,
+                artifact.relative_path,
+                artifact.sha256,
+            ),
+        )
+    )
+
+
+def _manifest_document(
+    artifacts: Sequence[LocalReplicationArtifact],
+    *,
+    store_id: str,
+) -> dict[str, Any]:
+    entries = [
+        {
+            "content_length": artifact.content_length,
+            "dataset": artifact.dataset,
+            "object_key": artifact.object_key,
+            "relative_path": artifact.relative_path,
+            "remote_dataset": artifact.remote_dataset,
+            "sha256": artifact.sha256,
+        }
+        for artifact in artifacts
+    ]
+    identity_payload = {
+        "contract": "durable-dataset-replication-v1",
+        "entries": entries,
+        "store_id": store_id,
+    }
+    return {
+        **identity_payload,
+        "manifest_id": (
+            "durable-replication-"
+            + content_sha256(canonical_json_payload(identity_payload))[:24]
+        ),
+    }
+
+
+def _safe_publication_evidence(result: Mapping[str, Any]) -> dict[str, Any]:
+    return {
+        key: value
+        for key, value in result.items()
+        if key not in {"bucket", "credentials", "kms_key_id", "region"}
+    }
+
+
+def replicate_local_datasets(
+    *,
+    store_id: str,
+    storage_config_path: Path,
+    durable_config_path: Path,
+    selected_datasets: Sequence[str] | None = None,
+    max_files: int | None = None,
+    max_total_bytes: int = DEFAULT_MAX_REPLICATION_BYTES,
+    enable_durable_write: bool = False,
+    environment: Mapping[str, str] | None = None,
+    config_loader: ConfigLoader | None = None,
+    storage_config_loader: StorageConfigLoader | None = None,
+    client_factory: ClientFactory | None = None,
+    publisher: Publisher | None = None,
+) -> dict[str, Any]:
+    selected_config_loader = config_loader or load_durable_s3_config
+    try:
+        durable_config = selected_config_loader(durable_config_path, store_id)
+    except ValidationError:
+        raise
+    except Exception:
+        raise ValidationError("durable-storage configuration is invalid") from None
+
+    selected_storage_loader = storage_config_loader or load_storage_config
+    try:
+        storage_config = selected_storage_loader(storage_config_path)
+    except Exception:
+        raise StorageError("local storage configuration is invalid") from None
+    if not isinstance(storage_config, dict):
+        raise StorageError("local storage configuration is invalid")
+
+    artifacts = inventory_local_replication_artifacts(
+        storage_config=storage_config,
+        durable_config=durable_config,
+        selected_datasets=selected_datasets,
+        max_files=max_files,
+        max_total_bytes=max_total_bytes,
+    )
+    manifest = _manifest_document(artifacts, store_id=durable_config.store_id)
+    manifest_payload = canonical_json_payload(manifest)
+    manifest_key = immutable_object_key(
+        durable_config,
+        dataset=MANIFEST_DATASET,
+        payload=manifest_payload,
+        extension="json",
+    )
+    base = {
+        "run_id": str(uuid4()),
+        "store_id": durable_config.store_id,
+        "store_enabled": durable_config.enabled,
+        "explicit_enable_flag": enable_durable_write,
+        "bucket_environment_variable": durable_config.bucket_env,
+        "region_environment_variable": durable_config.region_env,
+        "kms_key_environment_variable": durable_config.kms_key_env,
+        "credentials_recorded": False,
+        "plan": {
+            "artifact_count": len(artifacts),
+            "dataset_count": len({artifact.remote_dataset for artifact in artifacts}),
+            "manifest_id": manifest["manifest_id"],
+            "manifest_object_key": manifest_key,
+            "total_bytes": sum(artifact.content_length for artifact in artifacts),
+            "artifacts": [
+                {
+                    "content_length": artifact.content_length,
+                    "dataset": artifact.dataset,
+                    "object_key": artifact.object_key,
+                    "relative_path": artifact.relative_path,
+                    "remote_dataset": artifact.remote_dataset,
+                    "sha256": artifact.sha256,
+                }
+                for artifact in artifacts
+            ],
+        },
+    }
+
+    if not artifacts:
+        return {
+            **base,
+            "replication": {
+                "performed": False,
+                "reason": "no_artifacts",
+            },
+        }
+    if not enable_durable_write:
+        return {
+            **base,
+            "replication": {
+                "performed": False,
+                "reason": "explicit_enable_flag_required",
+            },
+        }
+    if not durable_config.enabled:
+        return {
+            **base,
+            "replication": {
+                "performed": False,
+                "reason": "store_disabled_in_configuration",
+            },
+        }
+
+    selected_environment = environment if environment is not None else os.environ
+    bucket = _environment_value(
+        selected_environment,
+        durable_config.bucket_env,
+        required=True,
+    )
+    region = _environment_value(
+        selected_environment,
+        durable_config.region_env,
+        required=True,
+    )
+    kms_key_id = (
+        _environment_value(
+            selected_environment,
+            durable_config.kms_key_env,
+            required=True,
+        )
+        if durable_config.kms_key_env is not None
+        else None
+    )
+    if bucket is None or region is None:
+        raise ValidationError("durable S3 bucket or region is missing")
+
+    selected_factory = client_factory or create_boto3_s3_client
+    client = selected_factory(region_name=region)
+    selected_publisher = publisher or put_immutable_object
+    results: list[dict[str, Any]] = []
+    for artifact in artifacts:
+        payload = _read_regular_file(
+            artifact.path,
+            expected_size=artifact.content_length,
+        )
+        if content_sha256(payload) != artifact.sha256:
+            raise StorageError("replication artifact changed after the plan was created")
+        result = selected_publisher(
+            client,
+            config=durable_config,
+            bucket=bucket,
+            dataset=artifact.remote_dataset,
+            payload=payload,
+            extension=artifact.extension,
+            content_type=artifact.content_type,
+            kms_key_id=kms_key_id,
+        )
+        if not isinstance(result, Mapping):
+            raise StorageError("durable S3 publisher returned invalid evidence")
+        safe_result = _safe_publication_evidence(result)
+        if safe_result.get("status") not in {"written", "already_present"}:
+            raise StorageError("durable S3 publisher returned invalid status")
+        results.append(
+            {
+                "dataset": artifact.dataset,
+                "relative_path": artifact.relative_path,
+                "remote_dataset": artifact.remote_dataset,
+                **safe_result,
+            }
+        )
+
+    manifest_result = selected_publisher(
+        client,
+        config=durable_config,
+        bucket=bucket,
+        dataset=MANIFEST_DATASET,
+        payload=manifest_payload,
+        extension="json",
+        content_type="application/json",
+        kms_key_id=kms_key_id,
+    )
+    if not isinstance(manifest_result, Mapping):
+        raise StorageError("durable S3 publisher returned invalid manifest evidence")
+    safe_manifest_result = _safe_publication_evidence(manifest_result)
+    if safe_manifest_result.get("status") not in {"written", "already_present"}:
+        raise StorageError("durable S3 publisher returned invalid manifest status")
+
+    written = sum(result["status"] == "written" for result in results)
+    already_present = sum(
+        result["status"] == "already_present" for result in results
+    )
+    return {
+        **base,
+        "replication": {
+            "performed": True,
+            "artifacts_written": written,
+            "artifacts_already_present": already_present,
+            "artifact_results": results,
+            "manifest": {
+                "manifest_id": manifest["manifest_id"],
+                **safe_manifest_result,
+            },
+        },
+    }
+
+
+def _positive_integer(value: str) -> int:
+    try:
+        parsed = int(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("must be a positive integer") from exc
+    if parsed < 1:
+        raise argparse.ArgumentTypeError("must be a positive integer")
+    return parsed
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Plan or explicitly replicate configured local Parquet datasets "
+            "through the immutable durable S3 adapter."
+        )
+    )
+    parser.add_argument("--store-id", default="primary-s3")
+    parser.add_argument(
+        "--storage-config",
+        type=Path,
+        default=Path("config/storage.yaml"),
+    )
+    parser.add_argument(
+        "--durable-config",
+        type=Path,
+        default=Path("config/durable_storage.yaml"),
+    )
+    parser.add_argument(
+        "--dataset",
+        action="append",
+        dest="datasets",
+        help="Configured raw dataset name or curated dataset key; repeatable.",
+    )
+    parser.add_argument("--max-files", type=_positive_integer)
+    parser.add_argument(
+        "--max-total-bytes",
+        type=_positive_integer,
+        default=DEFAULT_MAX_REPLICATION_BYTES,
+    )
+    parser.add_argument("--enable-durable-write", action="store_true")
+    parser.add_argument("--summary-json", type=Path)
+    return parser
+
+
+def _write_summary(path: Path, summary: Mapping[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_suffix(path.suffix + ".tmp")
+    try:
+        temporary.write_text(
+            json.dumps(summary, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        temporary.replace(path)
+    except OSError:
+        temporary.unlink(missing_ok=True)
+        raise StorageError("Unable to write durable replication summary") from None
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    try:
+        summary = replicate_local_datasets(
+            store_id=args.store_id,
+            storage_config_path=args.storage_config,
+            durable_config_path=args.durable_config,
+            selected_datasets=args.datasets,
+            max_files=args.max_files,
+            max_total_bytes=args.max_total_bytes,
+            enable_durable_write=args.enable_durable_write,
+        )
+        if args.summary_json is not None:
+            _write_summary(args.summary_json, summary)
+    except ValidationError:
+        print(
+            "Durable replication failed: configuration, environment, "
+            "selection, or bounds were invalid",
+            file=sys.stderr,
+        )
+        return 1
+    except StorageError:
+        print(
+            "Durable replication failed: bounded local inventory or "
+            "S3 operation failed",
+            file=sys.stderr,
+        )
+        return 1
+    except Exception:
+        print(
+            "Durable replication failed: unexpected local failure",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(json.dumps(summary, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/test_durable_replication_architecture_contract.py
+++ b/tests/unit/test_durable_replication_architecture_contract.py
@@ -1,0 +1,34 @@
+from pathlib import Path
+
+
+def test_durable_replication_documentation_matches_runtime_contract() -> None:
+    documentation = Path("docs/durable-s3-replication.md").read_text(
+        encoding="utf-8"
+    )
+    runtime = Path(
+        "src/orchestration/replicate_durable_datasets.py"
+    ).read_text(encoding="utf-8")
+
+    assert "replicate_durable_datasets" in documentation
+    assert "def replicate_local_datasets" in runtime
+    assert "--max-files" in documentation
+    assert "--max-total-bytes" in documentation
+    assert "max_files" in runtime
+    assert "max_total_bytes" in runtime
+
+    for required in (
+        "put_immutable_object",
+        "--enable-durable-write",
+        "replication-manifests",
+        "durable-dataset-replication-v1",
+        "no_artifacts",
+    ):
+        assert required in documentation
+        assert required in runtime
+
+    for prohibited in (
+        "terraform apply",
+        "create an S3 bucket",
+        "delete or overwrite remote objects",
+    ):
+        assert prohibited in documentation

--- a/tests/unit/test_replicate_durable_datasets.py
+++ b/tests/unit/test_replicate_durable_datasets.py
@@ -1,0 +1,474 @@
+from __future__ import annotations
+
+from dataclasses import replace
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+from src.common.exceptions import StorageError, ValidationError
+from src.orchestration import replicate_durable_datasets as replication
+from src.orchestration.replicate_durable_datasets import (
+    MANIFEST_DATASET,
+    inventory_local_replication_artifacts,
+    replicate_local_datasets,
+)
+from src.storage.durable_s3 import (
+    DurableS3Config,
+    content_sha256,
+    immutable_object_key,
+)
+
+
+def _durable_config(**overrides: Any) -> DurableS3Config:
+    values: dict[str, Any] = {
+        "store_id": "primary-s3",
+        "enabled": True,
+        "bucket_env": "DURABLE_BUCKET",
+        "region_env": "AWS_REGION",
+        "prefix": "risk-platform",
+        "server_side_encryption": "AES256",
+        "kms_key_env": None,
+        "max_object_bytes": 1_000_000,
+        "max_list_objects": 20,
+    }
+    values.update(overrides)
+    return DurableS3Config(**values)
+
+
+def _storage_config(tmp_path: Path) -> dict[str, Any]:
+    return {
+        "storage": {
+            "base_dir": str(tmp_path),
+            "raw": {
+                "base_path": str(tmp_path / "raw"),
+                "dataset": "market_events",
+            },
+            "curated": {
+                "base_path": str(tmp_path / "curated"),
+                "datasets": {
+                    "daily_returns": "daily_returns",
+                    "portfolio_risk_attribution": "portfolio_risk_attribution",
+                },
+            },
+            "format": "parquet",
+            "partitioning": {"granularity": "hourly"},
+        }
+    }
+
+
+def _write_storage_config(tmp_path: Path) -> tuple[dict[str, Any], Path]:
+    config = _storage_config(tmp_path)
+    path = tmp_path / "storage.yaml"
+    path.write_text(yaml.safe_dump(config), encoding="utf-8")
+    return config, path
+
+
+def _write_artifacts(tmp_path: Path) -> None:
+    raw = tmp_path / "raw" / "market_events" / "year=2026" / "month=08"
+    raw.mkdir(parents=True)
+    (raw / "raw-b.parquet").write_bytes(b"raw-b")
+    (raw / "raw-a.parquet").write_bytes(b"raw-a")
+
+    daily = tmp_path / "curated" / "daily_returns" / "year=2026"
+    daily.mkdir(parents=True)
+    (daily / "daily.parquet").write_bytes(b"daily")
+
+    attribution = tmp_path / "curated" / "portfolio_risk_attribution"
+    attribution.mkdir(parents=True)
+    (attribution / "attribution.parquet").write_bytes(b"attribution")
+
+
+def _publisher_calls() -> tuple[list[dict[str, Any]], Any]:
+    calls: list[dict[str, Any]] = []
+
+    def publisher(_client: Any, **kwargs: Any) -> dict[str, Any]:
+        calls.append(kwargs)
+        payload = kwargs["payload"]
+        key = immutable_object_key(
+            kwargs["config"],
+            dataset=kwargs["dataset"],
+            payload=payload,
+            extension=kwargs["extension"],
+        )
+        return {
+            "bucket_configured": True,
+            "content_length": len(payload),
+            "key": key,
+            "sha256": content_sha256(payload),
+            "status": "written",
+        }
+
+    return calls, publisher
+
+
+def test_inventory_is_deterministic_and_preserves_dataset_evidence(
+    tmp_path: Path,
+) -> None:
+    config, _ = _write_storage_config(tmp_path)
+    _write_artifacts(tmp_path)
+
+    artifacts = inventory_local_replication_artifacts(
+        storage_config=config,
+        durable_config=_durable_config(),
+        max_files=10,
+        max_total_bytes=1_000,
+    )
+
+    assert [
+        (artifact.remote_dataset, artifact.relative_path)
+        for artifact in artifacts
+    ] == [
+        ("curated-daily_returns", "year=2026/daily.parquet"),
+        (
+            "curated-portfolio_risk_attribution",
+            "attribution.parquet",
+        ),
+        ("raw-market_events", "year=2026/month=08/raw-a.parquet"),
+        ("raw-market_events", "year=2026/month=08/raw-b.parquet"),
+    ]
+    assert all(artifact.extension == "parquet" for artifact in artifacts)
+    assert all(
+        artifact.content_type == "application/vnd.apache.parquet"
+        for artifact in artifacts
+    )
+    assert all(
+        artifact.object_key.startswith("risk-platform/")
+        for artifact in artifacts
+    )
+
+
+def test_dataset_selection_is_explicit_and_unknown_names_fail(
+    tmp_path: Path,
+) -> None:
+    config, _ = _write_storage_config(tmp_path)
+    _write_artifacts(tmp_path)
+
+    selected = inventory_local_replication_artifacts(
+        storage_config=config,
+        durable_config=_durable_config(),
+        selected_datasets=["daily_returns"],
+    )
+    assert {artifact.dataset for artifact in selected} == {"daily_returns"}
+
+    with pytest.raises(ValidationError, match="not configured"):
+        inventory_local_replication_artifacts(
+            storage_config=config,
+            durable_config=_durable_config(),
+            selected_datasets=["unknown"],
+        )
+
+
+def test_plan_only_requires_no_environment_or_client(
+    tmp_path: Path,
+) -> None:
+    _, storage_path = _write_storage_config(tmp_path)
+    _write_artifacts(tmp_path)
+    clients: list[str] = []
+
+    summary = replicate_local_datasets(
+        store_id="primary-s3",
+        storage_config_path=storage_path,
+        durable_config_path=tmp_path / "durable.yaml",
+        selected_datasets=["daily_returns"],
+        enable_durable_write=False,
+        environment={},
+        config_loader=lambda *_: _durable_config(),
+        client_factory=lambda **_: clients.append("created"),
+    )
+
+    assert summary["replication"] == {
+        "performed": False,
+        "reason": "explicit_enable_flag_required",
+    }
+    assert summary["plan"]["artifact_count"] == 1
+    assert summary["plan"]["dataset_count"] == 1
+    assert summary["plan"]["manifest_id"].startswith(
+        "durable-replication-"
+    )
+    assert clients == []
+
+
+def test_disabled_store_blocks_execution_before_environment_resolution(
+    tmp_path: Path,
+) -> None:
+    _, storage_path = _write_storage_config(tmp_path)
+    _write_artifacts(tmp_path)
+    clients: list[str] = []
+
+    summary = replicate_local_datasets(
+        store_id="primary-s3",
+        storage_config_path=storage_path,
+        durable_config_path=tmp_path / "durable.yaml",
+        selected_datasets=["daily_returns"],
+        enable_durable_write=True,
+        environment={},
+        config_loader=lambda *_: _durable_config(enabled=False),
+        client_factory=lambda **_: clients.append("created"),
+    )
+
+    assert summary["replication"] == {
+        "performed": False,
+        "reason": "store_disabled_in_configuration",
+    }
+    assert clients == []
+
+
+def test_execution_delegates_objects_and_manifest_to_immutable_adapter(
+    tmp_path: Path,
+) -> None:
+    _, storage_path = _write_storage_config(tmp_path)
+    _write_artifacts(tmp_path)
+    calls, publisher = _publisher_calls()
+    regions: list[str] = []
+
+    summary = replicate_local_datasets(
+        store_id="primary-s3",
+        storage_config_path=storage_path,
+        durable_config_path=tmp_path / "durable.yaml",
+        selected_datasets=["daily_returns", "market_events"],
+        max_files=10,
+        max_total_bytes=1_000,
+        enable_durable_write=True,
+        environment={
+            "DURABLE_BUCKET": "secret-bucket-name",
+            "AWS_REGION": "eu-west-2",
+        },
+        config_loader=lambda *_: _durable_config(),
+        client_factory=lambda *, region_name: regions.append(region_name)
+        or object(),
+        publisher=publisher,
+    )
+
+    assert regions == ["eu-west-2"]
+    assert [call["dataset"] for call in calls] == [
+        "curated-daily_returns",
+        "raw-market_events",
+        "raw-market_events",
+        MANIFEST_DATASET,
+    ]
+    assert summary["replication"]["performed"] is True
+    assert summary["replication"]["artifacts_written"] == 3
+    assert summary["replication"]["artifacts_already_present"] == 0
+    assert summary["replication"]["manifest"]["status"] == "written"
+    assert "secret-bucket-name" not in str(summary)
+    assert "eu-west-2" not in str(summary)
+    assert summary["credentials_recorded"] is False
+
+
+def test_replay_statuses_are_counted_without_duplicate_manifest_identity(
+    tmp_path: Path,
+) -> None:
+    _, storage_path = _write_storage_config(tmp_path)
+    _write_artifacts(tmp_path)
+    statuses = iter(["already_present", "written"])
+
+    def publisher(_client: Any, **kwargs: Any) -> dict[str, Any]:
+        payload = kwargs["payload"]
+        return {
+            "content_length": len(payload),
+            "key": immutable_object_key(
+                kwargs["config"],
+                dataset=kwargs["dataset"],
+                payload=payload,
+                extension=kwargs["extension"],
+            ),
+            "sha256": content_sha256(payload),
+            "status": next(statuses),
+        }
+
+    summary = replicate_local_datasets(
+        store_id="primary-s3",
+        storage_config_path=storage_path,
+        durable_config_path=tmp_path / "durable.yaml",
+        selected_datasets=["daily_returns"],
+        enable_durable_write=True,
+        environment={
+            "DURABLE_BUCKET": "bucket",
+            "AWS_REGION": "eu-west-2",
+        },
+        config_loader=lambda *_: _durable_config(),
+        client_factory=lambda **_: object(),
+        publisher=publisher,
+    )
+
+    assert summary["replication"]["artifacts_written"] == 0
+    assert summary["replication"]["artifacts_already_present"] == 1
+    assert summary["replication"]["manifest"]["status"] == "written"
+
+
+def test_file_and_total_byte_bounds_fail_before_publication(
+    tmp_path: Path,
+) -> None:
+    config, _ = _write_storage_config(tmp_path)
+    _write_artifacts(tmp_path)
+
+    with pytest.raises(ValidationError, match="max_files"):
+        inventory_local_replication_artifacts(
+            storage_config=config,
+            durable_config=_durable_config(),
+            max_files=1,
+            max_total_bytes=1_000,
+        )
+
+    with pytest.raises(ValidationError, match="max_total_bytes"):
+        inventory_local_replication_artifacts(
+            storage_config=config,
+            durable_config=_durable_config(),
+            max_files=10,
+            max_total_bytes=2,
+        )
+
+
+def test_object_size_and_symlink_paths_fail_closed(
+    tmp_path: Path,
+) -> None:
+    config, _ = _write_storage_config(tmp_path)
+    _write_artifacts(tmp_path)
+
+    with pytest.raises(ValidationError, match="max_object_bytes"):
+        inventory_local_replication_artifacts(
+            storage_config=config,
+            durable_config=_durable_config(max_object_bytes=2),
+        )
+
+    real = tmp_path / "real-daily"
+    real.mkdir()
+    dataset = tmp_path / "curated" / "daily_returns"
+    for path in sorted(dataset.rglob("*"), reverse=True):
+        if path.is_file():
+            path.unlink()
+        elif path.is_dir():
+            path.rmdir()
+    dataset.rmdir()
+    try:
+        dataset.symlink_to(real, target_is_directory=True)
+    except OSError:
+        pytest.skip("symbolic links are unavailable")
+
+    with pytest.raises(StorageError, match="symbolic link"):
+        inventory_local_replication_artifacts(
+            storage_config=config,
+            durable_config=_durable_config(),
+            selected_datasets=["daily_returns"],
+        )
+
+
+def test_artifact_change_after_planning_fails_before_publication(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _, storage_path = _write_storage_config(tmp_path)
+    _write_artifacts(tmp_path)
+    original = replication._read_regular_file
+    reads = 0
+    published: list[str] = []
+
+    def changing_read(path: Path, *, expected_size: int) -> bytes:
+        nonlocal reads
+        reads += 1
+        payload = original(path, expected_size=expected_size)
+        if reads == 2:
+            return b"x" * expected_size
+        return payload
+
+    monkeypatch.setattr(replication, "_read_regular_file", changing_read)
+
+    with pytest.raises(StorageError, match="changed after the plan"):
+        replicate_local_datasets(
+            store_id="primary-s3",
+            storage_config_path=storage_path,
+            durable_config_path=tmp_path / "durable.yaml",
+            selected_datasets=["daily_returns"],
+            enable_durable_write=True,
+            environment={
+                "DURABLE_BUCKET": "bucket",
+                "AWS_REGION": "eu-west-2",
+            },
+            config_loader=lambda *_: _durable_config(),
+            client_factory=lambda **_: object(),
+            publisher=lambda *_args, **_kwargs: published.append("called")
+            or {"status": "written"},
+        )
+
+    assert published == []
+
+
+def test_manifest_identity_is_stable_and_changes_with_content(
+    tmp_path: Path,
+) -> None:
+    _, storage_path = _write_storage_config(tmp_path)
+    _write_artifacts(tmp_path)
+
+    first = replicate_local_datasets(
+        store_id="primary-s3",
+        storage_config_path=storage_path,
+        durable_config_path=tmp_path / "durable.yaml",
+        selected_datasets=["daily_returns"],
+        config_loader=lambda *_: _durable_config(),
+    )
+    second = replicate_local_datasets(
+        store_id="primary-s3",
+        storage_config_path=storage_path,
+        durable_config_path=tmp_path / "durable.yaml",
+        selected_datasets=["daily_returns"],
+        config_loader=lambda *_: _durable_config(),
+    )
+    assert first["plan"]["manifest_id"] == second["plan"]["manifest_id"]
+    assert first["plan"]["manifest_object_key"] == second["plan"][
+        "manifest_object_key"
+    ]
+
+    daily = next((tmp_path / "curated" / "daily_returns").rglob("*.parquet"))
+    daily.write_bytes(b"changed")
+    changed = replicate_local_datasets(
+        store_id="primary-s3",
+        storage_config_path=storage_path,
+        durable_config_path=tmp_path / "durable.yaml",
+        selected_datasets=["daily_returns"],
+        config_loader=lambda *_: _durable_config(),
+    )
+    assert changed["plan"]["manifest_id"] != first["plan"]["manifest_id"]
+
+
+def test_no_artifacts_returns_a_non_mutating_result(
+    tmp_path: Path,
+) -> None:
+    _, storage_path = _write_storage_config(tmp_path)
+
+    summary = replicate_local_datasets(
+        store_id="primary-s3",
+        storage_config_path=storage_path,
+        durable_config_path=tmp_path / "durable.yaml",
+        enable_durable_write=True,
+        config_loader=lambda *_: replace(_durable_config(), enabled=True),
+    )
+
+    assert summary["replication"] == {
+        "performed": False,
+        "reason": "no_artifacts",
+    }
+
+
+def test_invalid_publisher_status_fails_closed(
+    tmp_path: Path,
+) -> None:
+    _, storage_path = _write_storage_config(tmp_path)
+    _write_artifacts(tmp_path)
+
+    with pytest.raises(StorageError, match="invalid status"):
+        replicate_local_datasets(
+            store_id="primary-s3",
+            storage_config_path=storage_path,
+            durable_config_path=tmp_path / "durable.yaml",
+            selected_datasets=["daily_returns"],
+            enable_durable_write=True,
+            environment={
+                "DURABLE_BUCKET": "bucket",
+                "AWS_REGION": "eu-west-2",
+            },
+            config_loader=lambda *_: _durable_config(),
+            client_factory=lambda **_: object(),
+            publisher=lambda *_args, **_kwargs: {"status": "unknown"},
+        )


### PR DESCRIPTION
## Outcome

Add a thin, bounded replication workflow over the immutable S3 adapter merged in #85:

```text
configured local raw and curated Parquet
  -> deterministic bounded inventory
  -> SHA-256 content identities and immutable object keys
  -> plan-only evidence by default
  -> explicitly enabled adapter publication
  -> canonical content-addressed replication manifest
```

Primary arc42 block: `orchestration`, with one bounded interface to `storage`.

## No duplicate S3 client

The runner delegates every object write and existing-object verification to `src.storage.durable_s3.put_immutable_object`. It does not reimplement conditional writes, checksums, encryption, collision checks or overwrite refusal.

Local files map to safe durable dataset segments:

- raw: `raw-<configured raw dataset>`;
- curated: `curated-<configured curated dataset key>`.

The source partition-relative path remains in the manifest while object keys remain content-addressed.

## Plan and execution gates

The default command inventories and hashes local Parquet but does not resolve bucket/region/KMS values, create a boto3 client or perform a network request.

Publication requires both:

1. an enabled durable store; and
2. `--enable-durable-write`.

The bundled store remains disabled and contains no resource or credential value.

## Bounds and local safety

- Configured raw and curated roots only.
- `*.parquet` only.
- Regular, non-symbolic-link files only.
- Non-empty files only.
- Per-object limit inherited from the durable store.
- File cap bounded by both the request and `max_list_objects`, with a hard 10,000 maximum.
- Total-byte request bound, default 1 GB and hard maximum 100 GB.
- Deterministic dataset/path/hash ordering.
- Size and SHA-256 reverified immediately before each adapter call.
- Unknown dataset selectors fail closed.

## Manifest and replay

After all artifacts are written or verified already present, the runner publishes a canonical `durable-dataset-replication-v1` JSON manifest through the same adapter under `replication-manifests`.

The manifest contains stable store, dataset, relative-path, size, digest and object-key evidence. It contains no run timestamp, random run ID, bucket, region, KMS value or credentials. Identical local state converges on the same manifest ID and object key. A partial artifact failure publishes no manifest; rerun remains safe because prior objects are immutable.

## Operator commands

Plan only:

```bash
.venv/bin/python -m src.orchestration.replicate_durable_datasets \
  --store-id primary-s3 \
  --dataset daily_returns \
  --dataset portfolio_risk_attribution \
  --summary-json .demo/durable-replication-plan.json
```

Explicit execution, only after configuration review:

```bash
.venv/bin/python -m src.orchestration.replicate_durable_datasets \
  --store-id primary-s3 \
  --dataset daily_returns \
  --max-files 1000 \
  --max-total-bytes 1000000000 \
  --enable-durable-write \
  --summary-json .demo/durable-replication-result.json
```

## Validation

GitHub Actions run `32628637996` (`ci` run 253) passed on exact head `46823de732cb84421194fbad38dac89d4a234326`:

- Security guardrails: passed.
- Python readiness: passed.
  - locked dependencies resolved;
  - Ruff passed;
  - mypy passed across 71 source files;
  - 608 tests passed;
  - dependency integrity passed;
  - `make readiness-check` passed.
- PostgreSQL contract: passed against PostgreSQL 16 with the complete schema/load/reconciliation replay.
- Infrastructure validation: passed without deployment or Terraform apply.

The focused new tests cover deterministic inventory, dataset selection, plan-only behaviour, disabled-store behaviour, adapter delegation, manifest-last ordering, replay counts, file and byte caps, per-object caps, symlinks, file mutation, stable manifest identity, no-artifact behaviour and invalid publisher status. No unresolved review threads or requested changes are present.

## Scope

The branch is one commit ahead of `main` and zero behind. It adds four files with 1,278 lines as one replication-orchestration contract.

No cloud resource, credential, lifecycle rule, delete/overwrite operation, restore path, scheduler, deployment or Terraform apply is included.

## Acceptance boundary

Validated and ready for squash merge as one bounded orchestration increment.