### PR TITLE
Add fixed-decay EWMA portfolio attribution

### DIFF
--- a/docs/portfolio-covariance-comparison.md
+++ b/docs/portfolio-covariance-comparison.md
@@ -1,0 +1,229 @@
+# Sample And EWMA Portfolio Covariance Comparison
+
+## Outcome
+
+This increment adds a second, versioned covariance estimator without changing the
+existing sample-covariance path:
+
+```text
+one aligned current portfolio-return window
+  -> existing annualised sample covariance
+  -> fixed-decay zero-mean EWMA covariance
+  -> method-specific implied correlation
+  -> method-specific Euler volatility attribution
+  -> two independently versioned portfolio_risk_attribution rows
+  -> paired comparison summary
+```
+
+The existing sample model remains:
+
+```text
+model_version      = portfolio-attribution-v1
+covariance_method  = sample_annualized
+correlation_method = pearson
+```
+
+The additional estimator is:
+
+```text
+model_version      = portfolio-attribution-ewma-v1
+covariance_method  = ewma_zero_mean_lambda_0_94_annualized
+correlation_method = implied_from_ewma_covariance
+EWMA decay         = 0.94
+```
+
+The pure EWMA calculation is implemented in:
+
+```text
+src/analytics/portfolio_attribution_ewma.py
+```
+
+The paired latest-window runner is:
+
+```text
+src/orchestration/run_portfolio_covariance_comparison.py
+```
+
+## Why A Separate Model Version
+
+The sample model is already retained, served and reconciled. Its calculation IDs
+must remain stable for replay and warehouse history.
+
+EWMA therefore uses a separate model version and method identity rather than
+changing the meaning of `portfolio-attribution-v1`. The existing PostgreSQL
+grain already includes:
+
+```text
+model_version
+covariance_method
+correlation_method
+```
+
+Both estimates can coexist for the same portfolio definition, event date and
+window without a table migration or overwrite.
+
+## Input Alignment
+
+The comparison command reads portfolio returns once and applies the same
+canonical validation and current-version selection to both estimators.
+
+For each event date, a corrected portfolio return is selected by:
+
+```text
+ts_ingest DESC
+calculation_id DESC
+```
+
+The runner rejects publication unless both models have identical:
+
+- portfolio and base currency;
+- definition fingerprint and weighting method;
+- covariance window and observation count;
+- window start and end;
+- event date;
+- annualisation basis; and
+- ordered input calculation IDs.
+
+Only the covariance estimator, correlation method, model version, calculation ID
+and resulting risk values differ.
+
+## Sample Covariance
+
+The existing sample model uses the ordinary demeaned sample covariance over the
+complete window:
+
+```text
+Sigma_sample_daily  = sample_covariance(r_t)
+Sigma_sample_annual = 252 * Sigma_sample_daily
+```
+
+Pearson correlation is calculated directly from the same return window.
+
+The implementation and calculation identity of this path are unchanged by this
+increment.
+
+## EWMA Covariance
+
+The EWMA model applies exponentially decreasing weights to older observations.
+For a window of `n` observations ordered oldest to newest:
+
+```text
+raw_weight_i = 0.94 ** (n - 1 - i)
+weight_i     = raw_weight_i / sum(raw_weight)
+```
+
+The newest observation therefore receives the largest weight. The finite-window
+normalisation makes each persisted snapshot self-contained.
+
+The covariance uses the explicit zero-daily-mean assumption:
+
+```text
+Sigma_ewma_daily  = sum(weight_i * r_i * r_i')
+Sigma_ewma_annual = 252 * Sigma_ewma_daily
+```
+
+This is intentionally distinct from an exponentially weighted, demeaned sample
+covariance. The method name records the zero-mean and fixed-decay assumptions so
+a future estimator cannot silently reuse the same identity.
+
+Correlation is implied from the EWMA covariance matrix:
+
+```text
+correlation_ij = covariance_ij / sqrt(variance_i * variance_j)
+```
+
+Where either variance is numerically zero, the correlation cell is persisted as
+JSON `null`, with the existing explicit undefined-correlation status.
+
+## Euler Attribution
+
+Both covariance matrices feed the same transparent Euler allocation:
+
+```text
+portfolio_variance   = w' * Sigma * w
+portfolio_volatility = sqrt(portfolio_variance)
+
+marginal_i  = (Sigma * w)_i / portfolio_volatility
+component_i = w_i * marginal_i
+share_i     = component_i / portfolio_volatility
+```
+
+For each model, component contributions must reconcile to that model's portfolio
+volatility within the existing numerical tolerance. A component contribution may
+be negative when covariance makes the constituent risk-reducing.
+
+## Operator Flow
+
+Generate current portfolio returns first, then run the paired comparison:
+
+```bash
+.venv/bin/python -m src.orchestration.run_portfolio_covariance_comparison \
+  --portfolio-id us-tech-equal \
+  --end-date 2026-03-31 \
+  --covariance-window 20 \
+  --summary-json .demo/portfolio-covariance-comparison.json
+```
+
+The command performs no provider request. It reads bounded local
+`portfolio_daily_returns` Parquet and writes both snapshots independently to:
+
+```text
+data/curated/portfolio_risk_attribution
+```
+
+Independent publication is important for replay. If the sample row already
+exists from a previous run, it reports `already_present` while the EWMA row can
+still be added without writing a duplicate sample record.
+
+## Summary Evidence
+
+The credential-free summary includes:
+
+- exact window and ordered input calculation IDs;
+- sample and EWMA model/method identities;
+- both deterministic calculation IDs;
+- both annualised variances and volatilities;
+- both largest absolute component contributions;
+- EWMA decay, oldest/newest weights and effective observation count;
+- EWMA minus sample volatility;
+- EWMA-to-sample volatility ratio when sample volatility is positive; and
+- which estimator produces the higher volatility for the selected window.
+
+The comparison is evidence, not a statement that one estimator is universally
+better. The estimators answer different questions: the sample model weights the
+window evenly after demeaning, while the fixed-decay model reacts more strongly
+to recent squared returns under a zero-mean assumption.
+
+## Warehouse Compatibility
+
+No schema or loader change is required.
+
+`risk_platform.portfolio_risk_attribution` already retains every calculation ID.
+`latest_portfolio_risk_attribution` separates current rows by model and methods.
+The covariance, correlation and contribution views therefore expose both models
+once the normal attribution warehouse load runs.
+
+The existing risk-limit policy remains bound to the sample attribution contract
+in this increment. Extending risk-limit policy configuration to choose a
+covariance method is a separate governance change; EWMA rows are not silently
+substituted into sample-based limits.
+
+## Safety And Bounds
+
+The paired runner reuses the existing attribution reader and therefore:
+
+- accepts only the configured `portfolio_daily_returns` dataset;
+- filters to one portfolio and exact definition fingerprint;
+- rejects symbolic-link paths and unsafe local files;
+- caps input at 4,096 files, 1 GB and 250,000 rows;
+- requires a complete covariance window;
+- publishes no partial calculation; and
+- performs no provider, network, deployment or infrastructure action.
+
+## Current Boundary
+
+This increment implements one fixed-decay latest-window EWMA model and paired
+sample comparison. It does not yet add rolling EWMA history, a SQL trend
+comparison view, configurable decay, shrinkage covariance, factor models,
+marginal VaR, FX conversion, leverage, short positions, transaction costs or
+scheduled rebalancing.

--- a/src/analytics/portfolio_attribution_ewma.py
+++ b/src/analytics/portfolio_attribution_ewma.py
@@ -1,0 +1,284 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+from collections.abc import Iterable
+from datetime import date
+from typing import Any
+
+import numpy as np
+import pandas as pd
+
+from ..common.exceptions import ValidationError
+from .portfolio_attribution import (
+    EULER_TOLERANCE,
+    MAX_COVARIANCE_WINDOW,
+    VARIANCE_EPSILON,
+    PortfolioAttributionOutput,
+    PortfolioReturnInput,
+    _current_records,
+    _definition_weights,
+    _json_document,
+    _matrix_document,
+    _positive_integer,
+)
+from .portfolio_risk import (
+    TRADING_DAYS_PER_YEAR,
+    WEIGHTING_METHOD,
+    PortfolioDefinition,
+)
+
+MODEL_VERSION = "portfolio-attribution-ewma-v1"
+COVARIANCE_METHOD = "ewma_zero_mean_lambda_0_94_annualized"
+CORRELATION_METHOD = "implied_from_ewma_covariance"
+EWMA_DECAY = 0.94
+
+
+def _ewma_observation_weights(observations: int) -> np.ndarray[Any, Any]:
+    observations = _positive_integer(
+        observations,
+        "observations",
+        MAX_COVARIANCE_WINDOW,
+    )
+    exponents = np.arange(observations - 1, -1, -1, dtype="float64")
+    raw_weights = np.power(EWMA_DECAY, exponents)
+    total = float(raw_weights.sum())
+    if not math.isfinite(total) or total <= 0:
+        raise ValidationError("EWMA observation weights are invalid")
+    weights = raw_weights / total
+    if not np.isfinite(weights).all():
+        raise ValidationError("EWMA observation weights are invalid")
+    return weights
+
+
+def _ewma_covariance_and_correlation(
+    component_frame: pd.DataFrame,
+) -> tuple[pd.DataFrame, pd.DataFrame, np.ndarray[Any, Any]]:
+    observations = len(component_frame)
+    weights = _ewma_observation_weights(observations)
+    values = component_frame.to_numpy(dtype="float64", copy=True)
+    if values.ndim != 2 or values.shape[0] != observations:
+        raise ValidationError("EWMA component returns have an invalid shape")
+    if not np.isfinite(values).all():
+        raise ValidationError("EWMA component returns must be finite")
+
+    # The RiskMetrics-style assumption is a zero daily expected return. The
+    # finite window is normalized so every published matrix is self-contained.
+    daily_covariance = values.T @ (values * weights[:, None])
+    daily_covariance = (daily_covariance + daily_covariance.T) / 2.0
+    annualized_values = daily_covariance * TRADING_DAYS_PER_YEAR
+    if not np.isfinite(annualized_values).all():
+        raise ValidationError("EWMA covariance contains a non-finite value")
+
+    labels = list(component_frame.columns)
+    annualized_covariance = pd.DataFrame(
+        annualized_values,
+        index=labels,
+        columns=labels,
+        dtype="float64",
+    )
+
+    variances = np.diag(annualized_values).copy()
+    if np.any(variances < -VARIANCE_EPSILON):
+        raise ValidationError("EWMA covariance contains a negative diagonal")
+    variances = np.maximum(variances, 0.0)
+    denominator = np.sqrt(np.outer(variances, variances))
+    correlation_values = np.full_like(annualized_values, np.nan)
+    np.divide(
+        annualized_values,
+        denominator,
+        out=correlation_values,
+        where=denominator > VARIANCE_EPSILON,
+    )
+    correlation_values = np.clip(correlation_values, -1.0, 1.0)
+    for index, variance in enumerate(variances):
+        if variance > VARIANCE_EPSILON:
+            correlation_values[index, index] = 1.0
+    correlation = pd.DataFrame(
+        correlation_values,
+        index=labels,
+        columns=labels,
+        dtype="float64",
+    )
+    return annualized_covariance, correlation, weights
+
+
+def _calculation_id(
+    definition: PortfolioDefinition,
+    input_calculation_ids: list[str],
+    covariance_window: int,
+) -> str:
+    payload = {
+        "annualization_days": TRADING_DAYS_PER_YEAR,
+        "correlation_method": CORRELATION_METHOD,
+        "covariance_method": COVARIANCE_METHOD,
+        "covariance_window": covariance_window,
+        "definition_fingerprint": definition.fingerprint,
+        "input_calculation_ids": input_calculation_ids,
+        "model_version": MODEL_VERSION,
+        "weighting_method": WEIGHTING_METHOD,
+    }
+    digest = hashlib.sha256(
+        json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    ).hexdigest()[:24]
+    return f"{MODEL_VERSION}-snapshot-{digest}"
+
+
+def build_portfolio_ewma_attribution(
+    records: Iterable[PortfolioReturnInput],
+    *,
+    definition: PortfolioDefinition,
+    covariance_window: int = 20,
+    end_date: date | None = None,
+) -> PortfolioAttributionOutput:
+    covariance_window = _positive_integer(
+        covariance_window,
+        "covariance_window",
+        MAX_COVARIANCE_WINDOW,
+    )
+    current, matched_records = _current_records(records, definition, end_date)
+    if len(current) < covariance_window:
+        raise ValidationError(
+            "EWMA portfolio attribution requires at least "
+            f"{covariance_window} current portfolio return observations"
+        )
+    window = current[-covariance_window:]
+    keys = tuple(constituent.key for constituent in definition.constituents)
+    component_frame = pd.DataFrame(
+        [record["component_returns"] for record in window],
+        columns=list(keys),
+        dtype="float64",
+    )
+    annualized_covariance, correlation, observation_weights = (
+        _ewma_covariance_and_correlation(component_frame)
+    )
+    covariance_json, _ = _matrix_document(
+        annualized_covariance,
+        keys,
+        allow_undefined=False,
+    )
+    correlation_json, undefined_correlation_cells = _matrix_document(
+        correlation,
+        keys,
+        allow_undefined=True,
+    )
+
+    portfolio_weights = _definition_weights(definition)
+    marginal_variance = {
+        key: math.fsum(
+            float(annualized_covariance.loc[key, other])
+            * portfolio_weights[other]
+            for other in keys
+        )
+        for key in keys
+    }
+    portfolio_variance = math.fsum(
+        portfolio_weights[key] * marginal_variance[key] for key in keys
+    )
+    if portfolio_variance < -VARIANCE_EPSILON:
+        raise ValidationError("EWMA covariance produced a negative portfolio variance")
+    portfolio_variance = max(0.0, portfolio_variance)
+    portfolio_volatility = math.sqrt(portfolio_variance)
+
+    constituent_volatility: dict[str, float] = {}
+    for key in keys:
+        diagonal = float(annualized_covariance.loc[key, key])
+        if diagonal < -VARIANCE_EPSILON:
+            raise ValidationError("EWMA covariance contains a negative diagonal")
+        constituent_volatility[key] = math.sqrt(max(0.0, diagonal))
+
+    if portfolio_volatility > VARIANCE_EPSILON:
+        marginal_contribution = {
+            key: marginal_variance[key] / portfolio_volatility for key in keys
+        }
+        component_contribution = {
+            key: portfolio_weights[key] * marginal_contribution[key] for key in keys
+        }
+        contribution_share = {
+            key: component_contribution[key] / portfolio_volatility for key in keys
+        }
+        volatility_status = "positive"
+    else:
+        marginal_contribution = {key: 0.0 for key in keys}
+        component_contribution = {key: 0.0 for key in keys}
+        contribution_share = {key: 0.0 for key in keys}
+        volatility_status = "zero"
+
+    euler_total = math.fsum(component_contribution.values())
+    if not math.isclose(
+        euler_total,
+        portfolio_volatility,
+        rel_tol=0.0,
+        abs_tol=EULER_TOLERANCE,
+    ):
+        raise ValidationError("EWMA component volatility contributions do not reconcile")
+
+    input_calculation_ids = [record["calculation_id"] for record in window]
+    snapshot = {
+        "model_version": MODEL_VERSION,
+        "calculation_id": _calculation_id(
+            definition,
+            input_calculation_ids,
+            covariance_window,
+        ),
+        "portfolio_id": definition.portfolio_id,
+        "base_currency": definition.base_currency,
+        "definition_fingerprint": definition.fingerprint,
+        "weighting_method": WEIGHTING_METHOD,
+        "covariance_method": COVARIANCE_METHOD,
+        "correlation_method": CORRELATION_METHOD,
+        "covariance_window": covariance_window,
+        "window_start": window[0]["ts_event"],
+        "window_end": window[-1]["ts_event"],
+        "window_observations": len(window),
+        "annualization_days": TRADING_DAYS_PER_YEAR,
+        "ts_event": window[-1]["ts_event"],
+        "ts_ingest": max(record["ts_ingest"] for record in window),
+        "constituent_count": len(keys),
+        "weights_json": _json_document(portfolio_weights),
+        "input_calculation_ids_json": _json_document(input_calculation_ids),
+        "input_first_calculation_id": input_calculation_ids[0],
+        "input_last_calculation_id": input_calculation_ids[-1],
+        "covariance_annualized_json": covariance_json,
+        "correlation_json": correlation_json,
+        "constituent_volatility_annualized_json": _json_document(
+            constituent_volatility
+        ),
+        "marginal_volatility_contribution_json": _json_document(
+            marginal_contribution
+        ),
+        "component_volatility_contribution_json": _json_document(
+            component_contribution
+        ),
+        "component_contribution_share_json": _json_document(contribution_share),
+        "portfolio_variance_annualized": portfolio_variance,
+        "portfolio_volatility_annualized": portfolio_volatility,
+        "volatility_status": volatility_status,
+        "correlation_status": (
+            "complete"
+            if undefined_correlation_cells == 0
+            else "undefined_zero_variance"
+        ),
+        "undefined_correlation_cells": undefined_correlation_cells,
+        "euler_residual": euler_total - portfolio_volatility,
+    }
+    effective_observations = 1.0 / math.fsum(
+        float(weight) ** 2 for weight in observation_weights
+    )
+    diagnostics = {
+        "matched_input_records": matched_records,
+        "current_portfolio_return_records": len(current),
+        "covariance_method": COVARIANCE_METHOD,
+        "correlation_method": CORRELATION_METHOD,
+        "covariance_window": covariance_window,
+        "ewma_decay": EWMA_DECAY,
+        "oldest_observation_weight": float(observation_weights[0]),
+        "newest_observation_weight": float(observation_weights[-1]),
+        "effective_observations": effective_observations,
+        "window_start": window[0]["ts_event"].date().isoformat(),
+        "window_end": window[-1]["ts_event"].date().isoformat(),
+        "volatility_status": volatility_status,
+        "undefined_correlation_cells": undefined_correlation_cells,
+    }
+    return PortfolioAttributionOutput(snapshot=snapshot, diagnostics=diagnostics)

--- a/src/orchestration/run_portfolio_covariance_comparison.py
+++ b/src/orchestration/run_portfolio_covariance_comparison.py
@@ -1,0 +1,324 @@
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import sys
+from collections.abc import Callable, Sequence
+from datetime import date
+from pathlib import Path
+from typing import Any
+from uuid import uuid4
+
+from ..analytics.portfolio_attribution import (
+    COVARIANCE_METHOD as SAMPLE_COVARIANCE_METHOD,
+    MODEL_VERSION as SAMPLE_MODEL_VERSION,
+    PortfolioAttributionOutput,
+    build_portfolio_attribution,
+)
+from ..analytics.portfolio_attribution_ewma import (
+    COVARIANCE_METHOD as EWMA_COVARIANCE_METHOD,
+    EWMA_DECAY,
+    MODEL_VERSION as EWMA_MODEL_VERSION,
+    build_portfolio_ewma_attribution,
+)
+from ..analytics.portfolio_risk import (
+    PortfolioDefinition,
+    load_portfolio_definition,
+)
+from ..common.exceptions import StorageError, ValidationError
+from ..storage.s3_writer import write_records
+from ..storage.storage_config import load_storage_config
+from .run_portfolio_attribution import (
+    OUTPUT_DATASET,
+    _calendar_date,
+    _positive_integer,
+    _require_datasets,
+    load_portfolio_return_records,
+)
+
+Reader = Callable[..., list[dict[str, Any]]]
+Writer = Callable[..., int]
+StorageConfigLoader = Callable[[Path], dict[str, Any]]
+DefinitionLoader = Callable[[Path, str], PortfolioDefinition]
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Calculate and persist aligned sample and EWMA portfolio "
+            "covariance attribution for one latest complete window."
+        )
+    )
+    parser.add_argument("--portfolio-id", required=True)
+    parser.add_argument(
+        "--portfolio-config",
+        type=Path,
+        default=Path("config/portfolios.yaml"),
+    )
+    parser.add_argument("--end-date", required=True, type=_calendar_date)
+    parser.add_argument("--covariance-window", type=_positive_integer, default=20)
+    parser.add_argument(
+        "--storage-config",
+        type=Path,
+        default=Path("config/storage.yaml"),
+    )
+    parser.add_argument("--summary-json", type=Path)
+    return parser
+
+
+def _publish_snapshots(
+    outputs: Sequence[PortfolioAttributionOutput],
+    *,
+    storage_config: dict[str, Any],
+    writer: Writer,
+) -> int:
+    written = 0
+    for output in outputs:
+        try:
+            result = writer(
+                [output.snapshot],
+                kind="curated",
+                dataset=OUTPUT_DATASET,
+                storage_config=storage_config,
+            )
+        except Exception:
+            raise StorageError(
+                "Portfolio covariance comparison publication failed; rerun is safe"
+            ) from None
+        if type(result) is not int or result not in {0, 1}:
+            raise StorageError(
+                "Portfolio covariance comparison publication returned an invalid result"
+            )
+        written += result
+    return written
+
+
+def _model_summary(output: PortfolioAttributionOutput) -> dict[str, Any]:
+    snapshot = output.snapshot
+    components = json.loads(snapshot["component_volatility_contribution_json"])
+    if not isinstance(components, dict) or not components:
+        raise ValidationError("portfolio attribution components are invalid")
+    largest_component = max(
+        sorted(components),
+        key=lambda key: abs(float(components[key])),
+    )
+    return {
+        "model_version": snapshot["model_version"],
+        "covariance_method": snapshot["covariance_method"],
+        "correlation_method": snapshot["correlation_method"],
+        "calculation_id": snapshot["calculation_id"],
+        "portfolio_variance_annualized": snapshot[
+            "portfolio_variance_annualized"
+        ],
+        "portfolio_volatility_annualized": snapshot[
+            "portfolio_volatility_annualized"
+        ],
+        "volatility_status": snapshot["volatility_status"],
+        "correlation_status": snapshot["correlation_status"],
+        "largest_absolute_component": largest_component,
+        "largest_absolute_component_contribution": components[largest_component],
+        "diagnostics": dict(output.diagnostics),
+    }
+
+
+def run_portfolio_covariance_comparison(
+    *,
+    portfolio_id: str,
+    portfolio_config_path: Path,
+    end_date: date,
+    covariance_window: int,
+    storage_config_path: Path,
+    reader: Reader | None = None,
+    writer: Writer | None = None,
+    storage_config_loader: StorageConfigLoader | None = None,
+    definition_loader: DefinitionLoader | None = None,
+) -> dict[str, Any]:
+    selected_storage_loader = storage_config_loader or load_storage_config
+    try:
+        storage_config = selected_storage_loader(storage_config_path)
+    except Exception:
+        raise StorageError("Storage configuration is invalid") from None
+    if not isinstance(storage_config, dict):
+        raise StorageError("Storage configuration is invalid")
+    _require_datasets(storage_config)
+
+    selected_definition_loader = definition_loader or load_portfolio_definition
+    try:
+        definition = selected_definition_loader(portfolio_config_path, portfolio_id)
+    except ValidationError:
+        raise
+    except Exception:
+        raise ValidationError("Portfolio configuration is invalid") from None
+
+    selected_reader = reader or load_portfolio_return_records
+    try:
+        records = selected_reader(
+            storage_config=storage_config,
+            portfolio_id=definition.portfolio_id,
+            definition_fingerprint=definition.fingerprint,
+            end_date=end_date,
+        )
+    except (StorageError, ValidationError):
+        raise
+    except Exception:
+        raise StorageError("Unable to read local portfolio returns") from None
+
+    sample = build_portfolio_attribution(
+        records,
+        definition=definition,
+        covariance_window=covariance_window,
+        end_date=end_date,
+    )
+    ewma = build_portfolio_ewma_attribution(
+        records,
+        definition=definition,
+        covariance_window=covariance_window,
+        end_date=end_date,
+    )
+
+    alignment_fields = (
+        "portfolio_id",
+        "base_currency",
+        "definition_fingerprint",
+        "weighting_method",
+        "covariance_window",
+        "window_start",
+        "window_end",
+        "window_observations",
+        "annualization_days",
+        "ts_event",
+        "input_calculation_ids_json",
+    )
+    if any(
+        sample.snapshot[field] != ewma.snapshot[field]
+        for field in alignment_fields
+    ):
+        raise ValidationError(
+            "sample and EWMA attribution calculations are not input-aligned"
+        )
+
+    selected_writer = writer or write_records
+    outputs = (sample, ewma)
+    written = _publish_snapshots(
+        outputs,
+        storage_config=storage_config,
+        writer=selected_writer,
+    )
+
+    sample_summary = _model_summary(sample)
+    ewma_summary = _model_summary(ewma)
+    sample_volatility = float(
+        sample.snapshot["portfolio_volatility_annualized"]
+    )
+    ewma_volatility = float(ewma.snapshot["portfolio_volatility_annualized"])
+    difference = ewma_volatility - sample_volatility
+    ratio = (
+        ewma_volatility / sample_volatility
+        if sample_volatility > 0
+        else None
+    )
+    if ratio is not None and not math.isfinite(ratio):
+        raise ValidationError("portfolio covariance comparison ratio is invalid")
+
+    return {
+        "run_id": str(uuid4()),
+        "portfolio_id": definition.portfolio_id,
+        "base_currency": definition.base_currency,
+        "definition_fingerprint": definition.fingerprint,
+        "selection": {
+            "end_date": end_date.isoformat(),
+            "covariance_window": covariance_window,
+            "window_start": sample.snapshot["window_start"].date().isoformat(),
+            "window_end": sample.snapshot["window_end"].date().isoformat(),
+            "input_calculation_ids": json.loads(
+                sample.snapshot["input_calculation_ids_json"]
+            ),
+        },
+        "parameters": {
+            "sample_covariance_method": SAMPLE_COVARIANCE_METHOD,
+            "sample_model_version": SAMPLE_MODEL_VERSION,
+            "ewma_covariance_method": EWMA_COVARIANCE_METHOD,
+            "ewma_model_version": EWMA_MODEL_VERSION,
+            "ewma_decay": EWMA_DECAY,
+        },
+        "curated_output": {
+            OUTPUT_DATASET: {
+                "records_selected": 2,
+                "records_written": written,
+                "records_already_present": 2 - written,
+            }
+        },
+        "models": {
+            "sample": sample_summary,
+            "ewma": ewma_summary,
+        },
+        "comparison": {
+            "ewma_minus_sample_volatility": difference,
+            "ewma_to_sample_volatility_ratio": ratio,
+            "higher_volatility_model": (
+                "ewma"
+                if difference > 0
+                else "sample"
+                if difference < 0
+                else "equal"
+            ),
+        },
+    }
+
+
+def _write_summary(path: Path, summary: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_suffix(path.suffix + ".tmp")
+    try:
+        temporary.write_text(
+            json.dumps(summary, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        temporary.replace(path)
+    except OSError:
+        temporary.unlink(missing_ok=True)
+        raise StorageError(
+            "Unable to write the portfolio covariance comparison summary"
+        ) from None
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    try:
+        summary = run_portfolio_covariance_comparison(
+            portfolio_id=args.portfolio_id,
+            portfolio_config_path=args.portfolio_config,
+            end_date=args.end_date,
+            covariance_window=args.covariance_window,
+            storage_config_path=args.storage_config,
+        )
+        if args.summary_json is not None:
+            _write_summary(args.summary_json, summary)
+    except ValidationError:
+        print(
+            "Portfolio covariance comparison failed: configuration, input data, "
+            "or options were invalid",
+            file=sys.stderr,
+        )
+        return 1
+    except StorageError:
+        print(
+            "Portfolio covariance comparison failed: local storage operation "
+            "failed; rerun is safe",
+            file=sys.stderr,
+        )
+        return 1
+    except Exception:
+        print(
+            "Portfolio covariance comparison failed: unexpected local failure",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(json.dumps(summary, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/integration/test_portfolio_covariance_comparison_pipeline.py
+++ b/tests/integration/test_portfolio_covariance_comparison_pipeline.py
@@ -1,0 +1,151 @@
+from __future__ import annotations
+
+import json
+from datetime import date, datetime, timedelta, timezone
+from pathlib import Path
+
+from src.analytics.portfolio_risk import (
+    WEIGHTING_METHOD,
+    load_portfolio_definition,
+)
+from src.orchestration.run_portfolio_covariance_comparison import (
+    run_portfolio_covariance_comparison,
+)
+from src.storage.s3_writer import write_records
+from src.warehouse.portfolio_attribution_loader import (
+    collect_attribution_records,
+)
+from tests.storage_config_helpers import build_storage_config, write_storage_config
+
+
+def _portfolio_config(tmp_path: Path) -> Path:
+    path = tmp_path / "portfolios.yaml"
+    path.write_text(
+        """
+portfolios:
+  us-tech-equal:
+    base_currency: USD
+    constituents:
+      - source: alpha_vantage
+        symbol: AAPL
+        weight: 0.5
+      - source: alpha_vantage
+        symbol: MSFT
+        weight: 0.5
+""".lstrip(),
+        encoding="utf-8",
+    )
+    return path
+
+
+def _portfolio_returns(definition_fingerprint: str) -> list[dict[str, object]]:
+    records: list[dict[str, object]] = []
+    ingested_at = datetime(2026, 1, 10, 12, tzinfo=timezone.utc)
+    for day, aapl, msft in [
+        (2, 0.10, 0.02),
+        (3, -0.04, 0.0),
+        (4, 0.06, 0.02),
+    ]:
+        component_returns = {
+            "alpha_vantage:AAPL": aapl,
+            "alpha_vantage:MSFT": msft,
+        }
+        records.append(
+            {
+                "model_version": "portfolio-risk-v1",
+                "calculation_id": f"portfolio-{day}",
+                "portfolio_id": "us-tech-equal",
+                "base_currency": "USD",
+                "definition_fingerprint": definition_fingerprint,
+                "weighting_method": WEIGHTING_METHOD,
+                "ts_event": datetime(2026, 1, day, tzinfo=timezone.utc),
+                "ts_ingest": ingested_at + timedelta(minutes=day),
+                "constituent_count": 2,
+                "weights_json": json.dumps(
+                    {
+                        "alpha_vantage:AAPL": 0.5,
+                        "alpha_vantage:MSFT": 0.5,
+                    },
+                    sort_keys=True,
+                ),
+                "component_calculation_ids_json": json.dumps(
+                    {
+                        "alpha_vantage:AAPL": f"AAPL-{day}",
+                        "alpha_vantage:MSFT": f"MSFT-{day}",
+                    },
+                    sort_keys=True,
+                ),
+                "component_returns_json": json.dumps(
+                    component_returns,
+                    sort_keys=True,
+                ),
+                "contributions_json": json.dumps(
+                    {
+                        key: 0.5 * value
+                        for key, value in component_returns.items()
+                    },
+                    sort_keys=True,
+                ),
+                "portfolio_return_1d": 0.5 * aapl + 0.5 * msft,
+            }
+        )
+    return records
+
+
+def test_covariance_comparison_publishes_two_models_and_replays(
+    tmp_path: Path,
+) -> None:
+    storage_config = build_storage_config(tmp_path)
+    storage_config_path = write_storage_config(tmp_path)
+    portfolio_config_path = _portfolio_config(tmp_path)
+    definition = load_portfolio_definition(
+        portfolio_config_path,
+        "us-tech-equal",
+    )
+    assert (
+        write_records(
+            _portfolio_returns(definition.fingerprint),
+            kind="curated",
+            dataset="portfolio_daily_returns",
+            storage_config=storage_config,
+        )
+        == 3
+    )
+
+    first = run_portfolio_covariance_comparison(
+        portfolio_id="us-tech-equal",
+        portfolio_config_path=portfolio_config_path,
+        end_date=date(2026, 1, 4),
+        covariance_window=3,
+        storage_config_path=storage_config_path,
+    )
+    second = run_portfolio_covariance_comparison(
+        portfolio_id="us-tech-equal",
+        portfolio_config_path=portfolio_config_path,
+        end_date=date(2026, 1, 4),
+        covariance_window=3,
+        storage_config_path=storage_config_path,
+    )
+
+    assert first["curated_output"]["portfolio_risk_attribution"] == {
+        "records_selected": 2,
+        "records_written": 2,
+        "records_already_present": 0,
+    }
+    assert second["curated_output"]["portfolio_risk_attribution"] == {
+        "records_selected": 2,
+        "records_written": 0,
+        "records_already_present": 2,
+    }
+
+    warehouse_rows = collect_attribution_records(storage_config_path)
+    assert len(warehouse_rows) == 2
+    assert {row["model_version"] for row in warehouse_rows} == {
+        "portfolio-attribution-v1",
+        "portfolio-attribution-ewma-v1",
+    }
+    assert {row["covariance_method"] for row in warehouse_rows} == {
+        "sample_annualized",
+        "ewma_zero_mean_lambda_0_94_annualized",
+    }
+    assert len({row["calculation_id"] for row in warehouse_rows}) == 2

--- a/tests/unit/test_portfolio_attribution_ewma.py
+++ b/tests/unit/test_portfolio_attribution_ewma.py
@@ -1,0 +1,284 @@
+from __future__ import annotations
+
+import json
+from datetime import date, datetime, timedelta, timezone
+
+import pytest
+
+from src.analytics.portfolio_attribution import build_portfolio_attribution
+from src.analytics.portfolio_attribution_ewma import (
+    CORRELATION_METHOD,
+    COVARIANCE_METHOD,
+    EWMA_DECAY,
+    MODEL_VERSION,
+    build_portfolio_ewma_attribution,
+)
+from src.analytics.portfolio_risk import (
+    WEIGHTING_METHOD,
+    PortfolioDefinition,
+    parse_portfolio_definition,
+)
+from src.common.exceptions import ValidationError
+
+
+def _definition() -> PortfolioDefinition:
+    return parse_portfolio_definition(
+        {
+            "portfolios": {
+                "us-tech-equal": {
+                    "base_currency": "USD",
+                    "constituents": [
+                        {
+                            "source": "alpha_vantage",
+                            "symbol": "AAPL",
+                            "weight": 0.5,
+                        },
+                        {
+                            "source": "alpha_vantage",
+                            "symbol": "MSFT",
+                            "weight": 0.5,
+                        },
+                    ],
+                }
+            }
+        },
+        "us-tech-equal",
+    )
+
+
+def _record(
+    day: int,
+    aapl: float,
+    msft: float,
+    *,
+    calculation_id: str | None = None,
+    ingested_at: datetime | None = None,
+) -> dict[str, object]:
+    definition = _definition()
+    ts_event = datetime(2026, 1, day, tzinfo=timezone.utc)
+    weights = {"alpha_vantage:AAPL": 0.5, "alpha_vantage:MSFT": 0.5}
+    component_returns = {
+        "alpha_vantage:AAPL": aapl,
+        "alpha_vantage:MSFT": msft,
+    }
+    return {
+        "model_version": "portfolio-risk-v1",
+        "calculation_id": calculation_id or f"portfolio-{day}",
+        "portfolio_id": definition.portfolio_id,
+        "base_currency": definition.base_currency,
+        "definition_fingerprint": definition.fingerprint,
+        "weighting_method": WEIGHTING_METHOD,
+        "ts_event": ts_event,
+        "ts_ingest": ingested_at or ts_event + timedelta(hours=1),
+        "constituent_count": 2,
+        "weights_json": json.dumps(weights, sort_keys=True),
+        "component_calculation_ids_json": json.dumps(
+            {
+                "alpha_vantage:AAPL": f"AAPL-{day}",
+                "alpha_vantage:MSFT": f"MSFT-{day}",
+            },
+            sort_keys=True,
+        ),
+        "component_returns_json": json.dumps(
+            component_returns,
+            sort_keys=True,
+        ),
+        "portfolio_return_1d": 0.5 * aapl + 0.5 * msft,
+    }
+
+
+def _records() -> list[dict[str, object]]:
+    return [
+        _record(2, 0.10, 0.02),
+        _record(3, -0.04, 0.0),
+        _record(4, 0.06, 0.02),
+    ]
+
+
+def test_ewma_attribution_calculates_expected_matrix_and_euler_risk() -> None:
+    output = build_portfolio_ewma_attribution(
+        _records(),
+        definition=_definition(),
+        covariance_window=3,
+        end_date=date(2026, 1, 4),
+    )
+    snapshot = output.snapshot
+    covariance = json.loads(snapshot["covariance_annualized_json"])
+    correlation = json.loads(snapshot["correlation_json"])
+    components = json.loads(snapshot["component_volatility_contribution_json"])
+    shares = json.loads(snapshot["component_contribution_share_json"])
+
+    assert snapshot["model_version"] == MODEL_VERSION
+    assert snapshot["covariance_method"] == COVARIANCE_METHOD
+    assert snapshot["correlation_method"] == CORRELATION_METHOD
+    assert snapshot["calculation_id"].startswith(f"{MODEL_VERSION}-snapshot-")
+    assert snapshot["portfolio_variance_annualized"] == pytest.approx(
+        0.4602471738206545
+    )
+    assert snapshot["portfolio_volatility_annualized"] == pytest.approx(
+        0.6784151927991107
+    )
+    assert covariance["alpha_vantage:AAPL"]["alpha_vantage:AAPL"] == (
+        pytest.approx(1.2441139028475716)
+    )
+    assert covariance["alpha_vantage:AAPL"]["alpha_vantage:MSFT"] == (
+        pytest.approx(0.2648159758278854)
+    )
+    assert correlation["alpha_vantage:AAPL"]["alpha_vantage:MSFT"] == (
+        pytest.approx(0.9155690359077874)
+    )
+    assert sum(components.values()) == pytest.approx(
+        snapshot["portfolio_volatility_annualized"]
+    )
+    assert sum(shares.values()) == pytest.approx(1.0)
+    assert output.diagnostics["ewma_decay"] == EWMA_DECAY
+    assert output.diagnostics["newest_observation_weight"] > output.diagnostics[
+        "oldest_observation_weight"
+    ]
+
+
+def test_sample_and_ewma_share_inputs_but_keep_distinct_versions() -> None:
+    sample = build_portfolio_attribution(
+        _records(),
+        definition=_definition(),
+        covariance_window=3,
+    )
+    ewma = build_portfolio_ewma_attribution(
+        _records(),
+        definition=_definition(),
+        covariance_window=3,
+    )
+
+    assert sample.snapshot["input_calculation_ids_json"] == ewma.snapshot[
+        "input_calculation_ids_json"
+    ]
+    assert sample.snapshot["window_start"] == ewma.snapshot["window_start"]
+    assert sample.snapshot["window_end"] == ewma.snapshot["window_end"]
+    assert sample.snapshot["calculation_id"] != ewma.snapshot["calculation_id"]
+    assert sample.snapshot["model_version"] != ewma.snapshot["model_version"]
+    assert sample.snapshot["covariance_method"] != ewma.snapshot[
+        "covariance_method"
+    ]
+
+
+def test_input_order_does_not_change_ewma_output() -> None:
+    forward = build_portfolio_ewma_attribution(
+        _records(),
+        definition=_definition(),
+        covariance_window=3,
+    )
+    reverse = build_portfolio_ewma_attribution(
+        reversed(_records()),
+        definition=_definition(),
+        covariance_window=3,
+    )
+
+    assert forward.snapshot == reverse.snapshot
+    assert forward.diagnostics == reverse.diagnostics
+
+
+def test_recent_shock_receives_more_weight_than_an_old_shock() -> None:
+    old_shock = [
+        _record(2, 0.20, 0.0),
+        _record(3, 0.0, 0.0),
+        _record(4, 0.0, 0.0),
+        _record(5, 0.0, 0.0),
+    ]
+    recent_shock = [
+        _record(2, 0.0, 0.0),
+        _record(3, 0.0, 0.0),
+        _record(4, 0.0, 0.0),
+        _record(5, 0.20, 0.0),
+    ]
+
+    old_output = build_portfolio_ewma_attribution(
+        old_shock,
+        definition=_definition(),
+        covariance_window=4,
+    )
+    recent_output = build_portfolio_ewma_attribution(
+        recent_shock,
+        definition=_definition(),
+        covariance_window=4,
+    )
+
+    assert recent_output.snapshot["portfolio_volatility_annualized"] > (
+        old_output.snapshot["portfolio_volatility_annualized"]
+    )
+
+
+def test_zero_returns_have_explicit_zero_and_undefined_correlation_status() -> None:
+    output = build_portfolio_ewma_attribution(
+        [
+            _record(2, 0.0, 0.0),
+            _record(3, 0.0, 0.0),
+            _record(4, 0.0, 0.0),
+        ],
+        definition=_definition(),
+        covariance_window=3,
+    )
+
+    correlation = json.loads(output.snapshot["correlation_json"])
+    components = json.loads(
+        output.snapshot["component_volatility_contribution_json"]
+    )
+    assert output.snapshot["portfolio_variance_annualized"] == 0.0
+    assert output.snapshot["portfolio_volatility_annualized"] == 0.0
+    assert output.snapshot["volatility_status"] == "zero"
+    assert output.snapshot["correlation_status"] == "undefined_zero_variance"
+    assert output.snapshot["undefined_correlation_cells"] == 4
+    assert all(value is None for row in correlation.values() for value in row.values())
+    assert components == {
+        "alpha_vantage:AAPL": 0.0,
+        "alpha_vantage:MSFT": 0.0,
+    }
+
+
+def test_latest_corrected_portfolio_return_version_is_used() -> None:
+    late = datetime(2026, 2, 1, tzinfo=timezone.utc)
+    records = [
+        _record(2, 0.10, 0.02),
+        _record(3, -0.04, 0.0, calculation_id="old"),
+        _record(
+            3,
+            0.04,
+            0.0,
+            calculation_id="new",
+            ingested_at=late,
+        ),
+        _record(4, 0.06, 0.02),
+    ]
+
+    output = build_portfolio_ewma_attribution(
+        records,
+        definition=_definition(),
+        covariance_window=3,
+    )
+
+    assert output.snapshot["ts_ingest"] == late
+    assert json.loads(output.snapshot["input_calculation_ids_json"]) == [
+        "portfolio-2",
+        "new",
+        "portfolio-4",
+    ]
+
+
+def test_insufficient_window_and_conflicting_identity_fail_closed() -> None:
+    with pytest.raises(ValidationError, match="requires at least 4"):
+        build_portfolio_ewma_attribution(
+            _records(),
+            definition=_definition(),
+            covariance_window=4,
+        )
+
+    conflicting = [
+        _record(2, 0.10, 0.02, calculation_id="same"),
+        _record(3, -0.04, 0.0, calculation_id="same"),
+        _record(4, 0.06, 0.02),
+    ]
+    with pytest.raises(ValidationError, match="conflicting records"):
+        build_portfolio_ewma_attribution(
+            conflicting,
+            definition=_definition(),
+            covariance_window=2,
+        )

--- a/tests/unit/test_portfolio_covariance_comparison_architecture_contract.py
+++ b/tests/unit/test_portfolio_covariance_comparison_architecture_contract.py
@@ -1,0 +1,51 @@
+from pathlib import Path
+
+
+def test_covariance_comparison_documentation_matches_runtime_contract() -> None:
+    documentation = Path("docs/portfolio-covariance-comparison.md").read_text(
+        encoding="utf-8"
+    )
+    analytics = Path(
+        "src/analytics/portfolio_attribution_ewma.py"
+    ).read_text(encoding="utf-8")
+    runner = Path(
+        "src/orchestration/run_portfolio_covariance_comparison.py"
+    ).read_text(encoding="utf-8")
+    schema = Path("sql/portfolio_attribution_schema.sql").read_text(
+        encoding="utf-8"
+    )
+
+    for required in (
+        "portfolio-attribution-ewma-v1",
+        "ewma_zero_mean_lambda_0_94_annualized",
+        "implied_from_ewma_covariance",
+    ):
+        assert required in documentation
+        assert required in analytics
+
+    assert "EWMA decay         = 0.94" in documentation
+    assert "EWMA_DECAY = 0.94" in analytics
+    assert "run_portfolio_covariance_comparison" in documentation
+    assert "run_portfolio_covariance_comparison" in runner
+    assert "ordered input calculation IDs" in documentation
+    assert "already_present" in documentation
+
+    for required in (
+        "input_calculation_ids_json",
+        "ewma_minus_sample_volatility",
+        "records_already_present",
+    ):
+        assert required in runner
+
+    assert "model_version" in schema
+    assert "covariance_method" in schema
+    assert "correlation_method" in schema
+    assert "PARTITION BY" in schema
+
+    for prohibited in (
+        "configurable decay",
+        "rolling EWMA history",
+        "provider request",
+        "infrastructure action",
+    ):
+        assert prohibited in documentation

--- a/tests/unit/test_run_portfolio_covariance_comparison.py
+++ b/tests/unit/test_run_portfolio_covariance_comparison.py
@@ -1,0 +1,216 @@
+from __future__ import annotations
+
+import json
+from datetime import date, datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from src.analytics.portfolio_risk import (
+    WEIGHTING_METHOD,
+    PortfolioDefinition,
+    parse_portfolio_definition,
+)
+from src.common.exceptions import StorageError
+from src.orchestration.run_portfolio_covariance_comparison import (
+    run_portfolio_covariance_comparison,
+)
+
+
+def _definition() -> PortfolioDefinition:
+    return parse_portfolio_definition(
+        {
+            "portfolios": {
+                "us-tech-equal": {
+                    "base_currency": "USD",
+                    "constituents": [
+                        {
+                            "source": "alpha_vantage",
+                            "symbol": "AAPL",
+                            "weight": 0.5,
+                        },
+                        {
+                            "source": "alpha_vantage",
+                            "symbol": "MSFT",
+                            "weight": 0.5,
+                        },
+                    ],
+                }
+            }
+        },
+        "us-tech-equal",
+    )
+
+
+def _records() -> list[dict[str, object]]:
+    definition = _definition()
+    records: list[dict[str, object]] = []
+    for day, aapl, msft in [
+        (2, 0.10, 0.02),
+        (3, -0.04, 0.0),
+        (4, 0.06, 0.02),
+    ]:
+        ts_event = datetime(2026, 1, day, tzinfo=timezone.utc)
+        component_returns = {
+            "alpha_vantage:AAPL": aapl,
+            "alpha_vantage:MSFT": msft,
+        }
+        records.append(
+            {
+                "model_version": "portfolio-risk-v1",
+                "calculation_id": f"portfolio-{day}",
+                "portfolio_id": definition.portfolio_id,
+                "base_currency": definition.base_currency,
+                "definition_fingerprint": definition.fingerprint,
+                "weighting_method": WEIGHTING_METHOD,
+                "ts_event": ts_event,
+                "ts_ingest": ts_event + timedelta(hours=1),
+                "constituent_count": 2,
+                "weights_json": json.dumps(
+                    {
+                        "alpha_vantage:AAPL": 0.5,
+                        "alpha_vantage:MSFT": 0.5,
+                    },
+                    sort_keys=True,
+                ),
+                "component_calculation_ids_json": json.dumps(
+                    {
+                        "alpha_vantage:AAPL": f"AAPL-{day}",
+                        "alpha_vantage:MSFT": f"MSFT-{day}",
+                    },
+                    sort_keys=True,
+                ),
+                "component_returns_json": json.dumps(
+                    component_returns,
+                    sort_keys=True,
+                ),
+                "portfolio_return_1d": 0.5 * aapl + 0.5 * msft,
+            }
+        )
+    return records
+
+
+def _storage_config() -> dict[str, Any]:
+    return {
+        "storage": {
+            "base_dir": "unused",
+            "raw": {"base_path": "unused/raw", "dataset": "market_events"},
+            "curated": {
+                "base_path": "unused/curated",
+                "datasets": {
+                    "portfolio_daily_returns": "portfolio_daily_returns",
+                    "portfolio_risk_attribution": "portfolio_risk_attribution",
+                },
+            },
+            "format": "parquet",
+            "partitioning": {"granularity": "hourly"},
+        }
+    }
+
+
+def test_comparison_publishes_aligned_sample_and_ewma_snapshots() -> None:
+    writes: list[dict[str, Any]] = []
+
+    def reader(**kwargs: Any) -> list[dict[str, object]]:
+        assert kwargs["portfolio_id"] == "us-tech-equal"
+        assert kwargs["definition_fingerprint"] == _definition().fingerprint
+        assert kwargs["end_date"] == date(2026, 1, 4)
+        return _records()
+
+    def writer(records: list[dict[str, Any]], *, dataset: str, **_: Any) -> int:
+        assert dataset == "portfolio_risk_attribution"
+        assert len(records) == 1
+        writes.append(records[0])
+        return 1
+
+    summary = run_portfolio_covariance_comparison(
+        portfolio_id="us-tech-equal",
+        portfolio_config_path=Path("unused.yaml"),
+        end_date=date(2026, 1, 4),
+        covariance_window=3,
+        storage_config_path=Path("unused-storage.yaml"),
+        reader=reader,
+        writer=writer,
+        storage_config_loader=lambda _: _storage_config(),
+        definition_loader=lambda *_: _definition(),
+    )
+
+    assert summary["curated_output"]["portfolio_risk_attribution"] == {
+        "records_selected": 2,
+        "records_written": 2,
+        "records_already_present": 0,
+    }
+    assert [record["model_version"] for record in writes] == [
+        "portfolio-attribution-v1",
+        "portfolio-attribution-ewma-v1",
+    ]
+    assert writes[0]["input_calculation_ids_json"] == writes[1][
+        "input_calculation_ids_json"
+    ]
+    assert summary["models"]["sample"]["covariance_method"] == (
+        "sample_annualized"
+    )
+    assert summary["models"]["ewma"]["covariance_method"] == (
+        "ewma_zero_mean_lambda_0_94_annualized"
+    )
+    assert summary["parameters"]["ewma_decay"] == 0.94
+    assert summary["comparison"]["ewma_minus_sample_volatility"] > 0
+    assert summary["comparison"]["higher_volatility_model"] == "ewma"
+
+
+def test_comparison_reports_replay_counts_per_snapshot() -> None:
+    results = iter([0, 1])
+
+    summary = run_portfolio_covariance_comparison(
+        portfolio_id="us-tech-equal",
+        portfolio_config_path=Path("unused.yaml"),
+        end_date=date(2026, 1, 4),
+        covariance_window=3,
+        storage_config_path=Path("unused-storage.yaml"),
+        reader=lambda **_: _records(),
+        writer=lambda *_args, **_kwargs: next(results),
+        storage_config_loader=lambda _: _storage_config(),
+        definition_loader=lambda *_: _definition(),
+    )
+
+    assert summary["curated_output"]["portfolio_risk_attribution"] == {
+        "records_selected": 2,
+        "records_written": 1,
+        "records_already_present": 1,
+    }
+
+
+def test_comparison_rejects_invalid_writer_result() -> None:
+    with pytest.raises(StorageError, match="invalid result"):
+        run_portfolio_covariance_comparison(
+            portfolio_id="us-tech-equal",
+            portfolio_config_path=Path("unused.yaml"),
+            end_date=date(2026, 1, 4),
+            covariance_window=3,
+            storage_config_path=Path("unused-storage.yaml"),
+            reader=lambda **_: _records(),
+            writer=lambda *_args, **_kwargs: 2,
+            storage_config_loader=lambda _: _storage_config(),
+            definition_loader=lambda *_: _definition(),
+        )
+
+
+def test_comparison_requires_both_attribution_datasets() -> None:
+    config = _storage_config()
+    del config["storage"]["curated"]["datasets"][
+        "portfolio_risk_attribution"
+    ]
+
+    with pytest.raises(StorageError, match="missing portfolio attribution datasets"):
+        run_portfolio_covariance_comparison(
+            portfolio_id="us-tech-equal",
+            portfolio_config_path=Path("unused.yaml"),
+            end_date=date(2026, 1, 4),
+            covariance_window=3,
+            storage_config_path=Path("unused-storage.yaml"),
+            reader=lambda **_: _records(),
+            writer=lambda *_args, **_kwargs: 1,
+            storage_config_loader=lambda _: config,
+            definition_loader=lambda *_: _definition(),
+        )


### PR DESCRIPTION
## Outcome

Add a second, explicitly versioned covariance estimator and a paired latest-window comparison path:

```text
one aligned current portfolio-return window
  -> existing annualised sample covariance
  -> zero-mean EWMA covariance with lambda 0.94
  -> method-specific correlation and Euler attribution
  -> two independently versioned portfolio_risk_attribution rows
  -> deterministic comparison summary
```

Primary arc42 block: `analytics`, with bounded interfaces to existing orchestration, curated publication and warehouse compatibility.

## Backward-compatible sample path

The existing sample model is not modified:

```text
portfolio-attribution-v1
sample_annualized
pearson
```

Its implementation, default commands, calculation-ID payload and retained rows remain unchanged.

The new method is isolated as:

```text
portfolio-attribution-ewma-v1
ewma_zero_mean_lambda_0_94_annualized
implied_from_ewma_covariance
```

The PostgreSQL attribution grain already includes model and method fields, so both calculations coexist without a table or loader migration.

## EWMA contract

For a complete window ordered oldest to newest:

```text
raw_weight_i = 0.94 ** (n - 1 - i)
weight_i     = raw_weight_i / sum(raw_weight)
Sigma_daily  = sum(weight_i * r_i * r_i')
Sigma_annual = 252 * Sigma_daily
```

The method records the zero-daily-mean and fixed-decay assumptions. The newest observation receives the largest weight. Correlation is implied from the EWMA covariance matrix; zero-variance cells remain JSON `null` with explicit status. The existing Euler calculation is applied to the EWMA covariance matrix and must reconcile component contributions to EWMA portfolio volatility.

## Paired comparison runner

```bash
.venv/bin/python -m src.orchestration.run_portfolio_covariance_comparison \
  --portfolio-id us-tech-equal \
  --end-date 2026-03-31 \
  --covariance-window 20 \
  --summary-json .demo/portfolio-covariance-comparison.json
```

The runner reads current portfolio returns once, applies the same definition and corrected-version selection, and rejects publication unless both models share the exact portfolio, window, event date and ordered input calculation IDs.

Each snapshot is published separately through the existing content-addressed writer. An already-present sample row therefore does not get duplicated when the EWMA row is added.

The summary exposes both models, deterministic calculation IDs, annualised variance/volatility, dominant component, EWMA diagnostics, absolute volatility difference, volatility ratio and the higher-volatility model for the selected window.

## Validation

Two initial runs exposed only brittle documentation assertions. The branch was rebuilt after each repair as a replacement one-commit history; no application check was bypassed.

GitHub Actions run `32629451748` (`ci` run 257) passed on exact head `3b54d816977374426dcc15418a7e24eb404ce465`:

- Security guardrails: passed.
- Python readiness: passed.
  - locked dependencies resolved;
  - Ruff passed;
  - mypy passed across 73 source files;
  - 621 tests passed;
  - dependency integrity passed;
  - `make readiness-check` passed.
- PostgreSQL contract: passed against PostgreSQL 16, including complete schema, load and reconciliation replay.
- Infrastructure validation: passed without deployment or Terraform apply.

Focused coverage includes expected EWMA matrices, distinct identities over aligned inputs, input-order independence, recent-shock weighting, zero-risk semantics, corrected current versions, publication/replay, invalid writer behaviour and Parquet-to-warehouse compatibility. No unresolved review threads or requested changes are present.

## Safety and scope

The path reuses the existing bounded attribution reader: one portfolio and definition, completed end date, 4,096 files, 1 GB and 250,000 matching rows. It performs no provider request, network operation, alert, deployment or infrastructure mutation.

The existing risk-limit policy remains sample-bound; EWMA is not silently substituted into sample thresholds.

The branch is one commit ahead of `main` and zero behind. It adds seven files with 1,539 lines as one latest-window estimator/comparison increment.

Rolling EWMA history, SQL trend comparison, configurable decay, shrinkage/factor covariance and method-aware risk-limit policies remain separate increments.

## Acceptance boundary

Validated and ready for squash merge as one analytics increment.