### PR TITLE
Add rolling sample and EWMA covariance comparison

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,7 @@ services:
       - ./sql/portfolio_risk_notification_outbox_schema.sql:/docker-entrypoint-initdb.d/07_portfolio_risk_notification_outbox_schema.sql:ro
       - ./sql/market_freshness_schema.sql:/docker-entrypoint-initdb.d/08_market_freshness_schema.sql:ro
       - ./sql/portfolio_risk_notification_delivery_schema.sql:/docker-entrypoint-initdb.d/09_portfolio_risk_notification_delivery_schema.sql:ro
+      - ./sql/portfolio_covariance_method_schema.sql:/docker-entrypoint-initdb.d/10_portfolio_covariance_method_schema.sql:ro
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U risk_user -d risk_platform"]
       interval: 5s

--- a/docs/portfolio-covariance-history-comparison.md
+++ b/docs/portfolio-covariance-history-comparison.md
@@ -1,0 +1,194 @@
+# Rolling Sample And EWMA Covariance Comparison
+
+## Outcome
+
+This increment extends the two latest-window covariance estimators into one
+bounded, aligned historical comparison:
+
+```text
+current portfolio-return versions
+  -> complete rolling windows
+  -> sample covariance and Euler attribution per date
+  -> fixed-decay EWMA covariance and Euler attribution per date
+  -> two versioned attribution rows per eligible date
+  -> PostgreSQL sample-versus-EWMA trend view
+```
+
+The sample history remains implemented by
+`src/analytics/portfolio_attribution_history.py`. The additional EWMA history is
+implemented by `src/analytics/portfolio_attribution_ewma_history.py`.
+
+The paired runner is:
+
+```text
+src/orchestration/run_portfolio_covariance_history_comparison.py
+```
+
+## Operator Flow
+
+After current `portfolio_daily_returns` exist, calculate both histories:
+
+```bash
+.venv/bin/python -m src.orchestration.run_portfolio_covariance_history_comparison \
+  --portfolio-id us-tech-equal \
+  --start-date 2026-01-01 \
+  --end-date 2026-03-31 \
+  --covariance-window 20 \
+  --max-snapshots 2500 \
+  --summary-json .demo/portfolio-covariance-history-comparison.json
+```
+
+The command performs no provider request. It reads the existing bounded local
+portfolio-return dataset and publishes both model rows to:
+
+```text
+data/curated/portfolio_risk_attribution
+```
+
+## Historical Semantics
+
+The history is current-version history, not point-in-time-as-known history.
+For each portfolio-return date, the canonical selection remains:
+
+```text
+ts_ingest DESC
+calculation_id DESC
+```
+
+A corrected return therefore creates new sample and EWMA calculation IDs for
+every affected rolling window. Earlier attribution versions remain retained in
+Parquet and PostgreSQL.
+
+For a five-observation history and a three-observation covariance window:
+
+```text
+observations 1-3 -> sample row + EWMA row ending date 3
+observations 2-4 -> sample row + EWMA row ending date 4
+observations 3-5 -> sample row + EWMA row ending date 5
+```
+
+## Start-Date Context
+
+`--start-date` filters emitted snapshot dates. It does not discard earlier return
+observations needed to build the first complete window.
+
+A snapshot emitted on March 1 with a twenty-observation window may therefore use
+February observations. This preserves complete model inputs while allowing a
+bounded output range.
+
+## Pair Alignment
+
+Before publication, each sample/EWMA pair must have identical:
+
+- portfolio and base currency;
+- definition fingerprint;
+- weighting method;
+- covariance window and observation count;
+- annualisation basis;
+- window start and end;
+- metric date; and
+- ordered input calculation IDs.
+
+The model version, covariance method, correlation method, calculation ID and risk
+values must remain distinct.
+
+A mismatch fails before the pair is published. This prevents a comparison from
+joining different portfolio definitions, dates, corrections or source windows.
+
+## Bounds And Replay
+
+The existing reader retains its limits of 4,096 files, 1 GB and 250,000 matching
+rows. Each model is additionally capped at 2,500 emitted snapshots per request,
+so one paired request can publish at most 5,000 attribution rows.
+
+Rows are published independently through the content-addressed writer. A partial
+run is replay-safe:
+
+- existing sample or EWMA rows report already present;
+- missing rows are written;
+- no retained row is overwritten; and
+- deterministic IDs allow the run to converge.
+
+The summary reports selected, written and already-present counts for both models.
+It does not include every historical matrix, keeping evidence bounded even for a
+large date range.
+
+## Comparison Summary
+
+The summary includes:
+
+- first and last paired snapshot dates;
+- number of paired dates;
+- dates where EWMA volatility is higher;
+- dates where sample volatility is higher;
+- equal-volatility dates;
+- latest sample and EWMA volatility, difference, ratio and calculation IDs; and
+- the date with the largest absolute volatility difference.
+
+This is model evidence rather than a recommendation to prefer one estimator.
+Sample covariance weights the demeaned window evenly. The EWMA model applies a
+fixed 0.94 decay to zero-mean return outer products and therefore responds more
+strongly to recent squared returns.
+
+## PostgreSQL Contract
+
+Fresh local PostgreSQL initialization applies:
+
+```text
+sql/portfolio_covariance_method_schema.sql
+```
+
+after the established attribution schema.
+
+For an already-running local database, apply it explicitly:
+
+```bash
+docker compose exec -T postgres psql -U risk_user -d risk_platform \
+  < sql/portfolio_covariance_method_schema.sql
+```
+
+The schema adds an idempotent check for the fixed EWMA v1 model and creates:
+
+```text
+risk_platform.portfolio_covariance_method_comparison
+```
+
+The view joins only current sample and EWMA rows with identical portfolio,
+definition, event date, weighting method, covariance window, annualisation basis,
+window boundaries, observation count and ordered input IDs.
+
+It exposes:
+
+- sample and EWMA calculation IDs and calculation timestamps;
+- both annualised variances and volatilities;
+- EWMA minus sample volatility;
+- EWMA-to-sample volatility ratio when sample volatility is positive; and
+- the higher-volatility model label.
+
+If only one model exists for a date, no comparison row is produced. Different
+portfolio definitions and covariance windows remain separate.
+
+## Reconciliation
+
+Run the focused method comparison checks after loading attribution history:
+
+```bash
+docker compose exec -T postgres psql -U risk_user -d risk_platform \
+  < sql/portfolio_covariance_method_consistency_checks.sql
+```
+
+The checks verify:
+
+- the view contains every exactly aligned current sample/EWMA pair;
+- volatility differences reconcile;
+- positive-sample volatility ratios reconcile;
+- higher-model labels agree with the underlying values; and
+- the comparison grain is unique.
+
+## Current Boundary
+
+This increment uses the fixed EWMA model introduced previously. It does not make
+decay configurable, change the sample-bound risk-limit policies, create a model
+approval workflow, add shrinkage or factor covariance, calculate marginal VaR,
+perform FX conversion, support leverage or shorting, schedule execution, deliver
+alerts, deploy infrastructure or run Terraform apply.

--- a/sql/portfolio_covariance_method_consistency_checks.sql
+++ b/sql/portfolio_covariance_method_consistency_checks.sql
@@ -1,0 +1,151 @@
+-- Reconciliation checks for the aligned sample-versus-EWMA covariance view.
+-- Run after attribution history has been loaded into PostgreSQL.
+
+WITH expected_pairs AS (
+    SELECT COUNT(*) AS row_count
+    FROM risk_platform.latest_portfolio_risk_attribution sample
+    JOIN risk_platform.latest_portfolio_risk_attribution ewma
+        ON ewma.portfolio_id = sample.portfolio_id
+        AND ewma.base_currency = sample.base_currency
+        AND ewma.definition_fingerprint = sample.definition_fingerprint
+        AND ewma.weighting_method = sample.weighting_method
+        AND ewma.covariance_window = sample.covariance_window
+        AND ewma.window_start = sample.window_start
+        AND ewma.window_end = sample.window_end
+        AND ewma.window_observations = sample.window_observations
+        AND ewma.annualization_days = sample.annualization_days
+        AND ewma.ts_event = sample.ts_event
+        AND ewma.input_calculation_ids_json
+            = sample.input_calculation_ids_json
+    WHERE
+        sample.model_version = 'portfolio-attribution-v1'
+        AND sample.covariance_method = 'sample_annualized'
+        AND sample.correlation_method = 'pearson'
+        AND ewma.model_version = 'portfolio-attribution-ewma-v1'
+        AND ewma.covariance_method
+            = 'ewma_zero_mean_lambda_0_94_annualized'
+        AND ewma.correlation_method = 'implied_from_ewma_covariance'
+),
+comparison_counts AS (
+    SELECT COUNT(*) AS row_count
+    FROM risk_platform.portfolio_covariance_method_comparison
+),
+integrity AS (
+    SELECT
+        (
+            SELECT COUNT(*)
+            FROM risk_platform.portfolio_covariance_method_comparison
+            WHERE
+                ABS(
+                    ewma_minus_sample_volatility
+                    - (
+                        ewma_portfolio_volatility_annualized
+                        - sample_portfolio_volatility_annualized
+                    )
+                ) > 0.000000000001
+        ) AS invalid_differences,
+        (
+            SELECT COUNT(*)
+            FROM risk_platform.portfolio_covariance_method_comparison
+            WHERE
+                sample_portfolio_volatility_annualized > 0
+                AND ABS(
+                    ewma_to_sample_volatility_ratio
+                    - (
+                        ewma_portfolio_volatility_annualized
+                        / sample_portfolio_volatility_annualized
+                    )
+                ) > 0.000000000001
+        ) AS invalid_ratios,
+        (
+            SELECT COUNT(*)
+            FROM risk_platform.portfolio_covariance_method_comparison
+            WHERE
+                (
+                    higher_volatility_model = 'ewma'
+                    AND ewma_portfolio_volatility_annualized
+                        <= sample_portfolio_volatility_annualized
+                )
+                OR (
+                    higher_volatility_model = 'sample'
+                    AND ewma_portfolio_volatility_annualized
+                        >= sample_portfolio_volatility_annualized
+                )
+                OR (
+                    higher_volatility_model = 'equal'
+                    AND ewma_portfolio_volatility_annualized
+                        <> sample_portfolio_volatility_annualized
+                )
+        ) AS invalid_higher_model_labels,
+        (
+            SELECT COUNT(*)
+            FROM (
+                SELECT
+                    portfolio_id,
+                    definition_fingerprint,
+                    metric_ts,
+                    weighting_method,
+                    covariance_window,
+                    annualization_days,
+                    COUNT(*) AS row_count
+                FROM risk_platform.portfolio_covariance_method_comparison
+                GROUP BY
+                    portfolio_id,
+                    definition_fingerprint,
+                    metric_ts,
+                    weighting_method,
+                    covariance_window,
+                    annualization_days
+                HAVING COUNT(*) > 1
+            ) duplicates
+        ) AS duplicate_comparison_grains
+)
+SELECT
+    'portfolio_covariance_method_pairs_complete' AS check_name,
+    expected_pairs.row_count::TEXT AS expected,
+    comparison_counts.row_count::TEXT AS actual,
+    CASE
+        WHEN expected_pairs.row_count = comparison_counts.row_count
+        THEN 'pass'
+        ELSE 'fail'
+    END AS status
+FROM expected_pairs
+CROSS JOIN comparison_counts
+
+UNION ALL
+
+SELECT
+    'portfolio_covariance_method_difference_reconciles',
+    '0',
+    invalid_differences::TEXT,
+    CASE WHEN invalid_differences = 0 THEN 'pass' ELSE 'fail' END
+FROM integrity
+
+UNION ALL
+
+SELECT
+    'portfolio_covariance_method_ratio_reconciles',
+    '0',
+    invalid_ratios::TEXT,
+    CASE WHEN invalid_ratios = 0 THEN 'pass' ELSE 'fail' END
+FROM integrity
+
+UNION ALL
+
+SELECT
+    'portfolio_covariance_method_higher_label_reconciles',
+    '0',
+    invalid_higher_model_labels::TEXT,
+    CASE WHEN invalid_higher_model_labels = 0 THEN 'pass' ELSE 'fail' END
+FROM integrity
+
+UNION ALL
+
+SELECT
+    'portfolio_covariance_method_grain_unique',
+    '0',
+    duplicate_comparison_grains::TEXT,
+    CASE WHEN duplicate_comparison_grains = 0 THEN 'pass' ELSE 'fail' END
+FROM integrity
+
+ORDER BY check_name;

--- a/sql/portfolio_covariance_method_schema.sql
+++ b/sql/portfolio_covariance_method_schema.sql
@@ -1,0 +1,91 @@
+-- PostgreSQL contract for aligned sample-versus-EWMA portfolio covariance serving.
+-- Apply after sql/portfolio_attribution_schema.sql.
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1
+        FROM pg_constraint
+        WHERE
+            conname = 'chk_portfolio_attribution_ewma_v1'
+            AND conrelid = 'risk_platform.portfolio_risk_attribution'::regclass
+    ) THEN
+        ALTER TABLE risk_platform.portfolio_risk_attribution
+            ADD CONSTRAINT chk_portfolio_attribution_ewma_v1 CHECK (
+                model_version <> 'portfolio-attribution-ewma-v1'
+                OR (
+                    weighting_method = 'constant_weight_daily_rebalanced'
+                    AND covariance_method
+                        = 'ewma_zero_mean_lambda_0_94_annualized'
+                    AND correlation_method
+                        = 'implied_from_ewma_covariance'
+                    AND annualization_days = 252
+                )
+            );
+    END IF;
+END
+$$;
+
+CREATE OR REPLACE VIEW risk_platform.portfolio_covariance_method_comparison AS
+SELECT
+    sample.portfolio_id,
+    sample.base_currency,
+    sample.definition_fingerprint,
+    sample.weighting_method,
+    sample.covariance_window,
+    sample.window_start,
+    sample.window_end,
+    sample.window_observations,
+    sample.annualization_days,
+    sample.ts_event AS metric_ts,
+    sample.input_calculation_ids_json,
+    sample.calculation_id AS sample_calculation_id,
+    sample.ts_ingest AS sample_calculation_ts,
+    sample.portfolio_variance_annualized
+        AS sample_portfolio_variance_annualized,
+    sample.portfolio_volatility_annualized
+        AS sample_portfolio_volatility_annualized,
+    ewma.calculation_id AS ewma_calculation_id,
+    ewma.ts_ingest AS ewma_calculation_ts,
+    ewma.portfolio_variance_annualized
+        AS ewma_portfolio_variance_annualized,
+    ewma.portfolio_volatility_annualized
+        AS ewma_portfolio_volatility_annualized,
+    ewma.portfolio_volatility_annualized
+        - sample.portfolio_volatility_annualized
+        AS ewma_minus_sample_volatility,
+    CASE
+        WHEN sample.portfolio_volatility_annualized > 0
+        THEN ewma.portfolio_volatility_annualized
+            / sample.portfolio_volatility_annualized
+        ELSE NULL
+    END AS ewma_to_sample_volatility_ratio,
+    CASE
+        WHEN ewma.portfolio_volatility_annualized
+            > sample.portfolio_volatility_annualized
+        THEN 'ewma'
+        WHEN ewma.portfolio_volatility_annualized
+            < sample.portfolio_volatility_annualized
+        THEN 'sample'
+        ELSE 'equal'
+    END AS higher_volatility_model
+FROM risk_platform.latest_portfolio_risk_attribution sample
+JOIN risk_platform.latest_portfolio_risk_attribution ewma
+    ON ewma.portfolio_id = sample.portfolio_id
+    AND ewma.base_currency = sample.base_currency
+    AND ewma.definition_fingerprint = sample.definition_fingerprint
+    AND ewma.weighting_method = sample.weighting_method
+    AND ewma.covariance_window = sample.covariance_window
+    AND ewma.window_start = sample.window_start
+    AND ewma.window_end = sample.window_end
+    AND ewma.window_observations = sample.window_observations
+    AND ewma.annualization_days = sample.annualization_days
+    AND ewma.ts_event = sample.ts_event
+    AND ewma.input_calculation_ids_json = sample.input_calculation_ids_json
+WHERE
+    sample.model_version = 'portfolio-attribution-v1'
+    AND sample.covariance_method = 'sample_annualized'
+    AND sample.correlation_method = 'pearson'
+    AND ewma.model_version = 'portfolio-attribution-ewma-v1'
+    AND ewma.covariance_method = 'ewma_zero_mean_lambda_0_94_annualized'
+    AND ewma.correlation_method = 'implied_from_ewma_covariance';

--- a/src/analytics/portfolio_attribution_ewma_history.py
+++ b/src/analytics/portfolio_attribution_ewma_history.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from datetime import date
+from typing import Any
+
+from ..common.exceptions import ValidationError
+from .portfolio_attribution import PortfolioReturnInput, _current_records
+from .portfolio_attribution_ewma import (
+    COVARIANCE_METHOD,
+    MODEL_VERSION,
+    build_portfolio_ewma_attribution,
+)
+from .portfolio_attribution_history import (
+    MAX_HISTORY_SNAPSHOTS,
+    PortfolioAttributionHistoryOutput,
+    _covariance_window,
+    _normalised_input_record,
+    _snapshot_limit,
+)
+from .portfolio_risk import PortfolioDefinition
+
+
+def build_portfolio_ewma_attribution_history(
+    records: Iterable[PortfolioReturnInput],
+    *,
+    definition: PortfolioDefinition,
+    covariance_window: int = 20,
+    start_date: date | None = None,
+    end_date: date | None = None,
+    max_snapshots: int = MAX_HISTORY_SNAPSHOTS,
+) -> PortfolioAttributionHistoryOutput:
+    covariance_window = _covariance_window(covariance_window)
+    max_snapshots = _snapshot_limit(max_snapshots)
+    if start_date is not None and end_date is not None and start_date > end_date:
+        raise ValidationError("start_date must be on or before end_date")
+
+    current, matched_records = _current_records(records, definition, end_date)
+    if len(current) < covariance_window:
+        raise ValidationError(
+            "EWMA portfolio attribution history requires at least "
+            f"{covariance_window} current portfolio return observations"
+        )
+
+    all_end_indexes = list(range(covariance_window - 1, len(current)))
+    selected_end_indexes = [
+        index
+        for index in all_end_indexes
+        if start_date is None or current[index]["ts_event"].date() >= start_date
+    ]
+    if not selected_end_indexes:
+        raise ValidationError(
+            "no EWMA portfolio attribution snapshots matched the requested date range"
+        )
+    if len(selected_end_indexes) > max_snapshots:
+        raise ValidationError(
+            "EWMA portfolio attribution history exceeds max_snapshots; provide a "
+            "later start_date or split the bounded request"
+        )
+
+    snapshots: list[dict[str, Any]] = []
+    for end_index in selected_end_indexes:
+        window = current[
+            end_index - covariance_window + 1 : end_index + 1
+        ]
+        output = build_portfolio_ewma_attribution(
+            (_normalised_input_record(record) for record in window),
+            definition=definition,
+            covariance_window=covariance_window,
+            end_date=window[-1]["ts_event"].date(),
+        )
+        snapshots.append(output.snapshot)
+
+    first_snapshot = snapshots[0]
+    last_snapshot = snapshots[-1]
+    diagnostics: Mapping[str, Any] = {
+        "model_version": MODEL_VERSION,
+        "covariance_method": COVARIANCE_METHOD,
+        "matched_input_records": matched_records,
+        "current_portfolio_return_records": len(current),
+        "covariance_window": covariance_window,
+        "available_snapshot_dates": len(all_end_indexes),
+        "snapshots_selected": len(snapshots),
+        "snapshots_skipped_before_start_date": (
+            len(all_end_indexes) - len(selected_end_indexes)
+        ),
+        "first_snapshot_date": first_snapshot["ts_event"].date().isoformat(),
+        "last_snapshot_date": last_snapshot["ts_event"].date().isoformat(),
+        "start_date": start_date.isoformat() if start_date is not None else None,
+        "end_date": (
+            end_date.isoformat()
+            if end_date is not None
+            else last_snapshot["ts_event"].date().isoformat()
+        ),
+        "max_snapshots": max_snapshots,
+    }
+    return PortfolioAttributionHistoryOutput(
+        snapshots=tuple(snapshots),
+        diagnostics=diagnostics,
+    )

--- a/src/orchestration/run_portfolio_covariance_history_comparison.py
+++ b/src/orchestration/run_portfolio_covariance_history_comparison.py
@@ -1,0 +1,371 @@
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import sys
+from collections.abc import Callable, Mapping, Sequence
+from datetime import date
+from pathlib import Path
+from typing import Any
+from uuid import uuid4
+
+from ..analytics.portfolio_attribution_history import (
+    MAX_HISTORY_SNAPSHOTS,
+    PortfolioAttributionHistoryOutput,
+    build_portfolio_attribution_history,
+)
+from ..analytics.portfolio_attribution_ewma_history import (
+    build_portfolio_ewma_attribution_history,
+)
+from ..analytics.portfolio_risk import (
+    PortfolioDefinition,
+    load_portfolio_definition,
+)
+from ..common.exceptions import StorageError, ValidationError
+from ..storage.s3_writer import write_records
+from ..storage.storage_config import load_storage_config
+from .run_portfolio_attribution import (
+    OUTPUT_DATASET,
+    _calendar_date,
+    _positive_integer,
+    _require_datasets,
+    load_portfolio_return_records,
+)
+from .run_portfolio_attribution_history import _max_snapshots
+
+Reader = Callable[..., list[dict[str, Any]]]
+Writer = Callable[..., int]
+StorageConfigLoader = Callable[[Path], dict[str, Any]]
+DefinitionLoader = Callable[[Path, str], PortfolioDefinition]
+
+ALIGNMENT_FIELDS = (
+    "portfolio_id",
+    "base_currency",
+    "definition_fingerprint",
+    "weighting_method",
+    "covariance_window",
+    "window_start",
+    "window_end",
+    "window_observations",
+    "annualization_days",
+    "ts_event",
+    "input_calculation_ids_json",
+)
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Build aligned rolling sample and EWMA covariance-attribution history "
+            "from local portfolio-return parquet."
+        )
+    )
+    parser.add_argument("--portfolio-id", required=True)
+    parser.add_argument(
+        "--portfolio-config",
+        type=Path,
+        default=Path("config/portfolios.yaml"),
+    )
+    parser.add_argument("--start-date", type=_calendar_date)
+    parser.add_argument("--end-date", required=True, type=_calendar_date)
+    parser.add_argument("--covariance-window", type=_positive_integer, default=20)
+    parser.add_argument(
+        "--max-snapshots",
+        type=_max_snapshots,
+        default=MAX_HISTORY_SNAPSHOTS,
+    )
+    parser.add_argument(
+        "--storage-config",
+        type=Path,
+        default=Path("config/storage.yaml"),
+    )
+    parser.add_argument("--summary-json", type=Path)
+    return parser
+
+
+def _aligned_pairs(
+    sample_history: PortfolioAttributionHistoryOutput,
+    ewma_history: PortfolioAttributionHistoryOutput,
+) -> tuple[tuple[dict[str, Any], dict[str, Any]], ...]:
+    if len(sample_history.snapshots) != len(ewma_history.snapshots):
+        raise ValidationError(
+            "sample and EWMA attribution histories contain different row counts"
+        )
+
+    pairs: list[tuple[dict[str, Any], dict[str, Any]]] = []
+    for sample, ewma in zip(
+        sample_history.snapshots,
+        ewma_history.snapshots,
+        strict=True,
+    ):
+        if any(sample[field] != ewma[field] for field in ALIGNMENT_FIELDS):
+            raise ValidationError(
+                "sample and EWMA attribution histories are not input-aligned"
+            )
+        if sample["calculation_id"] == ewma["calculation_id"]:
+            raise ValidationError(
+                "sample and EWMA attribution calculations must have distinct identities"
+            )
+        pairs.append((sample, ewma))
+    if not pairs:
+        raise ValidationError("portfolio covariance history comparison is empty")
+    return tuple(pairs)
+
+
+def _publish_pairs(
+    pairs: Sequence[tuple[dict[str, Any], dict[str, Any]]],
+    *,
+    storage_config: dict[str, Any],
+    writer: Writer,
+) -> int:
+    written = 0
+    for sample, ewma in pairs:
+        for snapshot in (sample, ewma):
+            try:
+                result = writer(
+                    [snapshot],
+                    kind="curated",
+                    dataset=OUTPUT_DATASET,
+                    storage_config=storage_config,
+                )
+            except Exception:
+                raise StorageError(
+                    "Portfolio covariance history publication failed; rerun is safe"
+                ) from None
+            if type(result) is not int or result not in {0, 1}:
+                raise StorageError(
+                    "Portfolio covariance history publication returned an invalid result"
+                )
+            written += result
+    return written
+
+
+def _comparison_evidence(
+    sample: Mapping[str, Any],
+    ewma: Mapping[str, Any],
+) -> dict[str, Any]:
+    sample_volatility = float(sample["portfolio_volatility_annualized"])
+    ewma_volatility = float(ewma["portfolio_volatility_annualized"])
+    if not math.isfinite(sample_volatility) or not math.isfinite(ewma_volatility):
+        raise ValidationError("portfolio covariance history contains non-finite risk")
+    difference = ewma_volatility - sample_volatility
+    ratio = ewma_volatility / sample_volatility if sample_volatility > 0 else None
+    if ratio is not None and not math.isfinite(ratio):
+        raise ValidationError("portfolio covariance history ratio is non-finite")
+    higher = (
+        "equal"
+        if math.isclose(difference, 0.0, rel_tol=0.0, abs_tol=1e-15)
+        else "ewma"
+        if difference > 0
+        else "sample"
+    )
+    return {
+        "date": sample["ts_event"].date().isoformat(),
+        "sample_calculation_id": sample["calculation_id"],
+        "ewma_calculation_id": ewma["calculation_id"],
+        "sample_volatility_annualized": sample_volatility,
+        "ewma_volatility_annualized": ewma_volatility,
+        "ewma_minus_sample_volatility": difference,
+        "ewma_to_sample_volatility_ratio": ratio,
+        "higher_volatility_model": higher,
+    }
+
+
+def _aggregate_comparisons(
+    pairs: Sequence[tuple[dict[str, Any], dict[str, Any]]],
+) -> dict[str, Any]:
+    comparisons = [
+        _comparison_evidence(sample, ewma) for sample, ewma in pairs
+    ]
+    latest = comparisons[-1]
+    maximum = max(
+        comparisons,
+        key=lambda comparison: (
+            abs(float(comparison["ewma_minus_sample_volatility"])),
+            str(comparison["date"]),
+        ),
+    )
+    return {
+        "paired_snapshot_dates": len(comparisons),
+        "ewma_higher_dates": sum(
+            comparison["higher_volatility_model"] == "ewma"
+            for comparison in comparisons
+        ),
+        "sample_higher_dates": sum(
+            comparison["higher_volatility_model"] == "sample"
+            for comparison in comparisons
+        ),
+        "equal_dates": sum(
+            comparison["higher_volatility_model"] == "equal"
+            for comparison in comparisons
+        ),
+        "latest": latest,
+        "maximum_absolute_difference": {
+            **maximum,
+            "absolute_volatility_difference": abs(
+                float(maximum["ewma_minus_sample_volatility"])
+            ),
+        },
+    }
+
+
+def run_portfolio_covariance_history_comparison(
+    *,
+    portfolio_id: str,
+    portfolio_config_path: Path,
+    end_date: date,
+    covariance_window: int,
+    storage_config_path: Path,
+    start_date: date | None = None,
+    max_snapshots: int = MAX_HISTORY_SNAPSHOTS,
+    reader: Reader | None = None,
+    writer: Writer | None = None,
+    storage_config_loader: StorageConfigLoader | None = None,
+    definition_loader: DefinitionLoader | None = None,
+) -> dict[str, Any]:
+    if start_date is not None and start_date > end_date:
+        raise ValidationError("start_date must be on or before end_date")
+
+    selected_storage_loader = storage_config_loader or load_storage_config
+    try:
+        storage_config = selected_storage_loader(storage_config_path)
+    except Exception:
+        raise StorageError("Storage configuration is invalid") from None
+    if not isinstance(storage_config, dict):
+        raise StorageError("Storage configuration is invalid")
+    _require_datasets(storage_config)
+
+    selected_definition_loader = definition_loader or load_portfolio_definition
+    try:
+        definition = selected_definition_loader(portfolio_config_path, portfolio_id)
+    except ValidationError:
+        raise
+    except Exception:
+        raise ValidationError("Portfolio configuration is invalid") from None
+
+    selected_reader = reader or load_portfolio_return_records
+    try:
+        records = tuple(
+            selected_reader(
+                storage_config=storage_config,
+                portfolio_id=definition.portfolio_id,
+                definition_fingerprint=definition.fingerprint,
+                end_date=end_date,
+            )
+        )
+    except (StorageError, ValidationError):
+        raise
+    except Exception:
+        raise StorageError("Unable to read local portfolio returns") from None
+
+    sample_history = build_portfolio_attribution_history(
+        records,
+        definition=definition,
+        covariance_window=covariance_window,
+        start_date=start_date,
+        end_date=end_date,
+        max_snapshots=max_snapshots,
+    )
+    ewma_history = build_portfolio_ewma_attribution_history(
+        records,
+        definition=definition,
+        covariance_window=covariance_window,
+        start_date=start_date,
+        end_date=end_date,
+        max_snapshots=max_snapshots,
+    )
+    pairs = _aligned_pairs(sample_history, ewma_history)
+
+    selected_writer = writer or write_records
+    written = _publish_pairs(
+        pairs,
+        storage_config=storage_config,
+        writer=selected_writer,
+    )
+    selected = 2 * len(pairs)
+    return {
+        "run_id": str(uuid4()),
+        "portfolio_id": definition.portfolio_id,
+        "base_currency": definition.base_currency,
+        "definition_fingerprint": definition.fingerprint,
+        "selection": {
+            "start_date": start_date.isoformat() if start_date is not None else None,
+            "end_date": end_date.isoformat(),
+            "covariance_window": covariance_window,
+            "max_snapshots_per_model": max_snapshots,
+            "first_snapshot_date": pairs[0][0]["ts_event"].date().isoformat(),
+            "last_snapshot_date": pairs[-1][0]["ts_event"].date().isoformat(),
+        },
+        "curated_output": {
+            OUTPUT_DATASET: {
+                "records_selected": selected,
+                "records_written": written,
+                "records_already_present": selected - written,
+                "sample_records_selected": len(pairs),
+                "ewma_records_selected": len(pairs),
+            }
+        },
+        "sample_diagnostics": dict(sample_history.diagnostics),
+        "ewma_diagnostics": dict(ewma_history.diagnostics),
+        "comparison": _aggregate_comparisons(pairs),
+    }
+
+
+def _write_summary(path: Path, summary: Mapping[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_suffix(path.suffix + ".tmp")
+    try:
+        temporary.write_text(
+            json.dumps(summary, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        temporary.replace(path)
+    except OSError:
+        temporary.unlink(missing_ok=True)
+        raise StorageError(
+            "Unable to write the portfolio covariance history summary"
+        ) from None
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    try:
+        summary = run_portfolio_covariance_history_comparison(
+            portfolio_id=args.portfolio_id,
+            portfolio_config_path=args.portfolio_config,
+            start_date=args.start_date,
+            end_date=args.end_date,
+            covariance_window=args.covariance_window,
+            max_snapshots=args.max_snapshots,
+            storage_config_path=args.storage_config,
+        )
+        if args.summary_json is not None:
+            _write_summary(args.summary_json, summary)
+    except ValidationError:
+        print(
+            "Portfolio covariance history comparison failed: configuration, "
+            "input data, or options were invalid",
+            file=sys.stderr,
+        )
+        return 1
+    except StorageError:
+        print(
+            "Portfolio covariance history comparison failed: local storage "
+            "operation failed; rerun is safe",
+            file=sys.stderr,
+        )
+        return 1
+    except Exception:
+        print(
+            "Portfolio covariance history comparison failed: unexpected local failure",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(json.dumps(summary, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/integration/test_portfolio_covariance_history_comparison_pipeline.py
+++ b/tests/integration/test_portfolio_covariance_history_comparison_pipeline.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+
+import json
+from datetime import date, datetime, timedelta, timezone
+from pathlib import Path
+
+from src.analytics.portfolio_risk import (
+    WEIGHTING_METHOD,
+    load_portfolio_definition,
+)
+from src.orchestration.run_portfolio_covariance_history_comparison import (
+    run_portfolio_covariance_history_comparison,
+)
+from src.storage.s3_writer import write_records
+from src.warehouse.portfolio_attribution_loader import collect_attribution_records
+from tests.storage_config_helpers import build_storage_config, write_storage_config
+
+
+def _portfolio_config(tmp_path: Path) -> Path:
+    path = tmp_path / "portfolios.yaml"
+    path.write_text(
+        """
+portfolios:
+  us-tech-equal:
+    base_currency: USD
+    constituents:
+      - source: alpha_vantage
+        symbol: AAPL
+        weight: 0.5
+      - source: alpha_vantage
+        symbol: MSFT
+        weight: 0.5
+""".lstrip(),
+        encoding="utf-8",
+    )
+    return path
+
+
+def _portfolio_returns(definition_fingerprint: str) -> list[dict[str, object]]:
+    records: list[dict[str, object]] = []
+    ingested_at = datetime(2026, 1, 10, 12, tzinfo=timezone.utc)
+    for day, aapl, msft in [
+        (2, 0.10, 0.02),
+        (3, -0.04, 0.0),
+        (4, 0.06, 0.02),
+        (5, 0.01, -0.01),
+        (6, -0.02, 0.03),
+    ]:
+        component_returns = {
+            "alpha_vantage:AAPL": aapl,
+            "alpha_vantage:MSFT": msft,
+        }
+        records.append(
+            {
+                "model_version": "portfolio-risk-v1",
+                "calculation_id": f"portfolio-{day}",
+                "portfolio_id": "us-tech-equal",
+                "base_currency": "USD",
+                "definition_fingerprint": definition_fingerprint,
+                "weighting_method": WEIGHTING_METHOD,
+                "ts_event": datetime(2026, 1, day, tzinfo=timezone.utc),
+                "ts_ingest": ingested_at + timedelta(minutes=day),
+                "constituent_count": 2,
+                "weights_json": json.dumps(
+                    {
+                        "alpha_vantage:AAPL": 0.5,
+                        "alpha_vantage:MSFT": 0.5,
+                    },
+                    sort_keys=True,
+                ),
+                "component_calculation_ids_json": json.dumps(
+                    {
+                        "alpha_vantage:AAPL": f"AAPL-{day}",
+                        "alpha_vantage:MSFT": f"MSFT-{day}",
+                    },
+                    sort_keys=True,
+                ),
+                "component_returns_json": json.dumps(
+                    component_returns,
+                    sort_keys=True,
+                ),
+                "contributions_json": json.dumps(
+                    {
+                        key: 0.5 * value
+                        for key, value in component_returns.items()
+                    },
+                    sort_keys=True,
+                ),
+                "portfolio_return_1d": 0.5 * aapl + 0.5 * msft,
+            }
+        )
+    return records
+
+
+def test_covariance_history_comparison_publishes_and_replays_both_models(
+    tmp_path: Path,
+) -> None:
+    storage_config = build_storage_config(tmp_path)
+    storage_config_path = write_storage_config(tmp_path)
+    portfolio_config_path = _portfolio_config(tmp_path)
+    definition = load_portfolio_definition(
+        portfolio_config_path,
+        "us-tech-equal",
+    )
+    assert (
+        write_records(
+            _portfolio_returns(definition.fingerprint),
+            kind="curated",
+            dataset="portfolio_daily_returns",
+            storage_config=storage_config,
+        )
+        == 5
+    )
+
+    first = run_portfolio_covariance_history_comparison(
+        portfolio_id="us-tech-equal",
+        portfolio_config_path=portfolio_config_path,
+        end_date=date(2026, 1, 6),
+        covariance_window=3,
+        max_snapshots=10,
+        storage_config_path=storage_config_path,
+    )
+    second = run_portfolio_covariance_history_comparison(
+        portfolio_id="us-tech-equal",
+        portfolio_config_path=portfolio_config_path,
+        end_date=date(2026, 1, 6),
+        covariance_window=3,
+        max_snapshots=10,
+        storage_config_path=storage_config_path,
+    )
+
+    assert first["curated_output"]["portfolio_risk_attribution"] == {
+        "records_selected": 6,
+        "records_written": 6,
+        "records_already_present": 0,
+        "sample_records_selected": 3,
+        "ewma_records_selected": 3,
+    }
+    assert second["curated_output"]["portfolio_risk_attribution"] == {
+        "records_selected": 6,
+        "records_written": 0,
+        "records_already_present": 6,
+        "sample_records_selected": 3,
+        "ewma_records_selected": 3,
+    }
+
+    rows = collect_attribution_records(storage_config_path)
+    assert len(rows) == 6
+    by_date: dict[date, list[dict[str, object]]] = {}
+    for row in rows:
+        by_date.setdefault(row["ts_event"].date(), []).append(row)
+    assert set(by_date) == {
+        date(2026, 1, 4),
+        date(2026, 1, 5),
+        date(2026, 1, 6),
+    }
+    for date_rows in by_date.values():
+        assert {row["model_version"] for row in date_rows} == {
+            "portfolio-attribution-v1",
+            "portfolio-attribution-ewma-v1",
+        }
+        assert len({row["calculation_id"] for row in date_rows}) == 2
+        assert len({row["input_calculation_ids_json"] for row in date_rows}) == 1

--- a/tests/unit/test_docker_compose_contract.py
+++ b/tests/unit/test_docker_compose_contract.py
@@ -34,6 +34,7 @@ def test_local_database_seed_mounts_are_read_only_and_ordered() -> None:
         "./sql/portfolio_risk_notification_outbox_schema.sql:/docker-entrypoint-initdb.d/07_portfolio_risk_notification_outbox_schema.sql:ro",
         "./sql/market_freshness_schema.sql:/docker-entrypoint-initdb.d/08_market_freshness_schema.sql:ro",
         "./sql/portfolio_risk_notification_delivery_schema.sql:/docker-entrypoint-initdb.d/09_portfolio_risk_notification_delivery_schema.sql:ro",
+        "./sql/portfolio_covariance_method_schema.sql:/docker-entrypoint-initdb.d/10_portfolio_covariance_method_schema.sql:ro",
     ]
     assert services["mongo"]["volumes"] == [
         "./mongo/init:/docker-entrypoint-initdb.d:ro"

--- a/tests/unit/test_portfolio_attribution_ewma_history.py
+++ b/tests/unit/test_portfolio_attribution_ewma_history.py
@@ -1,0 +1,224 @@
+from __future__ import annotations
+
+import json
+from datetime import date, datetime, timedelta, timezone
+
+import pytest
+
+from src.analytics.portfolio_attribution_ewma import MODEL_VERSION
+from src.analytics.portfolio_attribution_ewma_history import (
+    build_portfolio_ewma_attribution_history,
+)
+from src.analytics.portfolio_risk import (
+    WEIGHTING_METHOD,
+    PortfolioDefinition,
+    parse_portfolio_definition,
+)
+from src.common.exceptions import ValidationError
+
+
+def _definition() -> PortfolioDefinition:
+    return parse_portfolio_definition(
+        {
+            "portfolios": {
+                "us-tech-equal": {
+                    "base_currency": "USD",
+                    "constituents": [
+                        {
+                            "source": "alpha_vantage",
+                            "symbol": "AAPL",
+                            "weight": 0.5,
+                        },
+                        {
+                            "source": "alpha_vantage",
+                            "symbol": "MSFT",
+                            "weight": 0.5,
+                        },
+                    ],
+                }
+            }
+        },
+        "us-tech-equal",
+    )
+
+
+def _record(
+    day: int,
+    aapl: float,
+    msft: float,
+    *,
+    calculation_id: str | None = None,
+    ingested_at: datetime | None = None,
+) -> dict[str, object]:
+    definition = _definition()
+    ts_event = datetime(2026, 1, day, tzinfo=timezone.utc)
+    component_returns = {
+        "alpha_vantage:AAPL": aapl,
+        "alpha_vantage:MSFT": msft,
+    }
+    return {
+        "model_version": "portfolio-risk-v1",
+        "calculation_id": calculation_id or f"portfolio-{day}",
+        "portfolio_id": definition.portfolio_id,
+        "base_currency": definition.base_currency,
+        "definition_fingerprint": definition.fingerprint,
+        "weighting_method": WEIGHTING_METHOD,
+        "ts_event": ts_event,
+        "ts_ingest": ingested_at or ts_event + timedelta(hours=1),
+        "constituent_count": 2,
+        "weights_json": json.dumps(
+            {"alpha_vantage:AAPL": 0.5, "alpha_vantage:MSFT": 0.5},
+            sort_keys=True,
+        ),
+        "component_calculation_ids_json": json.dumps(
+            {
+                "alpha_vantage:AAPL": f"AAPL-{day}",
+                "alpha_vantage:MSFT": f"MSFT-{day}",
+            },
+            sort_keys=True,
+        ),
+        "component_returns_json": json.dumps(
+            component_returns,
+            sort_keys=True,
+        ),
+        "portfolio_return_1d": 0.5 * aapl + 0.5 * msft,
+    }
+
+
+def _records() -> list[dict[str, object]]:
+    return [
+        _record(2, 0.10, 0.02),
+        _record(3, -0.04, 0.0),
+        _record(4, 0.06, 0.02),
+        _record(5, 0.01, -0.01),
+        _record(6, -0.02, 0.03),
+    ]
+
+
+def test_ewma_history_emits_every_complete_window_in_date_order() -> None:
+    output = build_portfolio_ewma_attribution_history(
+        _records(),
+        definition=_definition(),
+        covariance_window=3,
+        end_date=date(2026, 1, 6),
+    )
+
+    assert [snapshot["ts_event"].date() for snapshot in output.snapshots] == [
+        date(2026, 1, 4),
+        date(2026, 1, 5),
+        date(2026, 1, 6),
+    ]
+    assert all(
+        snapshot["model_version"] == MODEL_VERSION
+        for snapshot in output.snapshots
+    )
+    assert len({snapshot["calculation_id"] for snapshot in output.snapshots}) == 3
+    assert output.diagnostics["snapshots_selected"] == 3
+    assert output.diagnostics["available_snapshot_dates"] == 3
+
+
+def test_start_date_filters_outputs_but_preserves_prior_window_context() -> None:
+    output = build_portfolio_ewma_attribution_history(
+        _records(),
+        definition=_definition(),
+        covariance_window=3,
+        start_date=date(2026, 1, 5),
+        end_date=date(2026, 1, 6),
+    )
+
+    assert [snapshot["ts_event"].date() for snapshot in output.snapshots] == [
+        date(2026, 1, 5),
+        date(2026, 1, 6),
+    ]
+    assert json.loads(output.snapshots[0]["input_calculation_ids_json"]) == [
+        "portfolio-3",
+        "portfolio-4",
+        "portfolio-5",
+    ]
+    assert output.diagnostics["snapshots_skipped_before_start_date"] == 1
+
+
+def test_input_order_does_not_change_ewma_history() -> None:
+    forward = build_portfolio_ewma_attribution_history(
+        _records(),
+        definition=_definition(),
+        covariance_window=3,
+    )
+    reverse = build_portfolio_ewma_attribution_history(
+        reversed(_records()),
+        definition=_definition(),
+        covariance_window=3,
+    )
+
+    assert forward.snapshots == reverse.snapshots
+    assert forward.diagnostics == reverse.diagnostics
+
+
+def test_late_correction_changes_every_affected_window_identity() -> None:
+    original = build_portfolio_ewma_attribution_history(
+        _records(),
+        definition=_definition(),
+        covariance_window=3,
+    )
+    corrected_records = [
+        *_records(),
+        _record(
+            4,
+            0.20,
+            0.02,
+            calculation_id="portfolio-4-corrected",
+            ingested_at=datetime(2026, 2, 1, tzinfo=timezone.utc),
+        ),
+    ]
+    corrected = build_portfolio_ewma_attribution_history(
+        corrected_records,
+        definition=_definition(),
+        covariance_window=3,
+    )
+
+    assert [snapshot["ts_event"] for snapshot in original.snapshots] == [
+        snapshot["ts_event"] for snapshot in corrected.snapshots
+    ]
+    assert all(
+        original_snapshot["calculation_id"]
+        != corrected_snapshot["calculation_id"]
+        for original_snapshot, corrected_snapshot in zip(
+            original.snapshots,
+            corrected.snapshots,
+            strict=True,
+        )
+    )
+
+
+def test_invalid_ranges_caps_and_missing_windows_fail_before_output() -> None:
+    with pytest.raises(ValidationError, match="start_date"):
+        build_portfolio_ewma_attribution_history(
+            _records(),
+            definition=_definition(),
+            covariance_window=3,
+            start_date=date(2026, 1, 6),
+            end_date=date(2026, 1, 5),
+        )
+
+    with pytest.raises(ValidationError, match="exceeds max_snapshots"):
+        build_portfolio_ewma_attribution_history(
+            _records(),
+            definition=_definition(),
+            covariance_window=3,
+            max_snapshots=2,
+        )
+
+    with pytest.raises(ValidationError, match="requires at least 6"):
+        build_portfolio_ewma_attribution_history(
+            _records(),
+            definition=_definition(),
+            covariance_window=6,
+        )
+
+    with pytest.raises(ValidationError, match="no EWMA"):
+        build_portfolio_ewma_attribution_history(
+            _records(),
+            definition=_definition(),
+            covariance_window=3,
+            start_date=date(2026, 2, 1),
+        )

--- a/tests/unit/test_portfolio_covariance_history_architecture_contract.py
+++ b/tests/unit/test_portfolio_covariance_history_architecture_contract.py
@@ -1,0 +1,49 @@
+from pathlib import Path
+
+
+def test_rolling_covariance_comparison_documentation_matches_runtime() -> None:
+    documentation = Path(
+        "docs/portfolio-covariance-history-comparison.md"
+    ).read_text(encoding="utf-8")
+    history = Path(
+        "src/analytics/portfolio_attribution_ewma_history.py"
+    ).read_text(encoding="utf-8")
+    runner = Path(
+        "src/orchestration/run_portfolio_covariance_history_comparison.py"
+    ).read_text(encoding="utf-8")
+    schema = Path("sql/portfolio_covariance_method_schema.sql").read_text(
+        encoding="utf-8"
+    )
+
+    for required in (
+        "build_portfolio_ewma_attribution_history",
+        "MAX_HISTORY_SNAPSHOTS",
+        "start_date",
+        "max_snapshots",
+    ):
+        assert required in history
+
+    for required in (
+        "run_portfolio_covariance_history_comparison",
+        "paired_snapshot_dates",
+        "maximum_absolute_difference",
+        "records_already_present",
+    ):
+        assert required in runner
+
+    for required in (
+        "run_portfolio_covariance_history_comparison",
+        "2,500",
+        "portfolio_covariance_method_comparison",
+        "portfolio_covariance_method_consistency_checks.sql",
+        "ordered input calculation IDs",
+    ):
+        assert required in documentation
+
+    for required in (
+        "portfolio-attribution-ewma-v1",
+        "ewma_zero_mean_lambda_0_94_annualized",
+        "implied_from_ewma_covariance",
+        "input_calculation_ids_json = sample.input_calculation_ids_json",
+    ):
+        assert required in schema

--- a/tests/unit/test_portfolio_covariance_method_reporting_sql_contract.py
+++ b/tests/unit/test_portfolio_covariance_method_reporting_sql_contract.py
@@ -1,0 +1,177 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+
+import duckdb
+import pytest
+import yaml
+
+
+def _read_sql(path: str) -> str:
+    return Path(path).read_text(encoding="utf-8")
+
+
+def _extract_statement(sql: str, prefix: str) -> str:
+    start = sql.index(prefix)
+    end = sql.index(";", start) + 1
+    return sql[start:end]
+
+
+def test_covariance_method_schema_registers_ewma_contract_and_view() -> None:
+    schema = _read_sql("sql/portfolio_covariance_method_schema.sql")
+
+    for required in (
+        "chk_portfolio_attribution_ewma_v1",
+        "portfolio-attribution-ewma-v1",
+        "ewma_zero_mean_lambda_0_94_annualized",
+        "implied_from_ewma_covariance",
+        "portfolio_covariance_method_comparison",
+        "ewma_minus_sample_volatility",
+        "ewma_to_sample_volatility_ratio",
+        "higher_volatility_model",
+        "input_calculation_ids_json = sample.input_calculation_ids_json",
+    ):
+        assert required in schema
+
+
+def test_covariance_method_view_pairs_only_exactly_aligned_inputs() -> None:
+    schema = _read_sql("sql/portfolio_covariance_method_schema.sql")
+    view = _extract_statement(
+        schema,
+        "CREATE OR REPLACE VIEW risk_platform.portfolio_covariance_method_comparison AS",
+    )
+
+    with duckdb.connect() as connection:
+        connection.execute("CREATE SCHEMA risk_platform")
+        connection.execute(
+            """
+            CREATE TABLE risk_platform.latest_portfolio_risk_attribution (
+                portfolio_id TEXT,
+                base_currency TEXT,
+                definition_fingerprint TEXT,
+                weighting_method TEXT,
+                covariance_window INTEGER,
+                window_start TIMESTAMPTZ,
+                window_end TIMESTAMPTZ,
+                window_observations INTEGER,
+                annualization_days INTEGER,
+                ts_event TIMESTAMPTZ,
+                input_calculation_ids_json TEXT,
+                calculation_id TEXT,
+                ts_ingest TIMESTAMPTZ,
+                portfolio_variance_annualized DOUBLE,
+                portfolio_volatility_annualized DOUBLE,
+                model_version TEXT,
+                covariance_method TEXT,
+                correlation_method TEXT
+            )
+            """
+        )
+        metric_time = datetime(2026, 1, 6, tzinfo=timezone.utc)
+        window_start = datetime(2026, 1, 4, tzinfo=timezone.utc)
+        sample_ingest = datetime(2026, 2, 1, tzinfo=timezone.utc)
+        ewma_ingest = datetime(2026, 2, 2, tzinfo=timezone.utc)
+        common = (
+            "us-tech",
+            "USD",
+            "definition-a",
+            "constant_weight_daily_rebalanced",
+            3,
+            window_start,
+            metric_time,
+            3,
+            252,
+            metric_time,
+            '["r4","r5","r6"]',
+        )
+        rows = [
+            (
+                *common,
+                "sample-6",
+                sample_ingest,
+                0.04,
+                0.20,
+                "portfolio-attribution-v1",
+                "sample_annualized",
+                "pearson",
+            ),
+            (
+                *common,
+                "ewma-6",
+                ewma_ingest,
+                0.0625,
+                0.25,
+                "portfolio-attribution-ewma-v1",
+                "ewma_zero_mean_lambda_0_94_annualized",
+                "implied_from_ewma_covariance",
+            ),
+            (
+                *common[:-1],
+                '["different","inputs","here"]',
+                "ewma-misaligned",
+                ewma_ingest,
+                0.09,
+                0.30,
+                "portfolio-attribution-ewma-v1",
+                "ewma_zero_mean_lambda_0_94_annualized",
+                "implied_from_ewma_covariance",
+            ),
+        ]
+        placeholders = ", ".join(["?"] * len(rows[0]))
+        connection.executemany(
+            "INSERT INTO risk_platform.latest_portfolio_risk_attribution VALUES "
+            f"({placeholders})",
+            rows,
+        )
+        connection.execute(view)
+
+        result = connection.execute(
+            """
+            SELECT
+                sample_calculation_id,
+                ewma_calculation_id,
+                sample_portfolio_volatility_annualized,
+                ewma_portfolio_volatility_annualized,
+                ewma_minus_sample_volatility,
+                ewma_to_sample_volatility_ratio,
+                higher_volatility_model
+            FROM risk_platform.portfolio_covariance_method_comparison
+            """
+        ).fetchall()
+        assert len(result) == 1
+        row = result[0]
+        assert row[0:4] == ("sample-6", "ewma-6", 0.20, 0.25)
+        assert row[4] == pytest.approx(0.05)
+        assert row[5] == pytest.approx(1.25)
+        assert row[6] == "ewma"
+
+
+def test_covariance_method_reconciliation_covers_pair_math_and_grain() -> None:
+    consistency = _read_sql(
+        "sql/portfolio_covariance_method_consistency_checks.sql"
+    )
+    for check_name in (
+        "portfolio_covariance_method_pairs_complete",
+        "portfolio_covariance_method_difference_reconciles",
+        "portfolio_covariance_method_ratio_reconciles",
+        "portfolio_covariance_method_higher_label_reconciles",
+        "portfolio_covariance_method_grain_unique",
+    ):
+        assert check_name in consistency
+
+
+def test_docker_initializes_covariance_method_schema_after_attribution() -> None:
+    compose = yaml.safe_load(Path("docker-compose.yml").read_text(encoding="utf-8"))
+    volumes = compose["services"]["postgres"]["volumes"]
+    attribution = (
+        "./sql/portfolio_attribution_schema.sql:"
+        "/docker-entrypoint-initdb.d/04_portfolio_attribution_schema.sql:ro"
+    )
+    comparison = (
+        "./sql/portfolio_covariance_method_schema.sql:"
+        "/docker-entrypoint-initdb.d/10_portfolio_covariance_method_schema.sql:ro"
+    )
+    assert attribution in volumes
+    assert comparison in volumes
+    assert volumes.index(attribution) < volumes.index(comparison)

--- a/tests/unit/test_run_portfolio_covariance_history_comparison.py
+++ b/tests/unit/test_run_portfolio_covariance_history_comparison.py
@@ -1,0 +1,249 @@
+from __future__ import annotations
+
+import json
+from datetime import date, datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from src.analytics.portfolio_risk import (
+    WEIGHTING_METHOD,
+    PortfolioDefinition,
+    parse_portfolio_definition,
+)
+from src.common.exceptions import StorageError, ValidationError
+from src.orchestration.run_portfolio_covariance_history_comparison import (
+    run_portfolio_covariance_history_comparison,
+)
+
+
+def _definition() -> PortfolioDefinition:
+    return parse_portfolio_definition(
+        {
+            "portfolios": {
+                "us-tech-equal": {
+                    "base_currency": "USD",
+                    "constituents": [
+                        {
+                            "source": "alpha_vantage",
+                            "symbol": "AAPL",
+                            "weight": 0.5,
+                        },
+                        {
+                            "source": "alpha_vantage",
+                            "symbol": "MSFT",
+                            "weight": 0.5,
+                        },
+                    ],
+                }
+            }
+        },
+        "us-tech-equal",
+    )
+
+
+def _records() -> list[dict[str, object]]:
+    definition = _definition()
+    records: list[dict[str, object]] = []
+    for day, aapl, msft in [
+        (2, 0.10, 0.02),
+        (3, -0.04, 0.0),
+        (4, 0.06, 0.02),
+        (5, 0.01, -0.01),
+        (6, -0.02, 0.03),
+    ]:
+        ts_event = datetime(2026, 1, day, tzinfo=timezone.utc)
+        component_returns = {
+            "alpha_vantage:AAPL": aapl,
+            "alpha_vantage:MSFT": msft,
+        }
+        records.append(
+            {
+                "model_version": "portfolio-risk-v1",
+                "calculation_id": f"portfolio-{day}",
+                "portfolio_id": definition.portfolio_id,
+                "base_currency": definition.base_currency,
+                "definition_fingerprint": definition.fingerprint,
+                "weighting_method": WEIGHTING_METHOD,
+                "ts_event": ts_event,
+                "ts_ingest": ts_event + timedelta(hours=1),
+                "constituent_count": 2,
+                "weights_json": json.dumps(
+                    {
+                        "alpha_vantage:AAPL": 0.5,
+                        "alpha_vantage:MSFT": 0.5,
+                    },
+                    sort_keys=True,
+                ),
+                "component_calculation_ids_json": json.dumps(
+                    {
+                        "alpha_vantage:AAPL": f"AAPL-{day}",
+                        "alpha_vantage:MSFT": f"MSFT-{day}",
+                    },
+                    sort_keys=True,
+                ),
+                "component_returns_json": json.dumps(
+                    component_returns,
+                    sort_keys=True,
+                ),
+                "portfolio_return_1d": 0.5 * aapl + 0.5 * msft,
+            }
+        )
+    return records
+
+
+def _storage_config() -> dict[str, Any]:
+    return {
+        "storage": {
+            "base_dir": "unused",
+            "raw": {"base_path": "unused/raw", "dataset": "market_events"},
+            "curated": {
+                "base_path": "unused/curated",
+                "datasets": {
+                    "portfolio_daily_returns": "portfolio_daily_returns",
+                    "portfolio_risk_attribution": "portfolio_risk_attribution",
+                },
+            },
+            "format": "parquet",
+            "partitioning": {"granularity": "hourly"},
+        }
+    }
+
+
+def test_history_comparison_publishes_two_aligned_rows_per_date() -> None:
+    writes: list[dict[str, Any]] = []
+
+    def writer(records: list[dict[str, Any]], *, dataset: str, **_: Any) -> int:
+        assert dataset == "portfolio_risk_attribution"
+        assert len(records) == 1
+        writes.append(records[0])
+        return 1
+
+    summary = run_portfolio_covariance_history_comparison(
+        portfolio_id="us-tech-equal",
+        portfolio_config_path=Path("unused.yaml"),
+        start_date=date(2026, 1, 5),
+        end_date=date(2026, 1, 6),
+        covariance_window=3,
+        max_snapshots=10,
+        storage_config_path=Path("unused-storage.yaml"),
+        reader=lambda **_: _records(),
+        writer=writer,
+        storage_config_loader=lambda _: _storage_config(),
+        definition_loader=lambda *_: _definition(),
+    )
+
+    assert summary["curated_output"]["portfolio_risk_attribution"] == {
+        "records_selected": 4,
+        "records_written": 4,
+        "records_already_present": 0,
+        "sample_records_selected": 2,
+        "ewma_records_selected": 2,
+    }
+    assert [record["model_version"] for record in writes] == [
+        "portfolio-attribution-v1",
+        "portfolio-attribution-ewma-v1",
+        "portfolio-attribution-v1",
+        "portfolio-attribution-ewma-v1",
+    ]
+    assert [record["ts_event"].date() for record in writes] == [
+        date(2026, 1, 5),
+        date(2026, 1, 5),
+        date(2026, 1, 6),
+        date(2026, 1, 6),
+    ]
+    assert writes[0]["input_calculation_ids_json"] == writes[1][
+        "input_calculation_ids_json"
+    ]
+    assert writes[2]["input_calculation_ids_json"] == writes[3][
+        "input_calculation_ids_json"
+    ]
+    comparison = summary["comparison"]
+    assert comparison["paired_snapshot_dates"] == 2
+    assert (
+        comparison["ewma_higher_dates"]
+        + comparison["sample_higher_dates"]
+        + comparison["equal_dates"]
+        == 2
+    )
+    assert comparison["latest"]["date"] == "2026-01-06"
+    assert comparison["maximum_absolute_difference"][
+        "absolute_volatility_difference"
+    ] >= 0
+
+
+def test_history_comparison_reports_partial_replay_counts() -> None:
+    results = iter([0, 0, 1, 1, 0, 1])
+
+    summary = run_portfolio_covariance_history_comparison(
+        portfolio_id="us-tech-equal",
+        portfolio_config_path=Path("unused.yaml"),
+        end_date=date(2026, 1, 6),
+        covariance_window=3,
+        max_snapshots=10,
+        storage_config_path=Path("unused-storage.yaml"),
+        reader=lambda **_: _records(),
+        writer=lambda *_args, **_kwargs: next(results),
+        storage_config_loader=lambda _: _storage_config(),
+        definition_loader=lambda *_: _definition(),
+    )
+
+    assert summary["curated_output"]["portfolio_risk_attribution"] == {
+        "records_selected": 6,
+        "records_written": 3,
+        "records_already_present": 3,
+        "sample_records_selected": 3,
+        "ewma_records_selected": 3,
+    }
+
+
+def test_history_comparison_fails_before_read_for_invalid_range() -> None:
+    reads: list[str] = []
+
+    with pytest.raises(ValidationError, match="start_date"):
+        run_portfolio_covariance_history_comparison(
+            portfolio_id="us-tech-equal",
+            portfolio_config_path=Path("unused.yaml"),
+            start_date=date(2026, 1, 7),
+            end_date=date(2026, 1, 6),
+            covariance_window=3,
+            storage_config_path=Path("unused-storage.yaml"),
+            reader=lambda **_: reads.append("read") or _records(),
+            writer=lambda *_args, **_kwargs: 1,
+            storage_config_loader=lambda _: _storage_config(),
+            definition_loader=lambda *_: _definition(),
+        )
+
+    assert reads == []
+
+
+def test_history_comparison_rejects_invalid_writer_result() -> None:
+    with pytest.raises(StorageError, match="invalid result"):
+        run_portfolio_covariance_history_comparison(
+            portfolio_id="us-tech-equal",
+            portfolio_config_path=Path("unused.yaml"),
+            end_date=date(2026, 1, 6),
+            covariance_window=3,
+            storage_config_path=Path("unused-storage.yaml"),
+            reader=lambda **_: _records(),
+            writer=lambda *_args, **_kwargs: 2,
+            storage_config_loader=lambda _: _storage_config(),
+            definition_loader=lambda *_: _definition(),
+        )
+
+
+def test_history_comparison_enforces_snapshot_cap_for_each_model() -> None:
+    with pytest.raises(ValidationError, match="exceeds max_snapshots"):
+        run_portfolio_covariance_history_comparison(
+            portfolio_id="us-tech-equal",
+            portfolio_config_path=Path("unused.yaml"),
+            end_date=date(2026, 1, 6),
+            covariance_window=3,
+            max_snapshots=2,
+            storage_config_path=Path("unused-storage.yaml"),
+            reader=lambda **_: _records(),
+            writer=lambda *_args, **_kwargs: 1,
+            storage_config_loader=lambda _: _storage_config(),
+            definition_loader=lambda *_: _definition(),
+        )


### PR DESCRIPTION
## Outcome

Extend current-version portfolio attribution into an aligned rolling sample-versus-EWMA series:

```text
current portfolio_daily_returns versions
  -> complete rolling windows
  -> existing sample covariance attribution per date
  -> fixed-decay EWMA covariance attribution per date
  -> two retained portfolio_risk_attribution rows per eligible date
  -> PostgreSQL sample-versus-EWMA trend view
```

Primary arc42 block: `analytics`, with bounded interfaces to orchestration and PostgreSQL serving.

## Rolling model contract

Add `build_portfolio_ewma_attribution_history` without modifying the existing sample-history implementation. Both histories reuse canonical corrected-version selection and complete windows. `start_date` filters emitted dates while retaining prior observations required for the first complete window.

Each model is capped at 2,500 snapshots per request. A paired request can therefore publish at most 5,000 attribution rows. Calculation IDs remain model-specific and bind each ordered current input window.

## Paired runner

```bash
.venv/bin/python -m src.orchestration.run_portfolio_covariance_history_comparison \
  --portfolio-id us-tech-equal \
  --start-date 2026-01-01 \
  --end-date 2026-03-31 \
  --covariance-window 20 \
  --max-snapshots 2500 \
  --summary-json .demo/portfolio-covariance-history-comparison.json
```

The runner reads bounded local portfolio returns once and rejects publication unless each sample/EWMA pair has the same portfolio, definition, weighting method, date, window, annualisation basis and ordered input calculation IDs.

Rows are published independently through the existing content-addressed writer. Partial completion is replay-safe. The bounded summary reports pair counts, model-high dates, the latest comparison and the maximum absolute volatility difference without embedding every historical matrix.

## PostgreSQL serving

Add an idempotent schema layer after the attribution schema:

- validates the fixed EWMA v1 model/method contract;
- creates `risk_platform.portfolio_covariance_method_comparison`.

The view pairs only current sample and EWMA rows with identical definitions, windows, dates and ordered input IDs. It exposes both calculation IDs/timestamps, variances, volatilities, difference, ratio and the higher-volatility model.

Fresh Docker initialization mounts this as schema layer 10. Existing local databases can apply it explicitly.

## Reconciliation

`sql/portfolio_covariance_method_consistency_checks.sql` verifies:

- every exactly aligned current pair appears in the view;
- volatility differences reconcile;
- positive-sample ratios reconcile;
- higher-model labels match the values; and
- comparison grains remain unique.

## Validation

GitHub Actions run `32630096022` (`ci` run 259) passed on exact head `a45551fc71ca595d715df6b7c988828263933f61`:

- Security guardrails: passed.
- Python readiness: passed.
  - locked dependencies resolved;
  - Ruff passed;
  - mypy passed across 75 source files;
  - 637 tests passed;
  - dependency integrity passed;
  - `make readiness-check` passed.
- PostgreSQL contract: passed against PostgreSQL 16, including the new tenth schema layer and the complete load/reconciliation replay.
- Infrastructure validation: passed without deployment or Terraform apply.

Focused tests cover rolling EWMA order, start-date context, input-order independence, late-correction versioning, caps and invalid ranges; paired publication and replay accounting; Parquet history integration; executable current-view pairing; PostgreSQL schema ordering; reconciliation coverage; and documentation/runtime drift. No unresolved review threads or requested changes are present.

## Scope

The branch is one commit ahead of `main` and zero behind. It changes 12 files with 1,771 additions and no deletions as one rolling analytics-to-serving increment.

It does not change sample calculation identities, make EWMA decay configurable, alter sample-bound risk-limit policies, add model approval, schedule execution, deliver alerts, deploy infrastructure or run Terraform apply.

## Acceptance boundary

Validated and ready for squash merge as one rolling analytics-to-serving increment.