### PR TITLE
Add method-aware portfolio risk-limit policies

### DIFF
--- a/config/portfolio_risk_limit_methods.yaml
+++ b/config/portfolio_risk_limit_methods.yaml
@@ -1,0 +1,15 @@
+method_policies:
+  us-tech-sample:
+    base_policy_id: us-tech-standard
+    attribution:
+      model_version: portfolio-attribution-v1
+      weighting_method: constant_weight_daily_rebalanced
+      covariance_method: sample_annualized
+      correlation_method: pearson
+  us-tech-ewma:
+    base_policy_id: us-tech-standard
+    attribution:
+      model_version: portfolio-attribution-ewma-v1
+      weighting_method: constant_weight_daily_rebalanced
+      covariance_method: ewma_zero_mean_lambda_0_94_annualized
+      correlation_method: implied_from_ewma_covariance

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,7 @@ services:
       - ./sql/market_freshness_schema.sql:/docker-entrypoint-initdb.d/08_market_freshness_schema.sql:ro
       - ./sql/portfolio_risk_notification_delivery_schema.sql:/docker-entrypoint-initdb.d/09_portfolio_risk_notification_delivery_schema.sql:ro
       - ./sql/portfolio_covariance_method_schema.sql:/docker-entrypoint-initdb.d/10_portfolio_covariance_method_schema.sql:ro
+      - ./sql/portfolio_risk_limits_method_schema.sql:/docker-entrypoint-initdb.d/11_portfolio_risk_limits_method_schema.sql:ro
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U risk_user -d risk_platform"]
       interval: 5s

--- a/docs/portfolio-risk-limit-methods.md
+++ b/docs/portfolio-risk-limit-methods.md
@@ -1,0 +1,173 @@
+# Method-Aware Portfolio Risk Limits
+
+## Outcome
+
+This increment makes risk-limit evaluation explicitly bind the attribution model
+and covariance/correlation methods:
+
+```text
+sample and EWMA attribution history
+  -> explicit method-policy binding
+  -> select one supported model/method contract
+  -> ignore the other method without failing
+  -> versioned portfolio-risk-limits-v2 evaluations
+  -> current sample-versus-EWMA limit comparison
+```
+
+It fixes an important compatibility boundary introduced when rolling sample and
+EWMA attribution began sharing `portfolio_risk_attribution`. The earlier
+sample-only evaluator treated a same-portfolio EWMA row as an invalid record.
+The method-aware path filters by an explicit contract before current-version
+selection, so both methods can coexist safely.
+
+## Configuration
+
+Method bindings live in:
+
+```text
+config/portfolio_risk_limit_methods.yaml
+```
+
+The bundled bindings are:
+
+```text
+us-tech-sample
+  -> base policy us-tech-standard
+  -> portfolio-attribution-v1
+  -> sample_annualized
+  -> pearson
+
+us-tech-ewma
+  -> base policy us-tech-standard
+  -> portfolio-attribution-ewma-v1
+  -> ewma_zero_mean_lambda_0_94_annualized
+  -> implied_from_ewma_covariance
+```
+
+A method binding references one existing effective-dated threshold policy. It
+does not copy thresholds. The combined method-policy fingerprint binds:
+
+- the effective-dated base-policy fingerprint;
+- method-policy ID;
+- attribution model version;
+- weighting method;
+- covariance method;
+- correlation method; and
+- risk-limit evaluation model version.
+
+Threshold changes, policy-version changes, or method changes therefore produce a
+new identity.
+
+Only two complete method tuples are accepted. Mixing the EWMA model with sample
+correlation, or the sample model with the EWMA covariance method, fails closed.
+
+## Evaluation
+
+The evaluator produces `portfolio-risk-limits-v2` rows in the existing curated
+dataset:
+
+```text
+portfolio_risk_limit_evaluations
+```
+
+Every selected attribution snapshot still produces:
+
+- `portfolio_volatility_annualized`; and
+- `largest_absolute_component_contribution_share`.
+
+The existing status semantics remain unchanged:
+
+```text
+observed < warning              -> ok
+warning <= observed < critical  -> warning
+observed >= critical            -> critical
+```
+
+Current attribution versions are selected within the chosen method by:
+
+```text
+ts_ingest DESC
+calculation_id DESC
+```
+
+A sample binding ignores EWMA rows, and an EWMA binding ignores sample rows.
+Malformed matching rows and conflicting calculation-ID reuse still fail closed.
+
+## Operator Commands
+
+Evaluate sample attribution:
+
+```bash
+.venv/bin/python -m src.orchestration.run_method_aware_portfolio_risk_limits \
+  --method-policy-id us-tech-sample \
+  --start-date 2026-01-01 \
+  --end-date 2026-03-31 \
+  --summary-json .demo/sample-risk-limits.json
+```
+
+Evaluate EWMA attribution:
+
+```bash
+.venv/bin/python -m src.orchestration.run_method_aware_portfolio_risk_limits \
+  --method-policy-id us-tech-ewma \
+  --start-date 2026-01-01 \
+  --end-date 2026-03-31 \
+  --summary-json .demo/ewma-risk-limits.json
+```
+
+Both commands use the existing bounded attribution collector:
+
+- 4,096 Parquet files;
+- 1 GB physical input;
+- 250,000 rows;
+- regular non-symbolic-link files only.
+
+Publication remains one deterministic content-addressed record at a time.
+Partial local completion is replay-safe.
+
+## PostgreSQL
+
+Apply the additive method layer after the covariance-method schema:
+
+```bash
+docker compose exec -T postgres psql -U risk_user -d risk_platform \
+  < sql/portfolio_risk_limits_method_schema.sql
+```
+
+The layer constrains `portfolio-risk-limits-v2` rows to one of the supported
+sample or fixed-decay EWMA tuples.
+
+The comparison view is:
+
+```text
+risk_platform.portfolio_risk_limit_method_comparison
+```
+
+It pairs current sample and EWMA evaluations only when they share:
+
+- base policy ID;
+- portfolio and definition;
+- event date;
+- metric and unit;
+- covariance window and annualisation basis; and
+- warning and critical thresholds.
+
+The view exposes observed values, statuses, breach flags, absolute and signed
+differences, status disagreement, the higher observed method, and the more
+severe method.
+
+Run focused reconciliation with:
+
+```bash
+docker compose exec -T postgres psql -U risk_user -d risk_platform \
+  < sql/portfolio_risk_limits_method_consistency_checks.sql
+```
+
+## Safety Boundary
+
+This increment does not claim that the sample and EWMA models should share the
+same thresholds. It requires an explicit method binding when they do. Formal
+model approval and method-specific threshold calibration remain separate work.
+
+It does not make provider requests, deliver alerts, acknowledge breaches, mutate
+positions, schedule execution, deploy infrastructure, or run `terraform apply`.

--- a/sql/portfolio_risk_limits_method_consistency_checks.sql
+++ b/sql/portfolio_risk_limits_method_consistency_checks.sql
@@ -1,0 +1,248 @@
+-- Reconciliation for method-aware portfolio risk-limit evaluations.
+-- Run after sql/portfolio_risk_limits_method_schema.sql.
+
+WITH current_v2 AS (
+    SELECT *
+    FROM risk_platform.latest_portfolio_risk_limit_evaluations
+    WHERE model_version = 'portfolio-risk-limits-v2'
+),
+invalid_contracts AS (
+    SELECT COUNT(*) AS invalid_rows
+    FROM current_v2
+    WHERE
+        weighting_method <> 'constant_weight_daily_rebalanced'
+        OR NOT (
+            (
+                attribution_model_version = 'portfolio-attribution-v1'
+                AND covariance_method = 'sample_annualized'
+                AND correlation_method = 'pearson'
+            )
+            OR (
+                attribution_model_version = 'portfolio-attribution-ewma-v1'
+                AND covariance_method =
+                    'ewma_zero_mean_lambda_0_94_annualized'
+                AND correlation_method =
+                    'implied_from_ewma_covariance'
+            )
+        )
+),
+exact_pairs AS (
+    SELECT
+        sample.policy_id,
+        sample.portfolio_id,
+        sample.base_currency,
+        sample.definition_fingerprint,
+        sample.ts_event,
+        sample.metric_name,
+        sample.unit,
+        sample.covariance_window,
+        sample.annualization_days,
+        sample.warning_threshold,
+        sample.critical_threshold,
+        sample.calculation_id AS sample_calculation_id,
+        ewma.calculation_id AS ewma_calculation_id
+    FROM current_v2 sample
+    JOIN current_v2 ewma
+        ON ewma.policy_id = sample.policy_id
+        AND ewma.portfolio_id = sample.portfolio_id
+        AND ewma.base_currency = sample.base_currency
+        AND ewma.definition_fingerprint = sample.definition_fingerprint
+        AND ewma.ts_event = sample.ts_event
+        AND ewma.metric_name = sample.metric_name
+        AND ewma.unit = sample.unit
+        AND ewma.covariance_window = sample.covariance_window
+        AND ewma.annualization_days = sample.annualization_days
+        AND ewma.warning_threshold = sample.warning_threshold
+        AND ewma.critical_threshold = sample.critical_threshold
+    WHERE
+        sample.attribution_model_version = 'portfolio-attribution-v1'
+        AND sample.covariance_method = 'sample_annualized'
+        AND sample.correlation_method = 'pearson'
+        AND ewma.attribution_model_version = 'portfolio-attribution-ewma-v1'
+        AND ewma.covariance_method =
+            'ewma_zero_mean_lambda_0_94_annualized'
+        AND ewma.correlation_method =
+            'implied_from_ewma_covariance'
+),
+comparison_integrity AS (
+    SELECT
+        (
+            SELECT COUNT(*)
+            FROM exact_pairs
+        ) AS expected_pairs,
+        (
+            SELECT COUNT(*)
+            FROM risk_platform.portfolio_risk_limit_method_comparison
+        ) AS actual_pairs,
+        (
+            SELECT COUNT(*)
+            FROM risk_platform.portfolio_risk_limit_method_comparison comparison
+            WHERE ABS(
+                comparison.observed_difference_ewma_minus_sample
+                - (
+                    comparison.ewma_observed_value
+                    - comparison.sample_observed_value
+                )
+            ) > 0.0000000001
+        ) AS invalid_differences,
+        (
+            SELECT COUNT(*)
+            FROM risk_platform.portfolio_risk_limit_method_comparison comparison
+            WHERE ABS(
+                comparison.absolute_observed_difference
+                - ABS(
+                    comparison.ewma_observed_value
+                    - comparison.sample_observed_value
+                )
+            ) > 0.0000000001
+        ) AS invalid_absolute_differences,
+        (
+            SELECT COUNT(*)
+            FROM risk_platform.portfolio_risk_limit_method_comparison comparison
+            WHERE comparison.status_disagreement
+                <> (comparison.sample_status <> comparison.ewma_status)
+        ) AS invalid_disagreement_flags,
+        (
+            SELECT COUNT(*)
+            FROM (
+                SELECT
+                    policy_id,
+                    portfolio_id,
+                    definition_fingerprint,
+                    metric_ts,
+                    metric_name,
+                    covariance_window,
+                    annualization_days,
+                    warning_threshold,
+                    critical_threshold,
+                    COUNT(*) AS row_count
+                FROM risk_platform.portfolio_risk_limit_method_comparison
+                GROUP BY
+                    policy_id,
+                    portfolio_id,
+                    definition_fingerprint,
+                    metric_ts,
+                    metric_name,
+                    covariance_window,
+                    annualization_days,
+                    warning_threshold,
+                    critical_threshold
+                HAVING COUNT(*) <> 1
+            ) duplicate_grain
+        ) AS duplicate_comparison_grains,
+        (
+            SELECT COUNT(*)
+            FROM risk_platform.portfolio_risk_limit_method_comparison comparison
+            WHERE comparison.higher_observed_method <> CASE
+                WHEN comparison.sample_observed_value
+                    > comparison.ewma_observed_value THEN 'sample'
+                WHEN comparison.ewma_observed_value
+                    > comparison.sample_observed_value THEN 'ewma'
+                ELSE 'equal'
+            END
+        ) AS invalid_higher_method,
+        (
+            SELECT COUNT(*)
+            FROM risk_platform.portfolio_risk_limit_method_comparison comparison
+            WHERE comparison.more_severe_method <> CASE
+                WHEN (
+                    CASE comparison.sample_status
+                        WHEN 'critical' THEN 2
+                        WHEN 'warning' THEN 1
+                        ELSE 0
+                    END
+                ) > (
+                    CASE comparison.ewma_status
+                        WHEN 'critical' THEN 2
+                        WHEN 'warning' THEN 1
+                        ELSE 0
+                    END
+                ) THEN 'sample'
+                WHEN (
+                    CASE comparison.ewma_status
+                        WHEN 'critical' THEN 2
+                        WHEN 'warning' THEN 1
+                        ELSE 0
+                    END
+                ) > (
+                    CASE comparison.sample_status
+                        WHEN 'critical' THEN 2
+                        WHEN 'warning' THEN 1
+                        ELSE 0
+                    END
+                ) THEN 'ewma'
+                ELSE 'equal'
+            END
+        ) AS invalid_severity_method
+)
+SELECT
+    'method_aware_risk_limit_contracts_supported' AS check_name,
+    '0' AS expected,
+    invalid_rows::TEXT AS actual,
+    CASE WHEN invalid_rows = 0 THEN 'pass' ELSE 'fail' END AS status
+FROM invalid_contracts
+
+UNION ALL
+
+SELECT
+    'method_aware_risk_limit_exact_pairs_exposed',
+    expected_pairs::TEXT,
+    actual_pairs::TEXT,
+    CASE WHEN expected_pairs = actual_pairs THEN 'pass' ELSE 'fail' END
+FROM comparison_integrity
+
+UNION ALL
+
+SELECT
+    'method_aware_risk_limit_difference_reconciles',
+    '0',
+    invalid_differences::TEXT,
+    CASE WHEN invalid_differences = 0 THEN 'pass' ELSE 'fail' END
+FROM comparison_integrity
+
+UNION ALL
+
+SELECT
+    'method_aware_risk_limit_absolute_difference_reconciles',
+    '0',
+    invalid_absolute_differences::TEXT,
+    CASE WHEN invalid_absolute_differences = 0 THEN 'pass' ELSE 'fail' END
+FROM comparison_integrity
+
+UNION ALL
+
+SELECT
+    'method_aware_risk_limit_disagreement_flag_reconciles',
+    '0',
+    invalid_disagreement_flags::TEXT,
+    CASE WHEN invalid_disagreement_flags = 0 THEN 'pass' ELSE 'fail' END
+FROM comparison_integrity
+
+UNION ALL
+
+SELECT
+    'method_aware_risk_limit_comparison_grain_unique',
+    '0',
+    duplicate_comparison_grains::TEXT,
+    CASE WHEN duplicate_comparison_grains = 0 THEN 'pass' ELSE 'fail' END
+FROM comparison_integrity
+
+UNION ALL
+
+SELECT
+    'method_aware_risk_limit_higher_method_reconciles',
+    '0',
+    invalid_higher_method::TEXT,
+    CASE WHEN invalid_higher_method = 0 THEN 'pass' ELSE 'fail' END
+FROM comparison_integrity
+
+UNION ALL
+
+SELECT
+    'method_aware_risk_limit_severity_method_reconciles',
+    '0',
+    invalid_severity_method::TEXT,
+    CASE WHEN invalid_severity_method = 0 THEN 'pass' ELSE 'fail' END
+FROM comparison_integrity
+
+ORDER BY check_name;

--- a/sql/portfolio_risk_limits_method_schema.sql
+++ b/sql/portfolio_risk_limits_method_schema.sql
@@ -1,0 +1,127 @@
+-- Method-aware risk-limit contract for sample and fixed-decay EWMA attribution.
+-- Apply after sql/portfolio_covariance_method_schema.sql.
+
+ALTER TABLE risk_platform.portfolio_risk_limit_evaluations
+    DROP CONSTRAINT IF EXISTS
+        portfolio_risk_limit_evaluations_v2_method_contract;
+
+ALTER TABLE risk_platform.portfolio_risk_limit_evaluations
+    ADD CONSTRAINT portfolio_risk_limit_evaluations_v2_method_contract
+    CHECK (
+        model_version <> 'portfolio-risk-limits-v2'
+        OR (
+            weighting_method = 'constant_weight_daily_rebalanced'
+            AND (
+                (
+                    attribution_model_version = 'portfolio-attribution-v1'
+                    AND covariance_method = 'sample_annualized'
+                    AND correlation_method = 'pearson'
+                )
+                OR (
+                    attribution_model_version =
+                        'portfolio-attribution-ewma-v1'
+                    AND covariance_method =
+                        'ewma_zero_mean_lambda_0_94_annualized'
+                    AND correlation_method =
+                        'implied_from_ewma_covariance'
+                )
+            )
+        )
+    );
+
+CREATE OR REPLACE VIEW
+    risk_platform.portfolio_risk_limit_method_comparison AS
+SELECT
+    sample.policy_id,
+    sample.portfolio_id,
+    sample.base_currency,
+    sample.definition_fingerprint,
+    sample.ts_event AS metric_ts,
+    GREATEST(sample.ts_ingest, ewma.ts_ingest) AS comparison_ts,
+    sample.metric_name,
+    sample.subject_type AS sample_subject_type,
+    sample.subject_key AS sample_subject_key,
+    ewma.subject_type AS ewma_subject_type,
+    ewma.subject_key AS ewma_subject_key,
+    sample.unit,
+    sample.covariance_window,
+    sample.annualization_days,
+    sample.warning_threshold,
+    sample.critical_threshold,
+    sample.policy_fingerprint AS sample_policy_fingerprint,
+    ewma.policy_fingerprint AS ewma_policy_fingerprint,
+    sample.calculation_id AS sample_evaluation_calculation_id,
+    ewma.calculation_id AS ewma_evaluation_calculation_id,
+    sample.attribution_calculation_id AS sample_attribution_calculation_id,
+    ewma.attribution_calculation_id AS ewma_attribution_calculation_id,
+    sample.observed_value AS sample_observed_value,
+    ewma.observed_value AS ewma_observed_value,
+    ewma.observed_value - sample.observed_value
+        AS observed_difference_ewma_minus_sample,
+    ABS(ewma.observed_value - sample.observed_value)
+        AS absolute_observed_difference,
+    sample.status AS sample_status,
+    ewma.status AS ewma_status,
+    sample.is_breach AS sample_is_breach,
+    ewma.is_breach AS ewma_is_breach,
+    sample.status <> ewma.status AS status_disagreement,
+    CASE
+        WHEN sample.observed_value > ewma.observed_value THEN 'sample'
+        WHEN ewma.observed_value > sample.observed_value THEN 'ewma'
+        ELSE 'equal'
+    END AS higher_observed_method,
+    CASE
+        WHEN (
+            CASE sample.status
+                WHEN 'critical' THEN 2
+                WHEN 'warning' THEN 1
+                ELSE 0
+            END
+        ) > (
+            CASE ewma.status
+                WHEN 'critical' THEN 2
+                WHEN 'warning' THEN 1
+                ELSE 0
+            END
+        ) THEN 'sample'
+        WHEN (
+            CASE ewma.status
+                WHEN 'critical' THEN 2
+                WHEN 'warning' THEN 1
+                ELSE 0
+            END
+        ) > (
+            CASE sample.status
+                WHEN 'critical' THEN 2
+                WHEN 'warning' THEN 1
+                ELSE 0
+            END
+        ) THEN 'ewma'
+        ELSE 'equal'
+    END AS more_severe_method
+FROM risk_platform.latest_portfolio_risk_limit_evaluations sample
+JOIN risk_platform.latest_portfolio_risk_limit_evaluations ewma
+    ON ewma.policy_id = sample.policy_id
+    AND ewma.portfolio_id = sample.portfolio_id
+    AND ewma.base_currency = sample.base_currency
+    AND ewma.definition_fingerprint = sample.definition_fingerprint
+    AND ewma.ts_event = sample.ts_event
+    AND ewma.metric_name = sample.metric_name
+    AND ewma.unit = sample.unit
+    AND ewma.covariance_window = sample.covariance_window
+    AND ewma.annualization_days = sample.annualization_days
+    AND ewma.warning_threshold = sample.warning_threshold
+    AND ewma.critical_threshold = sample.critical_threshold
+WHERE
+    sample.model_version = 'portfolio-risk-limits-v2'
+    AND sample.attribution_model_version = 'portfolio-attribution-v1'
+    AND sample.weighting_method = 'constant_weight_daily_rebalanced'
+    AND sample.covariance_method = 'sample_annualized'
+    AND sample.correlation_method = 'pearson'
+    AND ewma.model_version = 'portfolio-risk-limits-v2'
+    AND ewma.attribution_model_version = 'portfolio-attribution-ewma-v1'
+    AND ewma.weighting_method = 'constant_weight_daily_rebalanced'
+    AND ewma.covariance_method =
+        'ewma_zero_mean_lambda_0_94_annualized'
+    AND ewma.correlation_method =
+        'implied_from_ewma_covariance';

--- a/src/analytics/portfolio_risk_limit_method_evaluations.py
+++ b/src/analytics/portfolio_risk_limit_method_evaluations.py
@@ -1,0 +1,489 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
+from datetime import date, datetime, time, timezone
+from typing import Any, TypeAlias
+
+from ..common.exceptions import ValidationError
+from .portfolio_attribution import VARIANCE_EPSILON
+from .portfolio_risk_limit_method_policies import (
+    MODEL_VERSION,
+    MethodAwarePortfolioRiskLimitPolicy,
+)
+from .portfolio_risk_limits import (
+    CONCENTRATION_METRIC,
+    MAX_LIMIT_EVALUATIONS,
+    VOLATILITY_METRIC,
+    RiskLimitThresholds,
+)
+
+AttributionInput: TypeAlias = Mapping[str, Any]
+
+
+@dataclass(frozen=True, slots=True)
+class MethodAwarePortfolioRiskLimitOutput:
+    evaluations: tuple[dict[str, Any], ...]
+    diagnostics: Mapping[str, Any]
+
+
+def _required_text(value: Any, label: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ValidationError(f"{label} must be non-empty text")
+    return value.strip()
+
+
+def _finite_number(
+    value: Any,
+    label: str,
+    *,
+    minimum: float | None = None,
+) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ValidationError(f"{label} must be a finite number")
+    parsed = float(value)
+    if not math.isfinite(parsed):
+        raise ValidationError(f"{label} must be a finite number")
+    if minimum is not None and parsed < minimum:
+        raise ValidationError(f"{label} must be at least {minimum}")
+    return parsed
+
+
+def _positive_integer(value: Any, label: str, maximum: int) -> int:
+    if type(value) is not int or not 1 <= value <= maximum:
+        raise ValidationError(f"{label} must be an integer between 1 and {maximum}")
+    return value
+
+
+def _aware_utc(value: Any, label: str) -> datetime:
+    parsed: datetime | None = None
+    if isinstance(value, datetime):
+        parsed = value
+    elif isinstance(value, str):
+        try:
+            parsed = datetime.fromisoformat(value.strip().replace("Z", "+00:00"))
+        except ValueError:
+            parsed = None
+    if parsed is None or parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise ValidationError(f"{label} must be a timezone-aware timestamp")
+    return parsed.astimezone(timezone.utc)
+
+
+def _json_number_object(value: Any, label: str) -> dict[str, float]:
+    if isinstance(value, Mapping):
+        parsed: Any = dict(value)
+    elif isinstance(value, str):
+
+        def reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+            result: dict[str, Any] = {}
+            for key, item in pairs:
+                if key in result:
+                    raise ValidationError(f"{label} must not contain duplicate keys")
+                result[key] = item
+            return result
+
+        try:
+            parsed = json.loads(value, object_pairs_hook=reject_duplicate_keys)
+        except ValidationError:
+            raise
+        except (TypeError, ValueError):
+            raise ValidationError(f"{label} must be valid JSON") from None
+    else:
+        raise ValidationError(f"{label} must be a JSON object")
+    if not isinstance(parsed, dict) or len(parsed) < 2:
+        raise ValidationError(f"{label} must contain at least two constituent values")
+
+    values: dict[str, float] = {}
+    for key, item in parsed.items():
+        if not isinstance(key, str) or not key:
+            raise ValidationError(f"{label} must use non-empty text keys")
+        values[key] = _finite_number(item, f"{label}.{key}")
+    return dict(sorted(values.items()))
+
+
+def _normalise_attribution_record(
+    candidate: AttributionInput,
+    *,
+    policy: MethodAwarePortfolioRiskLimitPolicy,
+    definition_fingerprint: str,
+    end_date: date | None,
+) -> dict[str, Any] | None:
+    if not isinstance(candidate, Mapping):
+        raise ValidationError("risk-limit input must contain attribution mappings")
+
+    if (
+        candidate.get("portfolio_id") != policy.portfolio_id
+        or candidate.get("definition_fingerprint") != definition_fingerprint
+    ):
+        return None
+
+    covariance_window = candidate.get("covariance_window")
+    if type(covariance_window) is not int:
+        raise ValidationError("covariance_window must be an integer")
+    if covariance_window != policy.covariance_window:
+        return None
+
+    model_version = _required_text(
+        candidate.get("model_version"), "attribution model_version"
+    )
+    weighting_method = _required_text(
+        candidate.get("weighting_method"), "weighting_method"
+    )
+    covariance_method = _required_text(
+        candidate.get("covariance_method"), "covariance_method"
+    )
+    correlation_method = _required_text(
+        candidate.get("correlation_method"), "correlation_method"
+    )
+    annualization_days = candidate.get("annualization_days")
+    if type(annualization_days) is not int:
+        raise ValidationError("annualization_days must be an integer")
+
+    candidate_contract = (
+        model_version,
+        weighting_method,
+        covariance_method,
+        correlation_method,
+    )
+    if (
+        candidate_contract != policy.method.key
+        or annualization_days != policy.annualization_days
+    ):
+        return None
+
+    ts_event = _aware_utc(candidate.get("ts_event"), "ts_event")
+    if ts_event.time() != time.min:
+        raise ValidationError("attribution timestamps must use UTC midnight")
+    if end_date is not None and ts_event.date() > end_date:
+        return None
+    ts_ingest = _aware_utc(candidate.get("ts_ingest"), "ts_ingest")
+    if ts_ingest < ts_event:
+        raise ValidationError("ts_ingest must be on or after ts_event")
+
+    volatility = _finite_number(
+        candidate.get("portfolio_volatility_annualized"),
+        "portfolio_volatility_annualized",
+        minimum=0.0,
+    )
+    volatility_status = _required_text(
+        candidate.get("volatility_status"), "volatility_status"
+    )
+    if volatility_status not in {"positive", "zero"}:
+        raise ValidationError("volatility_status is invalid")
+    if (
+        volatility_status == "zero"
+        and volatility > VARIANCE_EPSILON
+    ) or (
+        volatility_status == "positive"
+        and volatility <= VARIANCE_EPSILON
+    ):
+        raise ValidationError("volatility_status does not match portfolio volatility")
+
+    return {
+        "calculation_id": _required_text(
+            candidate.get("calculation_id"), "attribution calculation_id"
+        ),
+        "model_version": model_version,
+        "portfolio_id": policy.portfolio_id,
+        "base_currency": _required_text(
+            candidate.get("base_currency"), "base_currency"
+        ),
+        "definition_fingerprint": definition_fingerprint,
+        "weighting_method": weighting_method,
+        "covariance_method": covariance_method,
+        "correlation_method": correlation_method,
+        "covariance_window": covariance_window,
+        "annualization_days": annualization_days,
+        "ts_event": ts_event,
+        "ts_ingest": ts_ingest,
+        "portfolio_volatility_annualized": volatility,
+        "component_contribution_shares": _json_number_object(
+            candidate.get("component_contribution_share_json"),
+            "component_contribution_share_json",
+        ),
+    }
+
+
+def _record_signature(record: Mapping[str, Any]) -> tuple[Any, ...]:
+    return (
+        record["model_version"],
+        record["portfolio_id"],
+        record["base_currency"],
+        record["definition_fingerprint"],
+        record["weighting_method"],
+        record["covariance_method"],
+        record["correlation_method"],
+        record["covariance_window"],
+        record["annualization_days"],
+        record["ts_event"],
+        record["ts_ingest"],
+        record["portfolio_volatility_annualized"],
+        tuple(record["component_contribution_shares"].items()),
+    )
+
+
+def _current_attributions(
+    records: Iterable[AttributionInput],
+    *,
+    policy: MethodAwarePortfolioRiskLimitPolicy,
+    definition_fingerprint: str,
+    end_date: date | None,
+) -> tuple[list[dict[str, Any]], int, int]:
+    current: dict[date, dict[str, Any]] = {}
+    seen_calculations: dict[str, tuple[Any, ...]] = {}
+    matched_records = 0
+    ignored_nonmatching_contract_records = 0
+    for candidate in records:
+        targeted = (
+            isinstance(candidate, Mapping)
+            and candidate.get("portfolio_id") == policy.portfolio_id
+            and candidate.get("definition_fingerprint") == definition_fingerprint
+            and candidate.get("covariance_window") == policy.covariance_window
+        )
+        record = _normalise_attribution_record(
+            candidate,
+            policy=policy,
+            definition_fingerprint=definition_fingerprint,
+            end_date=end_date,
+        )
+        if record is None:
+            if targeted:
+                ignored_nonmatching_contract_records += 1
+            continue
+        matched_records += 1
+        calculation_id = record["calculation_id"]
+        signature = _record_signature(record)
+        previous_signature = seen_calculations.get(calculation_id)
+        if previous_signature is not None:
+            if previous_signature != signature:
+                raise ValidationError(
+                    "attribution calculation IDs must not contain conflicting records"
+                )
+            continue
+        seen_calculations[calculation_id] = signature
+
+        event_date = record["ts_event"].date()
+        existing = current.get(event_date)
+        if existing is None or (
+            record["ts_ingest"],
+            calculation_id,
+        ) > (
+            existing["ts_ingest"],
+            existing["calculation_id"],
+        ):
+            current[event_date] = record
+
+    if not current:
+        raise ValidationError(
+            "no attribution snapshots matched the selected method policy and definition"
+        )
+    return (
+        [current[event_date] for event_date in sorted(current)],
+        matched_records,
+        ignored_nonmatching_contract_records,
+    )
+
+
+def _status(
+    observed_value: float,
+    thresholds: RiskLimitThresholds,
+) -> tuple[str, bool, float | None, float]:
+    if observed_value >= thresholds.critical:
+        return (
+            "critical",
+            True,
+            thresholds.critical,
+            observed_value - thresholds.critical,
+        )
+    if observed_value >= thresholds.warning:
+        return (
+            "warning",
+            True,
+            thresholds.warning,
+            observed_value - thresholds.warning,
+        )
+    return "ok", False, None, 0.0
+
+
+def _evaluation_id(
+    *,
+    policy: MethodAwarePortfolioRiskLimitPolicy,
+    attribution_calculation_id: str,
+    metric_name: str,
+) -> str:
+    payload = {
+        "attribution_calculation_id": attribution_calculation_id,
+        "metric_name": metric_name,
+        "model_version": MODEL_VERSION,
+        "policy_fingerprint": policy.fingerprint,
+    }
+    digest = hashlib.sha256(
+        json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    ).hexdigest()[:24]
+    return f"{MODEL_VERSION}-evaluation-{digest}"
+
+
+def _evaluation_record(
+    *,
+    record: Mapping[str, Any],
+    policy: MethodAwarePortfolioRiskLimitPolicy,
+    metric_name: str,
+    subject_type: str,
+    subject_key: str,
+    unit: str,
+    observed_value: float,
+    observed_signed_value: float,
+    thresholds: RiskLimitThresholds,
+) -> dict[str, Any]:
+    status, is_breach, breach_threshold, breach_excess = _status(
+        observed_value,
+        thresholds,
+    )
+    return {
+        "model_version": MODEL_VERSION,
+        "calculation_id": _evaluation_id(
+            policy=policy,
+            attribution_calculation_id=record["calculation_id"],
+            metric_name=metric_name,
+        ),
+        "policy_id": policy.policy_id,
+        "policy_fingerprint": policy.fingerprint,
+        "portfolio_id": policy.portfolio_id,
+        "base_currency": record["base_currency"],
+        "definition_fingerprint": record["definition_fingerprint"],
+        "attribution_calculation_id": record["calculation_id"],
+        "attribution_model_version": record["model_version"],
+        "weighting_method": record["weighting_method"],
+        "covariance_method": record["covariance_method"],
+        "correlation_method": record["correlation_method"],
+        "covariance_window": record["covariance_window"],
+        "annualization_days": record["annualization_days"],
+        "ts_event": record["ts_event"],
+        "ts_ingest": record["ts_ingest"],
+        "metric_name": metric_name,
+        "subject_type": subject_type,
+        "subject_key": subject_key,
+        "unit": unit,
+        "observed_value": observed_value,
+        "observed_signed_value": observed_signed_value,
+        "warning_threshold": thresholds.warning,
+        "critical_threshold": thresholds.critical,
+        "status": status,
+        "is_breach": is_breach,
+        "breach_threshold": breach_threshold,
+        "breach_excess": breach_excess,
+    }
+
+
+def evaluate_method_aware_portfolio_risk_limits(
+    records: Iterable[AttributionInput],
+    *,
+    policy: MethodAwarePortfolioRiskLimitPolicy,
+    definition_fingerprint: str,
+    start_date: date | None = None,
+    end_date: date | None = None,
+    max_evaluations: int = MAX_LIMIT_EVALUATIONS,
+) -> MethodAwarePortfolioRiskLimitOutput:
+    if not isinstance(definition_fingerprint, str) or not definition_fingerprint:
+        raise ValidationError("definition_fingerprint must be non-empty text")
+    if start_date is not None and end_date is not None and start_date > end_date:
+        raise ValidationError("start_date must be on or before end_date")
+    max_evaluations = _positive_integer(
+        max_evaluations,
+        "max_evaluations",
+        MAX_LIMIT_EVALUATIONS,
+    )
+
+    current, matched_records, ignored_nonmatching_contract_records = _current_attributions(
+        records,
+        policy=policy,
+        definition_fingerprint=definition_fingerprint,
+        end_date=end_date,
+    )
+    selected = [
+        record
+        for record in current
+        if start_date is None or record["ts_event"].date() >= start_date
+    ]
+    if not selected:
+        raise ValidationError(
+            "no method-aware risk-limit evaluations matched the requested date range"
+        )
+    if len(selected) * 2 > max_evaluations:
+        raise ValidationError(
+            "risk-limit evaluation exceeds max_evaluations; split the date range"
+        )
+
+    evaluations: list[dict[str, Any]] = []
+    for record in selected:
+        evaluations.append(
+            _evaluation_record(
+                record=record,
+                policy=policy,
+                metric_name=VOLATILITY_METRIC,
+                subject_type="portfolio",
+                subject_key=policy.portfolio_id,
+                unit="annualized_decimal",
+                observed_value=record["portfolio_volatility_annualized"],
+                observed_signed_value=record["portfolio_volatility_annualized"],
+                thresholds=policy.portfolio_volatility,
+            )
+        )
+        component_shares = record["component_contribution_shares"]
+        largest_component = min(
+            component_shares,
+            key=lambda key: (-abs(component_shares[key]), key),
+        )
+        signed_share = component_shares[largest_component]
+        evaluations.append(
+            _evaluation_record(
+                record=record,
+                policy=policy,
+                metric_name=CONCENTRATION_METRIC,
+                subject_type="constituent",
+                subject_key=largest_component,
+                unit="absolute_share",
+                observed_value=abs(signed_share),
+                observed_signed_value=signed_share,
+                thresholds=policy.component_concentration,
+            )
+        )
+
+    status_counts = {
+        status: sum(1 for item in evaluations if item["status"] == status)
+        for status in ("ok", "warning", "critical")
+    }
+    diagnostics = {
+        "method_policy_id": policy.method_policy_id,
+        "policy_id": policy.policy_id,
+        "policy_fingerprint": policy.fingerprint,
+        "base_policy_fingerprint": policy.base_policy.fingerprint,
+        "attribution_model_version": policy.method.attribution_model_version,
+        "weighting_method": policy.method.weighting_method,
+        "covariance_method": policy.method.covariance_method,
+        "correlation_method": policy.method.correlation_method,
+        "matched_input_records": matched_records,
+        "ignored_nonmatching_contract_records": (
+            ignored_nonmatching_contract_records
+        ),
+        "current_attribution_snapshots": len(current),
+        "snapshots_selected": len(selected),
+        "evaluations_selected": len(evaluations),
+        "status_counts": status_counts,
+        "first_evaluation_date": selected[0]["ts_event"].date().isoformat(),
+        "last_evaluation_date": selected[-1]["ts_event"].date().isoformat(),
+        "start_date": start_date.isoformat() if start_date is not None else None,
+        "end_date": (
+            end_date.isoformat()
+            if end_date is not None
+            else selected[-1]["ts_event"].date().isoformat()
+        ),
+        "max_evaluations": max_evaluations,
+    }
+    return MethodAwarePortfolioRiskLimitOutput(
+        evaluations=tuple(evaluations),
+        diagnostics=diagnostics,
+    )

--- a/src/analytics/portfolio_risk_limit_method_policies.py
+++ b/src/analytics/portfolio_risk_limit_method_policies.py
@@ -1,0 +1,289 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from collections.abc import Mapping
+from dataclasses import dataclass
+from datetime import date
+from pathlib import Path
+from typing import Any
+
+from ..common.config import load_yaml
+from ..common.exceptions import ValidationError
+from .portfolio_attribution import (
+    CORRELATION_METHOD as SAMPLE_CORRELATION_METHOD,
+    COVARIANCE_METHOD as SAMPLE_COVARIANCE_METHOD,
+    MODEL_VERSION as SAMPLE_ATTRIBUTION_MODEL_VERSION,
+)
+from .portfolio_attribution_ewma import (
+    CORRELATION_METHOD as EWMA_CORRELATION_METHOD,
+    COVARIANCE_METHOD as EWMA_COVARIANCE_METHOD,
+    MODEL_VERSION as EWMA_ATTRIBUTION_MODEL_VERSION,
+)
+from .portfolio_risk import WEIGHTING_METHOD
+from .portfolio_risk_limit_policies import (
+    EffectiveDatedPortfolioRiskLimitPolicy,
+    load_effective_portfolio_risk_limit_policy,
+    validate_policy_range,
+)
+from .portfolio_risk_limits import RiskLimitThresholds
+
+MODEL_VERSION = "portfolio-risk-limits-v2"
+MAX_METHOD_POLICIES = 100
+METHOD_POLICY_ID_PATTERN = re.compile(r"^[a-z0-9][a-z0-9_-]{0,63}$")
+
+
+@dataclass(frozen=True, slots=True)
+class AttributionMethodContract:
+    attribution_model_version: str
+    weighting_method: str
+    covariance_method: str
+    correlation_method: str
+
+    @property
+    def key(self) -> tuple[str, str, str, str]:
+        return (
+            self.attribution_model_version,
+            self.weighting_method,
+            self.covariance_method,
+            self.correlation_method,
+        )
+
+
+SAMPLE_METHOD_CONTRACT = AttributionMethodContract(
+    attribution_model_version=SAMPLE_ATTRIBUTION_MODEL_VERSION,
+    weighting_method=WEIGHTING_METHOD,
+    covariance_method=SAMPLE_COVARIANCE_METHOD,
+    correlation_method=SAMPLE_CORRELATION_METHOD,
+)
+EWMA_METHOD_CONTRACT = AttributionMethodContract(
+    attribution_model_version=EWMA_ATTRIBUTION_MODEL_VERSION,
+    weighting_method=WEIGHTING_METHOD,
+    covariance_method=EWMA_COVARIANCE_METHOD,
+    correlation_method=EWMA_CORRELATION_METHOD,
+)
+SUPPORTED_METHOD_CONTRACTS = frozenset(
+    {
+        SAMPLE_METHOD_CONTRACT.key,
+        EWMA_METHOD_CONTRACT.key,
+    }
+)
+
+
+@dataclass(frozen=True, slots=True)
+class MethodAwarePortfolioRiskLimitPolicy:
+    method_policy_id: str
+    base_policy: EffectiveDatedPortfolioRiskLimitPolicy
+    method: AttributionMethodContract
+
+    @property
+    def policy_id(self) -> str:
+        return self.base_policy.policy_id
+
+    @property
+    def policy_version_id(self) -> str:
+        return self.base_policy.policy_version_id
+
+    @property
+    def portfolio_id(self) -> str:
+        return self.base_policy.portfolio_id
+
+    @property
+    def covariance_window(self) -> int:
+        return self.base_policy.covariance_window
+
+    @property
+    def annualization_days(self) -> int:
+        return self.base_policy.annualization_days
+
+    @property
+    def portfolio_volatility(self) -> RiskLimitThresholds:
+        return self.base_policy.portfolio_volatility
+
+    @property
+    def component_concentration(self) -> RiskLimitThresholds:
+        return self.base_policy.component_concentration
+
+    @property
+    def effective_from(self) -> date:
+        return self.base_policy.effective_from
+
+    @property
+    def effective_to(self) -> date | None:
+        return self.base_policy.effective_to
+
+    @property
+    def fingerprint(self) -> str:
+        payload = {
+            "base_policy_fingerprint": self.base_policy.fingerprint,
+            "method_policy_id": self.method_policy_id,
+            "method": {
+                "attribution_model_version": self.method.attribution_model_version,
+                "correlation_method": self.method.correlation_method,
+                "covariance_method": self.method.covariance_method,
+                "weighting_method": self.method.weighting_method,
+            },
+            "model_version": MODEL_VERSION,
+        }
+        digest = hashlib.sha256(
+            json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+        ).hexdigest()[:24]
+        return f"risk-limit-method-policy-{digest}"
+
+
+def _identifier(value: Any, label: str) -> str:
+    if not isinstance(value, str):
+        raise ValidationError(f"{label} must be text")
+    parsed = value.strip().lower()
+    if METHOD_POLICY_ID_PATTERN.fullmatch(parsed) is None:
+        raise ValidationError(f"{label} has an invalid format")
+    return parsed
+
+
+def _required_text(value: Any, label: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ValidationError(f"{label} must be non-empty text")
+    return value.strip()
+
+
+def _method_contract(value: Any) -> AttributionMethodContract:
+    if not isinstance(value, Mapping):
+        raise ValidationError("method policy attribution must be a mapping")
+    expected_keys = {
+        "model_version",
+        "weighting_method",
+        "covariance_method",
+        "correlation_method",
+    }
+    if set(value) != expected_keys:
+        raise ValidationError(
+            "method policy attribution must contain exactly model_version, "
+            "weighting_method, covariance_method and correlation_method"
+        )
+    contract = AttributionMethodContract(
+        attribution_model_version=_required_text(
+            value.get("model_version"), "attribution.model_version"
+        ),
+        weighting_method=_required_text(
+            value.get("weighting_method"), "attribution.weighting_method"
+        ),
+        covariance_method=_required_text(
+            value.get("covariance_method"), "attribution.covariance_method"
+        ),
+        correlation_method=_required_text(
+            value.get("correlation_method"), "attribution.correlation_method"
+        ),
+    )
+    if contract.key not in SUPPORTED_METHOD_CONTRACTS:
+        raise ValidationError("method policy selects an unsupported model/method contract")
+    return contract
+
+
+def _parse_method_bindings(
+    payload: Mapping[str, Any],
+) -> dict[str, tuple[str, AttributionMethodContract]]:
+    method_policies = payload.get("method_policies")
+    if not isinstance(method_policies, Mapping):
+        raise ValidationError(
+            "method policy configuration must define a method_policies mapping"
+        )
+    if not 1 <= len(method_policies) <= MAX_METHOD_POLICIES:
+        raise ValidationError(
+            f"method_policies must contain between 1 and {MAX_METHOD_POLICIES} entries"
+        )
+
+    bindings: dict[str, tuple[str, AttributionMethodContract]] = {}
+    seen_contracts: set[tuple[str, tuple[str, str, str, str]]] = set()
+    for raw_id, raw_candidate in method_policies.items():
+        parsed_id = _identifier(raw_id, "method_policy_id")
+        if parsed_id in bindings:
+            raise ValidationError("method policy IDs must be unique")
+        if not isinstance(raw_candidate, Mapping):
+            raise ValidationError("each method policy must be a mapping")
+        if set(raw_candidate) != {"base_policy_id", "attribution"}:
+            raise ValidationError(
+                "method policy must contain exactly base_policy_id and attribution"
+            )
+        base_policy_id = _identifier(
+            raw_candidate.get("base_policy_id"),
+            "base_policy_id",
+        )
+        contract = _method_contract(raw_candidate.get("attribution"))
+        uniqueness_key = (base_policy_id, contract.key)
+        if uniqueness_key in seen_contracts:
+            raise ValidationError(
+                "one base policy may define at most one binding per method contract"
+            )
+        seen_contracts.add(uniqueness_key)
+        bindings[parsed_id] = (base_policy_id, contract)
+    return bindings
+
+
+def load_method_aware_portfolio_risk_limit_policy(
+    *,
+    method_policy_config_path: Path,
+    limits_config_path: Path,
+    method_policy_id: str,
+    as_of_date: date,
+) -> MethodAwarePortfolioRiskLimitPolicy:
+    canonical_id = _identifier(method_policy_id, "method_policy_id")
+    try:
+        payload = load_yaml(method_policy_config_path)
+    except Exception:
+        raise ValidationError("method policy configuration could not be loaded") from None
+    if not isinstance(payload, Mapping):
+        raise ValidationError("method policy configuration must be a mapping")
+
+    selected = _parse_method_bindings(payload).get(canonical_id)
+    if selected is None:
+        raise ValidationError(f"method policy '{canonical_id}' is not configured")
+    base_policy_id, contract = selected
+    base_policy = load_effective_portfolio_risk_limit_policy(
+        limits_config_path,
+        base_policy_id,
+        as_of_date,
+    )
+    return MethodAwarePortfolioRiskLimitPolicy(
+        method_policy_id=canonical_id,
+        base_policy=base_policy,
+        method=contract,
+    )
+
+
+def validate_method_policy_range(
+    policy: MethodAwarePortfolioRiskLimitPolicy,
+    *,
+    start_date: date | None,
+    end_date: date,
+) -> None:
+    validate_policy_range(
+        policy.base_policy,
+        start_date=start_date,
+        end_date=end_date,
+    )
+
+
+def method_policy_metadata(
+    policy: MethodAwarePortfolioRiskLimitPolicy,
+) -> dict[str, Any]:
+    return {
+        "method_policy_id": policy.method_policy_id,
+        "policy_id": policy.policy_id,
+        "policy_version_id": policy.policy_version_id,
+        "policy_fingerprint": policy.fingerprint,
+        "base_policy_fingerprint": policy.base_policy.fingerprint,
+        "limit_definition_fingerprint": (
+            policy.base_policy.limit_definition_fingerprint
+        ),
+        "effective_from": policy.effective_from.isoformat(),
+        "effective_to": (
+            policy.effective_to.isoformat()
+            if policy.effective_to is not None
+            else None
+        ),
+        "attribution_model_version": policy.method.attribution_model_version,
+        "weighting_method": policy.method.weighting_method,
+        "covariance_method": policy.method.covariance_method,
+        "correlation_method": policy.method.correlation_method,
+    }

--- a/src/orchestration/run_method_aware_portfolio_risk_limits.py
+++ b/src/orchestration/run_method_aware_portfolio_risk_limits.py
@@ -1,0 +1,337 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections.abc import Callable, Sequence
+from datetime import date
+from pathlib import Path
+from typing import Any
+from uuid import uuid4
+
+from ..analytics.portfolio_risk import PortfolioDefinition, load_portfolio_definition
+from ..analytics.portfolio_risk_limit_method_evaluations import (
+    evaluate_method_aware_portfolio_risk_limits,
+)
+from ..analytics.portfolio_risk_limit_method_policies import (
+    MethodAwarePortfolioRiskLimitPolicy,
+    load_method_aware_portfolio_risk_limit_policy,
+    method_policy_metadata,
+    validate_method_policy_range,
+)
+from ..analytics.portfolio_risk_limits import MAX_LIMIT_EVALUATIONS
+from ..common.exceptions import StorageError, ValidationError
+from ..storage.s3_writer import write_records
+from ..storage.storage_config import load_storage_config, validate_storage_config
+from ..warehouse.portfolio_attribution_loader import collect_attribution_records
+
+INPUT_DATASET = "portfolio_risk_attribution"
+OUTPUT_DATASET = "portfolio_risk_limit_evaluations"
+
+Reader = Callable[[Path], list[dict[str, Any]]]
+Writer = Callable[..., int]
+StorageConfigLoader = Callable[[Path], dict[str, Any]]
+DefinitionLoader = Callable[[Path, str], PortfolioDefinition]
+MethodPolicyLoader = Callable[..., MethodAwarePortfolioRiskLimitPolicy]
+
+
+def _calendar_date(value: str) -> date:
+    try:
+        parsed = date.fromisoformat(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(
+            "must be a calendar date in YYYY-MM-DD format"
+        ) from exc
+    if value != parsed.isoformat():
+        raise argparse.ArgumentTypeError(
+            "must be a calendar date in YYYY-MM-DD format"
+        )
+    return parsed
+
+
+def _max_evaluations(value: str) -> int:
+    try:
+        parsed = int(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(
+            "max_evaluations must be a positive integer"
+        ) from exc
+    if not 1 <= parsed <= MAX_LIMIT_EVALUATIONS:
+        raise argparse.ArgumentTypeError(
+            f"max_evaluations must be between 1 and {MAX_LIMIT_EVALUATIONS}"
+        )
+    return parsed
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Evaluate one explicitly bound sample or EWMA attribution history "
+            "against an effective-dated local risk-limit policy."
+        )
+    )
+    parser.add_argument("--method-policy-id", required=True)
+    parser.add_argument(
+        "--method-policies-config",
+        type=Path,
+        default=Path("config/portfolio_risk_limit_methods.yaml"),
+    )
+    parser.add_argument(
+        "--limits-config",
+        type=Path,
+        default=Path("config/portfolio_risk_limits.yaml"),
+    )
+    parser.add_argument(
+        "--portfolio-config",
+        type=Path,
+        default=Path("config/portfolios.yaml"),
+    )
+    parser.add_argument("--start-date", type=_calendar_date)
+    parser.add_argument("--end-date", required=True, type=_calendar_date)
+    parser.add_argument(
+        "--max-evaluations",
+        type=_max_evaluations,
+        default=MAX_LIMIT_EVALUATIONS,
+    )
+    parser.add_argument(
+        "--storage-config",
+        type=Path,
+        default=Path("config/storage.yaml"),
+    )
+    parser.add_argument("--summary-json", type=Path)
+    return parser
+
+
+def _require_datasets(storage_config: dict[str, Any]) -> None:
+    validate_storage_config(storage_config)
+    datasets = storage_config["storage"]["curated"]["datasets"]
+    missing = sorted(
+        dataset
+        for dataset in (INPUT_DATASET, OUTPUT_DATASET)
+        if dataset not in datasets
+    )
+    if missing:
+        raise StorageError(
+            "Storage configuration is missing method-aware risk-limit datasets: "
+            + ", ".join(missing)
+        )
+
+
+def _publish(
+    evaluations: tuple[dict[str, Any], ...],
+    *,
+    storage_config: dict[str, Any],
+    writer: Writer,
+) -> int:
+    written = 0
+    for evaluation in evaluations:
+        try:
+            result = writer(
+                [evaluation],
+                kind="curated",
+                dataset=OUTPUT_DATASET,
+                storage_config=storage_config,
+            )
+        except Exception:
+            raise StorageError(
+                "Method-aware risk-limit publication failed; rerun is safe"
+            ) from None
+        if type(result) is not int or result not in {0, 1}:
+            raise StorageError(
+                "Method-aware risk-limit publication returned an invalid result"
+            )
+        written += result
+    return written
+
+
+def run_method_aware_portfolio_risk_limits(
+    *,
+    method_policy_id: str,
+    method_policies_config_path: Path,
+    limits_config_path: Path,
+    portfolio_config_path: Path,
+    end_date: date,
+    storage_config_path: Path,
+    start_date: date | None = None,
+    max_evaluations: int = MAX_LIMIT_EVALUATIONS,
+    reader: Reader | None = None,
+    writer: Writer | None = None,
+    storage_config_loader: StorageConfigLoader | None = None,
+    definition_loader: DefinitionLoader | None = None,
+    method_policy_loader: MethodPolicyLoader | None = None,
+) -> dict[str, Any]:
+    if start_date is not None and start_date > end_date:
+        raise ValidationError("start_date must be on or before end_date")
+
+    selected_storage_loader = storage_config_loader or load_storage_config
+    try:
+        storage_config = selected_storage_loader(storage_config_path)
+    except Exception:
+        raise StorageError("Storage configuration is invalid") from None
+    if not isinstance(storage_config, dict):
+        raise StorageError("Storage configuration is invalid")
+    _require_datasets(storage_config)
+
+    selected_policy_loader = (
+        method_policy_loader or load_method_aware_portfolio_risk_limit_policy
+    )
+    try:
+        policy = selected_policy_loader(
+            method_policy_config_path=method_policies_config_path,
+            limits_config_path=limits_config_path,
+            method_policy_id=method_policy_id,
+            as_of_date=end_date,
+        )
+    except ValidationError:
+        raise
+    except Exception:
+        raise ValidationError(
+            "Method-aware portfolio risk-limit policy is invalid"
+        ) from None
+    if not isinstance(policy, MethodAwarePortfolioRiskLimitPolicy):
+        raise ValidationError(
+            "method policy loader returned an invalid policy binding"
+        )
+    validate_method_policy_range(
+        policy,
+        start_date=start_date,
+        end_date=end_date,
+    )
+
+    selected_definition_loader = definition_loader or load_portfolio_definition
+    try:
+        definition = selected_definition_loader(
+            portfolio_config_path,
+            policy.portfolio_id,
+        )
+    except ValidationError:
+        raise
+    except Exception:
+        raise ValidationError("Portfolio configuration is invalid") from None
+
+    selected_reader = reader or collect_attribution_records
+    try:
+        records = selected_reader(storage_config_path)
+    except StorageError:
+        raise
+    except Exception:
+        raise StorageError("Unable to read local portfolio attribution") from None
+
+    output = evaluate_method_aware_portfolio_risk_limits(
+        records,
+        policy=policy,
+        definition_fingerprint=definition.fingerprint,
+        start_date=start_date,
+        end_date=end_date,
+        max_evaluations=max_evaluations,
+    )
+    selected_writer = writer or write_records
+    written = _publish(
+        output.evaluations,
+        storage_config=storage_config,
+        writer=selected_writer,
+    )
+
+    latest_date = max(item["ts_event"] for item in output.evaluations)
+    latest = [
+        item for item in output.evaluations if item["ts_event"] == latest_date
+    ]
+    severity = {"ok": 0, "warning": 1, "critical": 2}
+    latest_status = max(latest, key=lambda item: severity[item["status"]])[
+        "status"
+    ]
+    selected = len(output.evaluations)
+    return {
+        "run_id": str(uuid4()),
+        "method_policy": method_policy_metadata(policy),
+        "portfolio_id": policy.portfolio_id,
+        "definition_fingerprint": definition.fingerprint,
+        "selection": dict(output.diagnostics),
+        "parameters": {
+            "start_date": start_date.isoformat() if start_date else None,
+            "end_date": end_date.isoformat(),
+            "max_evaluations": max_evaluations,
+        },
+        "curated_output": {
+            OUTPUT_DATASET: {
+                "records_selected": selected,
+                "records_written": written,
+                "records_already_present": selected - written,
+            }
+        },
+        "latest_status": {
+            "ts_event": latest_date.isoformat(),
+            "status": latest_status,
+            "metrics": [
+                {
+                    "metric_name": item["metric_name"],
+                    "subject_key": item["subject_key"],
+                    "observed_value": item["observed_value"],
+                    "status": item["status"],
+                    "is_breach": item["is_breach"],
+                    "calculation_id": item["calculation_id"],
+                }
+                for item in sorted(latest, key=lambda item: item["metric_name"])
+            ],
+        },
+    }
+
+
+def _write_summary(path: Path, summary: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary_path = path.with_suffix(path.suffix + ".tmp")
+    try:
+        temporary_path.write_text(
+            json.dumps(summary, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        temporary_path.replace(path)
+    except OSError:
+        temporary_path.unlink(missing_ok=True)
+        raise StorageError(
+            "Unable to write the method-aware risk-limit summary"
+        ) from None
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    try:
+        summary = run_method_aware_portfolio_risk_limits(
+            method_policy_id=args.method_policy_id,
+            method_policies_config_path=args.method_policies_config,
+            limits_config_path=args.limits_config,
+            portfolio_config_path=args.portfolio_config,
+            start_date=args.start_date,
+            end_date=args.end_date,
+            max_evaluations=args.max_evaluations,
+            storage_config_path=args.storage_config,
+        )
+        if args.summary_json is not None:
+            _write_summary(args.summary_json, summary)
+    except ValidationError:
+        print(
+            "Method-aware risk-limit evaluation failed: configuration, input "
+            "data or options were invalid",
+            file=sys.stderr,
+        )
+        return 1
+    except StorageError:
+        print(
+            "Method-aware risk-limit evaluation failed: local storage operation "
+            "failed; rerun is safe",
+            file=sys.stderr,
+        )
+        return 1
+    except Exception:
+        print(
+            "Method-aware risk-limit evaluation failed: unexpected local failure",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(json.dumps(summary, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/test_docker_compose_contract.py
+++ b/tests/unit/test_docker_compose_contract.py
@@ -35,6 +35,7 @@ def test_local_database_seed_mounts_are_read_only_and_ordered() -> None:
         "./sql/market_freshness_schema.sql:/docker-entrypoint-initdb.d/08_market_freshness_schema.sql:ro",
         "./sql/portfolio_risk_notification_delivery_schema.sql:/docker-entrypoint-initdb.d/09_portfolio_risk_notification_delivery_schema.sql:ro",
         "./sql/portfolio_covariance_method_schema.sql:/docker-entrypoint-initdb.d/10_portfolio_covariance_method_schema.sql:ro",
+        "./sql/portfolio_risk_limits_method_schema.sql:/docker-entrypoint-initdb.d/11_portfolio_risk_limits_method_schema.sql:ro",
     ]
     assert services["mongo"]["volumes"] == [
         "./mongo/init:/docker-entrypoint-initdb.d:ro"

--- a/tests/unit/test_portfolio_risk_limit_method_architecture_contract.py
+++ b/tests/unit/test_portfolio_risk_limit_method_architecture_contract.py
@@ -1,0 +1,25 @@
+from pathlib import Path
+
+
+def test_method_aware_risk_limit_contract_is_documented() -> None:
+    documentation = Path("docs/portfolio-risk-limit-methods.md").read_text(
+        encoding="utf-8"
+    )
+    method_config = Path(
+        "config/portfolio_risk_limit_methods.yaml"
+    ).read_text(encoding="utf-8")
+
+    for required in (
+        "portfolio-risk-limits-v2",
+        "us-tech-sample",
+        "us-tech-ewma",
+        "portfolio-attribution-v1",
+        "portfolio-attribution-ewma-v1",
+        "portfolio_risk_limit_method_comparison",
+        "run_method_aware_portfolio_risk_limits",
+        "status disagreement",
+    ):
+        assert required in documentation or required in method_config
+
+    assert "no threshold is silently reused" not in documentation.lower()
+    assert "explicit method binding" in documentation.lower()

--- a/tests/unit/test_portfolio_risk_limit_method_sql_contract.py
+++ b/tests/unit/test_portfolio_risk_limit_method_sql_contract.py
@@ -154,7 +154,7 @@ def test_method_comparison_view_pairs_aligned_current_evaluations() -> None:
                 status_disagreement,
                 higher_observed_method,
                 more_severe_method,
-                comparison_ts
+                epoch_us(comparison_ts) AS comparison_ts_us
             FROM risk_platform.portfolio_risk_limit_method_comparison
             """
         ).fetchone()
@@ -170,7 +170,7 @@ def test_method_comparison_view_pairs_aligned_current_evaluations() -> None:
         "ewma",
         "ewma",
     )
-    assert result[9] == ewma_ingest
+    assert result[9] == int(ewma_ingest.timestamp() * 1_000_000)
 
 
 def test_method_consistency_suite_covers_comparison_contract() -> None:

--- a/tests/unit/test_portfolio_risk_limit_method_sql_contract.py
+++ b/tests/unit/test_portfolio_risk_limit_method_sql_contract.py
@@ -1,0 +1,190 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+
+import duckdb
+import pytest
+
+
+def _read_sql(path: str) -> str:
+    return Path(path).read_text(encoding="utf-8")
+
+
+def _extract_statement(sql: str, prefix: str) -> str:
+    start = sql.index(prefix)
+    end = sql.index(";", start) + 1
+    return sql[start:end]
+
+
+def test_method_schema_constrains_v2_and_exposes_comparison_view() -> None:
+    sql = _read_sql("sql/portfolio_risk_limits_method_schema.sql")
+
+    assert "portfolio_risk_limit_evaluations_v2_method_contract" in sql
+    assert "portfolio-risk-limits-v2" in sql
+    assert "portfolio-attribution-v1" in sql
+    assert "portfolio-attribution-ewma-v1" in sql
+    assert "sample_annualized" in sql
+    assert "ewma_zero_mean_lambda_0_94_annualized" in sql
+    assert (
+        "CREATE OR REPLACE VIEW\n"
+        "    risk_platform.portfolio_risk_limit_method_comparison"
+    ) in sql
+
+
+def test_method_comparison_view_pairs_aligned_current_evaluations() -> None:
+    sql = _read_sql("sql/portfolio_risk_limits_method_schema.sql")
+    view_sql = _extract_statement(
+        sql,
+        "CREATE OR REPLACE VIEW\n"
+        "    risk_platform.portfolio_risk_limit_method_comparison AS",
+    )
+
+    with duckdb.connect() as connection:
+        connection.execute("CREATE SCHEMA risk_platform")
+        connection.execute(
+            """
+            CREATE TABLE
+                risk_platform.latest_portfolio_risk_limit_evaluations (
+                    calculation_id TEXT,
+                    model_version TEXT,
+                    policy_id TEXT,
+                    policy_fingerprint TEXT,
+                    portfolio_id TEXT,
+                    base_currency TEXT,
+                    definition_fingerprint TEXT,
+                    attribution_calculation_id TEXT,
+                    attribution_model_version TEXT,
+                    weighting_method TEXT,
+                    covariance_method TEXT,
+                    correlation_method TEXT,
+                    covariance_window INTEGER,
+                    annualization_days INTEGER,
+                    ts_event TIMESTAMPTZ,
+                    ts_ingest TIMESTAMPTZ,
+                    metric_name TEXT,
+                    subject_type TEXT,
+                    subject_key TEXT,
+                    unit TEXT,
+                    observed_value DOUBLE,
+                    warning_threshold DOUBLE,
+                    critical_threshold DOUBLE,
+                    status TEXT,
+                    is_breach BOOLEAN
+                )
+            """
+        )
+        metric_time = datetime(2026, 3, 31, tzinfo=timezone.utc)
+        sample_ingest = datetime(2026, 4, 1, 10, tzinfo=timezone.utc)
+        ewma_ingest = datetime(2026, 4, 1, 11, tzinfo=timezone.utc)
+        rows = [
+            (
+                "sample-evaluation",
+                "portfolio-risk-limits-v2",
+                "us-tech-standard",
+                "sample-policy-fingerprint",
+                "us-tech-equal",
+                "USD",
+                "definition-a",
+                "sample-attribution",
+                "portfolio-attribution-v1",
+                "constant_weight_daily_rebalanced",
+                "sample_annualized",
+                "pearson",
+                20,
+                252,
+                metric_time,
+                sample_ingest,
+                "portfolio_volatility_annualized",
+                "portfolio",
+                "us-tech-equal",
+                "annualized_decimal",
+                0.32,
+                0.30,
+                0.45,
+                "warning",
+                True,
+            ),
+            (
+                "ewma-evaluation",
+                "portfolio-risk-limits-v2",
+                "us-tech-standard",
+                "ewma-policy-fingerprint",
+                "us-tech-equal",
+                "USD",
+                "definition-a",
+                "ewma-attribution",
+                "portfolio-attribution-ewma-v1",
+                "constant_weight_daily_rebalanced",
+                "ewma_zero_mean_lambda_0_94_annualized",
+                "implied_from_ewma_covariance",
+                20,
+                252,
+                metric_time,
+                ewma_ingest,
+                "portfolio_volatility_annualized",
+                "portfolio",
+                "us-tech-equal",
+                "annualized_decimal",
+                0.48,
+                0.30,
+                0.45,
+                "critical",
+                True,
+            ),
+        ]
+        placeholders = ", ".join(["?"] * len(rows[0]))
+        connection.executemany(
+            "INSERT INTO "
+            "risk_platform.latest_portfolio_risk_limit_evaluations "
+            f"VALUES ({placeholders})",
+            rows,
+        )
+        connection.execute(view_sql)
+
+        result = connection.execute(
+            """
+            SELECT
+                sample_evaluation_calculation_id,
+                ewma_evaluation_calculation_id,
+                observed_difference_ewma_minus_sample,
+                absolute_observed_difference,
+                sample_status,
+                ewma_status,
+                status_disagreement,
+                higher_observed_method,
+                more_severe_method,
+                comparison_ts
+            FROM risk_platform.portfolio_risk_limit_method_comparison
+            """
+        ).fetchone()
+
+    assert result is not None
+    assert result[0:2] == ("sample-evaluation", "ewma-evaluation")
+    assert result[2] == pytest.approx(0.16)
+    assert result[3] == pytest.approx(0.16)
+    assert result[4:9] == (
+        "warning",
+        "critical",
+        True,
+        "ewma",
+        "ewma",
+    )
+    assert result[9] == ewma_ingest
+
+
+def test_method_consistency_suite_covers_comparison_contract() -> None:
+    sql = _read_sql(
+        "sql/portfolio_risk_limits_method_consistency_checks.sql"
+    )
+    for check_name in (
+        "method_aware_risk_limit_contracts_supported",
+        "method_aware_risk_limit_exact_pairs_exposed",
+        "method_aware_risk_limit_difference_reconciles",
+        "method_aware_risk_limit_absolute_difference_reconciles",
+        "method_aware_risk_limit_disagreement_flag_reconciles",
+        "method_aware_risk_limit_comparison_grain_unique",
+        "method_aware_risk_limit_higher_method_reconciles",
+        "method_aware_risk_limit_severity_method_reconciles",
+    ):
+        assert check_name in sql

--- a/tests/unit/test_portfolio_risk_limit_methods.py
+++ b/tests/unit/test_portfolio_risk_limit_methods.py
@@ -1,0 +1,324 @@
+from __future__ import annotations
+
+import json
+from datetime import date, datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+from src.analytics.portfolio_attribution import (
+    CORRELATION_METHOD as SAMPLE_CORRELATION_METHOD,
+    COVARIANCE_METHOD as SAMPLE_COVARIANCE_METHOD,
+    MODEL_VERSION as SAMPLE_MODEL_VERSION,
+)
+from src.analytics.portfolio_attribution_ewma import (
+    CORRELATION_METHOD as EWMA_CORRELATION_METHOD,
+    COVARIANCE_METHOD as EWMA_COVARIANCE_METHOD,
+    MODEL_VERSION as EWMA_MODEL_VERSION,
+)
+from src.analytics.portfolio_risk import WEIGHTING_METHOD
+from src.analytics.portfolio_risk_limit_method_evaluations import (
+    evaluate_method_aware_portfolio_risk_limits,
+)
+from src.analytics.portfolio_risk_limit_method_policies import (
+    EWMA_METHOD_CONTRACT,
+    MODEL_VERSION,
+    SAMPLE_METHOD_CONTRACT,
+    MethodAwarePortfolioRiskLimitPolicy,
+    load_method_aware_portfolio_risk_limit_policy,
+)
+from src.analytics.portfolio_risk_limit_policies import (
+    EffectiveDatedPortfolioRiskLimitPolicy,
+)
+from src.analytics.portfolio_risk_limits import RiskLimitThresholds
+from src.common.exceptions import ValidationError
+
+
+def _base_policy() -> EffectiveDatedPortfolioRiskLimitPolicy:
+    return EffectiveDatedPortfolioRiskLimitPolicy(
+        policy_id="us-tech-standard",
+        portfolio_id="us-tech-equal",
+        covariance_window=20,
+        annualization_days=252,
+        portfolio_volatility=RiskLimitThresholds(warning=0.30, critical=0.45),
+        component_concentration=RiskLimitThresholds(
+            warning=0.65,
+            critical=0.80,
+        ),
+        policy_version_id="us-tech-standard-v1",
+        effective_from=date(2026, 1, 1),
+        effective_to=None,
+    )
+
+
+def _policy(
+    *,
+    method_policy_id: str,
+    ewma: bool,
+) -> MethodAwarePortfolioRiskLimitPolicy:
+    return MethodAwarePortfolioRiskLimitPolicy(
+        method_policy_id=method_policy_id,
+        base_policy=_base_policy(),
+        method=EWMA_METHOD_CONTRACT if ewma else SAMPLE_METHOD_CONTRACT,
+    )
+
+
+def _record(
+    *,
+    day: int,
+    ewma: bool,
+    calculation_id: str,
+    volatility: float,
+    ingested_at: datetime | None = None,
+    shares: dict[str, float] | None = None,
+) -> dict[str, object]:
+    ts_event = datetime(2026, 1, day, tzinfo=timezone.utc)
+    return {
+        "calculation_id": calculation_id,
+        "model_version": EWMA_MODEL_VERSION if ewma else SAMPLE_MODEL_VERSION,
+        "portfolio_id": "us-tech-equal",
+        "base_currency": "USD",
+        "definition_fingerprint": "definition-a",
+        "weighting_method": WEIGHTING_METHOD,
+        "covariance_method": (
+            EWMA_COVARIANCE_METHOD if ewma else SAMPLE_COVARIANCE_METHOD
+        ),
+        "correlation_method": (
+            EWMA_CORRELATION_METHOD if ewma else SAMPLE_CORRELATION_METHOD
+        ),
+        "covariance_window": 20,
+        "annualization_days": 252,
+        "ts_event": ts_event,
+        "ts_ingest": ingested_at or ts_event + timedelta(hours=1),
+        "portfolio_volatility_annualized": volatility,
+        "volatility_status": "positive" if volatility > 0 else "zero",
+        "component_contribution_share_json": json.dumps(
+            shares
+            or {
+                "alpha_vantage:AAPL": 0.70,
+                "alpha_vantage:MSFT": 0.30,
+            },
+            sort_keys=True,
+        ),
+    }
+
+
+def test_bundled_method_bindings_are_explicit_and_distinct() -> None:
+    sample = load_method_aware_portfolio_risk_limit_policy(
+        method_policy_config_path=Path(
+            "config/portfolio_risk_limit_methods.yaml"
+        ),
+        limits_config_path=Path("config/portfolio_risk_limits.yaml"),
+        method_policy_id="us-tech-sample",
+        as_of_date=date(2026, 3, 31),
+    )
+    ewma = load_method_aware_portfolio_risk_limit_policy(
+        method_policy_config_path=Path(
+            "config/portfolio_risk_limit_methods.yaml"
+        ),
+        limits_config_path=Path("config/portfolio_risk_limits.yaml"),
+        method_policy_id="us-tech-ewma",
+        as_of_date=date(2026, 3, 31),
+    )
+
+    assert sample.policy_id == ewma.policy_id == "us-tech-standard"
+    assert sample.base_policy.fingerprint == ewma.base_policy.fingerprint
+    assert sample.method == SAMPLE_METHOD_CONTRACT
+    assert ewma.method == EWMA_METHOD_CONTRACT
+    assert sample.fingerprint != ewma.fingerprint
+
+
+def test_method_binding_rejects_a_mixed_unsupported_contract(
+    tmp_path: Path,
+) -> None:
+    config = tmp_path / "methods.yaml"
+    config.write_text(
+        """
+method_policies:
+  broken:
+    base_policy_id: us-tech-standard
+    attribution:
+      model_version: portfolio-attribution-ewma-v1
+      weighting_method: constant_weight_daily_rebalanced
+      covariance_method: sample_annualized
+      correlation_method: pearson
+""".lstrip(),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValidationError, match="unsupported"):
+        load_method_aware_portfolio_risk_limit_policy(
+            method_policy_config_path=config,
+            limits_config_path=Path("config/portfolio_risk_limits.yaml"),
+            method_policy_id="broken",
+            as_of_date=date(2026, 3, 31),
+        )
+
+
+def test_sample_and_ewma_rows_can_coexist_without_cross_method_failure() -> None:
+    records = [
+        _record(
+            day=2,
+            ewma=False,
+            calculation_id="sample-2",
+            volatility=0.32,
+        ),
+        _record(
+            day=2,
+            ewma=True,
+            calculation_id="ewma-2",
+            volatility=0.48,
+        ),
+    ]
+
+    sample = evaluate_method_aware_portfolio_risk_limits(
+        records,
+        policy=_policy(method_policy_id="sample", ewma=False),
+        definition_fingerprint="definition-a",
+    )
+    ewma = evaluate_method_aware_portfolio_risk_limits(
+        records,
+        policy=_policy(method_policy_id="ewma", ewma=True),
+        definition_fingerprint="definition-a",
+    )
+
+    assert {item["attribution_calculation_id"] for item in sample.evaluations} == {
+        "sample-2"
+    }
+    assert {item["attribution_calculation_id"] for item in ewma.evaluations} == {
+        "ewma-2"
+    }
+    assert sample.diagnostics["ignored_nonmatching_contract_records"] == 1
+    assert ewma.diagnostics["ignored_nonmatching_contract_records"] == 1
+    assert {item["model_version"] for item in sample.evaluations} == {
+        MODEL_VERSION
+    }
+    assert {item["model_version"] for item in ewma.evaluations} == {
+        MODEL_VERSION
+    }
+
+
+def test_method_specific_statuses_and_identities_are_retained() -> None:
+    records = [
+        _record(
+            day=2,
+            ewma=False,
+            calculation_id="sample-2",
+            volatility=0.32,
+        ),
+        _record(
+            day=2,
+            ewma=True,
+            calculation_id="ewma-2",
+            volatility=0.48,
+        ),
+    ]
+    sample = evaluate_method_aware_portfolio_risk_limits(
+        records,
+        policy=_policy(method_policy_id="sample", ewma=False),
+        definition_fingerprint="definition-a",
+    )
+    ewma = evaluate_method_aware_portfolio_risk_limits(
+        records,
+        policy=_policy(method_policy_id="ewma", ewma=True),
+        definition_fingerprint="definition-a",
+    )
+
+    sample_volatility = next(
+        item
+        for item in sample.evaluations
+        if item["metric_name"] == "portfolio_volatility_annualized"
+    )
+    ewma_volatility = next(
+        item
+        for item in ewma.evaluations
+        if item["metric_name"] == "portfolio_volatility_annualized"
+    )
+    assert sample_volatility["status"] == "warning"
+    assert ewma_volatility["status"] == "critical"
+    assert sample_volatility["policy_fingerprint"] != ewma_volatility[
+        "policy_fingerprint"
+    ]
+    assert sample_volatility["calculation_id"] != ewma_volatility[
+        "calculation_id"
+    ]
+
+
+def test_latest_correction_is_selected_within_the_chosen_method() -> None:
+    later = datetime(2026, 2, 1, tzinfo=timezone.utc)
+    records = [
+        _record(
+            day=2,
+            ewma=False,
+            calculation_id="sample-old",
+            volatility=0.32,
+        ),
+        _record(
+            day=2,
+            ewma=False,
+            calculation_id="sample-new",
+            volatility=0.50,
+            ingested_at=later,
+        ),
+        _record(
+            day=2,
+            ewma=True,
+            calculation_id="ewma-2",
+            volatility=0.40,
+        ),
+    ]
+
+    output = evaluate_method_aware_portfolio_risk_limits(
+        records,
+        policy=_policy(method_policy_id="sample", ewma=False),
+        definition_fingerprint="definition-a",
+    )
+
+    assert {item["attribution_calculation_id"] for item in output.evaluations} == {
+        "sample-new"
+    }
+    assert all(item["ts_ingest"] == later for item in output.evaluations)
+
+
+def test_conflicting_calculation_id_reuse_fails_closed() -> None:
+    records = [
+        _record(
+            day=2,
+            ewma=True,
+            calculation_id="same",
+            volatility=0.35,
+        ),
+        _record(
+            day=3,
+            ewma=True,
+            calculation_id="same",
+            volatility=0.40,
+        ),
+    ]
+
+    with pytest.raises(ValidationError, match="conflicting records"):
+        evaluate_method_aware_portfolio_risk_limits(
+            records,
+            policy=_policy(method_policy_id="ewma", ewma=True),
+            definition_fingerprint="definition-a",
+        )
+
+
+def test_evaluation_request_bound_is_enforced_before_output() -> None:
+    records = [
+        _record(
+            day=day,
+            ewma=False,
+            calculation_id=f"sample-{day}",
+            volatility=0.31,
+        )
+        for day in (2, 3)
+    ]
+
+    with pytest.raises(ValidationError, match="max_evaluations"):
+        evaluate_method_aware_portfolio_risk_limits(
+            records,
+            policy=_policy(method_policy_id="sample", ewma=False),
+            definition_fingerprint="definition-a",
+            max_evaluations=2,
+        )

--- a/tests/unit/test_run_method_aware_portfolio_risk_limits.py
+++ b/tests/unit/test_run_method_aware_portfolio_risk_limits.py
@@ -1,0 +1,230 @@
+from __future__ import annotations
+
+import json
+from datetime import date, datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from src.analytics.portfolio_attribution_ewma import (
+    CORRELATION_METHOD,
+    COVARIANCE_METHOD,
+    MODEL_VERSION as ATTRIBUTION_MODEL_VERSION,
+)
+from src.analytics.portfolio_risk import (
+    WEIGHTING_METHOD,
+    parse_portfolio_definition,
+)
+from src.analytics.portfolio_risk_limit_method_policies import (
+    EWMA_METHOD_CONTRACT,
+    MethodAwarePortfolioRiskLimitPolicy,
+)
+from src.analytics.portfolio_risk_limit_policies import (
+    EffectiveDatedPortfolioRiskLimitPolicy,
+)
+from src.analytics.portfolio_risk_limits import RiskLimitThresholds
+from src.common.exceptions import StorageError
+from src.orchestration.run_method_aware_portfolio_risk_limits import (
+    OUTPUT_DATASET,
+    run_method_aware_portfolio_risk_limits,
+)
+
+
+def _definition():
+    return parse_portfolio_definition(
+        {
+            "portfolios": {
+                "us-tech-equal": {
+                    "base_currency": "USD",
+                    "constituents": [
+                        {
+                            "source": "alpha_vantage",
+                            "symbol": "AAPL",
+                            "weight": 0.5,
+                        },
+                        {
+                            "source": "alpha_vantage",
+                            "symbol": "MSFT",
+                            "weight": 0.5,
+                        },
+                    ],
+                }
+            }
+        },
+        "us-tech-equal",
+    )
+
+
+def _policy() -> MethodAwarePortfolioRiskLimitPolicy:
+    base = EffectiveDatedPortfolioRiskLimitPolicy(
+        policy_id="us-tech-standard",
+        portfolio_id="us-tech-equal",
+        covariance_window=20,
+        annualization_days=252,
+        portfolio_volatility=RiskLimitThresholds(warning=0.30, critical=0.45),
+        component_concentration=RiskLimitThresholds(
+            warning=0.65,
+            critical=0.80,
+        ),
+        policy_version_id="us-tech-standard-v1",
+        effective_from=date(2026, 1, 1),
+        effective_to=None,
+    )
+    return MethodAwarePortfolioRiskLimitPolicy(
+        method_policy_id="us-tech-ewma",
+        base_policy=base,
+        method=EWMA_METHOD_CONTRACT,
+    )
+
+
+def _storage_config() -> dict[str, Any]:
+    return {
+        "storage": {
+            "base_dir": "unused",
+            "raw": {
+                "base_path": "unused/raw",
+                "dataset": "market_events",
+            },
+            "curated": {
+                "base_path": "unused/curated",
+                "datasets": {
+                    "portfolio_risk_attribution": (
+                        "portfolio_risk_attribution"
+                    ),
+                    OUTPUT_DATASET: OUTPUT_DATASET,
+                },
+            },
+            "format": "parquet",
+            "partitioning": {"granularity": "hourly"},
+        }
+    }
+
+
+def _records() -> list[dict[str, object]]:
+    definition = _definition()
+    ts_event = datetime(2026, 1, 20, tzinfo=timezone.utc)
+    return [
+        {
+            "calculation_id": "ewma-attribution-20",
+            "model_version": ATTRIBUTION_MODEL_VERSION,
+            "portfolio_id": "us-tech-equal",
+            "base_currency": "USD",
+            "definition_fingerprint": definition.fingerprint,
+            "weighting_method": WEIGHTING_METHOD,
+            "covariance_method": COVARIANCE_METHOD,
+            "correlation_method": CORRELATION_METHOD,
+            "covariance_window": 20,
+            "annualization_days": 252,
+            "ts_event": ts_event,
+            "ts_ingest": ts_event + timedelta(hours=1),
+            "portfolio_volatility_annualized": 0.48,
+            "volatility_status": "positive",
+            "component_contribution_share_json": json.dumps(
+                {
+                    "alpha_vantage:AAPL": 0.82,
+                    "alpha_vantage:MSFT": 0.18,
+                },
+                sort_keys=True,
+            ),
+        }
+    ]
+
+
+def test_runner_publishes_method_bound_evaluations() -> None:
+    writes: list[dict[str, Any]] = []
+
+    def writer(
+        records: list[dict[str, Any]],
+        *,
+        dataset: str,
+        **_: Any,
+    ) -> int:
+        assert dataset == OUTPUT_DATASET
+        assert len(records) == 1
+        writes.append(records[0])
+        return 1
+
+    summary = run_method_aware_portfolio_risk_limits(
+        method_policy_id="us-tech-ewma",
+        method_policies_config_path=Path("unused-methods.yaml"),
+        limits_config_path=Path("unused-limits.yaml"),
+        portfolio_config_path=Path("unused-portfolios.yaml"),
+        end_date=date(2026, 1, 20),
+        storage_config_path=Path("unused-storage.yaml"),
+        reader=lambda _: _records(),
+        writer=writer,
+        storage_config_loader=lambda _: _storage_config(),
+        definition_loader=lambda *_: _definition(),
+        method_policy_loader=lambda **_: _policy(),
+    )
+
+    assert summary["method_policy"]["method_policy_id"] == "us-tech-ewma"
+    assert summary["method_policy"]["covariance_method"] == COVARIANCE_METHOD
+    assert summary["curated_output"][OUTPUT_DATASET] == {
+        "records_selected": 2,
+        "records_written": 2,
+        "records_already_present": 0,
+    }
+    assert summary["latest_status"]["status"] == "critical"
+    assert len(writes) == 2
+    assert {row["attribution_model_version"] for row in writes} == {
+        ATTRIBUTION_MODEL_VERSION
+    }
+
+
+def test_runner_reports_replay_without_duplicate_publication() -> None:
+    summary = run_method_aware_portfolio_risk_limits(
+        method_policy_id="us-tech-ewma",
+        method_policies_config_path=Path("unused-methods.yaml"),
+        limits_config_path=Path("unused-limits.yaml"),
+        portfolio_config_path=Path("unused-portfolios.yaml"),
+        end_date=date(2026, 1, 20),
+        storage_config_path=Path("unused-storage.yaml"),
+        reader=lambda _: _records(),
+        writer=lambda *_args, **_kwargs: 0,
+        storage_config_loader=lambda _: _storage_config(),
+        definition_loader=lambda *_: _definition(),
+        method_policy_loader=lambda **_: _policy(),
+    )
+
+    assert summary["curated_output"][OUTPUT_DATASET][
+        "records_already_present"
+    ] == 2
+
+
+def test_runner_rejects_invalid_writer_result() -> None:
+    with pytest.raises(StorageError, match="invalid result"):
+        run_method_aware_portfolio_risk_limits(
+            method_policy_id="us-tech-ewma",
+            method_policies_config_path=Path("unused-methods.yaml"),
+            limits_config_path=Path("unused-limits.yaml"),
+            portfolio_config_path=Path("unused-portfolios.yaml"),
+            end_date=date(2026, 1, 20),
+            storage_config_path=Path("unused-storage.yaml"),
+            reader=lambda _: _records(),
+            writer=lambda *_args, **_kwargs: 2,
+            storage_config_loader=lambda _: _storage_config(),
+            definition_loader=lambda *_: _definition(),
+            method_policy_loader=lambda **_: _policy(),
+        )
+
+
+def test_runner_requires_output_dataset() -> None:
+    config = _storage_config()
+    del config["storage"]["curated"]["datasets"][OUTPUT_DATASET]
+
+    with pytest.raises(StorageError, match="missing method-aware"):
+        run_method_aware_portfolio_risk_limits(
+            method_policy_id="us-tech-ewma",
+            method_policies_config_path=Path("unused-methods.yaml"),
+            limits_config_path=Path("unused-limits.yaml"),
+            portfolio_config_path=Path("unused-portfolios.yaml"),
+            end_date=date(2026, 1, 20),
+            storage_config_path=Path("unused-storage.yaml"),
+            reader=lambda _: _records(),
+            writer=lambda *_args, **_kwargs: 1,
+            storage_config_loader=lambda _: config,
+            definition_loader=lambda *_: _definition(),
+            method_policy_loader=lambda **_: _policy(),
+        )


### PR DESCRIPTION
## Outcome

Make risk-limit evaluation explicitly bind the attribution model and covariance/correlation methods so sample and EWMA attribution histories can coexist safely:

```text
sample + EWMA portfolio_risk_attribution
  -> explicit method-policy binding
  -> select one supported method tuple
  -> ignore the other method without failing
  -> portfolio-risk-limits-v2 evidence
  -> sample-versus-EWMA current limit comparison
```

Primary arc42 block: `analytics`, with bounded interfaces to orchestration, the existing curated evaluation dataset and PostgreSQL serving.

## Compatibility gap closed

The established `portfolio-risk-limits-v1` evaluator is sample-bound. After PR #88, sample and fixed-decay EWMA rows share `portfolio_risk_attribution`; a same-portfolio EWMA row could therefore reach the sample evaluator and fail the complete request as an unsupported method.

This PR adds a method-aware path that filters by an explicit supported tuple before current-version selection. A sample binding ignores EWMA rows, and an EWMA binding ignores sample rows. Malformed matching rows and conflicting calculation-ID reuse still fail closed.

## Method policy

Add `config/portfolio_risk_limit_methods.yaml` with two explicit bindings over the existing effective-dated threshold policy:

- `us-tech-sample` -> `portfolio-attribution-v1` / `sample_annualized` / `pearson`;
- `us-tech-ewma` -> `portfolio-attribution-ewma-v1` / `ewma_zero_mean_lambda_0_94_annualized` / `implied_from_ewma_covariance`.

The combined fingerprint binds the effective base-policy fingerprint, method-policy ID, attribution model, weighting/covariance/correlation methods and `portfolio-risk-limits-v2`. Threshold, policy-version or method changes therefore create distinct evidence.

Only the two complete tuples are accepted. Unsupported mixed model/method combinations fail closed, and one base policy may define at most one binding for each method contract.

## Evaluation and orchestration

Add:

- `src.analytics.portfolio_risk_limit_method_policies`;
- `src.analytics.portfolio_risk_limit_method_evaluations`;
- `src.orchestration.run_method_aware_portfolio_risk_limits`.

Every selected current attribution snapshot still produces portfolio-volatility and largest-absolute-component-share evaluations with the existing warning/critical semantics. Current versions are selected within the chosen method by `ts_ingest DESC, calculation_id DESC`.

Example:

```bash
.venv/bin/python -m src.orchestration.run_method_aware_portfolio_risk_limits \
  --method-policy-id us-tech-ewma \
  --start-date 2026-01-01 \
  --end-date 2026-03-31 \
  --summary-json .demo/ewma-risk-limits.json
```

The existing 4,096-file, 1 GB, 250,000-row attribution read bounds and 10,000-evaluation request bound remain in force. Publication uses the existing content-addressed dataset and is replay-safe.

## PostgreSQL

Add `sql/portfolio_risk_limits_method_schema.sql` after schema layer 10. It constrains v2 rows to the supported sample or EWMA tuple and creates:

```text
risk_platform.portfolio_risk_limit_method_comparison
```

The view pairs current sample and EWMA evaluations only when policy ID, portfolio/definition, event date, metric/unit, covariance window, annualisation basis and thresholds align. It exposes values, statuses, breach flags, differences, disagreement and the higher/more-severe method.

`sql/portfolio_risk_limits_method_consistency_checks.sql` verifies supported tuples, pair completeness, difference arithmetic, disagreement labels and comparison-grain uniqueness.

## CI repair and validation

The first exact-head run passed security, PostgreSQL and infrastructure validation, but one DuckDB contract test decoded `TIMESTAMPTZ` through an optional `pytz` dependency that the production package does not require. The test now selects `epoch_us(comparison_ts)` and compares the exact UTC instant as an integer. No production dependency or validation gate was weakened.

GitHub Actions run `32634524756` (`ci` run 262) passed on exact head `37c4f3696811cc7fc3c8d7e88ce898d2d6f87185`:

- Security guardrails: passed.
- Python readiness: passed.
  - locked dependencies resolved;
  - Ruff passed;
  - mypy passed across 78 source files;
  - 652 tests passed in both quality and readiness runs;
  - `pip check` passed;
  - `make readiness-check` passed.
- PostgreSQL contract: passed against PostgreSQL 16.
- Infrastructure validation: passed without deployment or Terraform apply.

No unresolved review threads or requested changes are present.

## Scope

The branch is two working commits ahead of `main` and zero behind: the implementation plus the focused portability repair. It changes 13 files with 2,449 additions and no deletions. It will be squash-merged as one method-policy compatibility increment.

No provider request, model approval workflow, alert delivery, breach acknowledgement, position mutation, schedule activation, deployment or Terraform apply is included.

## Acceptance boundary

Validated and ready for squash merge as one method-aware risk-control increment.