### PR TITLE
Gate EWMA risk limits on current model approval

### DIFF
--- a/docs/model-approval-evidence.md
+++ b/docs/model-approval-evidence.md
@@ -2,8 +2,8 @@
 
 ## Outcome
 
-This increment adds append-only evidence that one supported analytical model
-contract was reviewed for a declared use:
+The repository records append-only model approval evidence and enforces it at the
+method-aware portfolio risk-limit boundary:
 
 ```text
 supported attribution model + fixed parameters
@@ -12,14 +12,18 @@ supported attribution model + fixed parameters
   -> optional targeted revocation event
   -> immutable PostgreSQL history
   -> deterministic current approval status
+  -> pre-read method-policy gate
+  -> risk-limit evaluation only when permitted
 ```
 
 The pure identity and validation contract is implemented in
 `src/warehouse/model_approval_contract.py`. PostgreSQL mutation is implemented in
-`src/warehouse/model_approval_registry.py`.
+`src/warehouse/model_approval_registry.py`. Runtime enforcement is implemented
+in `src/warehouse/model_approval_gate.py` and called by
+`src/orchestration/run_method_aware_portfolio_risk_limits.py`.
 
 This is evidence governance, not an external approval service and not a claim
-that the model is suitable for every use.
+that a model is suitable for every use.
 
 ## Supported Contracts
 
@@ -54,9 +58,9 @@ fixed_parameters = {
 }
 ```
 
-Mixed or unknown model/method tuples fail before database mutation. The fixed
-parameter document is canonical JSON and participates in the deterministic
-`model-contract-v1-*` fingerprint.
+Mixed or unknown model/method tuples fail before database mutation or analytical
+input access. The fixed-parameter document is canonical JSON and participates in
+the deterministic `model-contract-v1-*` fingerprint.
 
 ## Approval Identity
 
@@ -97,6 +101,63 @@ ID and stored revocation timestamp. A revocation timestamp cannot predate its
 approval. Reapproval requires a new approval request and therefore creates a new
 history row rather than removing the revocation.
 
+## Runtime Approval Gate
+
+Method-aware risk-limit execution resolves a deterministic
+`model-approval-gate-v1` decision after policy and portfolio validation but
+**before attribution Parquet is read and before any risk-limit record is
+published**.
+
+The baseline policy is explicit:
+
+```text
+portfolio-attribution-v1 + sample_annualized + pearson
+  -> baseline_exempt
+  -> no PostgreSQL approval query
+```
+
+The non-baseline fixed-decay EWMA policy is explicit:
+
+```text
+portfolio-attribution-ewma-v1
+  + ewma_zero_mean_lambda_0_94_annualized
+  + implied_from_ewma_covariance
+  -> query current_model_approval_status
+  -> approved: continue
+  -> absent or revoked: fail before attribution read
+```
+
+The gate uses the declared use case:
+
+```text
+portfolio-risk-limit-evaluation
+```
+
+It queries one current row by `use_case + contract_fingerprint`. Duplicate,
+unknown or incompatible status evidence fails closed. The DSN is selected from:
+
+```text
+--approval-dsn
+MODEL_APPROVAL_POSTGRES_DSN
+WAREHOUSE_POSTGRES_DSN
+local Docker PostgreSQL default
+```
+
+The sample baseline never opens that connection.
+
+A successful run summary includes a `model_approval_gate` object containing:
+
+- deterministic gate evidence ID;
+- contract and method-policy fingerprints;
+- decision (`baseline_exempt` or `approved`);
+- whether approval was required;
+- approval ID, timestamp and reviewer when applicable.
+
+It excludes the free-text review reason and fixed-parameter document. Approval
+identity remains run-level governance evidence; it does not alter analytical
+attribution or risk-limit calculation IDs. Reapproval therefore changes the gate
+evidence ID without manufacturing duplicate analytical facts.
+
 ## Operator Commands
 
 Apply the schema to an existing local PostgreSQL database:
@@ -121,6 +182,16 @@ Approve the fixed-decay EWMA contract for risk-limit evaluation:
   --reason "Reviewed for bounded local portfolio risk-limit evidence."
 ```
 
+Run the approved EWMA policy:
+
+```bash
+MODEL_APPROVAL_POSTGRES_DSN="postgresql://risk_user:risk_password@localhost:5433/risk_platform" \
+.venv/bin/python -m src.orchestration.run_method_aware_portfolio_risk_limits \
+  --method-policy-id us-tech-ewma \
+  --end-date 2026-03-31 \
+  --summary-json .demo/ewma-risk-limits.json
+```
+
 Revoke one exact approval:
 
 ```bash
@@ -131,8 +202,13 @@ Revoke one exact approval:
   --reason "Approval withdrawn after model review."
 ```
 
-The JSON summaries omit the free-text reason and fixed-parameter document. They
-return deterministic identifiers and non-sensitive contract metadata.
+A subsequent EWMA risk-limit run then fails before reading attribution data. A
+new approval request can reapprove the same immutable contract without deleting
+history.
+
+The JSON registry summaries omit the free-text reason and fixed-parameter
+document. They return deterministic identifiers and non-sensitive contract
+metadata.
 
 ## PostgreSQL Contract
 
@@ -176,12 +252,20 @@ revocations remain queryable in history.
 The PostgreSQL CI job:
 
 1. initializes `sql/model_approval_schema.sql` after the method-aware schemas;
-2. creates an EWMA approval and proves an identical retry is idempotent;
-3. revokes it and proves revocation replay is idempotent;
-4. creates a later reapproval and verifies deterministic current status;
-5. rejects conflicting request reuse;
-6. proves direct update and delete attempts fail; and
-7. runs `sql/model_approval_consistency_checks.sql`.
+2. proves the EWMA gate rejects an absent approval;
+3. creates an EWMA approval and proves an identical retry is idempotent;
+4. proves the gate binds that approval;
+5. revokes it, proves revocation replay is idempotent and proves the gate rejects
+   the revoked state;
+6. creates a later reapproval and proves the gate binds the new approval with a
+   new deterministic gate evidence ID;
+7. rejects conflicting request reuse;
+8. proves direct update and delete attempts fail; and
+9. runs `sql/model_approval_consistency_checks.sql`.
+
+Unit tests separately prove the sample baseline returns `baseline_exempt`
+without invoking an approval reader and that gate failure occurs before the
+attribution reader or publisher is called.
 
 The consistency suite checks history counts, references, timestamps, unique
 request grains, latest-selection semantics, status partitioning, supported
@@ -189,8 +273,7 @@ contracts and enabled append-only triggers.
 
 ## Boundary
 
-This increment does **not** yet require an approval during risk-limit execution.
-That enforcement is the next dependency-safe slice. It also does not provide:
+The implemented gate is deliberately narrow. It does not provide:
 
 - external maker-checker workflow;
 - authentication or directory integration;
@@ -200,6 +283,6 @@ That enforcement is the next dependency-safe slice. It also does not provide:
 - trade or position controls;
 - deployment or Terraform apply.
 
-The existing sample model remains the baseline. The following increment will
-require current approval only when a governed method policy targets the
-non-baseline EWMA contract.
+It governs only method-aware portfolio risk-limit execution. Other analytical
+commands remain evidence-producing tools and do not imply approval for a
+business use.

--- a/src/orchestration/run_method_aware_portfolio_risk_limits.py
+++ b/src/orchestration/run_method_aware_portfolio_risk_limits.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import sys
 from collections.abc import Callable, Sequence
 from datetime import date
@@ -23,6 +24,12 @@ from ..analytics.portfolio_risk_limits import MAX_LIMIT_EVALUATIONS
 from ..common.exceptions import StorageError, ValidationError
 from ..storage.s3_writer import write_records
 from ..storage.storage_config import load_storage_config, validate_storage_config
+from ..warehouse.model_approval_gate import (
+    ModelApprovalGateEvidence,
+    model_approval_gate_metadata,
+    resolve_model_approval_gate,
+)
+from ..warehouse.model_approval_registry import DEFAULT_POSTGRES_DSN
 from ..warehouse.portfolio_attribution_loader import collect_attribution_records
 
 INPUT_DATASET = "portfolio_risk_attribution"
@@ -33,6 +40,7 @@ Writer = Callable[..., int]
 StorageConfigLoader = Callable[[Path], dict[str, Any]]
 DefinitionLoader = Callable[[Path, str], PortfolioDefinition]
 MethodPolicyLoader = Callable[..., MethodAwarePortfolioRiskLimitPolicy]
+ApprovalGateResolver = Callable[..., ModelApprovalGateEvidence]
 
 
 def _calendar_date(value: str) -> date:
@@ -61,6 +69,13 @@ def _max_evaluations(value: str) -> int:
             f"max_evaluations must be between 1 and {MAX_LIMIT_EVALUATIONS}"
         )
     return parsed
+
+
+def _default_approval_dsn() -> str:
+    return os.environ.get(
+        "MODEL_APPROVAL_POSTGRES_DSN",
+        os.environ.get("WAREHOUSE_POSTGRES_DSN", DEFAULT_POSTGRES_DSN),
+    )
 
 
 def _build_parser() -> argparse.ArgumentParser:
@@ -97,6 +112,15 @@ def _build_parser() -> argparse.ArgumentParser:
         "--storage-config",
         type=Path,
         default=Path("config/storage.yaml"),
+    )
+    parser.add_argument(
+        "--approval-dsn",
+        default=_default_approval_dsn(),
+        help=(
+            "PostgreSQL DSN containing current model approvals. Defaults to "
+            "MODEL_APPROVAL_POSTGRES_DSN, WAREHOUSE_POSTGRES_DSN or the local "
+            "Docker DSN. The sample baseline does not open this connection."
+        ),
     )
     parser.add_argument("--summary-json", type=Path)
     return parser
@@ -144,6 +168,33 @@ def _publish(
     return written
 
 
+def _resolve_approval_gate(
+    *,
+    policy: MethodAwarePortfolioRiskLimitPolicy,
+    approval_dsn: str,
+    approval_gate_resolver: ApprovalGateResolver | None,
+) -> ModelApprovalGateEvidence:
+    selected_resolver = approval_gate_resolver or resolve_model_approval_gate
+    try:
+        evidence = selected_resolver(
+            method_policy_fingerprint=policy.fingerprint,
+            attribution_model_version=policy.method.attribution_model_version,
+            weighting_method=policy.method.weighting_method,
+            covariance_method=policy.method.covariance_method,
+            correlation_method=policy.method.correlation_method,
+            dsn=approval_dsn,
+        )
+    except (ValidationError, StorageError):
+        raise
+    except RuntimeError:
+        raise StorageError("Model approval gate dependency is unavailable") from None
+    except Exception:
+        raise StorageError("Unable to resolve the model approval gate") from None
+    if not isinstance(evidence, ModelApprovalGateEvidence):
+        raise StorageError("Model approval gate returned incompatible evidence")
+    return evidence
+
+
 def run_method_aware_portfolio_risk_limits(
     *,
     method_policy_id: str,
@@ -154,11 +205,13 @@ def run_method_aware_portfolio_risk_limits(
     storage_config_path: Path,
     start_date: date | None = None,
     max_evaluations: int = MAX_LIMIT_EVALUATIONS,
+    approval_dsn: str = DEFAULT_POSTGRES_DSN,
     reader: Reader | None = None,
     writer: Writer | None = None,
     storage_config_loader: StorageConfigLoader | None = None,
     definition_loader: DefinitionLoader | None = None,
     method_policy_loader: MethodPolicyLoader | None = None,
+    approval_gate_resolver: ApprovalGateResolver | None = None,
 ) -> dict[str, Any]:
     if start_date is not None and start_date > end_date:
         raise ValidationError("start_date must be on or before end_date")
@@ -209,6 +262,12 @@ def run_method_aware_portfolio_risk_limits(
     except Exception:
         raise ValidationError("Portfolio configuration is invalid") from None
 
+    approval_gate = _resolve_approval_gate(
+        policy=policy,
+        approval_dsn=approval_dsn,
+        approval_gate_resolver=approval_gate_resolver,
+    )
+
     selected_reader = reader or collect_attribution_records
     try:
         records = selected_reader(storage_config_path)
@@ -244,6 +303,7 @@ def run_method_aware_portfolio_risk_limits(
     return {
         "run_id": str(uuid4()),
         "method_policy": method_policy_metadata(policy),
+        "model_approval_gate": model_approval_gate_metadata(approval_gate),
         "portfolio_id": policy.portfolio_id,
         "definition_fingerprint": definition.fingerprint,
         "selection": dict(output.diagnostics),
@@ -305,6 +365,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             end_date=args.end_date,
             max_evaluations=args.max_evaluations,
             storage_config_path=args.storage_config,
+            approval_dsn=args.approval_dsn,
         )
         if args.summary_json is not None:
             _write_summary(args.summary_json, summary)

--- a/src/warehouse/model_approval_contract_check.py
+++ b/src/warehouse/model_approval_contract_check.py
@@ -8,6 +8,7 @@ from datetime import datetime, timezone
 from typing import Any
 
 from src.common.exceptions import ValidationError
+from src.warehouse.model_approval_gate import resolve_model_approval_gate
 from src.warehouse.model_approval_registry import (
     DEFAULT_POSTGRES_DSN,
     approve_model_contract,
@@ -15,10 +16,34 @@ from src.warehouse.model_approval_registry import (
 )
 
 USE_CASE = "portfolio-risk-limit-evaluation"
+METHOD_POLICY_FINGERPRINT = "risk-limit-method-policy-contract-check"
 EWMA_MODEL_VERSION = "portfolio-attribution-ewma-v1"
 WEIGHTING_METHOD = "constant_weight_daily_rebalanced"
 COVARIANCE_METHOD = "ewma_zero_mean_lambda_0_94_annualized"
 CORRELATION_METHOD = "implied_from_ewma_covariance"
+
+
+def _resolve_gate(*, dsn: str):
+    return resolve_model_approval_gate(
+        method_policy_fingerprint=METHOD_POLICY_FINGERPRINT,
+        attribution_model_version=EWMA_MODEL_VERSION,
+        weighting_method=WEIGHTING_METHOD,
+        covariance_method=COVARIANCE_METHOD,
+        correlation_method=CORRELATION_METHOD,
+        dsn=dsn,
+    )
+
+
+def _expect_gate_rejection(*, dsn: str, message: str) -> None:
+    try:
+        _resolve_gate(dsn=dsn)
+    except ValidationError as exc:
+        if message not in str(exc):
+            raise RuntimeError(
+                "model approval gate failed with an unexpected reason"
+            ) from exc
+        return
+    raise RuntimeError("model approval gate unexpectedly accepted the request")
 
 
 def _expect_append_only_rejection(
@@ -47,6 +72,8 @@ def run_model_approval_contract_check(*, dsn: str) -> dict[str, Any]:
     revoked_at = datetime(2026, 2, 10, 12, tzinfo=timezone.utc)
     second_approved_at = datetime(2026, 3, 10, 12, tzinfo=timezone.utc)
 
+    _expect_gate_rejection(dsn=dsn, message="current model approval is required")
+
     first = approve_model_contract(
         dsn=dsn,
         use_case_name=USE_CASE,
@@ -74,6 +101,10 @@ def run_model_approval_contract_check(*, dsn: str) -> dict[str, Any]:
     if first_retry["created"] or first_retry["approval_id"] != first["approval_id"]:
         raise RuntimeError("model approval retry did not converge")
 
+    first_gate = _resolve_gate(dsn=dsn)
+    if first_gate.approval_id != first["approval_id"]:
+        raise RuntimeError("model approval gate did not bind the first approval")
+
     revocation = revoke_model_approval(
         dsn=dsn,
         approval_id=str(first["approval_id"]),
@@ -96,6 +127,8 @@ def run_model_approval_contract_check(*, dsn: str) -> dict[str, Any]:
     ):
         raise RuntimeError("model approval revocation retry did not converge")
 
+    _expect_gate_rejection(dsn=dsn, message="current model approval is revoked")
+
     second = approve_model_contract(
         dsn=dsn,
         use_case_name=USE_CASE,
@@ -108,6 +141,11 @@ def run_model_approval_contract_check(*, dsn: str) -> dict[str, Any]:
         reason="Reapprove the same immutable model contract after review.",
         approved_at=second_approved_at,
     )
+    second_gate = _resolve_gate(dsn=dsn)
+    if second_gate.approval_id != second["approval_id"]:
+        raise RuntimeError("model approval gate did not bind the reapproval")
+    if second_gate.gate_evidence_id == first_gate.gate_evidence_id:
+        raise RuntimeError("model approval gate evidence did not change on reapproval")
 
     try:
         approve_model_contract(
@@ -198,11 +236,15 @@ def run_model_approval_contract_check(*, dsn: str) -> dict[str, Any]:
         "use_case": USE_CASE,
         "contract_fingerprint": second["contract_fingerprint"],
         "first_approval_id": first["approval_id"],
+        "first_gate_evidence_id": first_gate.gate_evidence_id,
         "revocation_id": revocation["revocation_id"],
         "current_approval_id": second["approval_id"],
+        "current_gate_evidence_id": second_gate.gate_evidence_id,
         "current_status": current[1],
         "approval_count": int(current[2]),
         "history_event_count": history_count,
+        "missing_gate_rejected": True,
+        "revoked_gate_rejected": True,
         "append_only_verified": True,
     }
 
@@ -210,8 +252,8 @@ def run_model_approval_contract_check(*, dsn: str) -> dict[str, Any]:
 def _parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description=(
-            "Exercise model approval idempotency, revocation, current status "
-            "and append-only PostgreSQL triggers."
+            "Exercise model approval idempotency, revocation, current status, "
+            "runtime gating and append-only PostgreSQL triggers."
         )
     )
     parser.add_argument(

--- a/src/warehouse/model_approval_gate.py
+++ b/src/warehouse/model_approval_gate.py
@@ -1,0 +1,261 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any
+
+from src.common.exceptions import StorageError, ValidationError
+from src.warehouse.model_approval_contract import (
+    SAMPLE_CONTRACT,
+    ModelContract,
+    build_model_contract,
+    bounded_text,
+)
+
+GATE_MODEL_VERSION = "model-approval-gate-v1"
+RISK_LIMIT_USE_CASE = "portfolio-risk-limit-evaluation"
+
+ApprovalStatusReader = Callable[..., Mapping[str, Any] | None]
+
+
+@dataclass(frozen=True, slots=True)
+class ModelApprovalGateEvidence:
+    gate_evidence_id: str
+    model_version: str
+    use_case: str
+    method_policy_fingerprint: str
+    contract_fingerprint: str
+    attribution_model_version: str
+    weighting_method: str
+    covariance_method: str
+    correlation_method: str
+    approval_required: bool
+    decision: str
+    approval_id: str | None
+    approved_at: datetime | None
+    approved_by: str | None
+
+
+def _evidence_id(
+    *,
+    method_policy_fingerprint: str,
+    contract: ModelContract,
+    decision: str,
+    approval_id: str | None,
+) -> str:
+    payload = {
+        "approval_id": approval_id,
+        "contract_fingerprint": contract.contract_fingerprint,
+        "decision": decision,
+        "method_policy_fingerprint": method_policy_fingerprint,
+        "model_version": GATE_MODEL_VERSION,
+        "use_case": RISK_LIMIT_USE_CASE,
+    }
+    digest = hashlib.sha256(
+        json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    ).hexdigest()[:24]
+    return f"{GATE_MODEL_VERSION}-{digest}"
+
+
+def _read_current_approval(
+    *,
+    dsn: str,
+    use_case: str,
+    contract_fingerprint: str,
+) -> Mapping[str, Any] | None:
+    try:
+        import psycopg
+    except ImportError as exc:  # pragma: no cover - required dependency in CI.
+        raise RuntimeError("Model approval gating requires psycopg") from exc
+
+    try:
+        with psycopg.connect(dsn) as connection:
+            connection.read_only = True
+            with connection.cursor() as cursor:
+                cursor.execute(
+                    """
+                    SELECT
+                        approval_id,
+                        approval_status,
+                        approved_at,
+                        approved_by,
+                        revocation_id,
+                        revoked_at
+                    FROM risk_platform.current_model_approval_status
+                    WHERE use_case = %s
+                      AND contract_fingerprint = %s
+                    """,
+                    (use_case, contract_fingerprint),
+                )
+                rows = cursor.fetchall()
+    except Exception:
+        raise StorageError("Unable to read current model approval status") from None
+
+    if len(rows) > 1:
+        raise StorageError("Current model approval status returned duplicate grains")
+    if not rows:
+        return None
+    row = rows[0]
+    return {
+        "approval_id": row[0],
+        "approval_status": row[1],
+        "approved_at": row[2],
+        "approved_by": row[3],
+        "revocation_id": row[4],
+        "revoked_at": row[5],
+    }
+
+
+def _contract(
+    *,
+    attribution_model_version: str,
+    weighting_method: str,
+    covariance_method: str,
+    correlation_method: str,
+) -> ModelContract:
+    return build_model_contract(
+        attribution_model_version=attribution_model_version,
+        weighting_method=weighting_method,
+        covariance_method=covariance_method,
+        correlation_method=correlation_method,
+    )
+
+
+def resolve_model_approval_gate(
+    *,
+    method_policy_fingerprint: str,
+    attribution_model_version: str,
+    weighting_method: str,
+    covariance_method: str,
+    correlation_method: str,
+    dsn: str,
+    approval_status_reader: ApprovalStatusReader | None = None,
+) -> ModelApprovalGateEvidence:
+    policy_fingerprint = bounded_text(
+        method_policy_fingerprint,
+        "method_policy_fingerprint",
+        256,
+    )
+    contract = _contract(
+        attribution_model_version=attribution_model_version,
+        weighting_method=weighting_method,
+        covariance_method=covariance_method,
+        correlation_method=correlation_method,
+    )
+
+    if (
+        contract.attribution_model_version,
+        contract.weighting_method,
+        contract.covariance_method,
+        contract.correlation_method,
+    ) == SAMPLE_CONTRACT:
+        decision = "baseline_exempt"
+        return ModelApprovalGateEvidence(
+            gate_evidence_id=_evidence_id(
+                method_policy_fingerprint=policy_fingerprint,
+                contract=contract,
+                decision=decision,
+                approval_id=None,
+            ),
+            model_version=GATE_MODEL_VERSION,
+            use_case=RISK_LIMIT_USE_CASE,
+            method_policy_fingerprint=policy_fingerprint,
+            contract_fingerprint=contract.contract_fingerprint,
+            attribution_model_version=contract.attribution_model_version,
+            weighting_method=contract.weighting_method,
+            covariance_method=contract.covariance_method,
+            correlation_method=contract.correlation_method,
+            approval_required=False,
+            decision=decision,
+            approval_id=None,
+            approved_at=None,
+            approved_by=None,
+        )
+
+    reader = approval_status_reader or _read_current_approval
+    try:
+        current = reader(
+            dsn=dsn,
+            use_case=RISK_LIMIT_USE_CASE,
+            contract_fingerprint=contract.contract_fingerprint,
+        )
+    except (ValidationError, StorageError, RuntimeError):
+        raise
+    except Exception:
+        raise StorageError("Unable to resolve current model approval") from None
+
+    if current is None:
+        raise ValidationError(
+            "a current model approval is required for the non-baseline method policy"
+        )
+    if not isinstance(current, Mapping):
+        raise StorageError("Current model approval status is incompatible")
+
+    status = current.get("approval_status")
+    if status == "revoked":
+        raise ValidationError(
+            "the current model approval is revoked for the non-baseline method policy"
+        )
+    if status != "approved":
+        raise StorageError("Current model approval status is invalid")
+
+    approval_id = bounded_text(current.get("approval_id"), "approval_id", 256)
+    approved_by = bounded_text(current.get("approved_by"), "approved_by")
+    approved_at = current.get("approved_at")
+    if (
+        not isinstance(approved_at, datetime)
+        or approved_at.tzinfo is None
+        or approved_at.utcoffset() is None
+    ):
+        raise StorageError("Current model approval timestamp is incompatible")
+    approved_at = approved_at.astimezone(timezone.utc)
+    decision = "approved"
+    return ModelApprovalGateEvidence(
+        gate_evidence_id=_evidence_id(
+            method_policy_fingerprint=policy_fingerprint,
+            contract=contract,
+            decision=decision,
+            approval_id=approval_id,
+        ),
+        model_version=GATE_MODEL_VERSION,
+        use_case=RISK_LIMIT_USE_CASE,
+        method_policy_fingerprint=policy_fingerprint,
+        contract_fingerprint=contract.contract_fingerprint,
+        attribution_model_version=contract.attribution_model_version,
+        weighting_method=contract.weighting_method,
+        covariance_method=contract.covariance_method,
+        correlation_method=contract.correlation_method,
+        approval_required=True,
+        decision=decision,
+        approval_id=approval_id,
+        approved_at=approved_at,
+        approved_by=approved_by,
+    )
+
+
+def model_approval_gate_metadata(
+    evidence: ModelApprovalGateEvidence,
+) -> dict[str, Any]:
+    return {
+        "gate_evidence_id": evidence.gate_evidence_id,
+        "model_version": evidence.model_version,
+        "use_case": evidence.use_case,
+        "method_policy_fingerprint": evidence.method_policy_fingerprint,
+        "contract_fingerprint": evidence.contract_fingerprint,
+        "attribution_model_version": evidence.attribution_model_version,
+        "weighting_method": evidence.weighting_method,
+        "covariance_method": evidence.covariance_method,
+        "correlation_method": evidence.correlation_method,
+        "approval_required": evidence.approval_required,
+        "decision": evidence.decision,
+        "approval_id": evidence.approval_id,
+        "approved_at": (
+            evidence.approved_at.isoformat()
+            if evidence.approved_at is not None
+            else None
+        ),
+        "approved_by": evidence.approved_by,
+    }

--- a/tests/unit/test_model_approval_gate.py
+++ b/tests/unit/test_model_approval_gate.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+import pytest
+
+from src.common.exceptions import StorageError, ValidationError
+from src.warehouse.model_approval_gate import (
+    GATE_MODEL_VERSION,
+    RISK_LIMIT_USE_CASE,
+    model_approval_gate_metadata,
+    resolve_model_approval_gate,
+)
+
+METHOD_POLICY_FINGERPRINT = "risk-limit-method-policy-test"
+SAMPLE = {
+    "attribution_model_version": "portfolio-attribution-v1",
+    "weighting_method": "constant_weight_daily_rebalanced",
+    "covariance_method": "sample_annualized",
+    "correlation_method": "pearson",
+}
+EWMA = {
+    "attribution_model_version": "portfolio-attribution-ewma-v1",
+    "weighting_method": "constant_weight_daily_rebalanced",
+    "covariance_method": "ewma_zero_mean_lambda_0_94_annualized",
+    "correlation_method": "implied_from_ewma_covariance",
+}
+
+
+def test_sample_baseline_is_exempt_without_reading_postgres() -> None:
+    calls = 0
+
+    def reader(**_: Any):
+        nonlocal calls
+        calls += 1
+        raise AssertionError("baseline exemption must not query approvals")
+
+    evidence = resolve_model_approval_gate(
+        method_policy_fingerprint=METHOD_POLICY_FINGERPRINT,
+        dsn="postgresql://unused",
+        approval_status_reader=reader,
+        **SAMPLE,
+    )
+    replay = resolve_model_approval_gate(
+        method_policy_fingerprint=METHOD_POLICY_FINGERPRINT,
+        dsn="postgresql://different-unused",
+        approval_status_reader=reader,
+        **SAMPLE,
+    )
+
+    assert evidence == replay
+    assert calls == 0
+    assert evidence.model_version == GATE_MODEL_VERSION
+    assert evidence.use_case == RISK_LIMIT_USE_CASE
+    assert evidence.approval_required is False
+    assert evidence.decision == "baseline_exempt"
+    assert evidence.approval_id is None
+    assert evidence.gate_evidence_id.startswith(f"{GATE_MODEL_VERSION}-")
+
+
+def test_ewma_requires_and_binds_one_current_approval() -> None:
+    approved_at = datetime(2026, 3, 10, 12, tzinfo=timezone.utc)
+    calls: list[dict[str, Any]] = []
+
+    def reader(**kwargs: Any):
+        calls.append(kwargs)
+        return {
+            "approval_id": "model-approval-v1-0123456789abcdef01234567",
+            "approval_status": "approved",
+            "approved_at": approved_at,
+            "approved_by": "model-risk@example.test",
+            "revocation_id": None,
+            "revoked_at": None,
+        }
+
+    evidence = resolve_model_approval_gate(
+        method_policy_fingerprint=METHOD_POLICY_FINGERPRINT,
+        dsn="postgresql://example",
+        approval_status_reader=reader,
+        **EWMA,
+    )
+    metadata = model_approval_gate_metadata(evidence)
+
+    assert len(calls) == 1
+    assert calls[0]["dsn"] == "postgresql://example"
+    assert calls[0]["use_case"] == RISK_LIMIT_USE_CASE
+    assert calls[0]["contract_fingerprint"].startswith("model-contract-v1-")
+    assert evidence.approval_required is True
+    assert evidence.decision == "approved"
+    assert evidence.approval_id == "model-approval-v1-0123456789abcdef01234567"
+    assert evidence.approved_at == approved_at
+    assert metadata["approval_id"] == evidence.approval_id
+    assert metadata["approved_at"] == approved_at.isoformat()
+    assert "reason" not in metadata
+
+
+def test_ewma_fails_when_current_approval_is_missing_or_revoked() -> None:
+    with pytest.raises(ValidationError, match="current model approval is required"):
+        resolve_model_approval_gate(
+            method_policy_fingerprint=METHOD_POLICY_FINGERPRINT,
+            dsn="postgresql://unused",
+            approval_status_reader=lambda **_: None,
+            **EWMA,
+        )
+
+    with pytest.raises(ValidationError, match="current model approval is revoked"):
+        resolve_model_approval_gate(
+            method_policy_fingerprint=METHOD_POLICY_FINGERPRINT,
+            dsn="postgresql://unused",
+            approval_status_reader=lambda **_: {
+                "approval_id": "model-approval-v1-0123456789abcdef01234567",
+                "approval_status": "revoked",
+                "approved_at": datetime(2026, 1, 1, tzinfo=timezone.utc),
+                "approved_by": "model-risk@example.test",
+                "revocation_id": "model-approval-revocation-v1-abcdef0123456789abcdef01",
+                "revoked_at": datetime(2026, 2, 1, tzinfo=timezone.utc),
+            },
+            **EWMA,
+        )
+
+
+def test_gate_rejects_incompatible_approval_evidence() -> None:
+    with pytest.raises(StorageError, match="status is invalid"):
+        resolve_model_approval_gate(
+            method_policy_fingerprint=METHOD_POLICY_FINGERPRINT,
+            dsn="postgresql://unused",
+            approval_status_reader=lambda **_: {
+                "approval_id": "model-approval-v1-0123456789abcdef01234567",
+                "approval_status": "pending",
+                "approved_at": datetime(2026, 1, 1, tzinfo=timezone.utc),
+                "approved_by": "model-risk@example.test",
+            },
+            **EWMA,
+        )
+
+    with pytest.raises(StorageError, match="timestamp is incompatible"):
+        resolve_model_approval_gate(
+            method_policy_fingerprint=METHOD_POLICY_FINGERPRINT,
+            dsn="postgresql://unused",
+            approval_status_reader=lambda **_: {
+                "approval_id": "model-approval-v1-0123456789abcdef01234567",
+                "approval_status": "approved",
+                "approved_at": datetime(2026, 1, 1),
+                "approved_by": "model-risk@example.test",
+            },
+            **EWMA,
+        )

--- a/tests/unit/test_model_approval_gate_architecture_contract.py
+++ b/tests/unit/test_model_approval_gate_architecture_contract.py
@@ -24,7 +24,7 @@ def test_model_approval_gate_is_documented_at_the_runtime_boundary() -> None:
         assert required in documentation
 
     assert "resolve_model_approval_gate" in runner
-    assert runner.index("_resolve_approval_gate(") < runner.index(
+    assert runner.index("approval_gate = _resolve_approval_gate(") < runner.index(
         "selected_reader = reader or collect_attribution_records"
     )
     assert "missing_gate_rejected" in contract_check

--- a/tests/unit/test_model_approval_gate_architecture_contract.py
+++ b/tests/unit/test_model_approval_gate_architecture_contract.py
@@ -1,0 +1,38 @@
+from pathlib import Path
+
+
+def test_model_approval_gate_is_documented_at_the_runtime_boundary() -> None:
+    documentation = Path("docs/model-approval-evidence.md").read_text(
+        encoding="utf-8"
+    )
+    runner = Path(
+        "src/orchestration/run_method_aware_portfolio_risk_limits.py"
+    ).read_text(encoding="utf-8")
+    contract_check = Path(
+        "src/warehouse/model_approval_contract_check.py"
+    ).read_text(encoding="utf-8")
+
+    for required in (
+        "model-approval-gate-v1",
+        "baseline_exempt",
+        "MODEL_APPROVAL_POSTGRES_DSN",
+        "model_approval_gate",
+        "before attribution Parquet is read",
+        "portfolio-risk-limit-evaluation",
+        "current_model_approval_status",
+    ):
+        assert required in documentation
+
+    assert "resolve_model_approval_gate" in runner
+    assert runner.index("_resolve_approval_gate(") < runner.index(
+        "selected_reader = reader or collect_attribution_records"
+    )
+    assert "missing_gate_rejected" in contract_check
+    assert "revoked_gate_rejected" in contract_check
+
+    stale = (
+        "does **not** yet require an approval during risk-limit execution",
+        "The following increment will require current approval",
+    )
+    for statement in stale:
+        assert statement not in documentation

--- a/tests/unit/test_run_method_aware_portfolio_risk_limits.py
+++ b/tests/unit/test_run_method_aware_portfolio_risk_limits.py
@@ -24,10 +24,16 @@ from src.analytics.portfolio_risk_limit_policies import (
     EffectiveDatedPortfolioRiskLimitPolicy,
 )
 from src.analytics.portfolio_risk_limits import RiskLimitThresholds
-from src.common.exceptions import StorageError
+from src.common.exceptions import StorageError, ValidationError
 from src.orchestration.run_method_aware_portfolio_risk_limits import (
     OUTPUT_DATASET,
     run_method_aware_portfolio_risk_limits,
+)
+from src.warehouse.model_approval_contract import build_model_contract
+from src.warehouse.model_approval_gate import (
+    GATE_MODEL_VERSION,
+    RISK_LIMIT_USE_CASE,
+    ModelApprovalGateEvidence,
 )
 
 
@@ -75,6 +81,32 @@ def _policy() -> MethodAwarePortfolioRiskLimitPolicy:
         method_policy_id="us-tech-ewma",
         base_policy=base,
         method=EWMA_METHOD_CONTRACT,
+    )
+
+
+def _approval_evidence() -> ModelApprovalGateEvidence:
+    policy = _policy()
+    contract = build_model_contract(
+        attribution_model_version=policy.method.attribution_model_version,
+        weighting_method=policy.method.weighting_method,
+        covariance_method=policy.method.covariance_method,
+        correlation_method=policy.method.correlation_method,
+    )
+    return ModelApprovalGateEvidence(
+        gate_evidence_id="model-approval-gate-v1-test",
+        model_version=GATE_MODEL_VERSION,
+        use_case=RISK_LIMIT_USE_CASE,
+        method_policy_fingerprint=policy.fingerprint,
+        contract_fingerprint=contract.contract_fingerprint,
+        attribution_model_version=contract.attribution_model_version,
+        weighting_method=contract.weighting_method,
+        covariance_method=contract.covariance_method,
+        correlation_method=contract.correlation_method,
+        approval_required=True,
+        decision="approved",
+        approval_id="model-approval-v1-0123456789abcdef01234567",
+        approved_at=datetime(2026, 1, 10, 12, tzinfo=timezone.utc),
+        approved_by="model-risk@example.test",
     )
 
 
@@ -131,7 +163,22 @@ def _records() -> list[dict[str, object]]:
     ]
 
 
-def test_runner_publishes_method_bound_evaluations() -> None:
+def _runner_kwargs() -> dict[str, Any]:
+    return {
+        "method_policy_id": "us-tech-ewma",
+        "method_policies_config_path": Path("unused-methods.yaml"),
+        "limits_config_path": Path("unused-limits.yaml"),
+        "portfolio_config_path": Path("unused-portfolios.yaml"),
+        "end_date": date(2026, 1, 20),
+        "storage_config_path": Path("unused-storage.yaml"),
+        "storage_config_loader": lambda _: _storage_config(),
+        "definition_loader": lambda *_: _definition(),
+        "method_policy_loader": lambda **_: _policy(),
+        "approval_gate_resolver": lambda **_: _approval_evidence(),
+    }
+
+
+def test_runner_publishes_method_bound_evaluations_after_approval() -> None:
     writes: list[dict[str, Any]] = []
 
     def writer(
@@ -146,21 +193,17 @@ def test_runner_publishes_method_bound_evaluations() -> None:
         return 1
 
     summary = run_method_aware_portfolio_risk_limits(
-        method_policy_id="us-tech-ewma",
-        method_policies_config_path=Path("unused-methods.yaml"),
-        limits_config_path=Path("unused-limits.yaml"),
-        portfolio_config_path=Path("unused-portfolios.yaml"),
-        end_date=date(2026, 1, 20),
-        storage_config_path=Path("unused-storage.yaml"),
+        **_runner_kwargs(),
         reader=lambda _: _records(),
         writer=writer,
-        storage_config_loader=lambda _: _storage_config(),
-        definition_loader=lambda *_: _definition(),
-        method_policy_loader=lambda **_: _policy(),
     )
 
     assert summary["method_policy"]["method_policy_id"] == "us-tech-ewma"
     assert summary["method_policy"]["covariance_method"] == COVARIANCE_METHOD
+    assert summary["model_approval_gate"]["decision"] == "approved"
+    assert summary["model_approval_gate"]["approval_id"] == (
+        "model-approval-v1-0123456789abcdef01234567"
+    )
     assert summary["curated_output"][OUTPUT_DATASET] == {
         "records_selected": 2,
         "records_written": 2,
@@ -175,17 +218,9 @@ def test_runner_publishes_method_bound_evaluations() -> None:
 
 def test_runner_reports_replay_without_duplicate_publication() -> None:
     summary = run_method_aware_portfolio_risk_limits(
-        method_policy_id="us-tech-ewma",
-        method_policies_config_path=Path("unused-methods.yaml"),
-        limits_config_path=Path("unused-limits.yaml"),
-        portfolio_config_path=Path("unused-portfolios.yaml"),
-        end_date=date(2026, 1, 20),
-        storage_config_path=Path("unused-storage.yaml"),
+        **_runner_kwargs(),
         reader=lambda _: _records(),
         writer=lambda *_args, **_kwargs: 0,
-        storage_config_loader=lambda _: _storage_config(),
-        definition_loader=lambda *_: _definition(),
-        method_policy_loader=lambda **_: _policy(),
     )
 
     assert summary["curated_output"][OUTPUT_DATASET][
@@ -193,38 +228,53 @@ def test_runner_reports_replay_without_duplicate_publication() -> None:
     ] == 2
 
 
+def test_runner_fails_approval_before_attribution_read_or_publication() -> None:
+    reads = 0
+    writes = 0
+
+    def reader(_: Path) -> list[dict[str, object]]:
+        nonlocal reads
+        reads += 1
+        return _records()
+
+    def writer(*_args: Any, **_kwargs: Any) -> int:
+        nonlocal writes
+        writes += 1
+        return 1
+
+    kwargs = _runner_kwargs()
+    kwargs["approval_gate_resolver"] = lambda **_: (_ for _ in ()).throw(
+        ValidationError("current approval missing")
+    )
+    with pytest.raises(ValidationError, match="current approval missing"):
+        run_method_aware_portfolio_risk_limits(
+            **kwargs,
+            reader=reader,
+            writer=writer,
+        )
+
+    assert reads == 0
+    assert writes == 0
+
+
 def test_runner_rejects_invalid_writer_result() -> None:
     with pytest.raises(StorageError, match="invalid result"):
         run_method_aware_portfolio_risk_limits(
-            method_policy_id="us-tech-ewma",
-            method_policies_config_path=Path("unused-methods.yaml"),
-            limits_config_path=Path("unused-limits.yaml"),
-            portfolio_config_path=Path("unused-portfolios.yaml"),
-            end_date=date(2026, 1, 20),
-            storage_config_path=Path("unused-storage.yaml"),
+            **_runner_kwargs(),
             reader=lambda _: _records(),
             writer=lambda *_args, **_kwargs: 2,
-            storage_config_loader=lambda _: _storage_config(),
-            definition_loader=lambda *_: _definition(),
-            method_policy_loader=lambda **_: _policy(),
         )
 
 
 def test_runner_requires_output_dataset() -> None:
     config = _storage_config()
     del config["storage"]["curated"]["datasets"][OUTPUT_DATASET]
+    kwargs = _runner_kwargs()
+    kwargs["storage_config_loader"] = lambda _: config
 
     with pytest.raises(StorageError, match="missing method-aware"):
         run_method_aware_portfolio_risk_limits(
-            method_policy_id="us-tech-ewma",
-            method_policies_config_path=Path("unused-methods.yaml"),
-            limits_config_path=Path("unused-limits.yaml"),
-            portfolio_config_path=Path("unused-portfolios.yaml"),
-            end_date=date(2026, 1, 20),
-            storage_config_path=Path("unused-storage.yaml"),
+            **kwargs,
             reader=lambda _: _records(),
             writer=lambda *_args, **_kwargs: 1,
-            storage_config_loader=lambda _: config,
-            definition_loader=lambda *_: _definition(),
-            method_policy_loader=lambda **_: _policy(),
         )


### PR DESCRIPTION
## Outcome

Enforce the append-only model-approval registry at the method-aware portfolio risk-limit boundary:

```text
method-aware risk-limit policy
  -> complete model contract fingerprint
  -> sample baseline exemption OR current EWMA approval
  -> deterministic gate evidence
  -> attribution read
  -> risk-limit evaluation and publication
```

Primary arc42 block: `orchestration`, with bounded interfaces to method policies, PostgreSQL governance evidence and the existing risk-limit evaluation path.

## Gate policy

Add `src.warehouse.model_approval_gate` with an explicit two-contract policy:

- sample baseline (`portfolio-attribution-v1`, `sample_annualized`, `pearson`):
  - `decision = baseline_exempt`;
  - no PostgreSQL approval query;
  - deterministic gate evidence still records the exact contract and method-policy fingerprint.
- fixed-decay EWMA (`portfolio-attribution-ewma-v1`, `ewma_zero_mean_lambda_0_94_annualized`, `implied_from_ewma_covariance`):
  - query one current row from `risk_platform.current_model_approval_status` using `portfolio-risk-limit-evaluation + model-contract-v1 fingerprint`;
  - continue only when the row is currently `approved`;
  - absent or revoked approval fails closed.

Unknown mixed tuples remain rejected by the shared model-contract builder. Duplicate current grains, invalid statuses and incompatible timestamps fail as storage-contract errors.

## Ordering and side effects

`run_method_aware_portfolio_risk_limits` now resolves the gate after policy and portfolio validation but before:

```text
collect_attribution_records
write_records
```

The focused runner test proves a rejected approval produces zero attribution-reader calls and zero publisher calls.

The CLI adds `--approval-dsn`. Its default precedence is:

```text
MODEL_APPROVAL_POSTGRES_DSN
WAREHOUSE_POSTGRES_DSN
local Docker PostgreSQL DSN
```

The sample baseline does not open this connection.

## Evidence identity

`model-approval-gate-v1-*` binds:

- declared use case;
- method-policy fingerprint;
- model-contract fingerprint;
- decision;
- current approval ID when required.

The credential-free run summary adds `model_approval_gate`, including the gate ID, decision, exact contract, whether approval was required, and approval ID/timestamp/reviewer where applicable. It excludes free-text reasons and fixed-parameter JSON.

Approval is run-level governance evidence. It deliberately does not alter attribution or risk-limit calculation IDs, so reapproval does not manufacture duplicate analytical facts.

## Live PostgreSQL contract

The existing real-engine model-governance probe exercises the full state transition:

1. no approval -> gate rejects;
2. approval -> gate binds the first approval;
3. revocation -> gate rejects the revoked current state;
4. reapproval -> gate binds the new approval and produces a new gate evidence ID;
5. existing retry, conflict, current-status and append-only trigger checks continue to run.

No CI workflow change was needed; the already-reviewed PostgreSQL contract step executes the expanded probe.

## Validation

GitHub Actions run `32636509111` (`ci` run 267) passed on exact head `047d803f0be010e5c50b41ea2b60a8087c2d69d4`:

- Security guardrails: passed.
- Python readiness: passed.
  - locked dependencies resolved;
  - Ruff passed;
  - mypy passed across 82 source files;
  - 666 tests passed in both quality and readiness runs;
  - `pip check` passed;
  - the standard readiness replay passed.
- PostgreSQL contract: passed against PostgreSQL 16.
  - the existing end-to-end warehouse/reconciliation contract passed;
  - absent, approved, revoked and reapproved EWMA gate states passed;
  - append-only mutation rejection and model-approval consistency passed.
- Infrastructure validation: passed without deployment or Terraform apply.

No unresolved review threads or requested changes are present.

## Scope

The branch is eight browser-workflow commits ahead of `main` and zero behind because each bounded file mutation was persisted separately. It changes seven files with 743 additions and 60 deletions. It will be squash-merged as one runtime-governance increment.

No external approval service, authentication integration, policy activation, trade control, provider request, deployment or Terraform apply is included.

## Acceptance boundary

Validated and ready for squash merge as one approval-gated runtime increment.