### PR TITLE
Add verified durable manifest restore

### DIFF
--- a/docs/durable-s3-replication.md
+++ b/docs/durable-s3-replication.md
@@ -2,8 +2,8 @@
 
 ## Outcome
 
-This increment adds a thin orchestration layer over the immutable S3 adapter that
-is already implemented in `src/storage/durable_s3.py`.
+This path adds a thin orchestration layer over the immutable S3 adapter already
+implemented in `src/storage/durable_s3.py`:
 
 ```text
 configured local raw and curated Parquet
@@ -20,8 +20,8 @@ The runner is:
 src/orchestration/replicate_durable_datasets.py
 ```
 
-It does not introduce another S3 client or another object identity. Every object
-write and replay verification delegates to `put_immutable_object`.
+It does not introduce another S3 object identity. Every object write and replay
+verification delegates to `put_immutable_object`.
 
 ## Plan First
 
@@ -98,30 +98,20 @@ The inventory:
 - includes only `*.parquet`;
 - is sorted by durable dataset, relative path and content hash;
 - rejects symbolic-link base paths, dataset paths and files;
-- rejects non-regular files;
-- rejects empty files;
-- rejects objects above the durable store's `max_object_bytes`;
+- rejects non-regular and empty files;
+- rejects objects above the store's `max_object_bytes`;
 - rejects unconfigured dataset selectors;
-- applies an explicit file cap;
-- applies an explicit total-byte cap; and
+- applies explicit file and total-byte caps; and
 - verifies that a file's size is unchanged while it is read.
 
 The requested file cap cannot exceed either the hard 10,000-file bound or the
-selected durable store's `max_list_objects`. The hard total-byte bound is 100 GB;
-the default request bound is 1 GB.
+selected store's `max_list_objects`. The hard total-byte bound is 100 GB; the
+default request bound is 1 GB.
 
 ## Immutable Publication
 
-For each planned file, execution calls the existing adapter with:
-
-```text
-dataset
-payload
-extension
-content type
-configured encryption controls
-```
-
+For each planned file, execution calls the existing adapter with its durable
+dataset, payload, extension, content type and configured encryption controls.
 The adapter owns:
 
 - the SHA-256 object identity;
@@ -148,7 +138,8 @@ present, the runner publishes one canonical JSON manifest under:
 replication-manifests
 ```
 
-The manifest contract is `durable-dataset-replication-v1` and contains only stable evidence:
+The manifest contract is `durable-dataset-replication-v1` and contains only
+stable evidence:
 
 - contract version;
 - store ID;
@@ -161,12 +152,15 @@ The manifest contract is `durable-dataset-replication-v1` and contains only stab
 
 It contains no run timestamp, random run ID, bucket, region, KMS key or
 credential. The manifest ID is a SHA-256-derived identity over its ordered
-entries. Repeating the same local state therefore converges on the same manifest
-object. A changed file, selected dataset or path creates a distinguishable
-manifest.
+entries. Repeating the same local state converges on the same manifest object. A
+changed file, selection or path creates a distinguishable manifest.
 
 The manifest is published last. Its presence means every referenced object
 completed the immutable adapter contract for that execution.
+
+The completed result JSON is also the explicit input to the verified restore
+path documented in `docs/durable-s3-restore.md`. Restore reconstructs this exact
+manifest identity; it does not list a prefix or select a mutable latest object.
 
 ## Failure And Replay Semantics
 
@@ -184,17 +178,18 @@ completed the immutable adapter contract for that execution.
 
 ## Boundary
 
-This increment does not:
+Replication does not:
 
 - create an S3 bucket, KMS key, IAM role or credential;
 - activate the bundled store;
 - upload anything in CI;
 - preserve a mutable partition hierarchy in object keys;
 - delete or overwrite remote objects;
-- restore objects to local storage;
 - schedule replication;
 - deploy infrastructure; or
 - run `terraform apply`.
 
 The source partition path is retained in the immutable manifest. Object keys stay
-content-addressed rather than becoming mutable copies of local paths.
+content-addressed rather than becoming mutable copies of local paths. Verified
+local restore is a separate explicit read workflow, not an implicit side effect
+of replication.

--- a/docs/durable-s3-restore.md
+++ b/docs/durable-s3-restore.md
@@ -1,0 +1,268 @@
+# Verified Durable Dataset Restore
+
+## Outcome
+
+This path restores one exact immutable replication manifest to the configured
+local raw and curated dataset layout:
+
+```text
+completed durable replication result
+  -> strict local summary validation
+  -> exact canonical manifest identity
+  -> plan-only local target inventory
+  -> explicit dual-gated S3 reads
+  -> remote manifest and object metadata verification
+  -> bounded payload digest verification
+  -> atomic no-overwrite local publication
+  -> deterministic replay evidence
+```
+
+The runner is:
+
+```text
+src/orchestration/restore_durable_datasets.py
+```
+
+It consumes the JSON result produced by
+`src/orchestration/replicate_durable_datasets.py`. It never lists an S3 prefix
+and never chooses a mutable "latest" manifest. The supplied result must identify
+one exact `durable-dataset-replication-v1` manifest.
+
+## Plan First
+
+The default command performs only local validation and inventory:
+
+```bash
+.venv/bin/python -m src.orchestration.restore_durable_datasets \
+  --replication-summary .demo/durable-replication-result.json \
+  --store-id primary-s3 \
+  --summary-json .demo/durable-restore-plan.json
+```
+
+Planning:
+
+- reads a strict bounded local JSON file;
+- loads durable and local storage configuration;
+- reconstructs the canonical replication manifest;
+- verifies its manifest ID and immutable object key;
+- maps every manifest entry to one configured local dataset root;
+- classifies each target as `missing`, `already_present`, or `conflict`;
+- calculates a deterministic `durable-restore-*` plan identity; and
+- reports whether the supplied replication result proves completed immutable
+  publication.
+
+Planning does **not**:
+
+- read bucket or region environment values;
+- create a boto3 client;
+- call S3;
+- create local directories; or
+- modify a local file.
+
+The summary contains store, manifest, dataset, relative-path, object-key, size and
+SHA-256 evidence. It excludes bucket, region, KMS and credential values.
+
+## Exact Manifest Contract
+
+Every artifact entry must contain exactly:
+
+```text
+content_length
+dataset
+object_key
+relative_path
+remote_dataset
+sha256
+```
+
+The runner reconstructs:
+
+```json
+{
+  "contract": "durable-dataset-replication-v1",
+  "entries": [],
+  "store_id": "primary-s3"
+}
+```
+
+It then derives the manifest ID from canonical JSON, adds that ID to the manifest
+document, and derives the content-addressed manifest object key with the existing
+immutable S3 adapter. The locally supplied `manifest_id`,
+`manifest_object_key`, artifact count, dataset count and total bytes must all
+match the reconstruction.
+
+Execution also requires the replication result to prove:
+
+- `replication.performed = true`;
+- one result for every ordered artifact;
+- every artifact result is `written` or `already_present` with matching identity;
+- written plus already-present counts reconcile; and
+- the published manifest result matches the reconstructed key, digest, size and
+  identity.
+
+A plan-only replication summary may be inspected, but it cannot authorize object
+reads.
+
+## Local Target Mapping
+
+Targets are derived only from `config/storage.yaml`.
+
+A manifest entry for:
+
+```text
+dataset = market_events
+remote_dataset = raw-market_events
+relative_path = year=2026/month=08/batch.parquet
+```
+
+maps beneath the configured raw `market_events` root.
+
+A manifest entry for:
+
+```text
+dataset = daily_returns
+remote_dataset = curated-daily_returns
+relative_path = year=2026/batch.parquet
+```
+
+maps beneath the configured curated `daily_returns` root.
+
+The runner rejects:
+
+- unconfigured dataset/remote-dataset pairs;
+- absolute paths;
+- `.` or `..` segments;
+- backslashes, doubled separators and control characters;
+- non-Parquet targets;
+- duplicate object keys or local targets;
+- symbolic-link configured bases, dataset roots, parent directories or targets;
+- non-directory parents; and
+- non-regular existing targets.
+
+Existing regular files are read only within the declared object-size bound. A
+matching size and SHA-256 is `already_present`; any mismatch is `conflict`.
+
+## Explicit Read Gate
+
+S3 reads require both:
+
+1. `enabled: true` for the selected store in
+   `config/durable_storage.yaml`; and
+2. the explicit `--enable-durable-read` command flag.
+
+For example:
+
+```bash
+export RISK_PLATFORM_DURABLE_BUCKET='configured-outside-git'
+export AWS_REGION='eu-west-2'
+
+.venv/bin/python -m src.orchestration.restore_durable_datasets \
+  --replication-summary .demo/durable-replication-result.json \
+  --store-id primary-s3 \
+  --max-total-bytes 1000000000 \
+  --enable-durable-read \
+  --summary-json .demo/durable-restore-result.json
+```
+
+The bundled store remains disabled. Missing environment values, local conflicts
+and incomplete replication evidence all fail before client creation.
+
+## Remote Verification
+
+Execution resolves only the configured bucket and region and creates one S3
+client. It performs no list operation.
+
+The exact manifest object is verified first with `head_object`:
+
+- metadata `storage-contract` must be
+  `immutable-content-addressed-v1`;
+- metadata `sha256` must equal the reconstructed manifest digest; and
+- `ContentLength` must equal the canonical manifest byte length.
+
+The body is then read with an expected-length-plus-one bound. Its exact length,
+SHA-256, canonical bytes and parsed document must match the locally reconstructed
+manifest.
+
+Before any artifact body is accepted, every declared artifact receives the same
+metadata, storage-contract and content-length verification. Only exact declared
+keys are used.
+
+A missing local artifact is downloaded with an expected-length-plus-one bound.
+The payload length, SHA-256 and immutable object key are recomputed before local
+publication. An already-present local artifact still receives remote metadata
+verification but does not require another artifact-body read.
+
+## Atomic No-Overwrite Publication
+
+A verified missing payload is written to a temporary regular file in the final
+directory, flushed and `fsync`ed. The runner then creates the final path through
+an atomic same-directory hard link.
+
+This provides no-overwrite behavior:
+
+- a missing target becomes `restored`;
+- a concurrently created matching target converges to `already_present`; and
+- a concurrently created conflicting target fails without replacement.
+
+The temporary file is always removed. The final file is reread and verified
+before the result is accepted.
+
+A failure after some files are restored is replay-safe: immutable matching files
+become `already_present` on the next execution, while remaining missing files are
+restored.
+
+## Bounds
+
+The restore applies all of these bounds before S3 client creation:
+
+- strict replication-summary file cap: 16 MB;
+- canonical manifest cap: 10 MB;
+- artifact count no greater than the smaller of 10,000 and the selected store's
+  `max_list_objects`;
+- every object no greater than `max_object_bytes`;
+- hard aggregate restore cap: 100 GB; and
+- default request aggregate cap: 1 GB.
+
+The artifact count does not authorize S3 listing. It bounds the exact manifest
+entries and exact key reads.
+
+## Evidence And Replay
+
+`restore_plan_id` binds:
+
+```text
+restore contract
+store ID
+manifest ID
+ordered dataset / relative path / SHA-256 identities
+```
+
+It is stable across machines and local states. Local status and execution results
+remain explicit but do not change the selected manifest identity.
+
+An execution result reports:
+
+- manifest verification;
+- exact remote object count verified;
+- artifact results by dataset and relative path;
+- restored count; and
+- already-present count.
+
+No bucket, region, KMS key or credential value is returned.
+
+## Boundary
+
+This increment does not:
+
+- discover manifests by prefix;
+- select a mutable latest object;
+- restore an unconfirmed plan-only replication;
+- overwrite or delete a local file;
+- write, delete or mutate S3 objects;
+- create a bucket, KMS key, role or credential;
+- schedule restore;
+- deploy infrastructure; or
+- run `terraform apply`.
+
+It restores exact immutable bytes. It does not reinterpret or recalculate the
+Parquet records.

--- a/docs/durable-s3-restore.md
+++ b/docs/durable-s3-restore.md
@@ -23,6 +23,9 @@ The runner is:
 src/orchestration/restore_durable_datasets.py
 ```
 
+The deterministic restore evidence contract is
+`durable-dataset-restore-v1`.
+
 It consumes the JSON result produced by
 `src/orchestration/replicate_durable_datasets.py`. It never lists an S3 prefix
 and never chooses a mutable "latest" manifest. The supplied result must identify

--- a/src/orchestration/restore_durable_datasets.py
+++ b/src/orchestration/restore_durable_datasets.py
@@ -1,0 +1,1039 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+import tempfile
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass, replace
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+from ..common.exceptions import StorageError, ValidationError
+from ..storage.durable_s3 import (
+    DurableS3Config,
+    canonical_json_payload,
+    content_sha256,
+    create_boto3_s3_client,
+    immutable_object_key,
+    load_durable_s3_config,
+)
+from ..storage.storage_config import load_storage_config, validate_storage_config
+from .replicate_durable_datasets import MANIFEST_DATASET
+
+RESTORE_CONTRACT = "durable-dataset-restore-v1"
+MANIFEST_CONTRACT = "durable-dataset-replication-v1"
+IMMUTABLE_STORAGE_CONTRACT = "immutable-content-addressed-v1"
+MAX_RESTORE_FILES = 10_000
+MAX_RESTORE_BYTES = 100_000_000_000
+DEFAULT_MAX_RESTORE_BYTES = 1_000_000_000
+MAX_REPLICATION_SUMMARY_BYTES = 16_000_000
+MAX_MANIFEST_BYTES = 10_000_000
+SHA256_PATTERN = re.compile(r"^[0-9a-f]{64}$")
+MANIFEST_ID_PATTERN = re.compile(r"^durable-replication-[0-9a-f]{24}$")
+
+ConfigLoader = Callable[[Path, str], DurableS3Config]
+StorageConfigLoader = Callable[[Path], dict[str, Any]]
+SummaryLoader = Callable[[Path], Mapping[str, Any]]
+ClientFactory = Callable[..., Any]
+
+
+class _DuplicateKeyError(ValueError):
+    pass
+
+
+@dataclass(frozen=True, slots=True)
+class DurableRestoreArtifact:
+    dataset: str
+    remote_dataset: str
+    relative_path: str
+    content_length: int
+    sha256: str
+    object_key: str
+    target_root: Path
+    target_path: Path
+    local_status: str
+
+
+@dataclass(frozen=True, slots=True)
+class DurableRestorePlan:
+    store_id: str
+    manifest_id: str
+    manifest_object_key: str
+    manifest_document: Mapping[str, Any]
+    manifest_payload: bytes
+    restore_plan_id: str
+    artifacts: tuple[DurableRestoreArtifact, ...]
+    total_bytes: int
+    replication_execution_confirmed: bool
+
+
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise _DuplicateKeyError
+        result[key] = value
+    return result
+
+
+def _reject_nonstandard_constant(_value: str) -> None:
+    raise ValueError
+
+
+def _required_text(value: Any, label: str, maximum: int = 1024) -> str:
+    if not isinstance(value, str):
+        raise ValidationError(f"{label} must be text")
+    parsed = value.strip()
+    if not parsed or len(parsed) > maximum:
+        raise ValidationError(
+            f"{label} must contain between 1 and {maximum} characters"
+        )
+    if any(ord(character) < 32 or ord(character) == 127 for character in parsed):
+        raise ValidationError(f"{label} must not contain control characters")
+    return parsed
+
+
+def _bounded_integer(value: Any, label: str, maximum: int) -> int:
+    if type(value) is not int or not 1 <= value <= maximum:
+        raise ValidationError(
+            f"{label} must be an integer between 1 and {maximum}"
+        )
+    return value
+
+
+def _sha256(value: Any, label: str) -> str:
+    parsed = _required_text(value, label, 64)
+    if SHA256_PATTERN.fullmatch(parsed) is None:
+        raise ValidationError(f"{label} must be a lowercase SHA-256 digest")
+    return parsed
+
+
+def _safe_segment(value: Any, label: str) -> str:
+    parsed = _required_text(value, label, 256)
+    if (
+        parsed in {".", ".."}
+        or "/" in parsed
+        or "\\" in parsed
+        or any(ord(character) < 32 for character in parsed)
+    ):
+        raise ValidationError(f"{label} must be one safe path segment")
+    return parsed
+
+
+def _safe_relative_path(value: Any) -> tuple[str, tuple[str, ...]]:
+    parsed = _required_text(value, "relative_path", 2048)
+    if parsed.startswith("/") or "\\" in parsed or "//" in parsed:
+        raise ValidationError("relative_path must be a safe relative POSIX path")
+    pure = PurePosixPath(parsed)
+    parts = pure.parts
+    if (
+        not parts
+        or len(parts) > 64
+        or any(part in {"", ".", ".."} for part in parts)
+        or pure.is_absolute()
+        or pure.as_posix() != parsed
+    ):
+        raise ValidationError("relative_path must be a safe relative POSIX path")
+    if not parts[-1].endswith(".parquet"):
+        raise ValidationError("restore artifacts must use the parquet extension")
+    return parsed, tuple(parts)
+
+
+def _load_replication_summary(path: Path) -> Mapping[str, Any]:
+    try:
+        if path.is_symlink() or not path.is_file():
+            raise StorageError(
+                "replication summary must be a regular non-symlink file"
+            )
+        if path.stat().st_size > MAX_REPLICATION_SUMMARY_BYTES:
+            raise ValidationError("replication summary exceeds the size limit")
+        payload = path.read_bytes()
+    except (ValidationError, StorageError):
+        raise
+    except OSError:
+        raise StorageError("replication summary could not be read") from None
+    if len(payload) > MAX_REPLICATION_SUMMARY_BYTES:
+        raise ValidationError("replication summary exceeds the size limit")
+    try:
+        parsed = json.loads(
+            payload.decode("utf-8"),
+            object_pairs_hook=_reject_duplicate_keys,
+            parse_constant=_reject_nonstandard_constant,
+        )
+    except (
+        UnicodeError,
+        json.JSONDecodeError,
+        _DuplicateKeyError,
+        TypeError,
+        ValueError,
+    ):
+        raise ValidationError("replication summary is not strict JSON") from None
+    if not isinstance(parsed, Mapping):
+        raise ValidationError("replication summary must be a JSON object")
+    return parsed
+
+
+def _environment_value(environment: Mapping[str, str], name: str) -> str:
+    value = environment.get(name)
+    if value is None or not value.strip():
+        raise ValidationError(
+            f"required durable-storage environment variable '{name}' is not set"
+        )
+    return value.strip()
+
+
+def _configured_target_roots(
+    storage_config: dict[str, Any],
+) -> Mapping[tuple[str, str], Path]:
+    validate_storage_config(storage_config)
+    storage = storage_config["storage"]
+    raw = storage["raw"]
+    curated = storage["curated"]
+
+    raw_dataset = _safe_segment(raw.get("dataset"), "raw dataset")
+    roots: dict[tuple[str, str], Path] = {
+        (
+            raw_dataset,
+            f"raw-{raw_dataset}",
+        ): Path(raw["base_path"]) / raw_dataset
+    }
+    datasets = curated.get("datasets")
+    if not isinstance(datasets, Mapping):
+        raise StorageError("curated datasets configuration is invalid")
+    for raw_key in sorted(datasets):
+        dataset_key = _safe_segment(raw_key, "curated dataset key")
+        dataset_name = _safe_segment(
+            datasets[raw_key],
+            f"curated dataset path for {dataset_key}",
+        )
+        pair = (dataset_key, f"curated-{dataset_key}")
+        if pair in roots:
+            raise StorageError("storage configuration contains duplicate datasets")
+        roots[pair] = Path(curated["base_path"]) / dataset_name
+    return roots
+
+
+def _assert_safe_local_target(root: Path, target: Path) -> None:
+    try:
+        target.relative_to(root)
+    except ValueError:
+        raise StorageError("restore target escaped its configured dataset") from None
+
+    base = root.parent
+    for candidate in (base, root):
+        if candidate.is_symlink():
+            raise StorageError("restore target path must not contain symbolic links")
+        if candidate.exists() and not candidate.is_dir():
+            raise StorageError("restore dataset path must be a directory")
+
+    relative = target.relative_to(root)
+    cursor = root
+    for segment in relative.parts[:-1]:
+        cursor = cursor / segment
+        if cursor.is_symlink():
+            raise StorageError("restore target path must not contain symbolic links")
+        if cursor.exists() and not cursor.is_dir():
+            raise StorageError("restore target parent must be a directory")
+    if target.is_symlink():
+        raise StorageError("restore target must not be a symbolic link")
+    if target.exists() and not target.is_file():
+        raise StorageError("restore target must be a regular file")
+
+
+def _read_local_file(path: Path, expected_size: int) -> bytes:
+    try:
+        size = path.stat().st_size
+        if size != expected_size:
+            raise ValidationError("local restore target has conflicting content")
+        payload = path.read_bytes()
+    except ValidationError:
+        raise
+    except OSError:
+        raise StorageError("local restore target could not be read") from None
+    if len(payload) != expected_size:
+        raise StorageError("local restore target changed while it was read")
+    return payload
+
+
+def _local_status(
+    *,
+    target_root: Path,
+    target_path: Path,
+    expected_size: int,
+    expected_sha256: str,
+) -> str:
+    _assert_safe_local_target(target_root, target_path)
+    if not target_path.exists():
+        return "missing"
+    try:
+        payload = _read_local_file(target_path, expected_size)
+    except ValidationError:
+        return "conflict"
+    if content_sha256(payload) != expected_sha256:
+        return "conflict"
+    return "already_present"
+
+
+def _expected_artifact_key(
+    config: DurableS3Config,
+    *,
+    remote_dataset: str,
+    digest: str,
+) -> str:
+    dataset = _safe_segment(remote_dataset, "remote_dataset")
+    return (
+        f"{config.prefix}/{dataset}/sha256={digest[:2]}/"
+        f"{digest}.parquet"
+    )
+
+
+def _artifact_from_entry(
+    entry: Mapping[str, Any],
+    *,
+    config: DurableS3Config,
+    roots: Mapping[tuple[str, str], Path],
+) -> DurableRestoreArtifact:
+    expected_keys = {
+        "content_length",
+        "dataset",
+        "object_key",
+        "relative_path",
+        "remote_dataset",
+        "sha256",
+    }
+    if set(entry) != expected_keys:
+        raise ValidationError("replication manifest artifact fields are not exact")
+
+    dataset = _safe_segment(entry.get("dataset"), "dataset")
+    remote_dataset = _safe_segment(
+        entry.get("remote_dataset"),
+        "remote_dataset",
+    )
+    relative_path, parts = _safe_relative_path(entry.get("relative_path"))
+    content_length = _bounded_integer(
+        entry.get("content_length"),
+        "content_length",
+        config.max_object_bytes,
+    )
+    digest = _sha256(entry.get("sha256"), "sha256")
+    object_key = _required_text(entry.get("object_key"), "object_key", 2048)
+    if object_key != _expected_artifact_key(
+        config,
+        remote_dataset=remote_dataset,
+        digest=digest,
+    ):
+        raise ValidationError(
+            "artifact object key does not match its immutable content identity"
+        )
+
+    target_root = roots.get((dataset, remote_dataset))
+    if target_root is None:
+        raise ValidationError(
+            "replication manifest references an unconfigured local dataset"
+        )
+    target_path = target_root.joinpath(*parts)
+    status = _local_status(
+        target_root=target_root,
+        target_path=target_path,
+        expected_size=content_length,
+        expected_sha256=digest,
+    )
+    return DurableRestoreArtifact(
+        dataset=dataset,
+        remote_dataset=remote_dataset,
+        relative_path=relative_path,
+        content_length=content_length,
+        sha256=digest,
+        object_key=object_key,
+        target_root=target_root,
+        target_path=target_path,
+        local_status=status,
+    )
+
+
+def _manifest_id(identity: Mapping[str, Any]) -> str:
+    return (
+        "durable-replication-"
+        + content_sha256(canonical_json_payload(identity))[:24]
+    )
+
+
+def _replication_execution_confirmed(
+    summary: Mapping[str, Any],
+    *,
+    artifacts: Sequence[DurableRestoreArtifact],
+    manifest_id: str,
+    manifest_key: str,
+    manifest_payload: bytes,
+) -> bool:
+    replication = summary.get("replication")
+    if not isinstance(replication, Mapping) or replication.get("performed") is not True:
+        return False
+
+    results = replication.get("artifact_results")
+    if not isinstance(results, list) or len(results) != len(artifacts):
+        return False
+    expected_results = [
+        (
+            artifact.dataset,
+            artifact.remote_dataset,
+            artifact.relative_path,
+            artifact.object_key,
+            artifact.sha256,
+            artifact.content_length,
+        )
+        for artifact in artifacts
+    ]
+    actual_results: list[tuple[Any, ...]] = []
+    for result in results:
+        if not isinstance(result, Mapping):
+            return False
+        if result.get("status") not in {"written", "already_present"}:
+            return False
+        actual_results.append(
+            (
+                result.get("dataset"),
+                result.get("remote_dataset"),
+                result.get("relative_path"),
+                result.get("key"),
+                result.get("sha256"),
+                result.get("content_length"),
+            )
+        )
+    if actual_results != expected_results:
+        return False
+
+    written = replication.get("artifacts_written")
+    already = replication.get("artifacts_already_present")
+    if (
+        type(written) is not int
+        or type(already) is not int
+        or written < 0
+        or already < 0
+        or written + already != len(artifacts)
+    ):
+        return False
+
+    manifest = replication.get("manifest")
+    if not isinstance(manifest, Mapping):
+        return False
+    return (
+        manifest.get("manifest_id") == manifest_id
+        and manifest.get("key") == manifest_key
+        and manifest.get("sha256") == content_sha256(manifest_payload)
+        and manifest.get("content_length") == len(manifest_payload)
+        and manifest.get("status") in {"written", "already_present"}
+    )
+
+
+def _build_restore_plan(
+    *,
+    summary: Mapping[str, Any],
+    config: DurableS3Config,
+    storage_config: dict[str, Any],
+    max_total_bytes: int,
+) -> DurableRestorePlan:
+    store_id = _required_text(summary.get("store_id"), "store_id", 128)
+    if store_id != config.store_id:
+        raise ValidationError("replication summary store_id does not match the request")
+
+    plan = summary.get("plan")
+    if not isinstance(plan, Mapping):
+        raise ValidationError("replication summary is missing the plan")
+    raw_artifacts = plan.get("artifacts")
+    if not isinstance(raw_artifacts, list):
+        raise ValidationError("replication plan artifacts must be a JSON array")
+    maximum_files = min(MAX_RESTORE_FILES, config.max_list_objects)
+    if len(raw_artifacts) > maximum_files:
+        raise ValidationError("restore plan exceeds the configured artifact limit")
+
+    roots = _configured_target_roots(storage_config)
+    artifacts: list[DurableRestoreArtifact] = []
+    total_bytes = 0
+    seen_targets: set[Path] = set()
+    seen_keys: set[str] = set()
+    for raw_entry in raw_artifacts:
+        if not isinstance(raw_entry, Mapping):
+            raise ValidationError("replication plan contains an invalid artifact")
+        artifact = _artifact_from_entry(
+            raw_entry,
+            config=config,
+            roots=roots,
+        )
+        total_bytes += artifact.content_length
+        if total_bytes > max_total_bytes:
+            raise ValidationError("restore plan exceeds max_total_bytes")
+        if artifact.target_path in seen_targets:
+            raise ValidationError("restore plan contains duplicate local targets")
+        if artifact.object_key in seen_keys:
+            raise ValidationError("restore plan contains duplicate object keys")
+        seen_targets.add(artifact.target_path)
+        seen_keys.add(artifact.object_key)
+        artifacts.append(artifact)
+
+    ordered = sorted(
+        artifacts,
+        key=lambda artifact: (
+            artifact.remote_dataset,
+            artifact.relative_path,
+            artifact.sha256,
+        ),
+    )
+    if artifacts != ordered:
+        raise ValidationError("replication plan artifacts are not deterministically ordered")
+
+    if plan.get("artifact_count") != len(artifacts):
+        raise ValidationError("replication plan artifact_count is inconsistent")
+    if plan.get("dataset_count") != len(
+        {artifact.remote_dataset for artifact in artifacts}
+    ):
+        raise ValidationError("replication plan dataset_count is inconsistent")
+    if plan.get("total_bytes") != total_bytes:
+        raise ValidationError("replication plan total_bytes is inconsistent")
+
+    entries = [
+        {
+            "content_length": artifact.content_length,
+            "dataset": artifact.dataset,
+            "object_key": artifact.object_key,
+            "relative_path": artifact.relative_path,
+            "remote_dataset": artifact.remote_dataset,
+            "sha256": artifact.sha256,
+        }
+        for artifact in artifacts
+    ]
+    identity: dict[str, Any] = {
+        "contract": MANIFEST_CONTRACT,
+        "entries": entries,
+        "store_id": store_id,
+    }
+    manifest_id = _manifest_id(identity)
+    if MANIFEST_ID_PATTERN.fullmatch(manifest_id) is None:
+        raise StorageError("computed replication manifest ID is invalid")
+    manifest_document: dict[str, Any] = {
+        **identity,
+        "manifest_id": manifest_id,
+    }
+    manifest_payload = canonical_json_payload(manifest_document)
+    if len(manifest_payload) > min(MAX_MANIFEST_BYTES, config.max_object_bytes):
+        raise ValidationError("replication manifest exceeds the restore size limit")
+    manifest_key = immutable_object_key(
+        config,
+        dataset=MANIFEST_DATASET,
+        payload=manifest_payload,
+        extension="json",
+    )
+    if plan.get("manifest_id") != manifest_id:
+        raise ValidationError("replication plan manifest_id is inconsistent")
+    if plan.get("manifest_object_key") != manifest_key:
+        raise ValidationError("replication plan manifest object key is inconsistent")
+
+    restore_identity = {
+        "artifacts": [
+            {
+                "dataset": artifact.dataset,
+                "relative_path": artifact.relative_path,
+                "sha256": artifact.sha256,
+            }
+            for artifact in artifacts
+        ],
+        "contract": RESTORE_CONTRACT,
+        "manifest_id": manifest_id,
+        "store_id": store_id,
+    }
+    restore_plan_id = (
+        "durable-restore-"
+        + content_sha256(canonical_json_payload(restore_identity))[:24]
+    )
+    confirmed = _replication_execution_confirmed(
+        summary,
+        artifacts=artifacts,
+        manifest_id=manifest_id,
+        manifest_key=manifest_key,
+        manifest_payload=manifest_payload,
+    )
+    return DurableRestorePlan(
+        store_id=store_id,
+        manifest_id=manifest_id,
+        manifest_object_key=manifest_key,
+        manifest_document=manifest_document,
+        manifest_payload=manifest_payload,
+        restore_plan_id=restore_plan_id,
+        artifacts=tuple(artifacts),
+        total_bytes=total_bytes,
+        replication_execution_confirmed=confirmed,
+    )
+
+
+def _head_verified_object(
+    client: Any,
+    *,
+    bucket: str,
+    key: str,
+    expected_sha256: str,
+    expected_length: int,
+) -> None:
+    try:
+        response = client.head_object(Bucket=bucket, Key=key)
+    except Exception:
+        raise StorageError("Unable to verify a durable restore object") from None
+    if not isinstance(response, Mapping):
+        raise StorageError("Durable restore object metadata is invalid")
+    metadata = response.get("Metadata")
+    if not isinstance(metadata, Mapping):
+        raise StorageError("Durable restore object metadata is missing")
+    if metadata.get("sha256") != expected_sha256:
+        raise StorageError("Durable restore object digest metadata does not match")
+    if metadata.get("storage-contract") != IMMUTABLE_STORAGE_CONTRACT:
+        raise StorageError("Durable restore object storage contract does not match")
+    if response.get("ContentLength") != expected_length:
+        raise StorageError("Durable restore object content length does not match")
+
+
+def _read_verified_object(
+    client: Any,
+    *,
+    bucket: str,
+    key: str,
+    expected_sha256: str,
+    expected_length: int,
+) -> bytes:
+    try:
+        response = client.get_object(Bucket=bucket, Key=key)
+    except Exception:
+        raise StorageError("Durable restore object read failed") from None
+    if not isinstance(response, Mapping):
+        raise StorageError("Durable restore object response is invalid")
+    response_length = response.get("ContentLength")
+    if response_length is not None and response_length != expected_length:
+        raise StorageError("Durable restore object read length does not match")
+    body = response.get("Body")
+    if body is None or not hasattr(body, "read"):
+        raise StorageError("Durable restore object body is invalid")
+    try:
+        payload = body.read(expected_length + 1)
+    except Exception:
+        raise StorageError("Durable restore object body could not be read") from None
+    finally:
+        close = getattr(body, "close", None)
+        if callable(close):
+            try:
+                close()
+            except Exception:
+                pass
+    if not isinstance(payload, bytes):
+        raise StorageError("Durable restore object body did not return bytes")
+    if len(payload) != expected_length:
+        raise StorageError("Durable restore object payload length does not match")
+    if content_sha256(payload) != expected_sha256:
+        raise StorageError("Durable restore object payload digest does not match")
+    return payload
+
+
+def _atomic_publish_no_overwrite(
+    artifact: DurableRestoreArtifact,
+    payload: bytes,
+) -> str:
+    current = _local_status(
+        target_root=artifact.target_root,
+        target_path=artifact.target_path,
+        expected_size=artifact.content_length,
+        expected_sha256=artifact.sha256,
+    )
+    if current == "already_present":
+        return current
+    if current == "conflict":
+        raise ValidationError("local restore target contains conflicting content")
+
+    try:
+        artifact.target_path.parent.mkdir(parents=True, exist_ok=True)
+    except OSError:
+        raise StorageError("restore target directory could not be created") from None
+    _assert_safe_local_target(artifact.target_root, artifact.target_path)
+
+    descriptor: int | None = None
+    temporary_path: Path | None = None
+    try:
+        descriptor, raw_temporary = tempfile.mkstemp(
+            prefix=".durable-restore-",
+            suffix=".tmp",
+            dir=artifact.target_path.parent,
+        )
+        temporary_path = Path(raw_temporary)
+        with os.fdopen(descriptor, "wb") as handle:
+            descriptor = None
+            handle.write(payload)
+            handle.flush()
+            os.fsync(handle.fileno())
+        if temporary_path.stat().st_size != artifact.content_length:
+            raise StorageError("temporary restore file length is inconsistent")
+        try:
+            os.link(temporary_path, artifact.target_path)
+        except FileExistsError:
+            raced = _local_status(
+                target_root=artifact.target_root,
+                target_path=artifact.target_path,
+                expected_size=artifact.content_length,
+                expected_sha256=artifact.sha256,
+            )
+            if raced == "already_present":
+                return raced
+            raise ValidationError(
+                "local restore target appeared with conflicting content"
+            ) from None
+        except OSError:
+            raise StorageError("restore target could not be published atomically") from None
+    finally:
+        if descriptor is not None:
+            try:
+                os.close(descriptor)
+            except OSError:
+                pass
+        if temporary_path is not None:
+            try:
+                temporary_path.unlink(missing_ok=True)
+            except OSError:
+                pass
+
+    verified = _local_status(
+        target_root=artifact.target_root,
+        target_path=artifact.target_path,
+        expected_size=artifact.content_length,
+        expected_sha256=artifact.sha256,
+    )
+    if verified != "already_present":
+        raise StorageError("published restore target did not verify")
+    return "restored"
+
+
+def _artifact_evidence(artifact: DurableRestoreArtifact) -> dict[str, Any]:
+    return {
+        "content_length": artifact.content_length,
+        "dataset": artifact.dataset,
+        "local_status": artifact.local_status,
+        "object_key": artifact.object_key,
+        "relative_path": artifact.relative_path,
+        "remote_dataset": artifact.remote_dataset,
+        "sha256": artifact.sha256,
+    }
+
+
+def _base_summary(
+    plan: DurableRestorePlan,
+    *,
+    config: DurableS3Config,
+    enable_durable_read: bool,
+) -> dict[str, Any]:
+    statuses = {
+        status: sum(
+            artifact.local_status == status for artifact in plan.artifacts
+        )
+        for status in ("missing", "already_present", "conflict")
+    }
+    return {
+        "contract": RESTORE_CONTRACT,
+        "credentials_recorded": False,
+        "explicit_enable_flag": enable_durable_read,
+        "manifest_id": plan.manifest_id,
+        "plan": {
+            "artifact_count": len(plan.artifacts),
+            "artifacts": [
+                _artifact_evidence(artifact) for artifact in plan.artifacts
+            ],
+            "local_status_counts": statuses,
+            "manifest_content_length": len(plan.manifest_payload),
+            "manifest_object_key": plan.manifest_object_key,
+            "remote_objects_to_verify": len(plan.artifacts) + 1,
+            "replication_execution_confirmed": (
+                plan.replication_execution_confirmed
+            ),
+            "total_bytes": plan.total_bytes,
+        },
+        "restore_plan_id": plan.restore_plan_id,
+        "store_enabled": config.enabled,
+        "store_id": plan.store_id,
+    }
+
+
+def restore_durable_replication(
+    *,
+    replication_summary_path: Path,
+    store_id: str,
+    storage_config_path: Path,
+    durable_config_path: Path,
+    max_total_bytes: int = DEFAULT_MAX_RESTORE_BYTES,
+    enable_durable_read: bool = False,
+    environment: Mapping[str, str] | None = None,
+    config_loader: ConfigLoader | None = None,
+    storage_config_loader: StorageConfigLoader | None = None,
+    summary_loader: SummaryLoader | None = None,
+    client_factory: ClientFactory | None = None,
+) -> dict[str, Any]:
+    max_total_bytes = _bounded_integer(
+        max_total_bytes,
+        "max_total_bytes",
+        MAX_RESTORE_BYTES,
+    )
+    selected_config_loader = config_loader or load_durable_s3_config
+    try:
+        config = selected_config_loader(durable_config_path, store_id)
+    except ValidationError:
+        raise
+    except Exception:
+        raise ValidationError("durable-storage configuration is invalid") from None
+
+    selected_storage_loader = storage_config_loader or load_storage_config
+    try:
+        storage_config = selected_storage_loader(storage_config_path)
+    except Exception:
+        raise StorageError("local storage configuration is invalid") from None
+    if not isinstance(storage_config, dict):
+        raise StorageError("local storage configuration is invalid")
+
+    selected_summary_loader = summary_loader or _load_replication_summary
+    try:
+        summary = selected_summary_loader(replication_summary_path)
+    except (ValidationError, StorageError):
+        raise
+    except Exception:
+        raise ValidationError("replication summary is invalid") from None
+    if not isinstance(summary, Mapping):
+        raise ValidationError("replication summary must be a mapping")
+
+    plan = _build_restore_plan(
+        summary=summary,
+        config=config,
+        storage_config=storage_config,
+        max_total_bytes=max_total_bytes,
+    )
+    base = _base_summary(
+        plan,
+        config=config,
+        enable_durable_read=enable_durable_read,
+    )
+    if not plan.artifacts:
+        return {
+            **base,
+            "restore": {"performed": False, "reason": "no_artifacts"},
+        }
+    if not enable_durable_read:
+        return {
+            **base,
+            "restore": {
+                "performed": False,
+                "reason": "explicit_enable_flag_required",
+            },
+        }
+    if not config.enabled:
+        return {
+            **base,
+            "restore": {
+                "performed": False,
+                "reason": "store_disabled_in_configuration",
+            },
+        }
+    if any(artifact.local_status == "conflict" for artifact in plan.artifacts):
+        raise ValidationError("restore plan contains conflicting local targets")
+    if not plan.replication_execution_confirmed:
+        raise ValidationError(
+            "restore execution requires a completed replication result summary"
+        )
+
+    selected_environment = environment if environment is not None else os.environ
+    bucket = _environment_value(selected_environment, config.bucket_env)
+    region = _environment_value(selected_environment, config.region_env)
+    selected_factory = client_factory or create_boto3_s3_client
+    client = selected_factory(region_name=region)
+
+    manifest_digest = content_sha256(plan.manifest_payload)
+    _head_verified_object(
+        client,
+        bucket=bucket,
+        key=plan.manifest_object_key,
+        expected_sha256=manifest_digest,
+        expected_length=len(plan.manifest_payload),
+    )
+    remote_manifest_payload = _read_verified_object(
+        client,
+        bucket=bucket,
+        key=plan.manifest_object_key,
+        expected_sha256=manifest_digest,
+        expected_length=len(plan.manifest_payload),
+    )
+    if remote_manifest_payload != plan.manifest_payload:
+        raise StorageError("remote replication manifest bytes do not match the plan")
+    try:
+        remote_manifest = json.loads(
+            remote_manifest_payload.decode("utf-8"),
+            object_pairs_hook=_reject_duplicate_keys,
+            parse_constant=_reject_nonstandard_constant,
+        )
+    except Exception:
+        raise StorageError("remote replication manifest is invalid") from None
+    if remote_manifest != plan.manifest_document:
+        raise StorageError("remote replication manifest contract does not match")
+
+    for artifact in plan.artifacts:
+        _head_verified_object(
+            client,
+            bucket=bucket,
+            key=artifact.object_key,
+            expected_sha256=artifact.sha256,
+            expected_length=artifact.content_length,
+        )
+
+    results: list[dict[str, Any]] = []
+    for planned_artifact in plan.artifacts:
+        current_status = _local_status(
+            target_root=planned_artifact.target_root,
+            target_path=planned_artifact.target_path,
+            expected_size=planned_artifact.content_length,
+            expected_sha256=planned_artifact.sha256,
+        )
+        artifact = replace(planned_artifact, local_status=current_status)
+        if current_status == "conflict":
+            raise ValidationError(
+                "local restore target changed to conflicting content"
+            )
+        if current_status == "already_present":
+            status = current_status
+        else:
+            payload = _read_verified_object(
+                client,
+                bucket=bucket,
+                key=artifact.object_key,
+                expected_sha256=artifact.sha256,
+                expected_length=artifact.content_length,
+            )
+            expected_key = immutable_object_key(
+                config,
+                dataset=artifact.remote_dataset,
+                payload=payload,
+                extension="parquet",
+            )
+            if expected_key != artifact.object_key:
+                raise StorageError(
+                    "downloaded artifact does not match its immutable object key"
+                )
+            status = _atomic_publish_no_overwrite(artifact, payload)
+        results.append(
+            {
+                "content_length": artifact.content_length,
+                "dataset": artifact.dataset,
+                "relative_path": artifact.relative_path,
+                "remote_dataset": artifact.remote_dataset,
+                "sha256": artifact.sha256,
+                "status": status,
+            }
+        )
+
+    restored = sum(result["status"] == "restored" for result in results)
+    already_present = sum(
+        result["status"] == "already_present" for result in results
+    )
+    return {
+        **base,
+        "restore": {
+            "artifact_results": results,
+            "artifacts_already_present": already_present,
+            "artifacts_restored": restored,
+            "manifest_verified": True,
+            "performed": True,
+            "remote_objects_verified": len(plan.artifacts) + 1,
+        },
+    }
+
+
+def _positive_integer(value: str) -> int:
+    try:
+        parsed = int(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("must be a positive integer") from exc
+    if parsed < 1:
+        raise argparse.ArgumentTypeError("must be a positive integer")
+    return parsed
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Plan or explicitly restore one exact immutable replication manifest "
+            "through bounded, verified S3 object reads."
+        )
+    )
+    parser.add_argument("--replication-summary", type=Path, required=True)
+    parser.add_argument("--store-id", default="primary-s3")
+    parser.add_argument(
+        "--storage-config",
+        type=Path,
+        default=Path("config/storage.yaml"),
+    )
+    parser.add_argument(
+        "--durable-config",
+        type=Path,
+        default=Path("config/durable_storage.yaml"),
+    )
+    parser.add_argument(
+        "--max-total-bytes",
+        type=_positive_integer,
+        default=DEFAULT_MAX_RESTORE_BYTES,
+    )
+    parser.add_argument("--enable-durable-read", action="store_true")
+    parser.add_argument("--summary-json", type=Path)
+    return parser
+
+
+def _write_summary(path: Path, summary: Mapping[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_suffix(path.suffix + ".tmp")
+    try:
+        temporary.write_text(
+            json.dumps(summary, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        temporary.replace(path)
+    except OSError:
+        temporary.unlink(missing_ok=True)
+        raise StorageError("Unable to write durable restore summary") from None
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    try:
+        summary = restore_durable_replication(
+            replication_summary_path=args.replication_summary,
+            store_id=args.store_id,
+            storage_config_path=args.storage_config,
+            durable_config_path=args.durable_config,
+            max_total_bytes=args.max_total_bytes,
+            enable_durable_read=args.enable_durable_read,
+        )
+        if args.summary_json is not None:
+            _write_summary(args.summary_json, summary)
+    except ValidationError:
+        print(
+            "Durable restore failed: manifest, configuration, environment, "
+            "local state or bounds were invalid",
+            file=sys.stderr,
+        )
+        return 1
+    except StorageError:
+        print(
+            "Durable restore failed: bounded manifest, S3 read or local "
+            "publication verification failed",
+            file=sys.stderr,
+        )
+        return 1
+    except Exception:
+        print("Durable restore failed: unexpected local failure", file=sys.stderr)
+        return 1
+
+    print(json.dumps(summary, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/test_durable_restore_architecture_contract.py
+++ b/tests/unit/test_durable_restore_architecture_contract.py
@@ -1,0 +1,60 @@
+from pathlib import Path
+
+
+def test_durable_restore_is_plan_first_exact_manifest_and_no_overwrite() -> None:
+    restore_documentation = Path("docs/durable-s3-restore.md").read_text(
+        encoding="utf-8"
+    )
+    replication_documentation = Path(
+        "docs/durable-s3-replication.md"
+    ).read_text(encoding="utf-8")
+    runner = Path(
+        "src/orchestration/restore_durable_datasets.py"
+    ).read_text(encoding="utf-8")
+
+    for required in (
+        "durable-dataset-restore-v1",
+        "durable-dataset-replication-v1",
+        "--enable-durable-read",
+        "plan-only",
+        "exact immutable replication manifest",
+        "head_object",
+        "expected-length-plus-one",
+        "Atomic No-Overwrite Publication",
+        "already_present",
+        "conflict",
+        "restore_plan_id",
+    ):
+        assert required in restore_documentation
+
+    assert "docs/durable-s3-restore.md" in replication_documentation
+    assert "restore objects to local storage" not in replication_documentation
+    assert "list_objects_v2" not in runner
+    assert "get_object" in runner
+    assert runner.index("if not enable_durable_read") < runner.index(
+        "client = selected_factory"
+    )
+    assert runner.index("if any(artifact.local_status == \"conflict\"") < (
+        runner.index("client = selected_factory")
+    )
+
+
+def test_restore_documentation_keeps_cloud_mutation_out_of_scope() -> None:
+    documentation = Path("docs/durable-s3-restore.md").read_text(
+        encoding="utf-8"
+    )
+
+    for prohibited in (
+        "select a mutable latest",
+        "overwrite or delete a local file",
+        "write, delete or mutate S3 objects",
+        "run `terraform apply`",
+    ):
+        assert prohibited in documentation
+
+    for false_claim in (
+        "restore is automatic",
+        "CI downloads production objects",
+        "creates an S3 bucket",
+    ):
+        assert false_claim not in documentation

--- a/tests/unit/test_restore_durable_datasets.py
+++ b/tests/unit/test_restore_durable_datasets.py
@@ -1,0 +1,460 @@
+from __future__ import annotations
+
+import copy
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from src.common.exceptions import StorageError, ValidationError
+from src.orchestration.replicate_durable_datasets import replicate_local_datasets
+from src.orchestration.restore_durable_datasets import (
+    RESTORE_CONTRACT,
+    restore_durable_replication,
+)
+from src.storage.durable_s3 import DurableS3Config
+
+
+class FakeBody:
+    def __init__(self, payload: bytes) -> None:
+        self.payload = payload
+        self.closed = False
+
+    def read(self, amount: int) -> bytes:
+        return self.payload[:amount]
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class FakeS3Client:
+    def __init__(self) -> None:
+        self.objects: dict[str, dict[str, Any]] = {}
+        self.head_calls: list[str] = []
+        self.get_calls: list[str] = []
+
+    def put_object(self, **kwargs: Any) -> dict[str, Any]:
+        key = kwargs["Key"]
+        payload = kwargs["Body"]
+        assert isinstance(key, str)
+        assert isinstance(payload, bytes)
+        self.objects[key] = {
+            "Body": payload,
+            "ContentLength": len(payload),
+            "Metadata": dict(kwargs["Metadata"]),
+        }
+        return {"ETag": f'"{len(self.objects)}"'}
+
+    def head_object(self, *, Bucket: str, Key: str) -> dict[str, Any]:
+        assert Bucket == "test-bucket"
+        self.head_calls.append(Key)
+        candidate = self.objects[Key]
+        return {
+            "ContentLength": candidate["ContentLength"],
+            "Metadata": dict(candidate["Metadata"]),
+        }
+
+    def get_object(self, *, Bucket: str, Key: str) -> dict[str, Any]:
+        assert Bucket == "test-bucket"
+        self.get_calls.append(Key)
+        candidate = self.objects[Key]
+        return {
+            "Body": FakeBody(candidate["Body"]),
+            "ContentLength": candidate["ContentLength"],
+        }
+
+
+def _durable_config(*, enabled: bool = True) -> DurableS3Config:
+    return DurableS3Config(
+        store_id="primary-s3",
+        enabled=enabled,
+        bucket_env="DURABLE_BUCKET",
+        region_env="AWS_REGION",
+        prefix="risk-platform",
+        server_side_encryption="AES256",
+        kms_key_env=None,
+        max_object_bytes=1_000_000,
+        max_list_objects=20,
+    )
+
+
+def _storage_config(root: Path) -> dict[str, Any]:
+    return {
+        "storage": {
+            "base_dir": str(root),
+            "raw": {
+                "base_path": str(root / "raw"),
+                "dataset": "market_events",
+            },
+            "curated": {
+                "base_path": str(root / "curated"),
+                "datasets": {
+                    "daily_returns": "daily_returns",
+                    "portfolio_risk_attribution": (
+                        "portfolio_risk_attribution"
+                    ),
+                },
+            },
+            "format": "parquet",
+            "partitioning": {"granularity": "hourly"},
+        }
+    }
+
+
+def _write_source_artifacts(root: Path) -> dict[str, bytes]:
+    raw_path = (
+        root
+        / "raw"
+        / "market_events"
+        / "year=2026"
+        / "month=08"
+        / "raw.parquet"
+    )
+    raw_path.parent.mkdir(parents=True)
+    raw_payload = b"raw-market-events"
+    raw_path.write_bytes(raw_payload)
+
+    daily_path = (
+        root
+        / "curated"
+        / "daily_returns"
+        / "year=2026"
+        / "daily.parquet"
+    )
+    daily_path.parent.mkdir(parents=True)
+    daily_payload = b"daily-returns"
+    daily_path.write_bytes(daily_payload)
+    return {
+        "market_events/year=2026/month=08/raw.parquet": raw_payload,
+        "daily_returns/year=2026/daily.parquet": daily_payload,
+    }
+
+
+def _replication_fixture(
+    tmp_path: Path,
+    *,
+    execute: bool = True,
+) -> tuple[
+    FakeS3Client,
+    Path,
+    dict[str, Any],
+    dict[str, bytes],
+    dict[str, Any],
+]:
+    source_root = tmp_path / "source"
+    target_root = tmp_path / "target"
+    source_config = _storage_config(source_root)
+    target_config = _storage_config(target_root)
+    payloads = _write_source_artifacts(source_root)
+    client = FakeS3Client()
+    factories: list[str] = []
+
+    summary = replicate_local_datasets(
+        store_id="primary-s3",
+        storage_config_path=tmp_path / "source-storage.yaml",
+        durable_config_path=tmp_path / "durable.yaml",
+        selected_datasets=["daily_returns", "market_events"],
+        max_files=20,
+        max_total_bytes=1_000_000,
+        enable_durable_write=execute,
+        environment={
+            "DURABLE_BUCKET": "test-bucket",
+            "AWS_REGION": "eu-west-2",
+        },
+        config_loader=lambda *_: _durable_config(),
+        storage_config_loader=lambda _: source_config,
+        client_factory=lambda **_: factories.append("created") or client,
+    )
+    assert factories == (["created"] if execute else [])
+    summary_path = tmp_path / "replication-summary.json"
+    summary_path.write_text(
+        json.dumps(summary, sort_keys=True),
+        encoding="utf-8",
+    )
+    return client, summary_path, target_config, payloads, summary
+
+
+def _restore(
+    *,
+    summary_path: Path,
+    target_config: dict[str, Any],
+    client: FakeS3Client,
+    enable: bool,
+    enabled_store: bool = True,
+    max_total_bytes: int = 1_000_000,
+    factories: list[str] | None = None,
+) -> dict[str, Any]:
+    client_factories = factories if factories is not None else []
+    return restore_durable_replication(
+        replication_summary_path=summary_path,
+        store_id="primary-s3",
+        storage_config_path=summary_path.parent / "target-storage.yaml",
+        durable_config_path=summary_path.parent / "durable.yaml",
+        max_total_bytes=max_total_bytes,
+        enable_durable_read=enable,
+        environment={
+            "DURABLE_BUCKET": "test-bucket",
+            "AWS_REGION": "eu-west-2",
+        },
+        config_loader=lambda *_: _durable_config(enabled=enabled_store),
+        storage_config_loader=lambda _: target_config,
+        client_factory=lambda **_: client_factories.append("created") or client,
+    )
+
+
+def test_plan_only_is_deterministic_and_creates_no_client_or_directory(
+    tmp_path: Path,
+) -> None:
+    client, summary_path, target_config, _, _ = _replication_fixture(tmp_path)
+    factories: list[str] = []
+
+    first = _restore(
+        summary_path=summary_path,
+        target_config=target_config,
+        client=client,
+        enable=False,
+        factories=factories,
+    )
+    second = _restore(
+        summary_path=summary_path,
+        target_config=target_config,
+        client=client,
+        enable=False,
+        factories=factories,
+    )
+
+    assert first["contract"] == RESTORE_CONTRACT
+    assert first["restore_plan_id"] == second["restore_plan_id"]
+    assert first["manifest_id"] == second["manifest_id"]
+    assert first["plan"]["artifact_count"] == 2
+    assert first["plan"]["local_status_counts"] == {
+        "missing": 2,
+        "already_present": 0,
+        "conflict": 0,
+    }
+    assert first["restore"] == {
+        "performed": False,
+        "reason": "explicit_enable_flag_required",
+    }
+    assert factories == []
+    assert not Path(target_config["storage"]["base_dir"]).exists()
+    assert "test-bucket" not in str(first)
+    assert "eu-west-2" not in str(first)
+    assert first["credentials_recorded"] is False
+
+
+def test_disabled_store_blocks_reads_before_client_creation(
+    tmp_path: Path,
+) -> None:
+    client, summary_path, target_config, _, _ = _replication_fixture(tmp_path)
+    factories: list[str] = []
+
+    result = _restore(
+        summary_path=summary_path,
+        target_config=target_config,
+        client=client,
+        enable=True,
+        enabled_store=False,
+        factories=factories,
+    )
+
+    assert result["restore"] == {
+        "performed": False,
+        "reason": "store_disabled_in_configuration",
+    }
+    assert factories == []
+
+
+def test_verified_restore_and_replay_converge_without_overwrite(
+    tmp_path: Path,
+) -> None:
+    client, summary_path, target_config, payloads, _ = _replication_fixture(
+        tmp_path
+    )
+    factories: list[str] = []
+
+    first = _restore(
+        summary_path=summary_path,
+        target_config=target_config,
+        client=client,
+        enable=True,
+        factories=factories,
+    )
+    first_gets = list(client.get_calls)
+    client.get_calls.clear()
+    second = _restore(
+        summary_path=summary_path,
+        target_config=target_config,
+        client=client,
+        enable=True,
+        factories=factories,
+    )
+
+    assert factories == ["created", "created"]
+    assert first["restore"]["performed"] is True
+    assert first["restore"]["manifest_verified"] is True
+    assert first["restore"]["remote_objects_verified"] == 3
+    assert first["restore"]["artifacts_restored"] == 2
+    assert first["restore"]["artifacts_already_present"] == 0
+    assert second["restore"]["artifacts_restored"] == 0
+    assert second["restore"]["artifacts_already_present"] == 2
+    assert second["restore_plan_id"] == first["restore_plan_id"]
+    assert len(first_gets) == 3
+    assert client.get_calls == [first["plan"]["manifest_object_key"]]
+
+    target_root = Path(target_config["storage"]["base_dir"])
+    assert (
+        target_root
+        / "raw"
+        / "market_events"
+        / "year=2026"
+        / "month=08"
+        / "raw.parquet"
+    ).read_bytes() == payloads["market_events/year=2026/month=08/raw.parquet"]
+    assert (
+        target_root
+        / "curated"
+        / "daily_returns"
+        / "year=2026"
+        / "daily.parquet"
+    ).read_bytes() == payloads["daily_returns/year=2026/daily.parquet"]
+
+
+def test_local_conflict_fails_before_environment_or_client_resolution(
+    tmp_path: Path,
+) -> None:
+    client, summary_path, target_config, _, _ = _replication_fixture(tmp_path)
+    target = (
+        Path(target_config["storage"]["curated"]["base_path"])
+        / "daily_returns"
+        / "year=2026"
+        / "daily.parquet"
+    )
+    target.parent.mkdir(parents=True)
+    target.write_bytes(b"conflicting-local-data")
+    factories: list[str] = []
+
+    with pytest.raises(ValidationError, match="conflicting local targets"):
+        _restore(
+            summary_path=summary_path,
+            target_config=target_config,
+            client=client,
+            enable=True,
+            factories=factories,
+        )
+
+    assert factories == []
+    assert target.read_bytes() == b"conflicting-local-data"
+
+
+def test_execution_requires_completed_replication_evidence(
+    tmp_path: Path,
+) -> None:
+    client, summary_path, target_config, _, summary = _replication_fixture(
+        tmp_path,
+        execute=False,
+    )
+    assert summary["replication"]["performed"] is False
+    factories: list[str] = []
+
+    with pytest.raises(ValidationError, match="completed replication result"):
+        _restore(
+            summary_path=summary_path,
+            target_config=target_config,
+            client=client,
+            enable=True,
+            factories=factories,
+        )
+
+    assert factories == []
+
+
+def test_manifest_metadata_and_payload_are_verified_before_artifacts(
+    tmp_path: Path,
+) -> None:
+    client, summary_path, target_config, _, summary = _replication_fixture(
+        tmp_path
+    )
+    manifest_key = summary["plan"]["manifest_object_key"]
+    client.objects[manifest_key]["Metadata"]["sha256"] = "0" * 64
+
+    with pytest.raises(StorageError, match="digest metadata"):
+        _restore(
+            summary_path=summary_path,
+            target_config=target_config,
+            client=client,
+            enable=True,
+        )
+
+    assert not Path(target_config["storage"]["base_dir"]).exists()
+
+
+def test_artifact_payload_digest_is_verified_before_local_publication(
+    tmp_path: Path,
+) -> None:
+    client, summary_path, target_config, _, summary = _replication_fixture(
+        tmp_path
+    )
+    artifact_key = summary["plan"]["artifacts"][0]["object_key"]
+    original = client.objects[artifact_key]["Body"]
+    client.objects[artifact_key]["Body"] = b"x" * len(original)
+
+    with pytest.raises(StorageError, match="payload digest"):
+        _restore(
+            summary_path=summary_path,
+            target_config=target_config,
+            client=client,
+            enable=True,
+        )
+
+    assert not Path(target_config["storage"]["base_dir"]).exists()
+
+
+def test_unsafe_manifest_path_and_total_byte_bound_fail_during_plan(
+    tmp_path: Path,
+) -> None:
+    client, summary_path, target_config, _, summary = _replication_fixture(
+        tmp_path
+    )
+    unsafe = copy.deepcopy(summary)
+    unsafe["plan"]["artifacts"][0]["relative_path"] = "../escape.parquet"
+    unsafe_path = tmp_path / "unsafe-summary.json"
+    unsafe_path.write_text(json.dumps(unsafe), encoding="utf-8")
+
+    with pytest.raises(ValidationError, match="safe relative POSIX path"):
+        _restore(
+            summary_path=unsafe_path,
+            target_config=target_config,
+            client=client,
+            enable=False,
+        )
+
+    with pytest.raises(ValidationError, match="max_total_bytes"):
+        _restore(
+            summary_path=summary_path,
+            target_config=target_config,
+            client=client,
+            enable=False,
+            max_total_bytes=1,
+        )
+
+
+def test_symbolic_link_target_base_fails_closed(tmp_path: Path) -> None:
+    client, summary_path, target_config, _, _ = _replication_fixture(tmp_path)
+    target_base = Path(target_config["storage"]["curated"]["base_path"])
+    real_base = tmp_path / "real-curated"
+    real_base.mkdir()
+    target_base.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        target_base.symlink_to(real_base, target_is_directory=True)
+    except OSError:
+        pytest.skip("symbolic links are unavailable")
+
+    with pytest.raises(StorageError, match="symbolic links"):
+        _restore(
+            summary_path=summary_path,
+            target_config=target_config,
+            client=client,
+            enable=False,
+        )


### PR DESCRIPTION
## Outcome

Restore one exact completed immutable replication manifest to the configured local raw and curated layout:

```text
completed durable replication result
  -> strict local summary validation
  -> exact canonical manifest identity
  -> plan-only local target inventory
  -> explicit dual-gated S3 reads
  -> remote manifest and object metadata verification
  -> bounded payload digest verification
  -> atomic no-overwrite local publication
  -> deterministic replay evidence
```

Primary arc42 block: `orchestration`, with bounded interfaces to the existing immutable S3 adapter and configured local storage datasets.

## Exact-manifest selection

Add `src.orchestration.restore_durable_datasets`. It consumes one local JSON result from `replicate_durable_datasets`; it never lists an S3 prefix and never selects a mutable latest object.

The runner reconstructs the complete `durable-dataset-replication-v1` manifest from the ordered artifact evidence and verifies:

- store ID;
- exact artifact fields;
- configured dataset/remote-dataset mapping;
- safe relative path;
- content length and SHA-256;
- content-addressed artifact object key;
- deterministic artifact order;
- artifact, dataset and byte totals;
- manifest ID;
- manifest immutable object key; and
- completed replication artifact and manifest result evidence.

A plan-only replication summary can be inspected but cannot authorize reads.

## Plan-only default

Without `--enable-durable-read`, the runner performs only strict local validation and local target inventory. It does not resolve bucket or region environment values, create a boto3 client, call S3 or create directories.

Each local target is classified as:

- `missing`;
- `already_present` when size and SHA-256 match; or
- `conflict` when an existing regular file differs.

The deterministic `durable-restore-*` plan identity binds the restore contract, store, manifest and ordered dataset/path/digest identities; local status does not change the selected manifest.

## Explicit read gate and bounds

Object reads require both:

1. `enabled: true` in the selected durable store; and
2. `--enable-durable-read`.

Execution also requires completed replication evidence and zero local conflicts before environment or client resolution.

Bounds applied before client creation:

- 16 MB strict local summary cap;
- 10 MB canonical manifest cap;
- artifact count no greater than the smaller of 10,000 and store `max_list_objects`;
- per-object store `max_object_bytes`;
- 100 GB hard aggregate cap; and
- 1 GB default request cap.

## Remote verification

Execution reads only the exact manifest key and exact artifact keys declared in that manifest.

For the manifest and every artifact, `head_object` must prove:

- metadata SHA-256;
- `immutable-content-addressed-v1` storage contract; and
- exact content length.

The canonical manifest body is read with an expected-length-plus-one bound and must match the locally reconstructed bytes and document exactly. All artifact metadata is verified before any artifact body is accepted.

Missing artifacts are read with the same bound. Payload length, SHA-256 and the immutable object key are recomputed before local publication. Already-present local artifacts still receive remote metadata verification but skip artifact-body download.

## Local no-overwrite publication

Targets are derived only from `config/storage.yaml`. The runner rejects unconfigured dataset pairs, unsafe relative paths, duplicate keys/targets, symbolic-link paths, invalid parents and non-regular targets.

A verified payload is written to a same-directory temporary file, flushed and `fsync`ed, then published through an atomic hard link. Existing targets are never replaced:

- missing -> `restored`;
- racing identical target -> `already_present`;
- racing conflicting target -> fail closed.

The final file is reread and verified. Partial completion is replay-safe.

## Evidence boundary

Summaries expose manifest, dataset, relative path, object key, size, digest, local state and restore counts. Bucket, region, KMS and credential values are excluded.

The implementation performs no S3 list, put, delete or mutation; no provider request; no deployment; and no Terraform apply.

## Validation

GitHub Actions run `32637411105` (`ci` run 270) passed on exact head `633daa69b850705018467e771c4d6052f85ae06b`:

- Security guardrails: passed.
- Python readiness: passed.
  - locked dependencies resolved;
  - Ruff passed;
  - mypy passed across 83 source files;
  - 677 tests passed in both quality and readiness runs;
  - `pip check` passed;
  - the standard readiness replay passed.
- PostgreSQL contract: passed against PostgreSQL 16, including the existing model-approval contract.
- Infrastructure validation: passed without deployment or Terraform apply.

Focused tests cover deterministic plan-only behavior with no client or directory creation, disabled-store gating, exact restore and replay convergence, local conflicts before client creation, completed-replication evidence, remote manifest metadata, artifact payload digest verification, unsafe paths and totals, symbolic-link targets and the absence of S3 listing.

No unresolved review threads or requested changes are present.

## Scope

The branch is two working commits ahead of `main` and zero behind, with five changed files, 1,853 additions and 28 deletions. It will be squash-merged as one restore/verification contract.

No PostgreSQL restore audit table is added merely for symmetry. A separate audit slice should follow only when an actual consumer needs retained restore-run history.

## Acceptance boundary

Validated and ready for squash merge as one durable-restore increment.