### PR TITLE
Add deterministic operational service-level report

### DIFF
--- a/config/operational_service_levels.yaml
+++ b/config/operational_service_levels.yaml
@@ -1,0 +1,16 @@
+policies:
+  us-tech-local:
+    schedule_id: us-tech-local
+    metrics:
+      schedule_lag_sessions:
+        warning: 1
+        critical: 2
+      market_freshness_exception_count:
+        warning: 1
+        critical: 2
+      notification_retry_exhausted_count:
+        warning: 1
+        critical: 2
+      notification_oldest_dead_letter_age_seconds:
+        warning: 900
+        critical: 3600

--- a/docs/operational-service-levels.md
+++ b/docs/operational-service-levels.md
@@ -1,0 +1,117 @@
+# Operational Service-Level Evidence
+
+## Outcome
+
+This increment turns the existing local schedule, market-freshness records and
+notification delivery history into one deterministic operational report:
+
+```text
+local schedule checkpoint
+  + exchange-calendar expected session
+  + current constituent freshness
+  + pending notification delivery attempts
+  -> four bounded service-level indicators
+  -> one reproducible overall status
+  -> credential-free JSON evidence
+```
+
+It is reporting evidence only. It does not execute the schedule, request market
+data, retry notifications, deliver messages, activate a cloud schedule or page an
+operator.
+
+## Policy
+
+`config/operational_service_levels.yaml` defines one versioned policy. Its
+fingerprint binds the policy ID, schedule ID, model version and all warning and
+critical thresholds. Threshold changes therefore produce a new report identity.
+
+The supported indicators are:
+
+| Indicator | Meaning |
+| --- | --- |
+| `schedule_lag_sessions` | Expected market sessions after the last successful local schedule checkpoint |
+| `market_freshness_exception_count` | Configured constituents whose current freshness evidence is missing, stale, gapped or for an older session |
+| `notification_retry_exhausted_count` | Undelivered notification events that reached the configured webhook attempt limit |
+| `notification_oldest_dead_letter_age_seconds` | Age of the oldest retry-exhausted event, measured from its latest attempt or event time |
+
+A value below the warning threshold is `ok`. A value at or above warning but
+below critical is `warning`. A value at or above critical is `critical`. A
+missing schedule checkpoint is explicitly `critical` with reason
+`checkpoint_missing` rather than being converted into an invented lag value.
+The overall status uses `critical > warning > ok` precedence.
+
+## Operator command
+
+Use an explicit UTC instant so repeated reviews are deterministic:
+
+```bash
+.venv/bin/python -m src.orchestration.run_operational_service_levels \
+  --policy-id us-tech-local \
+  --as-of 2026-04-01T12:00:00Z \
+  --summary-json .demo/operational-service-levels.json
+```
+
+The runner reads:
+
+- `config/operational_service_levels.yaml`;
+- `config/local_portfolio_schedules.yaml`;
+- `config/market_calendars.yaml`;
+- the effective portfolio mandate;
+- `config/notification_delivery.yaml`;
+- the bounded local schedule checkpoint; and
+- PostgreSQL current freshness and notification-delivery status views.
+
+It writes only the optional local JSON summary.
+
+## Schedule completion
+
+The schedule indicator uses the same schedule fingerprint and market calendar as
+the existing local scheduler. A checkpoint belonging to another schedule,
+configuration version or model fails closed. A checkpoint after the latest
+expected market session also fails.
+
+The lag is the number of configured market sessions after the checkpoint through
+the latest expected session on the report date. Weekends and holidays therefore
+do not create false calendar-day lag.
+
+## Market freshness
+
+The active portfolio mandate determines the exact source/symbol keys expected for
+the latest session. A constituent is exceptional when:
+
+- no current freshness row exists;
+- the row belongs to another session;
+- `freshness_status` is `gap_detected` or `stale`; or
+- trailing missing sessions are non-zero.
+
+Duplicate evidence for one constituent fails closed. Unrelated freshness rows are
+ignored after the PostgreSQL read is bounded.
+
+## Notification delivery
+
+The webhook configuration supplies the reviewed maximum attempts per event. An
+undelivered event becomes retry-exhausted once `attempt_count` reaches that
+limit. Dead-letter age is measured from `last_attempted_at`, falling back to the
+notification event time when no attempt timestamp exists.
+
+Future timestamps, duplicate event IDs, invalid attempt counts and oversized
+result sets fail closed. The report never retries or delivers an event.
+
+## Bounds and evidence
+
+The runner caps input at:
+
+- 1,000 current freshness rows;
+- 5,000 pending notification rows; and
+- the existing 64 KiB local schedule-state limit.
+
+The deterministic calculation ID binds policy, schedule, calendar, checkpoint,
+expected constituents, exceptions, retry-exhausted events, thresholds and the
+explicit report instant.
+
+## Current boundary
+
+This slice produces a deterministic JSON report. It does not yet retain report
+history in PostgreSQL, enforce an execution gate, define rolling availability
+objectives, render a dashboard or deliver alerts. Those are separate increments
+so reporting semantics can be reviewed before persistence and enforcement.

--- a/src/analytics/operational_service_levels.py
+++ b/src/analytics/operational_service_levels.py
@@ -238,15 +238,18 @@ def _freshness_exception_count(
 
     exceptions: list[str] = []
     for key in sorted(expected):
-        record = seen.get(key)
-        if record is None:
+        freshness_record = seen.get(key)
+        if freshness_record is None:
             exceptions.append(f"{key}:missing")
             continue
-        status = record.get("freshness_status")
+        status = freshness_record.get("freshness_status")
         if status not in {"current", "gap_detected", "stale"}:
             raise ValidationError("market freshness status is invalid")
-        as_of_date = _calendar_date(record.get("as_of_date"), "freshness as_of_date")
-        trailing = record.get("trailing_missing_session_count")
+        as_of_date = _calendar_date(
+            freshness_record.get("as_of_date"),
+            "freshness as_of_date",
+        )
+        trailing = freshness_record.get("trailing_missing_session_count")
         if type(trailing) is not int or trailing < 0:
             raise ValidationError(
                 "trailing_missing_session_count must be a non-negative integer"

--- a/src/analytics/operational_service_levels.py
+++ b/src/analytics/operational_service_levels.py
@@ -1,0 +1,431 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
+from datetime import date, datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from ..common.config import load_yaml
+from ..common.exceptions import ValidationError
+
+MODEL_VERSION = "operational-service-levels-v1"
+METRIC_NAMES = (
+    "schedule_lag_sessions",
+    "market_freshness_exception_count",
+    "notification_retry_exhausted_count",
+    "notification_oldest_dead_letter_age_seconds",
+)
+STATUS_RANK = {"ok": 0, "warning": 1, "critical": 2}
+MAX_POLICY_ID_LENGTH = 128
+MAX_NOTIFICATION_ROWS = 5_000
+MAX_FRESHNESS_ROWS = 1_000
+
+
+@dataclass(frozen=True, slots=True)
+class ServiceLevelThreshold:
+    warning: float
+    critical: float
+
+
+@dataclass(frozen=True, slots=True)
+class OperationalServiceLevelPolicy:
+    policy_id: str
+    schedule_id: str
+    metrics: Mapping[str, ServiceLevelThreshold]
+
+    @property
+    def fingerprint(self) -> str:
+        payload = {
+            "metrics": {
+                name: {
+                    "critical": self.metrics[name].critical,
+                    "warning": self.metrics[name].warning,
+                }
+                for name in METRIC_NAMES
+            },
+            "model_version": MODEL_VERSION,
+            "policy_id": self.policy_id,
+            "schedule_id": self.schedule_id,
+        }
+        digest = hashlib.sha256(
+            json.dumps(payload, sort_keys=True, separators=(",", ":")).encode(
+                "utf-8"
+            )
+        ).hexdigest()[:24]
+        return f"operational-slo-policy-{digest}"
+
+
+@dataclass(frozen=True, slots=True)
+class OperationalServiceLevelOutput:
+    report: Mapping[str, Any]
+    metrics: tuple[Mapping[str, Any], ...]
+
+
+def _required_segment(value: Any, label: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ValidationError(f"{label} must be non-empty text")
+    parsed = value.strip()
+    if (
+        len(parsed) > MAX_POLICY_ID_LENGTH
+        or parsed in {".", ".."}
+        or "/" in parsed
+        or "\\" in parsed
+        or any(ord(character) < 32 for character in parsed)
+    ):
+        raise ValidationError(f"{label} must be one safe text segment")
+    return parsed
+
+
+def _finite_nonnegative(value: Any, label: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ValidationError(f"{label} must be a finite non-negative number")
+    parsed = float(value)
+    if not math.isfinite(parsed) or parsed < 0:
+        raise ValidationError(f"{label} must be a finite non-negative number")
+    return parsed
+
+
+def _parse_threshold(value: Any, label: str) -> ServiceLevelThreshold:
+    if not isinstance(value, Mapping):
+        raise ValidationError(f"{label} must be a mapping")
+    warning = _finite_nonnegative(value.get("warning"), f"{label}.warning")
+    critical = _finite_nonnegative(value.get("critical"), f"{label}.critical")
+    if critical <= warning:
+        raise ValidationError(f"{label}.critical must be greater than warning")
+    return ServiceLevelThreshold(warning=warning, critical=critical)
+
+
+def parse_operational_service_level_policy(
+    payload: Mapping[str, Any],
+    policy_id: str,
+) -> OperationalServiceLevelPolicy:
+    if not isinstance(payload, Mapping):
+        raise ValidationError("operational service-level configuration must be a mapping")
+    policy_id = _required_segment(policy_id, "policy_id")
+    policies = payload.get("policies")
+    if not isinstance(policies, Mapping):
+        raise ValidationError(
+            "operational service-level configuration must define policies"
+        )
+    candidate = policies.get(policy_id)
+    if not isinstance(candidate, Mapping):
+        raise ValidationError(
+            f"operational service-level policy '{policy_id}' is not configured"
+        )
+    metrics = candidate.get("metrics")
+    if not isinstance(metrics, Mapping):
+        raise ValidationError("operational service-level policy must define metrics")
+    if set(metrics) != set(METRIC_NAMES):
+        raise ValidationError(
+            "operational service-level metrics must match the supported metric set"
+        )
+    return OperationalServiceLevelPolicy(
+        policy_id=policy_id,
+        schedule_id=_required_segment(candidate.get("schedule_id"), "schedule_id"),
+        metrics={
+            name: _parse_threshold(metrics[name], f"metrics.{name}")
+            for name in METRIC_NAMES
+        },
+    )
+
+
+def load_operational_service_level_policy(
+    path: Path,
+    policy_id: str,
+) -> OperationalServiceLevelPolicy:
+    try:
+        payload = load_yaml(path)
+    except Exception:
+        raise ValidationError(
+            "operational service-level configuration could not be loaded"
+        ) from None
+    if not isinstance(payload, Mapping):
+        raise ValidationError("operational service-level configuration must be a mapping")
+    return parse_operational_service_level_policy(payload, policy_id)
+
+
+def _aware_utc(value: Any, label: str) -> datetime:
+    if isinstance(value, datetime):
+        parsed = value
+    elif isinstance(value, str):
+        try:
+            parsed = datetime.fromisoformat(value.strip().replace("Z", "+00:00"))
+        except ValueError:
+            raise ValidationError(f"{label} must be an ISO-8601 timestamp") from None
+    else:
+        raise ValidationError(f"{label} must be a timezone-aware timestamp")
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise ValidationError(f"{label} must be a timezone-aware timestamp")
+    return parsed.astimezone(timezone.utc)
+
+
+def _calendar_date(value: Any, label: str) -> date:
+    if isinstance(value, datetime):
+        raise ValidationError(f"{label} must be a calendar date")
+    if isinstance(value, date):
+        return value
+    if not isinstance(value, str):
+        raise ValidationError(f"{label} must use YYYY-MM-DD")
+    try:
+        parsed = date.fromisoformat(value.strip())
+    except ValueError:
+        raise ValidationError(f"{label} must use YYYY-MM-DD") from None
+    if parsed.isoformat() != value.strip():
+        raise ValidationError(f"{label} must use YYYY-MM-DD")
+    return parsed
+
+
+def _status(value: float | None, threshold: ServiceLevelThreshold) -> str:
+    if value is None:
+        return "critical"
+    if value >= threshold.critical:
+        return "critical"
+    if value >= threshold.warning:
+        return "warning"
+    return "ok"
+
+
+def _metric(
+    *,
+    name: str,
+    value: float | None,
+    threshold: ServiceLevelThreshold,
+    unit: str,
+    reason: str | None = None,
+) -> dict[str, Any]:
+    status = _status(value, threshold)
+    return {
+        "metric_name": name,
+        "observed_value": value,
+        "unit": unit,
+        "warning_threshold": threshold.warning,
+        "critical_threshold": threshold.critical,
+        "status": status,
+        "reason": reason,
+    }
+
+
+def _freshness_exception_count(
+    records: Iterable[Mapping[str, Any]],
+    *,
+    expected_constituents: tuple[str, ...],
+    calendar_id: str,
+    latest_expected_session: date,
+) -> tuple[int, tuple[str, ...]]:
+    expected = set(expected_constituents)
+    seen: dict[str, Mapping[str, Any]] = {}
+    record_count = 0
+    for record in records:
+        record_count += 1
+        if record_count > MAX_FRESHNESS_ROWS:
+            raise ValidationError("market freshness evidence exceeds the row limit")
+        if not isinstance(record, Mapping):
+            raise ValidationError("market freshness evidence must contain mappings")
+        source = _required_segment(record.get("source"), "freshness source")
+        symbol = _required_segment(record.get("symbol"), "freshness symbol")
+        key = f"{source}:{symbol}"
+        if key not in expected:
+            continue
+        if key in seen:
+            raise ValidationError("market freshness evidence contains duplicate constituents")
+        if _required_segment(record.get("calendar_id"), "freshness calendar_id") != calendar_id:
+            raise ValidationError("market freshness evidence uses another calendar")
+        seen[key] = record
+
+    exceptions: list[str] = []
+    for key in sorted(expected):
+        record = seen.get(key)
+        if record is None:
+            exceptions.append(f"{key}:missing")
+            continue
+        status = record.get("freshness_status")
+        if status not in {"current", "gap_detected", "stale"}:
+            raise ValidationError("market freshness status is invalid")
+        as_of_date = _calendar_date(record.get("as_of_date"), "freshness as_of_date")
+        trailing = record.get("trailing_missing_session_count")
+        if type(trailing) is not int or trailing < 0:
+            raise ValidationError(
+                "trailing_missing_session_count must be a non-negative integer"
+            )
+        if (
+            status != "current"
+            or as_of_date != latest_expected_session
+            or trailing != 0
+        ):
+            exceptions.append(f"{key}:{status}")
+    return len(exceptions), tuple(exceptions)
+
+
+def _notification_metrics(
+    records: Iterable[Mapping[str, Any]],
+    *,
+    as_of: datetime,
+    maximum_attempts: int,
+) -> tuple[int, float, tuple[str, ...]]:
+    if type(maximum_attempts) is not int or not 1 <= maximum_attempts <= 10:
+        raise ValidationError("maximum_attempts must be an integer between 1 and 10")
+    seen: set[str] = set()
+    exhausted: list[tuple[str, float]] = []
+    count = 0
+    for record in records:
+        count += 1
+        if count > MAX_NOTIFICATION_ROWS:
+            raise ValidationError("notification delivery evidence exceeds the row limit")
+        if not isinstance(record, Mapping):
+            raise ValidationError("notification delivery evidence must contain mappings")
+        event_id = _required_segment(record.get("event_id"), "notification event_id")
+        if event_id in seen:
+            raise ValidationError("notification delivery evidence contains duplicate events")
+        seen.add(event_id)
+        delivered = record.get("delivered")
+        if type(delivered) is not bool:
+            raise ValidationError("notification delivered must be boolean")
+        attempt_count = record.get("attempt_count")
+        if type(attempt_count) is not int or not 0 <= attempt_count <= 10:
+            raise ValidationError("notification attempt_count must be between 0 and 10")
+        ts_event = _aware_utc(record.get("ts_event"), "notification ts_event")
+        last_attempt = record.get("last_attempted_at")
+        reference = (
+            _aware_utc(last_attempt, "notification last_attempted_at")
+            if last_attempt is not None
+            else ts_event
+        )
+        if reference > as_of:
+            raise ValidationError("notification evidence must not be in the future")
+        if not delivered and attempt_count >= maximum_attempts:
+            exhausted.append((event_id, (as_of - reference).total_seconds()))
+    oldest_age = max((age for _, age in exhausted), default=0.0)
+    return len(exhausted), oldest_age, tuple(event for event, _ in exhausted)
+
+
+def evaluate_operational_service_levels(
+    *,
+    policy: OperationalServiceLevelPolicy,
+    as_of: datetime,
+    schedule_fingerprint: str,
+    latest_expected_session: date,
+    schedule_checkpoint: date | None,
+    schedule_lag_sessions: int | None,
+    expected_constituents: tuple[str, ...],
+    calendar_id: str,
+    freshness_records: Iterable[Mapping[str, Any]],
+    notification_records: Iterable[Mapping[str, Any]],
+    maximum_notification_attempts: int,
+) -> OperationalServiceLevelOutput:
+    as_of = _aware_utc(as_of, "as_of")
+    schedule_fingerprint = _required_segment(
+        schedule_fingerprint,
+        "schedule_fingerprint",
+    )
+    calendar_id = _required_segment(calendar_id, "calendar_id")
+    if not expected_constituents or len(set(expected_constituents)) != len(
+        expected_constituents
+    ):
+        raise ValidationError("expected_constituents must be a unique non-empty tuple")
+    for key in expected_constituents:
+        if not isinstance(key, str) or ":" not in key:
+            raise ValidationError("expected constituent keys must use source:symbol")
+    if schedule_lag_sessions is not None and (
+        type(schedule_lag_sessions) is not int or schedule_lag_sessions < 0
+    ):
+        raise ValidationError("schedule_lag_sessions must be a non-negative integer")
+    if schedule_checkpoint is not None and schedule_checkpoint > latest_expected_session:
+        raise ValidationError("schedule checkpoint is after the latest expected session")
+
+    freshness_count, freshness_exceptions = _freshness_exception_count(
+        freshness_records,
+        expected_constituents=expected_constituents,
+        calendar_id=calendar_id,
+        latest_expected_session=latest_expected_session,
+    )
+    exhausted_count, oldest_dead_letter_age, exhausted_events = _notification_metrics(
+        notification_records,
+        as_of=as_of,
+        maximum_attempts=maximum_notification_attempts,
+    )
+    metrics = (
+        _metric(
+            name="schedule_lag_sessions",
+            value=(
+                float(schedule_lag_sessions)
+                if schedule_lag_sessions is not None
+                else None
+            ),
+            threshold=policy.metrics["schedule_lag_sessions"],
+            unit="sessions",
+            reason=("checkpoint_missing" if schedule_checkpoint is None else None),
+        ),
+        _metric(
+            name="market_freshness_exception_count",
+            value=float(freshness_count),
+            threshold=policy.metrics["market_freshness_exception_count"],
+            unit="constituents",
+        ),
+        _metric(
+            name="notification_retry_exhausted_count",
+            value=float(exhausted_count),
+            threshold=policy.metrics["notification_retry_exhausted_count"],
+            unit="events",
+        ),
+        _metric(
+            name="notification_oldest_dead_letter_age_seconds",
+            value=oldest_dead_letter_age,
+            threshold=policy.metrics[
+                "notification_oldest_dead_letter_age_seconds"
+            ],
+            unit="seconds",
+        ),
+    )
+    overall_status = max(
+        (str(metric["status"]) for metric in metrics),
+        key=STATUS_RANK.__getitem__,
+    )
+    identity_payload = {
+        "as_of": as_of.isoformat(),
+        "calendar_id": calendar_id,
+        "expected_constituents": sorted(expected_constituents),
+        "freshness_exceptions": list(freshness_exceptions),
+        "latest_expected_session": latest_expected_session.isoformat(),
+        "maximum_notification_attempts": maximum_notification_attempts,
+        "metrics": list(metrics),
+        "model_version": MODEL_VERSION,
+        "notification_retry_exhausted_events": list(exhausted_events),
+        "policy_fingerprint": policy.fingerprint,
+        "schedule_checkpoint": (
+            schedule_checkpoint.isoformat() if schedule_checkpoint is not None else None
+        ),
+        "schedule_fingerprint": schedule_fingerprint,
+    }
+    digest = hashlib.sha256(
+        json.dumps(
+            identity_payload,
+            sort_keys=True,
+            separators=(",", ":"),
+            allow_nan=False,
+        ).encode("utf-8")
+    ).hexdigest()[:24]
+    report = {
+        "calculation_id": f"{MODEL_VERSION}-report-{digest}",
+        "model_version": MODEL_VERSION,
+        "policy_id": policy.policy_id,
+        "policy_fingerprint": policy.fingerprint,
+        "schedule_id": policy.schedule_id,
+        "schedule_fingerprint": schedule_fingerprint,
+        "calendar_id": calendar_id,
+        "as_of": as_of.isoformat(),
+        "latest_expected_session": latest_expected_session.isoformat(),
+        "schedule_checkpoint": (
+            schedule_checkpoint.isoformat() if schedule_checkpoint is not None else None
+        ),
+        "expected_constituent_count": len(expected_constituents),
+        "freshness_exceptions": list(freshness_exceptions),
+        "notification_retry_exhausted_events": list(exhausted_events),
+        "maximum_notification_attempts": maximum_notification_attempts,
+        "overall_status": overall_status,
+        "metrics": list(metrics),
+    }
+    return OperationalServiceLevelOutput(report=report, metrics=metrics)

--- a/src/orchestration/run_operational_service_levels.py
+++ b/src/orchestration/run_operational_service_levels.py
@@ -1,0 +1,399 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections.abc import Callable, Mapping, Sequence
+from datetime import date, datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+from ..analytics.market_calendar import MarketCalendar, load_market_calendar
+from ..analytics.operational_service_levels import (
+    MAX_FRESHNESS_ROWS,
+    MAX_NOTIFICATION_ROWS,
+    OperationalServiceLevelPolicy,
+    evaluate_operational_service_levels,
+    load_operational_service_level_policy,
+)
+from ..analytics.portfolio_mandates import PortfolioMandate, load_portfolio_mandate
+from ..common.exceptions import StorageError, ValidationError
+from ..warehouse.postgres_loader import DEFAULT_POSTGRES_DSN
+from .deliver_portfolio_risk_notifications import (
+    WebhookDeliveryConfig,
+    load_webhook_delivery_config,
+)
+from .run_local_portfolio_schedule import (
+    MODEL_VERSION as SCHEDULE_MODEL_VERSION,
+)
+from .run_local_portfolio_schedule import (
+    LocalPortfolioSchedule,
+    load_local_portfolio_schedule,
+)
+
+MAX_STATE_BYTES = 65_536
+
+ScheduleLoader = Callable[[Path, str], LocalPortfolioSchedule]
+CalendarLoader = Callable[[Path, str], MarketCalendar]
+MandateLoader = Callable[[Path, str, date], PortfolioMandate]
+PolicyLoader = Callable[[Path, str], OperationalServiceLevelPolicy]
+DeliveryConfigLoader = Callable[[Path], WebhookDeliveryConfig]
+EvidenceReader = Callable[..., tuple[list[dict[str, Any]], list[dict[str, Any]]]]
+StateReader = Callable[[Path], Mapping[str, Any] | None]
+
+
+def _aware_timestamp(value: str) -> datetime:
+    try:
+        parsed = datetime.fromisoformat(value.strip().replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(
+            "must be a timezone-aware ISO-8601 timestamp"
+        ) from exc
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise argparse.ArgumentTypeError(
+            "must be a timezone-aware ISO-8601 timestamp"
+        )
+    return parsed.astimezone(timezone.utc)
+
+
+def _quote_identifier(value: str) -> str:
+    if not isinstance(value, str) or not value:
+        raise ValidationError("schema_name must be non-empty text")
+    return '"' + value.replace('"', '""') + '"'
+
+
+def read_operational_evidence(
+    *,
+    dsn: str,
+    calendar_id: str,
+    policy_id: str,
+    portfolio_id: str,
+    schema_name: str = "risk_platform",
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    if not isinstance(dsn, str) or not dsn.strip():
+        raise ValidationError("PostgreSQL DSN must be non-empty text")
+    try:
+        import psycopg
+        from psycopg.rows import dict_row
+    except ImportError as exc:
+        raise RuntimeError(
+            "Operational service-level reporting requires psycopg. Run `make setup`."
+        ) from exc
+
+    schema = _quote_identifier(schema_name)
+    freshness_sql = f"""
+        SELECT
+            source,
+            symbol,
+            calendar_id,
+            as_of_date,
+            freshness_status,
+            trailing_missing_session_count
+        FROM {schema}.current_daily_market_freshness
+        WHERE calendar_id = %s
+        ORDER BY source, symbol
+        LIMIT %s
+    """
+    notifications_sql = f"""
+        SELECT
+            event_id,
+            ts_event,
+            attempt_count,
+            delivered,
+            last_attempted_at
+        FROM {schema}.portfolio_risk_notification_delivery_status
+        WHERE policy_id = %s
+          AND portfolio_id = %s
+          AND NOT delivered
+        ORDER BY ts_event, event_id
+        LIMIT %s
+    """
+    try:
+        with psycopg.connect(dsn, row_factory=dict_row) as connection:
+            with connection.cursor() as cursor:
+                cursor.execute(
+                    freshness_sql,
+                    [calendar_id, MAX_FRESHNESS_ROWS + 1],
+                )
+                freshness = [dict(row) for row in cursor.fetchall()]
+                cursor.execute(
+                    notifications_sql,
+                    [policy_id, portfolio_id, MAX_NOTIFICATION_ROWS + 1],
+                )
+                notifications = [dict(row) for row in cursor.fetchall()]
+    except Exception:
+        raise StorageError(
+            "Unable to read operational service-level evidence from PostgreSQL"
+        ) from None
+    if len(freshness) > MAX_FRESHNESS_ROWS:
+        raise ValidationError("market freshness evidence exceeds the row limit")
+    if len(notifications) > MAX_NOTIFICATION_ROWS:
+        raise ValidationError("notification delivery evidence exceeds the row limit")
+    return freshness, notifications
+
+
+def _read_schedule_state(path: Path) -> Mapping[str, Any] | None:
+    if path.is_symlink():
+        raise StorageError("local schedule state must not be a symbolic link")
+    if not path.exists():
+        return None
+    if not path.is_file():
+        raise StorageError("local schedule state must be a regular file")
+    try:
+        if path.stat().st_size > MAX_STATE_BYTES:
+            raise StorageError("local schedule state exceeds the byte limit")
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except StorageError:
+        raise
+    except (OSError, ValueError):
+        raise StorageError("local schedule state is unreadable") from None
+    if not isinstance(payload, Mapping):
+        raise StorageError("local schedule state must be a JSON object")
+    return payload
+
+
+def _schedule_checkpoint(
+    state: Mapping[str, Any] | None,
+    *,
+    schedule: LocalPortfolioSchedule,
+) -> date | None:
+    if state is None:
+        return None
+    if state.get("model_version") != SCHEDULE_MODEL_VERSION:
+        raise ValidationError("local schedule state model version is unsupported")
+    if state.get("schedule_id") != schedule.schedule_id:
+        raise ValidationError("local schedule state belongs to another schedule")
+    if state.get("schedule_fingerprint") != schedule.fingerprint:
+        raise ValidationError(
+            "local schedule configuration changed; archive or reset its state"
+        )
+    raw = state.get("last_successful_session")
+    if not isinstance(raw, str):
+        raise ValidationError("local schedule state is missing its checkpoint")
+    try:
+        parsed = date.fromisoformat(raw)
+    except ValueError:
+        raise ValidationError("local schedule checkpoint must use YYYY-MM-DD") from None
+    if raw != parsed.isoformat():
+        raise ValidationError("local schedule checkpoint must use YYYY-MM-DD")
+    return parsed
+
+
+def _schedule_lag(
+    *,
+    calendar: MarketCalendar,
+    checkpoint: date | None,
+    latest_expected_session: date,
+) -> int | None:
+    if checkpoint is None:
+        return None
+    if checkpoint > latest_expected_session:
+        raise ValidationError(
+            "local schedule checkpoint is after the latest expected session"
+        )
+    if checkpoint == latest_expected_session:
+        return 0
+    return len(
+        calendar.sessions_between(
+            checkpoint + timedelta(days=1),
+            latest_expected_session,
+        )
+    )
+
+
+def run_operational_service_levels(
+    *,
+    policy_id: str,
+    as_of: datetime,
+    policy_config_path: Path,
+    schedule_config_path: Path,
+    calendar_config_path: Path,
+    portfolio_config_path: Path,
+    delivery_config_path: Path,
+    state_dir: Path,
+    dsn: str,
+    schema_name: str = "risk_platform",
+    policy_loader: PolicyLoader | None = None,
+    schedule_loader: ScheduleLoader | None = None,
+    calendar_loader: CalendarLoader | None = None,
+    mandate_loader: MandateLoader | None = None,
+    delivery_config_loader: DeliveryConfigLoader | None = None,
+    state_reader: StateReader | None = None,
+    evidence_reader: EvidenceReader | None = None,
+) -> dict[str, Any]:
+    if (
+        not isinstance(as_of, datetime)
+        or as_of.tzinfo is None
+        or as_of.utcoffset() is None
+    ):
+        raise ValidationError("as_of must be a timezone-aware timestamp")
+    as_of = as_of.astimezone(timezone.utc)
+    selected_policy_loader = policy_loader or load_operational_service_level_policy
+    policy = selected_policy_loader(policy_config_path, policy_id)
+    selected_schedule_loader = schedule_loader or load_local_portfolio_schedule
+    schedule = selected_schedule_loader(schedule_config_path, policy.schedule_id)
+    if schedule.schedule_id != policy.schedule_id:
+        raise ValidationError("service-level policy and schedule do not align")
+    selected_calendar_loader = calendar_loader or load_market_calendar
+    calendar = selected_calendar_loader(calendar_config_path, schedule.calendar_id)
+    as_of_date = as_of.date()
+    latest_expected_session = calendar.latest_expected_session(as_of_date)
+    selected_mandate_loader = mandate_loader or load_portfolio_mandate
+    mandate = selected_mandate_loader(
+        portfolio_config_path,
+        schedule.portfolio_id,
+        latest_expected_session,
+    )
+    selected_state_reader = state_reader or _read_schedule_state
+    state_path = state_dir / f"{schedule.schedule_id}.json"
+    state = selected_state_reader(state_path)
+    checkpoint = _schedule_checkpoint(state, schedule=schedule)
+    lag = _schedule_lag(
+        calendar=calendar,
+        checkpoint=checkpoint,
+        latest_expected_session=latest_expected_session,
+    )
+    selected_delivery_loader = (
+        delivery_config_loader or load_webhook_delivery_config
+    )
+    delivery = selected_delivery_loader(delivery_config_path)
+    selected_evidence_reader = evidence_reader or read_operational_evidence
+    freshness_records, notification_records = selected_evidence_reader(
+        dsn=dsn,
+        calendar_id=calendar.calendar_id,
+        policy_id=schedule.policy_id,
+        portfolio_id=schedule.portfolio_id,
+        schema_name=schema_name,
+    )
+    expected_constituents = tuple(
+        constituent.key for constituent in mandate.constituents
+    )
+    output = evaluate_operational_service_levels(
+        policy=policy,
+        as_of=as_of,
+        schedule_fingerprint=schedule.fingerprint,
+        latest_expected_session=latest_expected_session,
+        schedule_checkpoint=checkpoint,
+        schedule_lag_sessions=lag,
+        expected_constituents=expected_constituents,
+        calendar_id=calendar.calendar_id,
+        freshness_records=freshness_records,
+        notification_records=notification_records,
+        maximum_notification_attempts=delivery.max_attempts_per_event,
+    )
+    return {
+        **dict(output.report),
+        "portfolio_id": schedule.portfolio_id,
+        "risk_limit_policy_id": schedule.policy_id,
+        "mandate_id": mandate.mandate_id,
+        "mandate_fingerprint": mandate.fingerprint,
+        "provider_request_performed": False,
+        "external_delivery_performed": False,
+        "cloud_schedule_activated": False,
+    }
+
+
+def _write_summary(path: Path, summary: Mapping[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_suffix(path.suffix + ".tmp")
+    try:
+        temporary.write_text(
+            json.dumps(summary, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        temporary.replace(path)
+    except OSError:
+        temporary.unlink(missing_ok=True)
+        raise StorageError(
+            "Unable to write the operational service-level summary"
+        ) from None
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Build a deterministic local operational service-level report."
+    )
+    parser.add_argument("--policy-id", required=True)
+    parser.add_argument("--as-of", required=True, type=_aware_timestamp)
+    parser.add_argument(
+        "--policy-config",
+        type=Path,
+        default=Path("config/operational_service_levels.yaml"),
+    )
+    parser.add_argument(
+        "--schedule-config",
+        type=Path,
+        default=Path("config/local_portfolio_schedules.yaml"),
+    )
+    parser.add_argument(
+        "--calendar-config",
+        type=Path,
+        default=Path("config/market_calendars.yaml"),
+    )
+    parser.add_argument(
+        "--portfolio-config",
+        type=Path,
+        default=Path("config/portfolios.yaml"),
+    )
+    parser.add_argument(
+        "--delivery-config",
+        type=Path,
+        default=Path("config/notification_delivery.yaml"),
+    )
+    parser.add_argument(
+        "--state-dir",
+        type=Path,
+        default=Path(".schedule"),
+    )
+    parser.add_argument(
+        "--dsn",
+        default=DEFAULT_POSTGRES_DSN,
+    )
+    parser.add_argument("--schema", default="risk_platform")
+    parser.add_argument("--summary-json", type=Path)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    try:
+        summary = run_operational_service_levels(
+            policy_id=args.policy_id,
+            as_of=args.as_of,
+            policy_config_path=args.policy_config,
+            schedule_config_path=args.schedule_config,
+            calendar_config_path=args.calendar_config,
+            portfolio_config_path=args.portfolio_config,
+            delivery_config_path=args.delivery_config,
+            state_dir=args.state_dir,
+            dsn=args.dsn,
+            schema_name=args.schema,
+        )
+        if args.summary_json is not None:
+            _write_summary(args.summary_json, summary)
+    except ValidationError:
+        print(
+            "Operational service-level reporting failed: configuration or evidence "
+            "was invalid",
+            file=sys.stderr,
+        )
+        return 1
+    except StorageError:
+        print(
+            "Operational service-level reporting failed: local or PostgreSQL "
+            "evidence could not be read",
+            file=sys.stderr,
+        )
+        return 1
+    except Exception:
+        print(
+            "Operational service-level reporting failed: unexpected local failure",
+            file=sys.stderr,
+        )
+        return 1
+    print(json.dumps(summary, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/test_operational_service_levels.py
+++ b/tests/unit/test_operational_service_levels.py
@@ -1,0 +1,180 @@
+from __future__ import annotations
+
+from datetime import date, datetime, timedelta, timezone
+
+import pytest
+
+from src.analytics.operational_service_levels import (
+    evaluate_operational_service_levels,
+    parse_operational_service_level_policy,
+)
+from src.common.exceptions import ValidationError
+
+
+def _policy_payload() -> dict[str, object]:
+    return {
+        "policies": {
+            "us-tech-local": {
+                "schedule_id": "us-tech-local",
+                "metrics": {
+                    "schedule_lag_sessions": {"warning": 1, "critical": 2},
+                    "market_freshness_exception_count": {
+                        "warning": 1,
+                        "critical": 2,
+                    },
+                    "notification_retry_exhausted_count": {
+                        "warning": 1,
+                        "critical": 2,
+                    },
+                    "notification_oldest_dead_letter_age_seconds": {
+                        "warning": 900,
+                        "critical": 3600,
+                    },
+                },
+            }
+        }
+    }
+
+
+def _policy():
+    return parse_operational_service_level_policy(
+        _policy_payload(),
+        "us-tech-local",
+    )
+
+
+def _freshness(status: str = "current") -> list[dict[str, object]]:
+    return [
+        {
+            "source": "alpha_vantage",
+            "symbol": symbol,
+            "calendar_id": "XNYS",
+            "as_of_date": date(2026, 3, 31),
+            "freshness_status": status,
+            "trailing_missing_session_count": 0 if status != "stale" else 1,
+        }
+        for symbol in ("AAPL", "MSFT")
+    ]
+
+
+def _evaluate(
+    *,
+    lag: int | None = 0,
+    checkpoint: date | None = date(2026, 3, 31),
+    freshness: list[dict[str, object]] | None = None,
+    notifications: list[dict[str, object]] | None = None,
+):
+    return evaluate_operational_service_levels(
+        policy=_policy(),
+        as_of=datetime(2026, 4, 1, 12, tzinfo=timezone.utc),
+        schedule_fingerprint="local-schedule-example",
+        latest_expected_session=date(2026, 3, 31),
+        schedule_checkpoint=checkpoint,
+        schedule_lag_sessions=lag,
+        expected_constituents=(
+            "alpha_vantage:AAPL",
+            "alpha_vantage:MSFT",
+        ),
+        calendar_id="XNYS",
+        freshness_records=_freshness() if freshness is None else freshness,
+        notification_records=[] if notifications is None else notifications,
+        maximum_notification_attempts=3,
+    )
+
+
+def test_current_evidence_produces_deterministic_ok_report() -> None:
+    first = _evaluate()
+    second = _evaluate()
+
+    assert first.report == second.report
+    assert first.report["overall_status"] == "ok"
+    assert first.report["calculation_id"].startswith(
+        "operational-service-levels-v1-report-"
+    )
+    assert {metric["status"] for metric in first.metrics} == {"ok"}
+    assert first.report["freshness_exceptions"] == []
+    assert first.report["notification_retry_exhausted_events"] == []
+
+
+def test_missing_checkpoint_and_stale_inputs_produce_critical_report() -> None:
+    as_of = datetime(2026, 4, 1, 12, tzinfo=timezone.utc)
+    notifications = [
+        {
+            "event_id": "event-1",
+            "ts_event": as_of - timedelta(hours=3),
+            "attempt_count": 3,
+            "delivered": False,
+            "last_attempted_at": as_of - timedelta(hours=2),
+        }
+    ]
+    output = _evaluate(
+        lag=None,
+        checkpoint=None,
+        freshness=_freshness("stale"),
+        notifications=notifications,
+    )
+    metrics = {metric["metric_name"]: metric for metric in output.metrics}
+
+    assert output.report["overall_status"] == "critical"
+    assert metrics["schedule_lag_sessions"] == {
+        "metric_name": "schedule_lag_sessions",
+        "observed_value": None,
+        "unit": "sessions",
+        "warning_threshold": 1.0,
+        "critical_threshold": 2.0,
+        "status": "critical",
+        "reason": "checkpoint_missing",
+    }
+    assert metrics["market_freshness_exception_count"]["observed_value"] == 2.0
+    assert metrics["notification_retry_exhausted_count"]["status"] == "warning"
+    assert (
+        metrics["notification_oldest_dead_letter_age_seconds"]["observed_value"]
+        == 7200.0
+    )
+    assert output.report["notification_retry_exhausted_events"] == ["event-1"]
+
+
+def test_missing_freshness_record_is_counted_as_an_exception() -> None:
+    output = _evaluate(freshness=_freshness()[:1])
+
+    assert output.report["freshness_exceptions"] == [
+        "alpha_vantage:MSFT:missing"
+    ]
+    metrics = {metric["metric_name"]: metric for metric in output.metrics}
+    assert metrics["market_freshness_exception_count"]["status"] == "warning"
+
+
+def test_duplicate_evidence_and_future_attempts_fail_closed() -> None:
+    with pytest.raises(ValidationError, match="duplicate constituents"):
+        _evaluate(freshness=[*_freshness(), _freshness()[0]])
+
+    as_of = datetime(2026, 4, 1, 12, tzinfo=timezone.utc)
+    with pytest.raises(ValidationError, match="must not be in the future"):
+        _evaluate(
+            notifications=[
+                {
+                    "event_id": "event-future",
+                    "ts_event": as_of,
+                    "attempt_count": 3,
+                    "delivered": False,
+                    "last_attempted_at": as_of + timedelta(seconds=1),
+                }
+            ]
+        )
+
+
+def test_policy_thresholds_and_metric_set_are_strict() -> None:
+    payload = _policy_payload()
+    candidate = payload["policies"]["us-tech-local"]  # type: ignore[index]
+    candidate["metrics"]["schedule_lag_sessions"] = {  # type: ignore[index]
+        "warning": 2,
+        "critical": 2,
+    }
+    with pytest.raises(ValidationError, match="greater than warning"):
+        parse_operational_service_level_policy(payload, "us-tech-local")
+
+    payload = _policy_payload()
+    candidate = payload["policies"]["us-tech-local"]  # type: ignore[index]
+    del candidate["metrics"]["schedule_lag_sessions"]  # type: ignore[index]
+    with pytest.raises(ValidationError, match="supported metric set"):
+        parse_operational_service_level_policy(payload, "us-tech-local")

--- a/tests/unit/test_run_operational_service_levels.py
+++ b/tests/unit/test_run_operational_service_levels.py
@@ -1,0 +1,249 @@
+from __future__ import annotations
+
+from datetime import date, datetime, time, timezone
+from pathlib import Path
+
+import pytest
+
+from src.analytics.market_calendar import MarketCalendar
+from src.analytics.operational_service_levels import (
+    parse_operational_service_level_policy,
+)
+from src.analytics.portfolio_mandates import PortfolioMandate
+from src.analytics.portfolio_risk import PortfolioConstituent
+from src.common.exceptions import ValidationError
+from src.orchestration.deliver_portfolio_risk_notifications import (
+    WebhookDeliveryConfig,
+)
+from src.orchestration.run_local_portfolio_schedule import (
+    MODEL_VERSION as SCHEDULE_MODEL_VERSION,
+)
+from src.orchestration.run_local_portfolio_schedule import LocalPortfolioSchedule
+from src.orchestration.run_operational_service_levels import (
+    run_operational_service_levels,
+)
+
+
+def _policy():
+    return parse_operational_service_level_policy(
+        {
+            "policies": {
+                "us-tech-local": {
+                    "schedule_id": "us-tech-local",
+                    "metrics": {
+                        "schedule_lag_sessions": {
+                            "warning": 1,
+                            "critical": 2,
+                        },
+                        "market_freshness_exception_count": {
+                            "warning": 1,
+                            "critical": 2,
+                        },
+                        "notification_retry_exhausted_count": {
+                            "warning": 1,
+                            "critical": 2,
+                        },
+                        "notification_oldest_dead_letter_age_seconds": {
+                            "warning": 900,
+                            "critical": 3600,
+                        },
+                    },
+                }
+            }
+        },
+        "us-tech-local",
+    )
+
+
+def _schedule() -> LocalPortfolioSchedule:
+    return LocalPortfolioSchedule(
+        schedule_id="us-tech-local",
+        enabled=False,
+        portfolio_id="us-tech-equal",
+        policy_id="us-tech-standard",
+        calendar_id="XNYS",
+        maximum_catch_up_sessions=5,
+        volatility_window=20,
+        var_window=60,
+        var_confidence=0.95,
+        covariance_window=20,
+        max_snapshots=5,
+        max_evaluations=100,
+        max_notification_events=100,
+    )
+
+
+def _calendar() -> MarketCalendar:
+    return MarketCalendar(
+        calendar_id="XNYS",
+        timezone_name="America/New_York",
+        valid_from=date(2026, 1, 1),
+        valid_to=date(2027, 1, 1),
+        session_weekdays=(0, 1, 2, 3, 4),
+        holidays=frozenset(),
+        regular_close_time=time(16, 0),
+        early_closes={},
+    )
+
+
+def _mandate() -> PortfolioMandate:
+    return PortfolioMandate(
+        portfolio_id="us-tech-equal",
+        base_currency="USD",
+        constituents=(
+            PortfolioConstituent(
+                source="alpha_vantage",
+                symbol="AAPL",
+                weight=0.5,
+            ),
+            PortfolioConstituent(
+                source="alpha_vantage",
+                symbol="MSFT",
+                weight=0.5,
+            ),
+        ),
+        mandate_id="us-tech-2026",
+        effective_from=date(2026, 1, 1),
+        effective_to=None,
+    )
+
+
+def _delivery() -> WebhookDeliveryConfig:
+    return WebhookDeliveryConfig(
+        enabled=False,
+        endpoint_env="RISK_NOTIFICATION_WEBHOOK_URL",
+        timeout_seconds=5,
+        max_batch_events=25,
+        max_attempts_per_event=3,
+        initial_backoff_seconds=1,
+    )
+
+
+def _freshness() -> list[dict[str, object]]:
+    return [
+        {
+            "source": "alpha_vantage",
+            "symbol": symbol,
+            "calendar_id": "XNYS",
+            "as_of_date": date(2026, 3, 31),
+            "freshness_status": "current",
+            "trailing_missing_session_count": 0,
+        }
+        for symbol in ("AAPL", "MSFT")
+    ]
+
+
+def test_runner_combines_schedule_state_and_postgres_evidence() -> None:
+    schedule = _schedule()
+    calls: list[dict[str, object]] = []
+
+    def evidence_reader(**kwargs):
+        calls.append(dict(kwargs))
+        return _freshness(), []
+
+    summary = run_operational_service_levels(
+        policy_id="us-tech-local",
+        as_of=datetime(2026, 3, 31, 12, tzinfo=timezone.utc),
+        policy_config_path=Path("unused-policy.yaml"),
+        schedule_config_path=Path("unused-schedule.yaml"),
+        calendar_config_path=Path("unused-calendar.yaml"),
+        portfolio_config_path=Path("unused-portfolio.yaml"),
+        delivery_config_path=Path("unused-delivery.yaml"),
+        state_dir=Path("unused-state"),
+        dsn="postgresql://example",
+        policy_loader=lambda *_: _policy(),
+        schedule_loader=lambda *_: schedule,
+        calendar_loader=lambda *_: _calendar(),
+        mandate_loader=lambda *_: _mandate(),
+        delivery_config_loader=lambda *_: _delivery(),
+        state_reader=lambda _: {
+            "model_version": SCHEDULE_MODEL_VERSION,
+            "schedule_id": schedule.schedule_id,
+            "schedule_fingerprint": schedule.fingerprint,
+            "last_successful_session": "2026-03-30",
+        },
+        evidence_reader=evidence_reader,
+    )
+
+    assert summary["overall_status"] == "warning"
+    assert summary["schedule_checkpoint"] == "2026-03-30"
+    metrics = {metric["metric_name"]: metric for metric in summary["metrics"]}
+    assert metrics["schedule_lag_sessions"]["observed_value"] == 1.0
+    assert summary["provider_request_performed"] is False
+    assert summary["external_delivery_performed"] is False
+    assert summary["cloud_schedule_activated"] is False
+    assert calls == [
+        {
+            "dsn": "postgresql://example",
+            "calendar_id": "XNYS",
+            "policy_id": "us-tech-standard",
+            "portfolio_id": "us-tech-equal",
+            "schema_name": "risk_platform",
+        }
+    ]
+
+
+def test_missing_state_is_reported_without_executing_the_schedule() -> None:
+    summary = run_operational_service_levels(
+        policy_id="us-tech-local",
+        as_of=datetime(2026, 3, 31, 12, tzinfo=timezone.utc),
+        policy_config_path=Path("unused-policy.yaml"),
+        schedule_config_path=Path("unused-schedule.yaml"),
+        calendar_config_path=Path("unused-calendar.yaml"),
+        portfolio_config_path=Path("unused-portfolio.yaml"),
+        delivery_config_path=Path("unused-delivery.yaml"),
+        state_dir=Path("unused-state"),
+        dsn="postgresql://example",
+        policy_loader=lambda *_: _policy(),
+        schedule_loader=lambda *_: _schedule(),
+        calendar_loader=lambda *_: _calendar(),
+        mandate_loader=lambda *_: _mandate(),
+        delivery_config_loader=lambda *_: _delivery(),
+        state_reader=lambda _: None,
+        evidence_reader=lambda **_: (_freshness(), []),
+    )
+
+    assert summary["overall_status"] == "critical"
+    schedule_metric = next(
+        metric
+        for metric in summary["metrics"]
+        if metric["metric_name"] == "schedule_lag_sessions"
+    )
+    assert schedule_metric["reason"] == "checkpoint_missing"
+
+
+def test_changed_schedule_state_fails_closed_before_evidence_read() -> None:
+    schedule = _schedule()
+    called = False
+
+    def evidence_reader(**_):
+        nonlocal called
+        called = True
+        return [], []
+
+    with pytest.raises(ValidationError, match="configuration changed"):
+        run_operational_service_levels(
+            policy_id="us-tech-local",
+            as_of=datetime(2026, 3, 31, 12, tzinfo=timezone.utc),
+            policy_config_path=Path("unused-policy.yaml"),
+            schedule_config_path=Path("unused-schedule.yaml"),
+            calendar_config_path=Path("unused-calendar.yaml"),
+            portfolio_config_path=Path("unused-portfolio.yaml"),
+            delivery_config_path=Path("unused-delivery.yaml"),
+            state_dir=Path("unused-state"),
+            dsn="postgresql://example",
+            policy_loader=lambda *_: _policy(),
+            schedule_loader=lambda *_: schedule,
+            calendar_loader=lambda *_: _calendar(),
+            mandate_loader=lambda *_: _mandate(),
+            delivery_config_loader=lambda *_: _delivery(),
+            state_reader=lambda _: {
+                "model_version": SCHEDULE_MODEL_VERSION,
+                "schedule_id": schedule.schedule_id,
+                "schedule_fingerprint": "changed",
+                "last_successful_session": "2026-03-31",
+            },
+            evidence_reader=evidence_reader,
+        )
+
+    assert called is False


### PR DESCRIPTION
## Outcome

Add a bounded, deterministic operational report over controls that already exist in the repository:

```text
local schedule checkpoint
  + exchange-calendar expected session
  + current constituent freshness
  + pending notification delivery attempts
  -> four service-level indicators
  -> one reproducible overall status
  -> credential-free JSON evidence
```

Primary arc42 block: `analytics`, with bounded read-only interfaces to local schedule state, effective portfolio mandates, market-calendar configuration, current PostgreSQL freshness evidence and notification-delivery status.

## Versioned policy

Add `config/operational_service_levels.yaml` with one reviewed threshold policy bound to `us-tech-local`.

The supported metrics are:

- `schedule_lag_sessions`;
- `market_freshness_exception_count`;
- `notification_retry_exhausted_count`; and
- `notification_oldest_dead_letter_age_seconds`.

A deterministic policy fingerprint binds the policy ID, schedule ID, model version and all warning and critical thresholds. Threshold changes therefore create a distinct report identity.

## Schedule completion evidence

The report validates the existing local scheduler state model, schedule ID and schedule fingerprint. Lag is measured in configured market sessions after the last successful checkpoint through the latest expected exchange session; weekends and holidays do not create false lag.

A missing checkpoint is explicitly `critical` with `reason = checkpoint_missing`. A checkpoint from another schedule/configuration or after the latest expected session fails closed.

## Market freshness evidence

The effective portfolio mandate defines the exact expected source/symbol keys. A constituent counts as exceptional when its current freshness row is missing, belongs to another session, has `gap_detected`/`stale` status or has trailing missing sessions.

Duplicate matching evidence and malformed status/date/count values fail closed.

## Notification delivery evidence

The reviewed webhook configuration supplies the maximum attempts per event. An undelivered event is retry-exhausted once its attempt count reaches that limit. Dead-letter age is measured from `last_attempted_at`, with `ts_event` as the explicit fallback.

Duplicate events, future timestamps, invalid attempt counts and oversized reads fail closed. The report never retries or delivers a notification.

## Runner and bounds

Add `src.orchestration.run_operational_service_levels`:

```bash
.venv/bin/python -m src.orchestration.run_operational_service_levels \
  --policy-id us-tech-local \
  --as-of 2026-04-01T12:00:00Z \
  --summary-json .demo/operational-service-levels.json
```

The runner caps evidence at:

- 1,000 current freshness rows;
- 5,000 pending notification rows; and
- 64 KiB for local schedule state.

The report calculation ID binds the explicit report instant, policy, schedule, calendar, checkpoint, expected constituents, exceptions, exhausted events and metric results.

## Validation and repair

The first exact-head run found one mypy variable-shadowing/narrowing issue in the freshness loop. The optional lookup now uses a dedicated `freshness_record` variable; no validation gate was weakened.

GitHub Actions run `32638878002` (`ci` run 273) passed on exact head `a1c5fed81a2a56619ba36ddbe96426ccc3279319`:

- Security guardrails: passed.
- Python readiness: passed.
  - locked dependencies resolved;
  - Ruff passed;
  - mypy passed across 85 source files;
  - 685 tests passed in both quality and readiness runs;
  - `pip check` passed;
  - the standard readiness replay passed.
- PostgreSQL contract: passed against PostgreSQL 16, including model-approval checks.
- Infrastructure validation: passed without deployment or Terraform apply.

Focused tests cover deterministic healthy evidence, market-session lag, missing checkpoints, stale/missing freshness evidence, retry exhaustion, dead-letter age, strict policy thresholds, duplicate/future evidence rejection and changed schedule-state rejection before PostgreSQL reads.

No unresolved review threads or requested changes are present.

## Scope

The branch is seven file-level working commits ahead of `main` and zero behind because the connector rejected the atomic tree write and one focused CI repair followed. It changes exactly six files with 1,395 additions and no deletions. It will be squash-merged as one report-only operational evidence increment.

No schedule execution, market-provider request, notification retry/delivery, PostgreSQL report persistence, execution gate, dashboard, paging, deployment or Terraform apply is included.

## Acceptance boundary

Validated and ready for squash merge as one operational evidence increment.