### PR TITLE
Add read-only operational readiness gate

### DIFF
--- a/config/operational_readiness_gates.yaml
+++ b/config/operational_readiness_gates.yaml
@@ -1,0 +1,5 @@
+gates:
+  us-tech-local:
+    operational_policy_id: us-tech-local
+    max_report_age_seconds: 3600
+    allow_warning: false

--- a/docs/operational-readiness-gate.md
+++ b/docs/operational-readiness-gate.md
@@ -1,0 +1,99 @@
+# Operational Readiness Gate
+
+## Outcome
+
+This increment turns the latest retained operational service-level report into one
+read-only, deterministic readiness decision:
+
+```text
+current gate policy
+  + current operational threshold policy
+  + current local schedule fingerprint
+  + latest expected market session
+  + effective portfolio mandate fingerprint
+  + latest exact-contract retained report
+  -> allow or block
+  -> deterministic JSON evidence and process exit code
+```
+
+The gate is incapable of executing the portfolio schedule, requesting provider
+data, retrying or delivering notifications, activating a cloud schedule, changing
+positions or deploying infrastructure.
+
+## Gate policy
+
+`config/operational_readiness_gates.yaml` defines:
+
+- the operational service-level policy to evaluate;
+- the maximum retained-report age; and
+- whether a current `warning` report may pass.
+
+The demonstration gate is strict: warning and critical reports block, and the
+report may be at most one hour old. Its deterministic fingerprint binds all gate
+settings, so policy changes produce distinguishable decision evidence.
+
+Critical status always blocks. `allow_warning` can permit warning evidence but
+cannot permit critical evidence.
+
+## Exact current contract
+
+Before querying PostgreSQL, the runner resolves:
+
+- the current operational service-level policy and fingerprint;
+- the linked local schedule and fingerprint;
+- the schedule calendar;
+- the latest expected market session at the explicit evaluation instant; and
+- the effective portfolio mandate and fingerprint for that session.
+
+It then reads at most two rows from
+`risk_platform.latest_operational_service_level_reports`, filtering by the exact
+policy, schedule, calendar, portfolio, risk-limit policy and mandate contract.
+Zero rows becomes a deterministic `report_missing` block. More than one exact row
+fails closed because the serving grain is inconsistent.
+
+## Decision rules
+
+The gate blocks for any of these reasons:
+
+| Reason | Meaning |
+| --- | --- |
+| `report_missing` | No retained report matches the exact current contract |
+| `report_timestamp_future` | The report timestamp is after the explicit gate instant |
+| `report_age_exceeds_limit` | The report is older than the configured maximum age |
+| `report_session_mismatch` | The report covers a different latest expected market session |
+| `report_status_warning` | The report is warning and the gate does not allow warnings |
+| `report_status_critical` | The report is critical |
+
+Malformed identities, digests, timestamps, statuses or configuration bindings are
+invalid evidence and fail closed rather than becoming a normal policy decision.
+
+The decision is `allow` only when no reason remains.
+
+## Operator command
+
+Use an explicit UTC timestamp:
+
+```bash
+.venv/bin/python -m src.warehouse.operational_readiness_gate \
+  --gate-id us-tech-local \
+  --evaluated-at 2026-04-01T12:00:00Z \
+  --summary-json .demo/operational-readiness-gate.json
+```
+
+Exit codes are:
+
+- `0` — allowed;
+- `2` — valid evidence produced a blocked decision; and
+- `1` — configuration, retained evidence or PostgreSQL access was invalid.
+
+The JSON evidence includes the gate and report identities, exact current
+fingerprints, expected session, report age/future offset, report status, decision
+and ordered reasons. It explicitly records that no schedule, provider, delivery
+or cloud activation side effect occurred.
+
+## Current boundary
+
+This is a reviewable read-only gate. It is not wired into the local scheduler,
+notification delivery or deployment workflows. A later integration slice may
+consume the exit code only after deciding which operation should be protected and
+how an operator may override or acknowledge a block.

--- a/src/warehouse/operational_readiness_gate.py
+++ b/src/warehouse/operational_readiness_gate.py
@@ -1,0 +1,643 @@
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+import os
+import re
+import sys
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass
+from datetime import date, datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from src.analytics.market_calendar import MarketCalendar, load_market_calendar
+from src.analytics.operational_service_levels import (
+    OperationalServiceLevelPolicy,
+    load_operational_service_level_policy,
+)
+from src.analytics.portfolio_mandates import (
+    PortfolioMandate,
+    load_portfolio_mandate,
+)
+from src.common.config import load_yaml
+from src.common.exceptions import StorageError, ValidationError
+from src.orchestration.run_local_portfolio_schedule import (
+    LocalPortfolioSchedule,
+    load_local_portfolio_schedule,
+)
+from src.warehouse.postgres_loader import DEFAULT_POSTGRES_DSN
+
+MODEL_VERSION = "operational-readiness-gate-v1"
+MAX_REPORT_AGE_SECONDS = 7 * 24 * 60 * 60
+CALCULATION_ID_PATTERN = re.compile(
+    r"^operational-service-levels-v1-report-[0-9a-f]{24}$"
+)
+SHA256_PATTERN = re.compile(r"^[0-9a-f]{64}$")
+SAFE_SEGMENT_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$")
+
+
+@dataclass(frozen=True, slots=True)
+class OperationalReadinessGatePolicy:
+    gate_id: str
+    operational_policy_id: str
+    max_report_age_seconds: int
+    allow_warning: bool
+
+    @property
+    def fingerprint(self) -> str:
+        payload = {
+            "allow_warning": self.allow_warning,
+            "gate_id": self.gate_id,
+            "max_report_age_seconds": self.max_report_age_seconds,
+            "model_version": MODEL_VERSION,
+            "operational_policy_id": self.operational_policy_id,
+        }
+        digest = hashlib.sha256(
+            json.dumps(payload, sort_keys=True, separators=(",", ":")).encode(
+                "utf-8"
+            )
+        ).hexdigest()[:24]
+        return f"operational-readiness-gate-{digest}"
+
+
+GatePolicyLoader = Callable[[Path, str], OperationalReadinessGatePolicy]
+OperationalPolicyLoader = Callable[[Path, str], OperationalServiceLevelPolicy]
+ScheduleLoader = Callable[[Path, str], LocalPortfolioSchedule]
+CalendarLoader = Callable[[Path, str], MarketCalendar]
+MandateLoader = Callable[[Path, str, date], PortfolioMandate]
+ReportReader = Callable[..., Mapping[str, Any] | None]
+
+
+def _safe_segment(value: Any, label: str) -> str:
+    if not isinstance(value, str) or not SAFE_SEGMENT_PATTERN.fullmatch(value):
+        raise ValidationError(f"{label} must be one safe text segment")
+    return value
+
+
+def _bounded_fingerprint(value: Any, label: str) -> str:
+    if not isinstance(value, str) or not value or len(value) > 256:
+        raise ValidationError(f"{label} must be non-empty bounded text")
+    if value != value.strip() or any(ord(character) < 32 for character in value):
+        raise ValidationError(f"{label} must be canonical bounded text")
+    return value
+
+
+def _positive_age_limit(value: Any) -> int:
+    if type(value) is not int or not 1 <= value <= MAX_REPORT_AGE_SECONDS:
+        raise ValidationError(
+            "max_report_age_seconds must be an integer between 1 and "
+            f"{MAX_REPORT_AGE_SECONDS}"
+        )
+    return value
+
+
+def parse_operational_readiness_gate_policy(
+    payload: Mapping[str, Any],
+    gate_id: str,
+) -> OperationalReadinessGatePolicy:
+    if not isinstance(payload, Mapping):
+        raise ValidationError("operational readiness configuration must be a mapping")
+    gate_id = _safe_segment(gate_id, "gate_id")
+    gates = payload.get("gates")
+    if not isinstance(gates, Mapping):
+        raise ValidationError("operational readiness configuration must define gates")
+    candidate = gates.get(gate_id)
+    if not isinstance(candidate, Mapping) or set(candidate) != {
+        "operational_policy_id",
+        "max_report_age_seconds",
+        "allow_warning",
+    }:
+        raise ValidationError(
+            f"operational readiness gate '{gate_id}' has an invalid contract"
+        )
+    allow_warning = candidate.get("allow_warning")
+    if type(allow_warning) is not bool:
+        raise ValidationError("allow_warning must be boolean")
+    return OperationalReadinessGatePolicy(
+        gate_id=gate_id,
+        operational_policy_id=_safe_segment(
+            candidate.get("operational_policy_id"),
+            "operational_policy_id",
+        ),
+        max_report_age_seconds=_positive_age_limit(
+            candidate.get("max_report_age_seconds")
+        ),
+        allow_warning=allow_warning,
+    )
+
+
+def load_operational_readiness_gate_policy(
+    path: Path,
+    gate_id: str,
+) -> OperationalReadinessGatePolicy:
+    try:
+        payload = load_yaml(path)
+    except Exception:
+        raise ValidationError(
+            "operational readiness configuration could not be loaded"
+        ) from None
+    if not isinstance(payload, Mapping):
+        raise ValidationError("operational readiness configuration must be a mapping")
+    return parse_operational_readiness_gate_policy(payload, gate_id)
+
+
+def _aware_utc(value: Any, label: str) -> datetime:
+    if isinstance(value, datetime):
+        parsed = value
+    elif isinstance(value, str):
+        try:
+            parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        except ValueError:
+            raise ValidationError(f"{label} must be an ISO-8601 timestamp") from None
+    else:
+        raise ValidationError(f"{label} must be a timezone-aware timestamp")
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise ValidationError(f"{label} must be a timezone-aware timestamp")
+    return parsed.astimezone(timezone.utc)
+
+
+def _calendar_date(value: Any, label: str) -> date:
+    if isinstance(value, datetime):
+        raise ValidationError(f"{label} must be a calendar date")
+    if isinstance(value, date):
+        return value
+    if not isinstance(value, str):
+        raise ValidationError(f"{label} must use YYYY-MM-DD")
+    try:
+        parsed = date.fromisoformat(value)
+    except ValueError:
+        raise ValidationError(f"{label} must use YYYY-MM-DD") from None
+    if value != parsed.isoformat():
+        raise ValidationError(f"{label} must use YYYY-MM-DD")
+    return parsed
+
+
+def _quote_identifier(value: str) -> str:
+    if not isinstance(value, str) or not value:
+        raise ValidationError("schema_name must be non-empty text")
+    return '"' + value.replace('"', '""') + '"'
+
+
+def read_latest_operational_report(
+    *,
+    dsn: str,
+    operational_policy_id: str,
+    operational_policy_fingerprint: str,
+    schedule_id: str,
+    schedule_fingerprint: str,
+    calendar_id: str,
+    portfolio_id: str,
+    risk_limit_policy_id: str,
+    mandate_fingerprint: str,
+    schema_name: str = "risk_platform",
+) -> Mapping[str, Any] | None:
+    if not isinstance(dsn, str) or not dsn.strip():
+        raise ValidationError("PostgreSQL DSN must be non-empty text")
+    schema = _quote_identifier(schema_name)
+    try:
+        import psycopg
+        from psycopg.rows import dict_row
+    except ImportError as exc:
+        raise RuntimeError("Operational readiness requires psycopg") from exc
+
+    query = f"""
+        SELECT
+            calculation_id,
+            policy_id,
+            policy_fingerprint,
+            schedule_id,
+            schedule_fingerprint,
+            calendar_id,
+            portfolio_id,
+            risk_limit_policy_id,
+            mandate_fingerprint,
+            as_of,
+            latest_expected_session,
+            overall_status,
+            document_sha256
+        FROM {schema}.latest_operational_service_level_reports
+        WHERE policy_id = %s
+          AND policy_fingerprint = %s
+          AND schedule_id = %s
+          AND schedule_fingerprint = %s
+          AND calendar_id = %s
+          AND portfolio_id = %s
+          AND risk_limit_policy_id = %s
+          AND mandate_fingerprint = %s
+        ORDER BY as_of DESC, calculation_id DESC
+        LIMIT 2
+    """
+    try:
+        with psycopg.connect(dsn, row_factory=dict_row) as connection:
+            with connection.cursor() as cursor:
+                cursor.execute(
+                    query,
+                    (
+                        operational_policy_id,
+                        operational_policy_fingerprint,
+                        schedule_id,
+                        schedule_fingerprint,
+                        calendar_id,
+                        portfolio_id,
+                        risk_limit_policy_id,
+                        mandate_fingerprint,
+                    ),
+                )
+                rows = [dict(row) for row in cursor.fetchall()]
+    except Exception:
+        raise StorageError(
+            "Unable to read the latest operational service-level report"
+        ) from None
+    if len(rows) > 1:
+        raise StorageError(
+            "latest operational service-level report grain is not unique"
+        )
+    return rows[0] if rows else None
+
+
+def _validate_report(
+    report: Mapping[str, Any],
+    *,
+    operational_policy_id: str,
+    operational_policy_fingerprint: str,
+    schedule_id: str,
+    schedule_fingerprint: str,
+    calendar_id: str,
+    portfolio_id: str,
+    risk_limit_policy_id: str,
+    mandate_fingerprint: str,
+) -> dict[str, Any]:
+    calculation_id = report.get("calculation_id")
+    if not isinstance(calculation_id, str) or not CALCULATION_ID_PATTERN.fullmatch(
+        calculation_id
+    ):
+        raise ValidationError("latest operational report calculation ID is invalid")
+    document_sha256 = report.get("document_sha256")
+    if not isinstance(document_sha256, str) or not SHA256_PATTERN.fullmatch(
+        document_sha256
+    ):
+        raise ValidationError("latest operational report document digest is invalid")
+    expected_text = {
+        "policy_id": operational_policy_id,
+        "policy_fingerprint": operational_policy_fingerprint,
+        "schedule_id": schedule_id,
+        "schedule_fingerprint": schedule_fingerprint,
+        "calendar_id": calendar_id,
+        "portfolio_id": portfolio_id,
+        "risk_limit_policy_id": risk_limit_policy_id,
+        "mandate_fingerprint": mandate_fingerprint,
+    }
+    for key, expected in expected_text.items():
+        if report.get(key) != expected:
+            raise ValidationError(
+                f"latest operational report {key} does not match current configuration"
+            )
+    status = report.get("overall_status")
+    if status not in {"ok", "warning", "critical"}:
+        raise ValidationError("latest operational report status is invalid")
+    return {
+        "calculation_id": calculation_id,
+        "document_sha256": document_sha256,
+        "as_of": _aware_utc(report.get("as_of"), "report as_of"),
+        "latest_expected_session": _calendar_date(
+            report.get("latest_expected_session"),
+            "report latest_expected_session",
+        ),
+        "overall_status": status,
+    }
+
+
+def evaluate_operational_readiness(
+    *,
+    gate_policy: OperationalReadinessGatePolicy,
+    evaluated_at: datetime,
+    latest_expected_session: date,
+    operational_policy_fingerprint: str,
+    schedule_id: str,
+    schedule_fingerprint: str,
+    calendar_id: str,
+    portfolio_id: str,
+    risk_limit_policy_id: str,
+    mandate_fingerprint: str,
+    report: Mapping[str, Any] | None,
+) -> dict[str, Any]:
+    evaluated_at = _aware_utc(evaluated_at, "evaluated_at")
+    schedule_id = _safe_segment(schedule_id, "schedule_id")
+    calendar_id = _safe_segment(calendar_id, "calendar_id")
+    portfolio_id = _safe_segment(portfolio_id, "portfolio_id")
+    risk_limit_policy_id = _safe_segment(
+        risk_limit_policy_id,
+        "risk_limit_policy_id",
+    )
+    operational_policy_fingerprint = _bounded_fingerprint(
+        operational_policy_fingerprint,
+        "operational_policy_fingerprint",
+    )
+    schedule_fingerprint = _bounded_fingerprint(
+        schedule_fingerprint,
+        "schedule_fingerprint",
+    )
+    mandate_fingerprint = _bounded_fingerprint(
+        mandate_fingerprint,
+        "mandate_fingerprint",
+    )
+
+    reasons: list[str] = []
+    validated_report: dict[str, Any] | None = None
+    report_age_seconds: float | None = None
+    report_future_seconds: float | None = None
+    if report is None:
+        reasons.append("report_missing")
+    else:
+        validated_report = _validate_report(
+            report,
+            operational_policy_id=gate_policy.operational_policy_id,
+            operational_policy_fingerprint=operational_policy_fingerprint,
+            schedule_id=schedule_id,
+            schedule_fingerprint=schedule_fingerprint,
+            calendar_id=calendar_id,
+            portfolio_id=portfolio_id,
+            risk_limit_policy_id=risk_limit_policy_id,
+            mandate_fingerprint=mandate_fingerprint,
+        )
+        delta_seconds = (
+            evaluated_at - validated_report["as_of"]
+        ).total_seconds()
+        report_age_seconds = max(0.0, delta_seconds)
+        report_future_seconds = max(0.0, -delta_seconds)
+        if delta_seconds < 0:
+            reasons.append("report_timestamp_future")
+        elif report_age_seconds > gate_policy.max_report_age_seconds:
+            reasons.append("report_age_exceeds_limit")
+        if validated_report["latest_expected_session"] != latest_expected_session:
+            reasons.append("report_session_mismatch")
+        status = validated_report["overall_status"]
+        if status == "critical":
+            reasons.append("report_status_critical")
+        elif status == "warning" and not gate_policy.allow_warning:
+            reasons.append("report_status_warning")
+
+    decision = "allow" if not reasons else "block"
+    identity_payload = {
+        "calendar_id": calendar_id,
+        "decision": decision,
+        "evaluated_at": evaluated_at.isoformat(),
+        "gate_fingerprint": gate_policy.fingerprint,
+        "latest_expected_session": latest_expected_session.isoformat(),
+        "mandate_fingerprint": mandate_fingerprint,
+        "operational_policy_fingerprint": operational_policy_fingerprint,
+        "portfolio_id": portfolio_id,
+        "reasons": reasons,
+        "report_calculation_id": (
+            validated_report["calculation_id"]
+            if validated_report is not None
+            else None
+        ),
+        "report_document_sha256": (
+            validated_report["document_sha256"]
+            if validated_report is not None
+            else None
+        ),
+        "risk_limit_policy_id": risk_limit_policy_id,
+        "schedule_fingerprint": schedule_fingerprint,
+        "schedule_id": schedule_id,
+    }
+    digest = hashlib.sha256(
+        json.dumps(
+            identity_payload,
+            sort_keys=True,
+            separators=(",", ":"),
+            allow_nan=False,
+        ).encode("utf-8")
+    ).hexdigest()[:24]
+    return {
+        "decision_id": f"{MODEL_VERSION}-decision-{digest}",
+        "model_version": MODEL_VERSION,
+        "gate_id": gate_policy.gate_id,
+        "gate_fingerprint": gate_policy.fingerprint,
+        "operational_policy_id": gate_policy.operational_policy_id,
+        "operational_policy_fingerprint": operational_policy_fingerprint,
+        "schedule_id": schedule_id,
+        "schedule_fingerprint": schedule_fingerprint,
+        "calendar_id": calendar_id,
+        "portfolio_id": portfolio_id,
+        "risk_limit_policy_id": risk_limit_policy_id,
+        "mandate_fingerprint": mandate_fingerprint,
+        "evaluated_at": evaluated_at.isoformat(),
+        "latest_expected_session": latest_expected_session.isoformat(),
+        "max_report_age_seconds": gate_policy.max_report_age_seconds,
+        "allow_warning": gate_policy.allow_warning,
+        "report_calculation_id": (
+            validated_report["calculation_id"]
+            if validated_report is not None
+            else None
+        ),
+        "report_document_sha256": (
+            validated_report["document_sha256"]
+            if validated_report is not None
+            else None
+        ),
+        "report_as_of": (
+            validated_report["as_of"].isoformat()
+            if validated_report is not None
+            else None
+        ),
+        "report_latest_expected_session": (
+            validated_report["latest_expected_session"].isoformat()
+            if validated_report is not None
+            else None
+        ),
+        "report_status": (
+            validated_report["overall_status"]
+            if validated_report is not None
+            else None
+        ),
+        "report_age_seconds": report_age_seconds,
+        "report_future_seconds": report_future_seconds,
+        "decision": decision,
+        "reasons": reasons,
+        "schedule_executed": False,
+        "provider_request_performed": False,
+        "notification_delivery_performed": False,
+        "cloud_schedule_activated": False,
+    }
+
+
+def run_operational_readiness_gate(
+    *,
+    gate_id: str,
+    evaluated_at: datetime,
+    dsn: str,
+    gate_config_path: Path,
+    operational_policy_config_path: Path,
+    schedule_config_path: Path,
+    calendar_config_path: Path,
+    portfolio_config_path: Path,
+    schema_name: str = "risk_platform",
+    gate_policy_loader: GatePolicyLoader | None = None,
+    operational_policy_loader: OperationalPolicyLoader | None = None,
+    schedule_loader: ScheduleLoader | None = None,
+    calendar_loader: CalendarLoader | None = None,
+    mandate_loader: MandateLoader | None = None,
+    report_reader: ReportReader | None = None,
+) -> dict[str, Any]:
+    evaluated_at = _aware_utc(evaluated_at, "evaluated_at")
+    selected_gate_loader = (
+        gate_policy_loader or load_operational_readiness_gate_policy
+    )
+    gate_policy = selected_gate_loader(gate_config_path, gate_id)
+    selected_policy_loader = (
+        operational_policy_loader or load_operational_service_level_policy
+    )
+    operational_policy = selected_policy_loader(
+        operational_policy_config_path,
+        gate_policy.operational_policy_id,
+    )
+    selected_schedule_loader = schedule_loader or load_local_portfolio_schedule
+    schedule = selected_schedule_loader(
+        schedule_config_path,
+        operational_policy.schedule_id,
+    )
+    if schedule.schedule_id != operational_policy.schedule_id:
+        raise ValidationError("operational policy and schedule do not align")
+    selected_calendar_loader = calendar_loader or load_market_calendar
+    calendar = selected_calendar_loader(calendar_config_path, schedule.calendar_id)
+    latest_expected_session = calendar.latest_expected_session(evaluated_at.date())
+    selected_mandate_loader = mandate_loader or load_portfolio_mandate
+    mandate = selected_mandate_loader(
+        portfolio_config_path,
+        schedule.portfolio_id,
+        latest_expected_session,
+    )
+    selected_report_reader = report_reader or read_latest_operational_report
+    report = selected_report_reader(
+        dsn=dsn,
+        operational_policy_id=operational_policy.policy_id,
+        operational_policy_fingerprint=operational_policy.fingerprint,
+        schedule_id=schedule.schedule_id,
+        schedule_fingerprint=schedule.fingerprint,
+        calendar_id=calendar.calendar_id,
+        portfolio_id=schedule.portfolio_id,
+        risk_limit_policy_id=schedule.policy_id,
+        mandate_fingerprint=mandate.fingerprint,
+        schema_name=schema_name,
+    )
+    return evaluate_operational_readiness(
+        gate_policy=gate_policy,
+        evaluated_at=evaluated_at,
+        latest_expected_session=latest_expected_session,
+        operational_policy_fingerprint=operational_policy.fingerprint,
+        schedule_id=schedule.schedule_id,
+        schedule_fingerprint=schedule.fingerprint,
+        calendar_id=calendar.calendar_id,
+        portfolio_id=schedule.portfolio_id,
+        risk_limit_policy_id=schedule.policy_id,
+        mandate_fingerprint=mandate.fingerprint,
+        report=report,
+    )
+
+
+def _timestamp(value: str) -> datetime:
+    try:
+        return _aware_utc(value, "evaluated_at")
+    except ValidationError as exc:
+        raise argparse.ArgumentTypeError(str(exc)) from exc
+
+
+def _write_summary(path: Path, summary: Mapping[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_suffix(path.suffix + ".tmp")
+    try:
+        temporary.write_text(
+            json.dumps(summary, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        temporary.replace(path)
+    except OSError:
+        temporary.unlink(missing_ok=True)
+        raise StorageError("Unable to write operational readiness evidence") from None
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Evaluate one read-only operational readiness gate."
+    )
+    parser.add_argument("--gate-id", required=True)
+    parser.add_argument("--evaluated-at", required=True, type=_timestamp)
+    parser.add_argument(
+        "--dsn",
+        default=os.environ.get("WAREHOUSE_POSTGRES_DSN", DEFAULT_POSTGRES_DSN),
+    )
+    parser.add_argument(
+        "--gate-config",
+        type=Path,
+        default=Path("config/operational_readiness_gates.yaml"),
+    )
+    parser.add_argument(
+        "--operational-policy-config",
+        type=Path,
+        default=Path("config/operational_service_levels.yaml"),
+    )
+    parser.add_argument(
+        "--schedule-config",
+        type=Path,
+        default=Path("config/local_portfolio_schedules.yaml"),
+    )
+    parser.add_argument(
+        "--calendar-config",
+        type=Path,
+        default=Path("config/market_calendars.yaml"),
+    )
+    parser.add_argument(
+        "--portfolio-config",
+        type=Path,
+        default=Path("config/portfolios.yaml"),
+    )
+    parser.add_argument("--schema", default="risk_platform")
+    parser.add_argument("--summary-json", type=Path)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    try:
+        result = run_operational_readiness_gate(
+            gate_id=args.gate_id,
+            evaluated_at=args.evaluated_at,
+            dsn=args.dsn,
+            gate_config_path=args.gate_config,
+            operational_policy_config_path=args.operational_policy_config,
+            schedule_config_path=args.schedule_config,
+            calendar_config_path=args.calendar_config,
+            portfolio_config_path=args.portfolio_config,
+            schema_name=args.schema,
+        )
+        if args.summary_json is not None:
+            _write_summary(args.summary_json, result)
+    except ValidationError:
+        print(
+            "Operational readiness failed: configuration or retained evidence was invalid",
+            file=sys.stderr,
+        )
+        return 1
+    except StorageError:
+        print(
+            "Operational readiness failed: PostgreSQL or local evidence could not be read",
+            file=sys.stderr,
+        )
+        return 1
+    except Exception:
+        print(
+            "Operational readiness failed: unexpected local failure",
+            file=sys.stderr,
+        )
+        return 1
+    print(json.dumps(result, sort_keys=True))
+    return 0 if result["decision"] == "allow" else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/warehouse/operational_readiness_gate.py
+++ b/src/warehouse/operational_readiness_gate.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import argparse
 import hashlib
 import json
-import math
 import os
 import re
 import sys

--- a/tests/unit/test_operational_readiness_gate.py
+++ b/tests/unit/test_operational_readiness_gate.py
@@ -1,0 +1,313 @@
+from __future__ import annotations
+
+from datetime import date, datetime, time, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from src.analytics.market_calendar import MarketCalendar
+from src.analytics.operational_service_levels import (
+    parse_operational_service_level_policy,
+)
+from src.analytics.portfolio_mandates import PortfolioMandate
+from src.analytics.portfolio_risk import PortfolioConstituent
+from src.common.exceptions import ValidationError
+from src.orchestration.run_local_portfolio_schedule import LocalPortfolioSchedule
+from src.warehouse.operational_readiness_gate import (
+    evaluate_operational_readiness,
+    parse_operational_readiness_gate_policy,
+    run_operational_readiness_gate,
+)
+
+
+def _gate_policy(*, allow_warning: bool = False):
+    return parse_operational_readiness_gate_policy(
+        {
+            "gates": {
+                "us-tech-local": {
+                    "operational_policy_id": "us-tech-local",
+                    "max_report_age_seconds": 3600,
+                    "allow_warning": allow_warning,
+                }
+            }
+        },
+        "us-tech-local",
+    )
+
+
+def _operational_policy():
+    return parse_operational_service_level_policy(
+        {
+            "policies": {
+                "us-tech-local": {
+                    "schedule_id": "us-tech-local",
+                    "metrics": {
+                        "schedule_lag_sessions": {
+                            "warning": 1,
+                            "critical": 2,
+                        },
+                        "market_freshness_exception_count": {
+                            "warning": 1,
+                            "critical": 2,
+                        },
+                        "notification_retry_exhausted_count": {
+                            "warning": 1,
+                            "critical": 2,
+                        },
+                        "notification_oldest_dead_letter_age_seconds": {
+                            "warning": 900,
+                            "critical": 3600,
+                        },
+                    },
+                }
+            }
+        },
+        "us-tech-local",
+    )
+
+
+def _schedule() -> LocalPortfolioSchedule:
+    return LocalPortfolioSchedule(
+        schedule_id="us-tech-local",
+        enabled=False,
+        portfolio_id="us-tech-equal",
+        policy_id="us-tech-standard",
+        calendar_id="XNYS",
+        maximum_catch_up_sessions=5,
+        volatility_window=20,
+        var_window=60,
+        var_confidence=0.95,
+        covariance_window=20,
+        max_snapshots=5,
+        max_evaluations=100,
+        max_notification_events=100,
+    )
+
+
+def _calendar() -> MarketCalendar:
+    return MarketCalendar(
+        calendar_id="XNYS",
+        timezone_name="America/New_York",
+        valid_from=date(2026, 1, 1),
+        valid_to=date(2027, 1, 1),
+        session_weekdays=(0, 1, 2, 3, 4),
+        holidays=frozenset(),
+        regular_close_time=time(16, 0),
+        early_closes={},
+    )
+
+
+def _mandate() -> PortfolioMandate:
+    return PortfolioMandate(
+        portfolio_id="us-tech-equal",
+        base_currency="USD",
+        constituents=(
+            PortfolioConstituent(
+                source="alpha_vantage",
+                symbol="AAPL",
+                weight=0.5,
+            ),
+            PortfolioConstituent(
+                source="alpha_vantage",
+                symbol="MSFT",
+                weight=0.5,
+            ),
+        ),
+        mandate_id="us-tech-2026",
+        effective_from=date(2026, 1, 1),
+        effective_to=None,
+    )
+
+
+def _report(
+    *,
+    status: str = "ok",
+    as_of: datetime | None = None,
+    expected_session: date = date(2026, 3, 31),
+) -> dict[str, Any]:
+    operational_policy = _operational_policy()
+    schedule = _schedule()
+    mandate = _mandate()
+    return {
+        "calculation_id": (
+            "operational-service-levels-v1-report-aaaaaaaaaaaaaaaaaaaaaaaa"
+        ),
+        "policy_id": operational_policy.policy_id,
+        "policy_fingerprint": operational_policy.fingerprint,
+        "schedule_id": schedule.schedule_id,
+        "schedule_fingerprint": schedule.fingerprint,
+        "calendar_id": "XNYS",
+        "portfolio_id": schedule.portfolio_id,
+        "risk_limit_policy_id": schedule.policy_id,
+        "mandate_fingerprint": mandate.fingerprint,
+        "as_of": as_of or datetime(2026, 4, 1, 11, 55, tzinfo=timezone.utc),
+        "latest_expected_session": expected_session,
+        "overall_status": status,
+        "document_sha256": "b" * 64,
+    }
+
+
+def _evaluate(
+    *,
+    gate_policy=None,
+    report: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    operational_policy = _operational_policy()
+    schedule = _schedule()
+    mandate = _mandate()
+    return evaluate_operational_readiness(
+        gate_policy=gate_policy or _gate_policy(),
+        evaluated_at=datetime(2026, 4, 1, 12, tzinfo=timezone.utc),
+        latest_expected_session=date(2026, 3, 31),
+        operational_policy_fingerprint=operational_policy.fingerprint,
+        schedule_id=schedule.schedule_id,
+        schedule_fingerprint=schedule.fingerprint,
+        calendar_id="XNYS",
+        portfolio_id=schedule.portfolio_id,
+        risk_limit_policy_id=schedule.policy_id,
+        mandate_fingerprint=mandate.fingerprint,
+        report=_report() if report is None else report,
+    )
+
+
+def test_healthy_current_report_allows_deterministically() -> None:
+    first = _evaluate()
+    second = _evaluate()
+
+    assert first == second
+    assert first["decision"] == "allow"
+    assert first["reasons"] == []
+    assert first["report_age_seconds"] == 300.0
+    assert first["report_future_seconds"] == 0.0
+    assert first["schedule_executed"] is False
+    assert first["provider_request_performed"] is False
+    assert first["notification_delivery_performed"] is False
+    assert first["cloud_schedule_activated"] is False
+
+
+def test_warning_policy_is_explicit_and_critical_always_blocks() -> None:
+    warning = _report(status="warning")
+    blocked = _evaluate(report=warning)
+    allowed = _evaluate(
+        gate_policy=_gate_policy(allow_warning=True),
+        report=warning,
+    )
+    critical = _evaluate(report=_report(status="critical"))
+
+    assert blocked["decision"] == "block"
+    assert blocked["reasons"] == ["report_status_warning"]
+    assert allowed["decision"] == "allow"
+    assert allowed["reasons"] == []
+    assert critical["decision"] == "block"
+    assert critical["reasons"] == ["report_status_critical"]
+
+
+def test_missing_stale_future_and_session_mismatch_reports_block() -> None:
+    operational_policy = _operational_policy()
+    schedule = _schedule()
+    mandate = _mandate()
+    missing = evaluate_operational_readiness(
+        gate_policy=_gate_policy(),
+        evaluated_at=datetime(2026, 4, 1, 12, tzinfo=timezone.utc),
+        latest_expected_session=date(2026, 3, 31),
+        operational_policy_fingerprint=operational_policy.fingerprint,
+        schedule_id=schedule.schedule_id,
+        schedule_fingerprint=schedule.fingerprint,
+        calendar_id="XNYS",
+        portfolio_id=schedule.portfolio_id,
+        risk_limit_policy_id=schedule.policy_id,
+        mandate_fingerprint=mandate.fingerprint,
+        report=None,
+    )
+    stale = _evaluate(
+        report=_report(
+            as_of=datetime(2026, 4, 1, 10, tzinfo=timezone.utc),
+        )
+    )
+    future = _evaluate(
+        report=_report(
+            as_of=datetime(2026, 4, 1, 12, 1, tzinfo=timezone.utc),
+        )
+    )
+    mismatched = _evaluate(
+        report=_report(expected_session=date(2026, 3, 30))
+    )
+
+    assert missing["reasons"] == ["report_missing"]
+    assert stale["reasons"] == ["report_age_exceeds_limit"]
+    assert future["reasons"] == ["report_timestamp_future"]
+    assert future["report_future_seconds"] == 60.0
+    assert mismatched["reasons"] == ["report_session_mismatch"]
+
+
+def test_gate_policy_contract_is_strict() -> None:
+    with pytest.raises(ValidationError, match="invalid contract"):
+        parse_operational_readiness_gate_policy(
+            {
+                "gates": {
+                    "us-tech-local": {
+                        "operational_policy_id": "us-tech-local",
+                        "max_report_age_seconds": 3600,
+                    }
+                }
+            },
+            "us-tech-local",
+        )
+    with pytest.raises(ValidationError, match="between 1"):
+        parse_operational_readiness_gate_policy(
+            {
+                "gates": {
+                    "us-tech-local": {
+                        "operational_policy_id": "us-tech-local",
+                        "max_report_age_seconds": 0,
+                        "allow_warning": False,
+                    }
+                }
+            },
+            "us-tech-local",
+        )
+
+
+def test_runner_resolves_exact_current_contract_before_read() -> None:
+    operational_policy = _operational_policy()
+    schedule = _schedule()
+    mandate = _mandate()
+    calls: list[dict[str, Any]] = []
+
+    def report_reader(**kwargs: Any) -> dict[str, Any]:
+        calls.append(dict(kwargs))
+        return _report()
+
+    result = run_operational_readiness_gate(
+        gate_id="us-tech-local",
+        evaluated_at=datetime(2026, 4, 1, 12, tzinfo=timezone.utc),
+        dsn="postgresql://example",
+        gate_config_path=Path("unused-gate.yaml"),
+        operational_policy_config_path=Path("unused-policy.yaml"),
+        schedule_config_path=Path("unused-schedule.yaml"),
+        calendar_config_path=Path("unused-calendar.yaml"),
+        portfolio_config_path=Path("unused-portfolio.yaml"),
+        gate_policy_loader=lambda *_: _gate_policy(),
+        operational_policy_loader=lambda *_: operational_policy,
+        schedule_loader=lambda *_: schedule,
+        calendar_loader=lambda *_: _calendar(),
+        mandate_loader=lambda *_: mandate,
+        report_reader=report_reader,
+    )
+
+    assert result["decision"] == "allow"
+    assert calls == [
+        {
+            "dsn": "postgresql://example",
+            "operational_policy_id": operational_policy.policy_id,
+            "operational_policy_fingerprint": operational_policy.fingerprint,
+            "schedule_id": schedule.schedule_id,
+            "schedule_fingerprint": schedule.fingerprint,
+            "calendar_id": "XNYS",
+            "portfolio_id": schedule.portfolio_id,
+            "risk_limit_policy_id": schedule.policy_id,
+            "mandate_fingerprint": mandate.fingerprint,
+            "schema_name": "risk_platform",
+        }
+    ]


### PR DESCRIPTION
## Outcome

Turn the latest retained operational service-level report into one deterministic, read-only readiness decision:

```text
current gate policy
  + current operational threshold policy
  + current schedule fingerprint
  + latest expected market session
  + effective portfolio mandate fingerprint
  + latest exact-contract retained report
  -> allow or block
  -> deterministic JSON evidence and exit code
```

Primary arc42 block: `warehouse`, with read-only interfaces to current configuration and `latest_operational_service_level_reports`.

## Exact current-contract selection

Before PostgreSQL access, the runner resolves the current:

- operational service-level policy and fingerprint;
- linked local schedule and fingerprint;
- market calendar and latest expected session; and
- effective portfolio mandate and fingerprint.

It queries at most two rows from the latest report view using the exact policy, schedule, calendar, portfolio, risk-limit policy and mandate contract. No row becomes a deterministic block. More than one exact row fails closed as an inconsistent serving grain.

## Gate policy

`config/operational_readiness_gates.yaml` binds:

- the operational service-level policy;
- the maximum report age; and
- whether warning status is allowed.

The policy fingerprint binds all settings. Critical status always blocks; `allow_warning` cannot override critical evidence.

## Decision rules

A valid report blocks when it is:

- missing;
- timestamped in the future;
- older than the configured maximum age;
- for another latest expected market session;
- warning when warnings are disallowed; or
- critical.

Malformed identities, SHA-256 evidence, timestamps, statuses or configuration bindings are invalid evidence rather than normal policy reasons and fail closed.

The gate emits deterministic evidence containing the gate/report identities, exact current fingerprints, expected session, report age or future offset, status, decision and ordered reasons.

## Operator contract

```bash
.venv/bin/python -m src.warehouse.operational_readiness_gate \
  --gate-id us-tech-local \
  --evaluated-at 2026-04-01T12:00:00Z \
  --summary-json .demo/operational-readiness-gate.json
```

Exit codes:

- `0` — allowed;
- `2` — valid evidence produced a blocked decision;
- `1` — invalid configuration, retained evidence or PostgreSQL access.

The evidence explicitly records that no schedule, provider, notification-delivery or cloud-schedule side effect occurred.

## Validation and repair

The first exact-head run identified one unused `math` import in the new gate module. The import was removed without changing the decision contract or weakening Ruff.

GitHub Actions run `32640647600` passed on exact head `0d26a99acf3fa7ab54195e8ad2df5cef5155663a`:

- Security guardrails: passed.
- Python readiness: passed, including Ruff, mypy, the complete test suite, dependency integrity and the standard readiness replay.
- PostgreSQL contract: passed against PostgreSQL 16, including the existing model-approval and operational service-level persistence contracts.
- Infrastructure validation: passed without deployment or Terraform apply.

Focused tests cover deterministic healthy allow, explicit warning handling, unconditional critical blocking, missing/stale/future/session-mismatched reports, strict policy shape and bounds, exact current-contract filters, and side-effect-free evidence.

No unresolved review threads or requested changes are present.

## Scope

The branch changes exactly four files. Connector file writes and the focused lint repair created multiple working commits; the PR will be squash-merged as one read-only gate increment.

The gate is not wired into scheduling, notification delivery, deployment or trading controls. No provider request, position mutation, cloud activation or Terraform apply is included.

## Acceptance boundary

Validated and ready for squash merge as one read-only operational gate increment.