### PR TITLE
Add rolling operational SLO attainment report

### DIFF
--- a/config/operational_service_level_objectives.yaml
+++ b/config/operational_service_level_objectives.yaml
@@ -1,0 +1,22 @@
+objective_policies:
+  us-tech-local-20-session:
+    operational_policy_id: us-tech-local
+    window_sessions: 20
+    minimum_observations: 10
+    targets:
+      schedule_completion_attainment:
+        source_metric_name: schedule_lag_sessions
+        success_threshold: 0
+        target_ratio: 0.95
+      market_freshness_attainment:
+        source_metric_name: market_freshness_exception_count
+        success_threshold: 0
+        target_ratio: 0.95
+      notification_retry_exhaustion_free_attainment:
+        source_metric_name: notification_retry_exhausted_count
+        success_threshold: 0
+        target_ratio: 0.99
+      notification_dead_letter_duration_attainment:
+        source_metric_name: notification_oldest_dead_letter_age_seconds
+        success_threshold: 900
+        target_ratio: 0.95

--- a/docs/operational-service-level-objectives.md
+++ b/docs/operational-service-level-objectives.md
@@ -1,0 +1,138 @@
+# Rolling Operational Service-Level Objectives
+
+## Outcome
+
+This report-only path turns retained operational service-level reports into one
+deterministic rolling objective-attainment decision:
+
+```text
+current operational report per expected market session
+  -> exact current policy, schedule, calendar and mandate contract
+  -> bounded market-session window
+  -> four objective-attainment ratios
+  -> explicit insufficient, met or missed status
+  -> credential-free JSON evidence
+```
+
+It does not rerun the scheduler, query a market-data provider, retry a
+notification, deliver an alert, activate a cloud schedule or perform automated
+remediation.
+
+## Versioned Objective Policy
+
+`config/operational_service_level_objectives.yaml` defines a policy with:
+
+- the retained operational service-level policy it evaluates;
+- a bounded objective window measured in expected market sessions;
+- the minimum retained observations required before attainment can be judged;
+- one success threshold and target ratio for each supported objective.
+
+The first model version is `operational-slo-attainment-v1`. Objective policy
+fingerprints use the `operational-slo-objective-policy-` prefix and bind all
+window, minimum-history, source-metric, threshold and target settings. Changing an objective therefore creates a new evidence identity rather
+than relabelling an earlier result.
+
+The four objectives are:
+
+| Objective | Source metric | A session succeeds when |
+| --- | --- | --- |
+| Schedule completion | `schedule_lag_sessions` | lag is at or below the configured threshold |
+| Constituent freshness | `market_freshness_exception_count` | exception count is at or below the configured threshold |
+| Retry-exhaustion incidence | `notification_retry_exhausted_count` | exhausted-event count is at or below the configured threshold |
+| Dead-letter duration | `notification_oldest_dead_letter_age_seconds` | oldest age is at or below the configured threshold |
+
+## Session Window And Corrections
+
+The runner resolves the current operational policy, local schedule, market
+calendar and effective portfolio mandate before reading retained reports. It then
+builds the last configured expected market sessions ending at
+`--through-session`.
+
+For each expected session, the current retained report is selected by:
+
+```text
+as_of DESC
+calculation_id DESC
+```
+
+Identical duplicate calculation IDs are ignored. Reusing one calculation ID for
+conflicting report content fails closed.
+
+Only reports matching the exact current contract are eligible:
+
+```text
+operational policy fingerprint
+schedule fingerprint
+calendar ID
+portfolio ID
+risk-limit policy ID
+mandate fingerprint
+```
+
+A report from an older policy, schedule or mandate cannot enter the objective
+window silently.
+
+## Missing Reports And Insufficient History
+
+The denominator is the configured expected market-session window, not merely the
+number of reports that happen to exist. A missing report therefore counts against
+attainment once the minimum-history requirement has been reached.
+
+Before `minimum_observations` current reports exist, every objective and the
+overall result use:
+
+```text
+history_status = insufficient
+overall_status = insufficient
+```
+
+This is distinct from an objective miss. Once the minimum is reached, each
+objective is `met` or `missed` using:
+
+```text
+attainment_ratio = successful expected sessions / expected sessions in window
+```
+
+The evidence separately records observed failures and missing-report sessions so
+a consumer can distinguish bad operational values from absent reporting.
+
+## Operator Command
+
+After operational service-level reports have been recorded in PostgreSQL:
+
+```bash
+.venv/bin/python -m src.orchestration.run_operational_service_level_objectives \
+  --objective-policy-id us-tech-local-20-session \
+  --through-session 2026-03-31 \
+  --summary-json .demo/operational-slo-attainment.json
+```
+
+The requested date must be an expected session in the configured calendar. The
+PostgreSQL reader is restricted to the exact current contract and selected
+window, and it caps one request at 10,000 retained rows.
+
+## Evidence Contract
+
+The report records:
+
+- deterministic calculation, model and objective-policy identities;
+- exact operational policy, schedule, calendar, portfolio, risk-limit policy and
+  mandate identities;
+- expected window boundaries and missing report sessions;
+- current input report calculation IDs and document SHA-256 values;
+- available and expected observation counts;
+- objective thresholds, targets, success/failure counts and attainment ratios;
+- `insufficient`, `met` or `missed` status; and
+- explicit false side-effect flags.
+
+The calculation ID binds the complete expected-session window, current report
+identities and digests, objective settings and resulting objective rows.
+Corrections or policy changes therefore produce distinguishable evidence.
+
+## Current Boundary
+
+This increment writes optional local JSON only. It does not yet persist objective
+attainment in PostgreSQL or expose current attainment views. Append-only history
+and queryable serving are the next separate dependency layer. It also does not
+add a dashboard, paging, automatic gate integration, schedule activation or
+external notification delivery.

--- a/src/analytics/operational_service_level_objective_policy.py
+++ b/src/analytics/operational_service_level_objective_policy.py
@@ -1,0 +1,175 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import re
+from collections.abc import Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from ..common.config import load_yaml
+from ..common.exceptions import ValidationError
+
+MODEL_VERSION = "operational-slo-attainment-v1"
+OBJECTIVE_NAMES = (
+    "schedule_completion_attainment",
+    "market_freshness_attainment",
+    "notification_retry_exhaustion_free_attainment",
+    "notification_dead_letter_duration_attainment",
+)
+OBJECTIVE_SOURCE_METRICS = {
+    "schedule_completion_attainment": "schedule_lag_sessions",
+    "market_freshness_attainment": "market_freshness_exception_count",
+    "notification_retry_exhaustion_free_attainment": (
+        "notification_retry_exhausted_count"
+    ),
+    "notification_dead_letter_duration_attainment": (
+        "notification_oldest_dead_letter_age_seconds"
+    ),
+}
+EXPECTED_UNITS = {
+    "schedule_lag_sessions": "sessions",
+    "market_freshness_exception_count": "constituents",
+    "notification_retry_exhausted_count": "events",
+    "notification_oldest_dead_letter_age_seconds": "seconds",
+}
+MAX_WINDOW_SESSIONS = 10 * 252
+SAFE_SEGMENT_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$")
+
+
+@dataclass(frozen=True, slots=True)
+class ObjectiveTarget:
+    source_metric_name: str
+    success_threshold: float
+    target_ratio: float
+
+
+@dataclass(frozen=True, slots=True)
+class OperationalObjectivePolicy:
+    objective_policy_id: str
+    operational_policy_id: str
+    window_sessions: int
+    minimum_observations: int
+    objectives: Mapping[str, ObjectiveTarget]
+
+    @property
+    def fingerprint(self) -> str:
+        payload = {
+            "minimum_observations": self.minimum_observations,
+            "model_version": MODEL_VERSION,
+            "objective_policy_id": self.objective_policy_id,
+            "objectives": {
+                name: {
+                    "source_metric_name": self.objectives[name].source_metric_name,
+                    "success_threshold": self.objectives[name].success_threshold,
+                    "target_ratio": self.objectives[name].target_ratio,
+                }
+                for name in OBJECTIVE_NAMES
+            },
+            "operational_policy_id": self.operational_policy_id,
+            "window_sessions": self.window_sessions,
+        }
+        digest = hashlib.sha256(
+            json.dumps(payload, sort_keys=True, separators=(",", ":")).encode(
+                "utf-8"
+            )
+        ).hexdigest()[:24]
+        return f"operational-slo-objective-policy-{digest}"
+
+
+def _safe_segment(value: Any, label: str) -> str:
+    if not isinstance(value, str) or not SAFE_SEGMENT_PATTERN.fullmatch(value):
+        raise ValidationError(f"{label} must be one safe text segment")
+    return value
+
+
+def _nonnegative_number(value: Any, label: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ValidationError(f"{label} must be a finite non-negative number")
+    parsed = float(value)
+    if not math.isfinite(parsed) or parsed < 0:
+        raise ValidationError(f"{label} must be a finite non-negative number")
+    return parsed
+
+
+def _target(name: str, raw: Any) -> ObjectiveTarget:
+    if not isinstance(raw, Mapping) or set(raw) != {
+        "source_metric_name",
+        "success_threshold",
+        "target_ratio",
+    }:
+        raise ValidationError(f"targets.{name} has an invalid contract")
+    metric_name = OBJECTIVE_SOURCE_METRICS[name]
+    if raw.get("source_metric_name") != metric_name:
+        raise ValidationError(f"targets.{name} uses the wrong source metric")
+    target_ratio = _nonnegative_number(raw.get("target_ratio"), "target_ratio")
+    if not 0 < target_ratio <= 1:
+        raise ValidationError("target_ratio must be greater than zero and at most one")
+    return ObjectiveTarget(
+        source_metric_name=metric_name,
+        success_threshold=_nonnegative_number(
+            raw.get("success_threshold"),
+            "success_threshold",
+        ),
+        target_ratio=target_ratio,
+    )
+
+
+def parse_operational_objective_policy(
+    payload: Mapping[str, Any],
+    objective_policy_id: str,
+) -> OperationalObjectivePolicy:
+    if not isinstance(payload, Mapping):
+        raise ValidationError("operational objective configuration must be a mapping")
+    objective_policy_id = _safe_segment(
+        objective_policy_id,
+        "objective_policy_id",
+    )
+    policies = payload.get("objective_policies")
+    if not isinstance(policies, Mapping):
+        raise ValidationError("objective_policies must be configured")
+    raw = policies.get(objective_policy_id)
+    if not isinstance(raw, Mapping) or set(raw) != {
+        "operational_policy_id",
+        "window_sessions",
+        "minimum_observations",
+        "targets",
+    }:
+        raise ValidationError("operational objective policy has an invalid contract")
+    window_sessions = raw.get("window_sessions")
+    if type(window_sessions) is not int or not 2 <= window_sessions <= MAX_WINDOW_SESSIONS:
+        raise ValidationError("window_sessions is outside the supported range")
+    minimum_observations = raw.get("minimum_observations")
+    if (
+        type(minimum_observations) is not int
+        or not 2 <= minimum_observations <= window_sessions
+    ):
+        raise ValidationError("minimum_observations must fit inside the window")
+    targets = raw.get("targets")
+    if not isinstance(targets, Mapping) or tuple(targets) != OBJECTIVE_NAMES:
+        raise ValidationError("targets must use the canonical objective order")
+    return OperationalObjectivePolicy(
+        objective_policy_id=objective_policy_id,
+        operational_policy_id=_safe_segment(
+            raw.get("operational_policy_id"),
+            "operational_policy_id",
+        ),
+        window_sessions=window_sessions,
+        minimum_observations=minimum_observations,
+        objectives={name: _target(name, targets[name]) for name in OBJECTIVE_NAMES},
+    )
+
+
+def load_operational_objective_policy(
+    path: Path,
+    objective_policy_id: str,
+) -> OperationalObjectivePolicy:
+    try:
+        payload = load_yaml(path)
+    except Exception:
+        raise ValidationError("operational objective configuration could not be loaded") from None
+    if not isinstance(payload, Mapping):
+        raise ValidationError("operational objective configuration must be a mapping")
+    return parse_operational_objective_policy(payload, objective_policy_id)

--- a/src/analytics/operational_service_level_objective_reports.py
+++ b/src/analytics/operational_service_level_objective_reports.py
@@ -1,0 +1,188 @@
+from __future__ import annotations
+
+import math
+import re
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
+from datetime import date, datetime, timezone
+from typing import Any
+
+from ..common.exceptions import ValidationError
+from .operational_service_level_objective_policy import EXPECTED_UNITS
+from .operational_service_levels import METRIC_NAMES
+
+MAX_REPORT_ROWS = 10_000
+REPORT_ID_PATTERN = re.compile(
+    r"^operational-service-levels-v1-report-[0-9a-f]{24}$"
+)
+DOCUMENT_SHA256_PATTERN = re.compile(r"^[0-9a-f]{64}$")
+
+
+@dataclass(frozen=True, slots=True)
+class SelectedOperationalReports:
+    reports: tuple[Mapping[str, Any], ...]
+    input_rows_scanned: int
+
+
+def _aware_utc(value: Any, label: str) -> datetime:
+    if isinstance(value, datetime):
+        parsed = value
+    elif isinstance(value, str):
+        try:
+            parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        except ValueError:
+            raise ValidationError(f"{label} must be ISO-8601") from None
+    else:
+        raise ValidationError(f"{label} must be timezone-aware")
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise ValidationError(f"{label} must be timezone-aware")
+    return parsed.astimezone(timezone.utc)
+
+
+def _calendar_date(value: Any, label: str) -> date:
+    if isinstance(value, datetime):
+        raise ValidationError(f"{label} must be a calendar date")
+    if isinstance(value, date):
+        return value
+    if not isinstance(value, str):
+        raise ValidationError(f"{label} must use YYYY-MM-DD")
+    try:
+        parsed = date.fromisoformat(value)
+    except ValueError:
+        raise ValidationError(f"{label} must use YYYY-MM-DD") from None
+    if value != parsed.isoformat():
+        raise ValidationError(f"{label} must use YYYY-MM-DD")
+    return parsed
+
+
+def _metric_values(value: Any) -> dict[str, float | None]:
+    if not isinstance(value, list) or len(value) != len(METRIC_NAMES):
+        raise ValidationError("report metrics must contain four indicators")
+    result: dict[str, float | None] = {}
+    names: list[str] = []
+    for raw in value:
+        if not isinstance(raw, Mapping):
+            raise ValidationError("report metrics must contain mappings")
+        name = raw.get("metric_name")
+        if name not in METRIC_NAMES or not isinstance(name, str):
+            raise ValidationError("report metric name is unsupported")
+        if raw.get("unit") != EXPECTED_UNITS[name]:
+            raise ValidationError("report metric unit is incompatible")
+        observed = raw.get("observed_value")
+        if observed is None:
+            if name != "schedule_lag_sessions" or raw.get("reason") != "checkpoint_missing":
+                raise ValidationError("only a missing checkpoint may have no value")
+            parsed: float | None = None
+        else:
+            if isinstance(observed, bool) or not isinstance(observed, (int, float)):
+                raise ValidationError("report metric value must be numeric")
+            parsed = float(observed)
+            if not math.isfinite(parsed) or parsed < 0:
+                raise ValidationError("report metric value must be finite and non-negative")
+        result[name] = parsed
+        names.append(name)
+    if tuple(names) != METRIC_NAMES:
+        raise ValidationError("report metrics must use the canonical order")
+    return result
+
+
+def _normalise_report(
+    raw: Mapping[str, Any],
+    *,
+    expected_contract: Mapping[str, str],
+    expected_sessions: frozenset[date],
+) -> dict[str, Any] | None:
+    if not isinstance(raw, Mapping):
+        raise ValidationError("objective input must contain mappings")
+    if any(raw.get(key) != expected for key, expected in expected_contract.items()):
+        return None
+    calculation_id = raw.get("calculation_id")
+    if not isinstance(calculation_id, str) or not REPORT_ID_PATTERN.fullmatch(
+        calculation_id
+    ):
+        raise ValidationError("report calculation_id is incompatible")
+    document_sha256 = raw.get("document_sha256")
+    if not isinstance(document_sha256, str) or not DOCUMENT_SHA256_PATTERN.fullmatch(
+        document_sha256
+    ):
+        raise ValidationError("report document_sha256 is incompatible")
+    session = _calendar_date(
+        raw.get("latest_expected_session"),
+        "latest_expected_session",
+    )
+    if session not in expected_sessions:
+        return None
+    return {
+        **expected_contract,
+        "calculation_id": calculation_id,
+        "document_sha256": document_sha256,
+        "as_of": _aware_utc(raw.get("as_of"), "report as_of"),
+        "latest_expected_session": session,
+        "metrics": _metric_values(raw.get("metrics_json")),
+    }
+
+
+def _signature(report: Mapping[str, Any]) -> tuple[Any, ...]:
+    return (
+        *(report[key] for key in (
+            "policy_id",
+            "policy_fingerprint",
+            "schedule_id",
+            "schedule_fingerprint",
+            "calendar_id",
+            "portfolio_id",
+            "risk_limit_policy_id",
+            "mandate_fingerprint",
+        )),
+        report["as_of"],
+        report["latest_expected_session"],
+        report["document_sha256"],
+        tuple(report["metrics"].items()),
+    )
+
+
+def select_current_operational_reports(
+    reports: Iterable[Mapping[str, Any]],
+    *,
+    expected_contract: Mapping[str, str],
+    expected_sessions: tuple[date, ...],
+) -> SelectedOperationalReports:
+    current: dict[date, dict[str, Any]] = {}
+    seen_ids: dict[str, tuple[Any, ...]] = {}
+    input_rows = 0
+    session_set = frozenset(expected_sessions)
+    for raw in reports:
+        input_rows += 1
+        if input_rows > MAX_REPORT_ROWS:
+            raise ValidationError("objective input exceeds the row limit")
+        report = _normalise_report(
+            raw,
+            expected_contract=expected_contract,
+            expected_sessions=session_set,
+        )
+        if report is None:
+            continue
+        calculation_id = report["calculation_id"]
+        signature = _signature(report)
+        previous = seen_ids.get(calculation_id)
+        if previous is not None:
+            if previous != signature:
+                raise ValidationError("report calculation ID has conflicting content")
+            continue
+        seen_ids[calculation_id] = signature
+        session = report["latest_expected_session"]
+        existing = current.get(session)
+        if existing is None or (
+            report["as_of"],
+            calculation_id,
+        ) > (
+            existing["as_of"],
+            existing["calculation_id"],
+        ):
+            current[session] = report
+    if not current:
+        raise ValidationError("no reports matched the requested objective window")
+    return SelectedOperationalReports(
+        reports=tuple(current[session] for session in sorted(current)),
+        input_rows_scanned=input_rows,
+    )

--- a/src/analytics/operational_service_level_objectives.py
+++ b/src/analytics/operational_service_level_objectives.py
@@ -1,0 +1,265 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
+from datetime import date, datetime
+from typing import Any
+
+from ..common.exceptions import ValidationError
+from .operational_service_level_objective_policy import (
+    EXPECTED_UNITS,
+    MODEL_VERSION,
+    OBJECTIVE_NAMES,
+    ObjectiveTarget,
+    OperationalObjectivePolicy,
+    load_operational_objective_policy,
+    parse_operational_objective_policy,
+)
+from .operational_service_level_objective_reports import (
+    MAX_REPORT_ROWS,
+    select_current_operational_reports,
+)
+
+POLICY_FINGERPRINT_PATTERN = re.compile(
+    r"^operational-slo-policy-[0-9a-f]{24}$"
+)
+SAFE_SEGMENT_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$")
+
+
+@dataclass(frozen=True, slots=True)
+class OperationalObjectiveOutput:
+    report: Mapping[str, Any]
+    objectives: tuple[Mapping[str, Any], ...]
+
+
+def _safe_segment(value: Any, label: str) -> str:
+    if not isinstance(value, str) or not SAFE_SEGMENT_PATTERN.fullmatch(value):
+        raise ValidationError(f"{label} must be one safe text segment")
+    return value
+
+
+def _fingerprint(value: Any, label: str) -> str:
+    if not isinstance(value, str) or not value or len(value) > 256:
+        raise ValidationError(f"{label} must be non-empty bounded text")
+    if value != value.strip() or any(ord(character) < 32 for character in value):
+        raise ValidationError(f"{label} must be canonical bounded text")
+    return value
+
+
+def _validate_sessions(
+    expected_sessions: tuple[date, ...],
+    *,
+    through_session: date,
+    maximum: int,
+) -> None:
+    if (
+        not isinstance(expected_sessions, tuple)
+        or not expected_sessions
+        or len(expected_sessions) > maximum
+        or any(
+            not isinstance(session, date) or isinstance(session, datetime)
+            for session in expected_sessions
+        )
+        or tuple(sorted(set(expected_sessions))) != expected_sessions
+        or expected_sessions[-1] != through_session
+    ):
+        raise ValidationError("expected session window is invalid")
+
+
+def evaluate_operational_objectives(
+    *,
+    objective_policy: OperationalObjectivePolicy,
+    through_session: date,
+    expected_sessions: tuple[date, ...],
+    operational_policy_fingerprint: str,
+    schedule_id: str,
+    schedule_fingerprint: str,
+    calendar_id: str,
+    portfolio_id: str,
+    risk_limit_policy_id: str,
+    mandate_id: str,
+    mandate_fingerprint: str,
+    reports: Iterable[Mapping[str, Any]],
+) -> OperationalObjectiveOutput:
+    if not isinstance(through_session, date) or isinstance(through_session, datetime):
+        raise ValidationError("through_session must be a calendar date")
+    _validate_sessions(
+        expected_sessions,
+        through_session=through_session,
+        maximum=objective_policy.window_sessions,
+    )
+    operational_policy_fingerprint = _fingerprint(
+        operational_policy_fingerprint,
+        "operational_policy_fingerprint",
+    )
+    if not POLICY_FINGERPRINT_PATTERN.fullmatch(operational_policy_fingerprint):
+        raise ValidationError("operational policy fingerprint is incompatible")
+    schedule_id = _safe_segment(schedule_id, "schedule_id")
+    schedule_fingerprint = _fingerprint(schedule_fingerprint, "schedule_fingerprint")
+    calendar_id = _safe_segment(calendar_id, "calendar_id")
+    portfolio_id = _safe_segment(portfolio_id, "portfolio_id")
+    risk_limit_policy_id = _safe_segment(
+        risk_limit_policy_id,
+        "risk_limit_policy_id",
+    )
+    mandate_id = _safe_segment(mandate_id, "mandate_id")
+    mandate_fingerprint = _fingerprint(mandate_fingerprint, "mandate_fingerprint")
+    expected_contract = {
+        "policy_id": objective_policy.operational_policy_id,
+        "policy_fingerprint": operational_policy_fingerprint,
+        "schedule_id": schedule_id,
+        "schedule_fingerprint": schedule_fingerprint,
+        "calendar_id": calendar_id,
+        "portfolio_id": portfolio_id,
+        "risk_limit_policy_id": risk_limit_policy_id,
+        "mandate_fingerprint": mandate_fingerprint,
+    }
+    selected = select_current_operational_reports(
+        reports,
+        expected_contract=expected_contract,
+        expected_sessions=expected_sessions,
+    )
+    by_session = {
+        report["latest_expected_session"]: report for report in selected.reports
+    }
+    window = [
+        by_session[session] for session in expected_sessions if session in by_session
+    ]
+    missing_sessions = tuple(
+        session for session in expected_sessions if session not in by_session
+    )
+    observations_available = len(window)
+    observations_expected = len(expected_sessions)
+    history_status = (
+        "ready"
+        if observations_available >= objective_policy.minimum_observations
+        else "insufficient"
+    )
+    objective_rows: list[dict[str, Any]] = []
+    for objective_name in OBJECTIVE_NAMES:
+        target: ObjectiveTarget = objective_policy.objectives[objective_name]
+        successful = sum(
+            1
+            for report in window
+            if report["metrics"][target.source_metric_name] is not None
+            and float(report["metrics"][target.source_metric_name])
+            <= target.success_threshold
+        )
+        attainment_ratio = successful / observations_expected
+        status = (
+            "insufficient"
+            if history_status == "insufficient"
+            else (
+                "met"
+                if attainment_ratio >= target.target_ratio
+                else "missed"
+            )
+        )
+        objective_rows.append(
+            {
+                "objective_name": objective_name,
+                "source_metric_name": target.source_metric_name,
+                "source_unit": EXPECTED_UNITS[target.source_metric_name],
+                "success_threshold": target.success_threshold,
+                "target_ratio": target.target_ratio,
+                "successful_observations": successful,
+                "failed_observations": observations_available - successful,
+                "missing_report_observations": len(missing_sessions),
+                "observations_available": observations_available,
+                "observations_expected": observations_expected,
+                "attainment_ratio": attainment_ratio,
+                "status": status,
+            }
+        )
+    overall_status = (
+        "insufficient"
+        if history_status == "insufficient"
+        else (
+            "missed"
+            if any(row["status"] == "missed" for row in objective_rows)
+            else "met"
+        )
+    )
+    input_ids = [str(report["calculation_id"]) for report in window]
+    input_digests = [str(report["document_sha256"]) for report in window]
+    calculated_at = max(report["as_of"] for report in window)
+    missing_dates = [session.isoformat() for session in missing_sessions]
+    identity = {
+        "calculated_at": calculated_at.isoformat(),
+        "expected_sessions": [session.isoformat() for session in expected_sessions],
+        "input_report_calculation_ids": input_ids,
+        "input_report_document_sha256": input_digests,
+        "mandate_fingerprint": mandate_fingerprint,
+        "missing_report_sessions": missing_dates,
+        "objective_policy_fingerprint": objective_policy.fingerprint,
+        "objectives": objective_rows,
+        "operational_policy_fingerprint": operational_policy_fingerprint,
+        "schedule_fingerprint": schedule_fingerprint,
+        "through_session": through_session.isoformat(),
+    }
+    digest = hashlib.sha256(
+        json.dumps(
+            identity,
+            sort_keys=True,
+            separators=(",", ":"),
+            allow_nan=False,
+        ).encode("utf-8")
+    ).hexdigest()[:24]
+    report = {
+        "calculation_id": f"{MODEL_VERSION}-report-{digest}",
+        "model_version": MODEL_VERSION,
+        "objective_policy_id": objective_policy.objective_policy_id,
+        "objective_policy_fingerprint": objective_policy.fingerprint,
+        "operational_policy_id": objective_policy.operational_policy_id,
+        "operational_policy_fingerprint": operational_policy_fingerprint,
+        "schedule_id": schedule_id,
+        "schedule_fingerprint": schedule_fingerprint,
+        "calendar_id": calendar_id,
+        "portfolio_id": portfolio_id,
+        "risk_limit_policy_id": risk_limit_policy_id,
+        "mandate_id": mandate_id,
+        "mandate_fingerprint": mandate_fingerprint,
+        "through_session": through_session.isoformat(),
+        "window_start_session": expected_sessions[0].isoformat(),
+        "window_end_session": expected_sessions[-1].isoformat(),
+        "window_sessions": objective_policy.window_sessions,
+        "minimum_observations": objective_policy.minimum_observations,
+        "observations_available": observations_available,
+        "observations_expected": observations_expected,
+        "missing_report_sessions": missing_dates,
+        "window_complete": (
+            observations_expected == objective_policy.window_sessions
+            and not missing_sessions
+        ),
+        "history_status": history_status,
+        "overall_status": overall_status,
+        "calculated_at": calculated_at.isoformat(),
+        "input_report_calculation_ids": input_ids,
+        "input_report_document_sha256": input_digests,
+        "objectives": objective_rows,
+        "input_rows_scanned": selected.input_rows_scanned,
+        "provider_request_performed": False,
+        "external_delivery_performed": False,
+        "cloud_schedule_activated": False,
+        "automated_remediation_performed": False,
+    }
+    return OperationalObjectiveOutput(
+        report=report,
+        objectives=tuple(objective_rows),
+    )
+
+
+__all__ = [
+    "MAX_REPORT_ROWS",
+    "MODEL_VERSION",
+    "OBJECTIVE_NAMES",
+    "ObjectiveTarget",
+    "OperationalObjectiveOutput",
+    "OperationalObjectivePolicy",
+    "evaluate_operational_objectives",
+    "load_operational_objective_policy",
+    "parse_operational_objective_policy",
+]

--- a/src/orchestration/run_operational_service_level_objectives.py
+++ b/src/orchestration/run_operational_service_level_objectives.py
@@ -1,0 +1,331 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections.abc import Callable, Mapping, Sequence
+from datetime import date
+from pathlib import Path
+from typing import Any
+
+from ..analytics.market_calendar import MarketCalendar, load_market_calendar
+from ..analytics.operational_service_level_objectives import (
+    MAX_REPORT_ROWS,
+    OperationalObjectivePolicy,
+    evaluate_operational_objectives,
+    load_operational_objective_policy,
+)
+from ..analytics.operational_service_levels import (
+    OperationalServiceLevelPolicy,
+    load_operational_service_level_policy,
+)
+from ..analytics.portfolio_mandates import (
+    PortfolioMandate,
+    load_portfolio_mandate,
+)
+from ..common.exceptions import StorageError, ValidationError
+from ..warehouse.postgres_loader import DEFAULT_POSTGRES_DSN
+from .run_local_portfolio_schedule import (
+    LocalPortfolioSchedule,
+    load_local_portfolio_schedule,
+)
+
+ObjectivePolicyLoader = Callable[[Path, str], OperationalObjectivePolicy]
+OperationalPolicyLoader = Callable[[Path, str], OperationalServiceLevelPolicy]
+ScheduleLoader = Callable[[Path, str], LocalPortfolioSchedule]
+CalendarLoader = Callable[[Path, str], MarketCalendar]
+MandateLoader = Callable[[Path, str, date], PortfolioMandate]
+ReportReader = Callable[..., list[dict[str, Any]]]
+
+
+def _calendar_date(value: str) -> date:
+    try:
+        parsed = date.fromisoformat(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("must use YYYY-MM-DD") from exc
+    if value != parsed.isoformat():
+        raise argparse.ArgumentTypeError("must use YYYY-MM-DD")
+    return parsed
+
+
+def _quote_identifier(value: str) -> str:
+    if not isinstance(value, str) or not value:
+        raise ValidationError("schema_name must be non-empty text")
+    return '"' + value.replace('"', '""') + '"'
+
+
+def read_operational_report_history(
+    *,
+    dsn: str,
+    operational_policy_id: str,
+    operational_policy_fingerprint: str,
+    schedule_id: str,
+    schedule_fingerprint: str,
+    calendar_id: str,
+    portfolio_id: str,
+    risk_limit_policy_id: str,
+    mandate_fingerprint: str,
+    window_start_session: date,
+    through_session: date,
+    schema_name: str = "risk_platform",
+) -> list[dict[str, Any]]:
+    if not isinstance(dsn, str) or not dsn.strip():
+        raise ValidationError("PostgreSQL DSN must be non-empty text")
+    schema = _quote_identifier(schema_name)
+    try:
+        import psycopg
+        from psycopg.rows import dict_row
+    except ImportError as exc:
+        raise RuntimeError(
+            "Operational objective reporting requires psycopg. Run `make setup`."
+        ) from exc
+
+    query = f"""
+        SELECT
+            calculation_id,
+            policy_id,
+            policy_fingerprint,
+            schedule_id,
+            schedule_fingerprint,
+            calendar_id,
+            portfolio_id,
+            risk_limit_policy_id,
+            mandate_fingerprint,
+            as_of,
+            latest_expected_session,
+            metrics_json,
+            document_sha256
+        FROM {schema}.operational_service_level_reports
+        WHERE policy_id = %s
+          AND policy_fingerprint = %s
+          AND schedule_id = %s
+          AND schedule_fingerprint = %s
+          AND calendar_id = %s
+          AND portfolio_id = %s
+          AND risk_limit_policy_id = %s
+          AND mandate_fingerprint = %s
+          AND latest_expected_session >= %s
+          AND latest_expected_session <= %s
+        ORDER BY latest_expected_session, as_of, calculation_id
+        LIMIT %s
+    """
+    try:
+        with psycopg.connect(dsn, row_factory=dict_row) as connection:
+            with connection.cursor() as cursor:
+                cursor.execute(
+                    query,
+                    (
+                        operational_policy_id,
+                        operational_policy_fingerprint,
+                        schedule_id,
+                        schedule_fingerprint,
+                        calendar_id,
+                        portfolio_id,
+                        risk_limit_policy_id,
+                        mandate_fingerprint,
+                        window_start_session,
+                        through_session,
+                        MAX_REPORT_ROWS + 1,
+                    ),
+                )
+                rows = [dict(row) for row in cursor.fetchall()]
+    except Exception:
+        raise StorageError(
+            "Unable to read retained operational service-level reports"
+        ) from None
+    if len(rows) > MAX_REPORT_ROWS:
+        raise ValidationError("operational objective input exceeds the row limit")
+    return rows
+
+
+def run_operational_service_level_objectives(
+    *,
+    objective_policy_id: str,
+    through_session: date,
+    objective_config_path: Path,
+    operational_policy_config_path: Path,
+    schedule_config_path: Path,
+    calendar_config_path: Path,
+    portfolio_config_path: Path,
+    dsn: str,
+    schema_name: str = "risk_platform",
+    objective_policy_loader: ObjectivePolicyLoader | None = None,
+    operational_policy_loader: OperationalPolicyLoader | None = None,
+    schedule_loader: ScheduleLoader | None = None,
+    calendar_loader: CalendarLoader | None = None,
+    mandate_loader: MandateLoader | None = None,
+    report_reader: ReportReader | None = None,
+) -> dict[str, Any]:
+    selected_objective_loader = (
+        objective_policy_loader or load_operational_objective_policy
+    )
+    objective_policy = selected_objective_loader(
+        objective_config_path,
+        objective_policy_id,
+    )
+    selected_operational_loader = (
+        operational_policy_loader or load_operational_service_level_policy
+    )
+    operational_policy = selected_operational_loader(
+        operational_policy_config_path,
+        objective_policy.operational_policy_id,
+    )
+    selected_schedule_loader = schedule_loader or load_local_portfolio_schedule
+    schedule = selected_schedule_loader(
+        schedule_config_path,
+        operational_policy.schedule_id,
+    )
+    if schedule.schedule_id != operational_policy.schedule_id:
+        raise ValidationError("operational policy and schedule do not align")
+    selected_calendar_loader = calendar_loader or load_market_calendar
+    calendar = selected_calendar_loader(
+        calendar_config_path,
+        schedule.calendar_id,
+    )
+    if calendar.latest_expected_session(through_session) != through_session:
+        raise ValidationError("through_session must be an expected market session")
+    available_sessions = calendar.sessions_between(
+        calendar.valid_from,
+        through_session,
+    )
+    expected_sessions = available_sessions[-objective_policy.window_sessions :]
+    if not expected_sessions:
+        raise ValidationError(
+            "calendar coverage contains no objective-window sessions"
+        )
+    selected_mandate_loader = mandate_loader or load_portfolio_mandate
+    mandate = selected_mandate_loader(
+        portfolio_config_path,
+        schedule.portfolio_id,
+        through_session,
+    )
+    selected_report_reader = report_reader or read_operational_report_history
+    reports = selected_report_reader(
+        dsn=dsn,
+        operational_policy_id=operational_policy.policy_id,
+        operational_policy_fingerprint=operational_policy.fingerprint,
+        schedule_id=schedule.schedule_id,
+        schedule_fingerprint=schedule.fingerprint,
+        calendar_id=calendar.calendar_id,
+        portfolio_id=schedule.portfolio_id,
+        risk_limit_policy_id=schedule.policy_id,
+        mandate_fingerprint=mandate.fingerprint,
+        window_start_session=expected_sessions[0],
+        through_session=through_session,
+        schema_name=schema_name,
+    )
+    output = evaluate_operational_objectives(
+        objective_policy=objective_policy,
+        through_session=through_session,
+        expected_sessions=expected_sessions,
+        operational_policy_fingerprint=operational_policy.fingerprint,
+        schedule_id=schedule.schedule_id,
+        schedule_fingerprint=schedule.fingerprint,
+        calendar_id=calendar.calendar_id,
+        portfolio_id=schedule.portfolio_id,
+        risk_limit_policy_id=schedule.policy_id,
+        mandate_id=mandate.mandate_id,
+        mandate_fingerprint=mandate.fingerprint,
+        reports=reports,
+    )
+    return dict(output.report)
+
+
+def _write_summary(path: Path, summary: Mapping[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_suffix(path.suffix + ".tmp")
+    try:
+        temporary.write_text(
+            json.dumps(summary, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        temporary.replace(path)
+    except OSError:
+        temporary.unlink(missing_ok=True)
+        raise StorageError(
+            "Unable to write the operational objective summary"
+        ) from None
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Build deterministic rolling operational service-level "
+            "objective attainment evidence."
+        )
+    )
+    parser.add_argument("--objective-policy-id", required=True)
+    parser.add_argument("--through-session", required=True, type=_calendar_date)
+    parser.add_argument(
+        "--objective-config",
+        type=Path,
+        default=Path("config/operational_service_level_objectives.yaml"),
+    )
+    parser.add_argument(
+        "--operational-policy-config",
+        type=Path,
+        default=Path("config/operational_service_levels.yaml"),
+    )
+    parser.add_argument(
+        "--schedule-config",
+        type=Path,
+        default=Path("config/local_portfolio_schedules.yaml"),
+    )
+    parser.add_argument(
+        "--calendar-config",
+        type=Path,
+        default=Path("config/market_calendars.yaml"),
+    )
+    parser.add_argument(
+        "--portfolio-config",
+        type=Path,
+        default=Path("config/portfolios.yaml"),
+    )
+    parser.add_argument("--dsn", default=DEFAULT_POSTGRES_DSN)
+    parser.add_argument("--schema", default="risk_platform")
+    parser.add_argument("--summary-json", type=Path)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    try:
+        summary = run_operational_service_level_objectives(
+            objective_policy_id=args.objective_policy_id,
+            through_session=args.through_session,
+            objective_config_path=args.objective_config,
+            operational_policy_config_path=args.operational_policy_config,
+            schedule_config_path=args.schedule_config,
+            calendar_config_path=args.calendar_config,
+            portfolio_config_path=args.portfolio_config,
+            dsn=args.dsn,
+            schema_name=args.schema,
+        )
+        if args.summary_json is not None:
+            _write_summary(args.summary_json, summary)
+    except ValidationError:
+        print(
+            "Operational objective reporting failed: configuration or retained "
+            "evidence was invalid",
+            file=sys.stderr,
+        )
+        return 1
+    except StorageError:
+        print(
+            "Operational objective reporting failed: PostgreSQL or local output "
+            "could not be accessed",
+            file=sys.stderr,
+        )
+        return 1
+    except Exception:
+        print(
+            "Operational objective reporting failed: unexpected local failure",
+            file=sys.stderr,
+        )
+        return 1
+    print(json.dumps(summary, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/test_operational_readiness_gate.py
+++ b/tests/unit/test_operational_readiness_gate.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import date, datetime, time, timedelta, timezone
+from datetime import date, datetime, time, timezone
 from pathlib import Path
 from typing import Any
 
@@ -92,7 +92,7 @@ def _calendar() -> MarketCalendar:
         valid_from=date(2026, 1, 1),
         valid_to=date(2027, 1, 1),
         session_weekdays=(0, 1, 2, 3, 4),
-        holidays=frozenset(),
+        holidays=frozenset({date(2026, 4, 1)}),
         regular_close_time=time(16, 0),
         early_closes={},
     )

--- a/tests/unit/test_operational_service_level_objectives.py
+++ b/tests/unit/test_operational_service_level_objectives.py
@@ -1,0 +1,263 @@
+from __future__ import annotations
+
+from datetime import date, datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from src.analytics.operational_service_level_objectives import (
+    OBJECTIVE_NAMES,
+    evaluate_operational_objectives,
+    load_operational_objective_policy,
+    parse_operational_objective_policy,
+)
+from src.common.exceptions import ValidationError
+
+
+def _policy_payload(
+    *,
+    window_sessions: int = 3,
+    minimum_observations: int = 2,
+    schedule_target_ratio: float = 2 / 3,
+) -> dict[str, object]:
+    return {
+        "objective_policies": {
+            "demo": {
+                "operational_policy_id": "operations",
+                "window_sessions": window_sessions,
+                "minimum_observations": minimum_observations,
+                "targets": {
+                    "schedule_completion_attainment": {
+                        "source_metric_name": "schedule_lag_sessions",
+                        "success_threshold": 0,
+                        "target_ratio": schedule_target_ratio,
+                    },
+                    "market_freshness_attainment": {
+                        "source_metric_name": "market_freshness_exception_count",
+                        "success_threshold": 0,
+                        "target_ratio": 2 / 3,
+                    },
+                    "notification_retry_exhaustion_free_attainment": {
+                        "source_metric_name": (
+                            "notification_retry_exhausted_count"
+                        ),
+                        "success_threshold": 0,
+                        "target_ratio": 1.0,
+                    },
+                    "notification_dead_letter_duration_attainment": {
+                        "source_metric_name": (
+                            "notification_oldest_dead_letter_age_seconds"
+                        ),
+                        "success_threshold": 900,
+                        "target_ratio": 1.0,
+                    },
+                },
+            }
+        }
+    }
+
+
+def _report(
+    day: int,
+    *,
+    schedule_lag: float = 0,
+    freshness_exceptions: float = 0,
+    retry_exhausted: float = 0,
+    dead_letter_age: float = 0,
+    calculation_id: str | None = None,
+    as_of_hour: int = 1,
+) -> dict[str, object]:
+    metric_names = (
+        "schedule_lag_sessions",
+        "market_freshness_exception_count",
+        "notification_retry_exhausted_count",
+        "notification_oldest_dead_letter_age_seconds",
+    )
+    values = (
+        schedule_lag,
+        freshness_exceptions,
+        retry_exhausted,
+        dead_letter_age,
+    )
+    units = ("sessions", "constituents", "events", "seconds")
+    metrics = [
+        {
+            "metric_name": name,
+            "observed_value": value,
+            "unit": unit,
+            "warning_threshold": 1,
+            "critical_threshold": 2,
+            "status": "ok",
+            "reason": None,
+        }
+        for name, value, unit in zip(metric_names, values, units, strict=True)
+    ]
+    return {
+        "calculation_id": calculation_id
+        or f"operational-service-levels-v1-report-{day:024x}",
+        "policy_id": "operations",
+        "policy_fingerprint": "operational-slo-policy-" + "a" * 24,
+        "schedule_id": "schedule",
+        "schedule_fingerprint": "schedule-fingerprint",
+        "calendar_id": "XNYS",
+        "portfolio_id": "portfolio",
+        "risk_limit_policy_id": "risk-policy",
+        "mandate_fingerprint": "mandate-fingerprint",
+        "as_of": datetime(
+            2026,
+            1,
+            day,
+            as_of_hour,
+            tzinfo=timezone.utc,
+        ),
+        "latest_expected_session": date(2026, 1, day),
+        "metrics_json": metrics,
+        "document_sha256": f"{day:064x}",
+    }
+
+
+def _evaluate(
+    reports: list[dict[str, object]],
+    *,
+    window_sessions: int = 3,
+    minimum_observations: int = 2,
+    schedule_target_ratio: float = 2 / 3,
+):
+    policy = parse_operational_objective_policy(
+        _policy_payload(
+            window_sessions=window_sessions,
+            minimum_observations=minimum_observations,
+            schedule_target_ratio=schedule_target_ratio,
+        ),
+        "demo",
+    )
+    sessions = tuple(
+        date(2026, 1, day) for day in range(1, window_sessions + 1)
+    )
+    return evaluate_operational_objectives(
+        objective_policy=policy,
+        through_session=sessions[-1],
+        expected_sessions=sessions,
+        operational_policy_fingerprint="operational-slo-policy-" + "a" * 24,
+        schedule_id="schedule",
+        schedule_fingerprint="schedule-fingerprint",
+        calendar_id="XNYS",
+        portfolio_id="portfolio",
+        risk_limit_policy_id="risk-policy",
+        mandate_id="mandate",
+        mandate_fingerprint="mandate-fingerprint",
+        reports=reports,
+    )
+
+
+def test_objective_policy_loads_the_reviewed_configuration() -> None:
+    policy = load_operational_objective_policy(
+        Path("config/operational_service_level_objectives.yaml"),
+        "us-tech-local-20-session",
+    )
+
+    assert policy.operational_policy_id == "us-tech-local"
+    assert policy.window_sessions == 20
+    assert policy.minimum_observations == 10
+    assert tuple(policy.objectives) == OBJECTIVE_NAMES
+    assert policy.fingerprint.startswith("operational-slo-objective-policy-")
+
+
+def test_ready_window_reports_met_and_missed_objectives() -> None:
+    output = _evaluate(
+        [
+            _report(1),
+            _report(2, freshness_exceptions=1),
+            _report(3, dead_letter_age=901),
+        ]
+    )
+    rows = {row["objective_name"]: row for row in output.objectives}
+
+    assert output.report["history_status"] == "ready"
+    assert output.report["window_complete"] is True
+    assert output.report["overall_status"] == "missed"
+    assert rows["schedule_completion_attainment"]["status"] == "met"
+    assert rows["market_freshness_attainment"][
+        "attainment_ratio"
+    ] == pytest.approx(2 / 3)
+    assert rows["notification_dead_letter_duration_attainment"][
+        "status"
+    ] == "missed"
+
+
+def test_insufficient_history_is_not_reported_as_objective_failure() -> None:
+    output = _evaluate(
+        [_report(1)],
+        window_sessions=3,
+        minimum_observations=2,
+    )
+
+    assert output.report["history_status"] == "insufficient"
+    assert output.report["overall_status"] == "insufficient"
+    assert all(row["status"] == "insufficient" for row in output.objectives)
+
+
+def test_missing_expected_session_counts_against_attainment() -> None:
+    output = _evaluate(
+        [_report(1), _report(3)],
+        window_sessions=3,
+        minimum_observations=2,
+    )
+    row = {
+        item["objective_name"]: item for item in output.objectives
+    }["schedule_completion_attainment"]
+
+    assert output.report["history_status"] == "ready"
+    assert output.report["window_complete"] is False
+    assert output.report["missing_report_sessions"] == ["2026-01-02"]
+    assert row["attainment_ratio"] == pytest.approx(2 / 3)
+    assert row["missing_report_observations"] == 1
+
+
+def test_latest_report_correction_wins_for_one_session() -> None:
+    older = _report(
+        2,
+        schedule_lag=1,
+        calculation_id=(
+            "operational-service-levels-v1-report-" + "1" * 24
+        ),
+        as_of_hour=1,
+    )
+    newer = _report(
+        2,
+        schedule_lag=0,
+        calculation_id=(
+            "operational-service-levels-v1-report-" + "2" * 24
+        ),
+        as_of_hour=2,
+    )
+
+    output = _evaluate([_report(1), older, newer, _report(3)])
+
+    input_ids = output.report["input_report_calculation_ids"]
+    assert newer["calculation_id"] in input_ids
+    assert older["calculation_id"] not in input_ids
+
+
+def test_conflicting_report_calculation_id_fails_closed() -> None:
+    first = _report(
+        1,
+        calculation_id=(
+            "operational-service-levels-v1-report-" + "f" * 24
+        ),
+    )
+    conflicting = dict(first)
+    conflicting["document_sha256"] = "b" * 64
+
+    with pytest.raises(ValidationError, match="conflicting content"):
+        _evaluate([first, conflicting, _report(2), _report(3)])
+
+
+def test_policy_change_produces_a_new_fingerprint() -> None:
+    baseline = parse_operational_objective_policy(_policy_payload(), "demo")
+    changed = parse_operational_objective_policy(
+        _policy_payload(schedule_target_ratio=0.8),
+        "demo",
+    )
+
+    assert baseline.fingerprint != changed.fingerprint

--- a/tests/unit/test_operational_service_level_objectives_architecture_contract.py
+++ b/tests/unit/test_operational_service_level_objectives_architecture_contract.py
@@ -1,0 +1,24 @@
+from pathlib import Path
+
+
+def test_operational_objective_documentation_matches_report_only_contract() -> None:
+    documentation = " ".join(
+        Path("docs/operational-service-level-objectives.md")
+        .read_text(encoding="utf-8")
+        .split()
+    )
+
+    for required in (
+        "operational-slo-attainment-v1",
+        "operational-slo-objective-policy-",
+        "minimum_observations",
+        "history_status = insufficient",
+        "missing report",
+        "as_of DESC",
+        "calculation_id DESC",
+        "run_operational_service_level_objectives",
+        "provider",
+        "automated remediation",
+        "does not yet persist objective attainment in PostgreSQL",
+    ):
+        assert required.lower() in documentation.lower()

--- a/tests/unit/test_run_operational_service_level_objectives.py
+++ b/tests/unit/test_run_operational_service_level_objectives.py
@@ -1,0 +1,181 @@
+from __future__ import annotations
+
+from datetime import date, datetime, timezone
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from src.analytics.operational_service_level_objectives import (
+    parse_operational_objective_policy,
+)
+from src.common.exceptions import ValidationError
+from src.orchestration.run_operational_service_level_objectives import (
+    run_operational_service_level_objectives,
+)
+
+
+def _objective_policy():
+    return parse_operational_objective_policy(
+        {
+            "objective_policies": {
+                "demo": {
+                    "operational_policy_id": "operations",
+                    "window_sessions": 2,
+                    "minimum_observations": 2,
+                    "targets": {
+                        "schedule_completion_attainment": {
+                            "source_metric_name": "schedule_lag_sessions",
+                            "success_threshold": 0,
+                            "target_ratio": 1,
+                        },
+                        "market_freshness_attainment": {
+                            "source_metric_name": (
+                                "market_freshness_exception_count"
+                            ),
+                            "success_threshold": 0,
+                            "target_ratio": 1,
+                        },
+                        "notification_retry_exhaustion_free_attainment": {
+                            "source_metric_name": (
+                                "notification_retry_exhausted_count"
+                            ),
+                            "success_threshold": 0,
+                            "target_ratio": 1,
+                        },
+                        "notification_dead_letter_duration_attainment": {
+                            "source_metric_name": (
+                                "notification_oldest_dead_letter_age_seconds"
+                            ),
+                            "success_threshold": 900,
+                            "target_ratio": 1,
+                        },
+                    },
+                }
+            }
+        },
+        "demo",
+    )
+
+
+def _report(day: int) -> dict[str, object]:
+    names = (
+        "schedule_lag_sessions",
+        "market_freshness_exception_count",
+        "notification_retry_exhausted_count",
+        "notification_oldest_dead_letter_age_seconds",
+    )
+    units = ("sessions", "constituents", "events", "seconds")
+    return {
+        "calculation_id": (
+            f"operational-service-levels-v1-report-{day:024x}"
+        ),
+        "policy_id": "operations",
+        "policy_fingerprint": "operational-slo-policy-" + "a" * 24,
+        "schedule_id": "schedule",
+        "schedule_fingerprint": "schedule-fingerprint",
+        "calendar_id": "XNYS",
+        "portfolio_id": "portfolio",
+        "risk_limit_policy_id": "risk-policy",
+        "mandate_fingerprint": "mandate-fingerprint",
+        "as_of": datetime(2026, 1, day, 1, tzinfo=timezone.utc),
+        "latest_expected_session": date(2026, 1, day),
+        "metrics_json": [
+            {
+                "metric_name": name,
+                "observed_value": 0,
+                "unit": unit,
+                "warning_threshold": 1,
+                "critical_threshold": 2,
+                "status": "ok",
+                "reason": None,
+            }
+            for name, unit in zip(names, units, strict=True)
+        ],
+        "document_sha256": f"{day:064x}",
+    }
+
+
+class _Calendar:
+    calendar_id = "XNYS"
+    valid_from = date(2026, 1, 1)
+
+    def latest_expected_session(self, value: date) -> date:
+        return value
+
+    def sessions_between(self, start: date, end: date) -> tuple[date, ...]:
+        del start
+        return tuple(date(2026, 1, day) for day in range(1, end.day + 1))
+
+
+def _run(*, calendar: Any, report_reader: Any):
+    return run_operational_service_level_objectives(
+        objective_policy_id="demo",
+        through_session=date(2026, 1, 2),
+        objective_config_path=Path("objectives.yaml"),
+        operational_policy_config_path=Path("operations.yaml"),
+        schedule_config_path=Path("schedule.yaml"),
+        calendar_config_path=Path("calendar.yaml"),
+        portfolio_config_path=Path("portfolio.yaml"),
+        dsn="postgresql://example",
+        objective_policy_loader=lambda *_: _objective_policy(),
+        operational_policy_loader=lambda *_: SimpleNamespace(
+            policy_id="operations",
+            schedule_id="schedule",
+            fingerprint="operational-slo-policy-" + "a" * 24,
+        ),
+        schedule_loader=lambda *_: SimpleNamespace(
+            schedule_id="schedule",
+            calendar_id="XNYS",
+            portfolio_id="portfolio",
+            policy_id="risk-policy",
+            fingerprint="schedule-fingerprint",
+        ),
+        calendar_loader=lambda *_: calendar,
+        mandate_loader=lambda *_: SimpleNamespace(
+            mandate_id="mandate",
+            fingerprint="mandate-fingerprint",
+        ),
+        report_reader=report_reader,
+    )
+
+
+def test_runner_binds_the_exact_current_contract_and_session_window() -> None:
+    captured: dict[str, Any] = {}
+
+    def reader(**kwargs: Any) -> list[dict[str, object]]:
+        captured.update(kwargs)
+        return [_report(1), _report(2)]
+
+    result = _run(calendar=_Calendar(), report_reader=reader)
+
+    assert result["overall_status"] == "met"
+    assert result["provider_request_performed"] is False
+    assert result["external_delivery_performed"] is False
+    assert result["automated_remediation_performed"] is False
+    assert captured["operational_policy_fingerprint"] == (
+        "operational-slo-policy-" + "a" * 24
+    )
+    assert captured["window_start_session"] == date(2026, 1, 1)
+    assert captured["through_session"] == date(2026, 1, 2)
+
+
+def test_non_session_request_fails_before_report_read() -> None:
+    class NonSessionCalendar(_Calendar):
+        def latest_expected_session(self, value: date) -> date:
+            del value
+            return date(2026, 1, 1)
+
+    called = False
+
+    def reader(**kwargs: Any) -> list[dict[str, object]]:
+        nonlocal called
+        called = True
+        del kwargs
+        return []
+
+    with pytest.raises(ValidationError, match="expected market session"):
+        _run(calendar=NonSessionCalendar(), report_reader=reader)
+
+    assert called is False


### PR DESCRIPTION
## Outcome

Add a deterministic, report-only rolling objective layer over retained operational service-level reports:

```text
current operational report per expected market session
  -> exact current policy, schedule, calendar and mandate contract
  -> bounded market-session window
  -> four objective-attainment ratios
  -> explicit insufficient, met or missed status
  -> credential-free JSON evidence
```

Primary arc42 block: `analytics`, with bounded interfaces to PostgreSQL evidence selection and local orchestration.

## Objective policy

Add `config/operational_service_level_objectives.yaml` and model version `operational-slo-attainment-v1`.

The policy fingerprint binds the operational policy ID, expected-session window, minimum observations, source metrics, success thresholds and target ratios. The first policy evaluates schedule completion, constituent freshness, retry-exhaustion incidence and dead-letter duration.

## Session semantics

The runner resolves the current operational policy, schedule, calendar and effective mandate before querying retained reports. It builds the configured expected market-session window ending at `--through-session` and reads only the exact current contract.

For each session, corrections are ranked by:

```text
as_of DESC
calculation_id DESC
```

Identical duplicates are ignored; conflicting reuse of one calculation ID fails closed.

Missing expected sessions count against attainment once `minimum_observations` is reached. Before that threshold, the report uses `history_status = insufficient` and does not mislabel missing history as an objective failure.

## Operator path

```bash
.venv/bin/python -m src.orchestration.run_operational_service_level_objectives \
  --objective-policy-id us-tech-local-20-session \
  --through-session 2026-03-31 \
  --summary-json .demo/operational-slo-attainment.json
```

The reader is bounded to 10,000 retained rows and the command performs no provider request, external delivery, cloud schedule activation or automated remediation.

## Validation

The first CI attempts exposed two stale unused imports and a pre-existing readiness fixture whose evaluation date was an open market session while its report claimed the prior session. The branch was rebuilt as a single replacement commit with the imports removed and the fixture calendar made explicit; no gate rule or check was weakened.

GitHub Actions run `32666646060` (`ci` run 286) passed on exact head `ffc8708a20d636f130380e010659bd82779490a0`:

- Security guardrails: passed.
- Python readiness: passed.
  - locked dependencies resolved;
  - Ruff passed;
  - mypy passed across 92 source files;
  - 706 tests passed;
  - `pip check` passed;
  - `make readiness-check` passed.
- PostgreSQL contract: passed.
- Infrastructure validation: passed.
  - Kubernetes overlays rendered;
  - Terraform formatting, initialization and validation passed without applying infrastructure.

No unresolved review threads or requested changes are present.

## Scope

The branch is one commit ahead of `main` and changes 10 files with 1,588 additions and one deletion. The baseline adjustment removes a stale import and makes the existing readiness fixture's prior-session calendar assumption explicit.

This PR deliberately does not persist objective reports in PostgreSQL, expose objective views, add dashboards, deliver alerts, integrate the readiness gate, schedule execution, deploy infrastructure or run `terraform apply`. Append-only objective history is the next dependency layer.

## Acceptance boundary

This PR is validated and ready for squash merge as one report-only analytics increment.