### PR TITLE
Persist rolling operational SLO attainment history

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,7 @@ services:
       - ./sql/portfolio_risk_limits_method_schema.sql:/docker-entrypoint-initdb.d/11_portfolio_risk_limits_method_schema.sql:ro
       - ./sql/model_approval_schema.sql:/docker-entrypoint-initdb.d/12_model_approval_schema.sql:ro
       - ./sql/operational_service_levels_schema.sql:/docker-entrypoint-initdb.d/13_operational_service_levels_schema.sql:ro
+      - ./sql/operational_service_level_objectives_schema.sql:/docker-entrypoint-initdb.d/14_operational_service_level_objectives_schema.sql:ro
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U risk_user -d risk_platform"]
       interval: 5s

--- a/docs/operational-service-level-objectives.md
+++ b/docs/operational-service-level-objectives.md
@@ -2,8 +2,9 @@
 
 ## Outcome
 
-This report-only path turns retained operational service-level reports into one
-deterministic rolling objective-attainment decision:
+This path turns retained operational service-level reports into deterministic
+rolling objective-attainment evidence and preserves every accepted calculation in
+PostgreSQL:
 
 ```text
 current operational report per expected market session
@@ -11,7 +12,9 @@ current operational report per expected market session
   -> bounded market-session window
   -> four objective-attainment ratios
   -> explicit insufficient, met or missed status
-  -> credential-free JSON evidence
+  -> optional credential-free JSON evidence
+  -> append-only PostgreSQL history
+  -> current objective and exception views
 ```
 
 It does not rerun the scheduler, query a market-data provider, retry a
@@ -29,8 +32,9 @@ remediation.
 
 The first model version is `operational-slo-attainment-v1`. Objective policy
 fingerprints use the `operational-slo-objective-policy-` prefix and bind all
-window, minimum-history, source-metric, threshold and target settings. Changing an objective therefore creates a new evidence identity rather
-than relabelling an earlier result.
+window, minimum-history, source-metric, threshold and target settings. Changing
+an objective therefore creates a new evidence identity rather than relabelling
+an earlier result.
 
 The four objectives are:
 
@@ -55,7 +59,7 @@ as_of DESC
 calculation_id DESC
 ```
 
-Identical duplicate calculation IDs are ignored. Reusing one calculation ID for
+An identical duplicate calculation ID is ignored. Reusing one calculation ID for
 conflicting report content fails closed.
 
 Only reports matching the exact current contract are eligible:
@@ -93,10 +97,10 @@ objective is `met` or `missed` using:
 attainment_ratio = successful expected sessions / expected sessions in window
 ```
 
-The evidence separately records observed failures and missing-report sessions so
+The evidence separately records observed failures and missing report sessions so
 a consumer can distinguish bad operational values from absent reporting.
 
-## Operator Command
+## Report-Only Operator Command
 
 After operational service-level reports have been recorded in PostgreSQL:
 
@@ -111,9 +115,88 @@ The requested date must be an expected session in the configured calendar. The
 PostgreSQL reader is restricted to the exact current contract and selected
 window, and it caps one request at 10,000 retained rows.
 
+## Append-Only Recording
+
+Record an accepted report explicitly:
+
+```bash
+.venv/bin/python -m \
+  src.warehouse.operational_service_level_objective_recorder \
+  --report .demo/operational-slo-attainment.json
+```
+
+The recorder:
+
+- validates the exact report and objective shapes;
+- rechecks observation counts, attainment ratios and statuses;
+- requires every report-only side-effect flag to remain false;
+- serialises a canonical JSON document and records its SHA-256 digest;
+- inserts on `calculation_id` without overwriting history;
+- converges on replay when the stored digest matches; and
+- rejects reuse of one calculation ID for different content.
+
+Database triggers block update and delete operations on retained objective
+reports.
+
+## PostgreSQL Serving Contract
+
+The base history table is:
+
+```text
+risk_platform.operational_service_level_objective_reports
+```
+
+It stores scalar identity and window fields, ordered source report IDs and
+digests, the complete objective document, the canonical report document and its
+SHA-256 digest.
+
+The historical objective rows are exposed through:
+
+```text
+risk_platform.operational_service_level_objective_metric_history
+```
+
+Current report versions are selected within the exact objective-policy,
+operational-policy, schedule, calendar, portfolio, risk-limit policy, mandate,
+model and through-session grain by:
+
+```text
+calculated_at DESC
+calculation_id DESC
+```
+
+The current views are:
+
+```text
+risk_platform.latest_operational_service_level_objective_reports
+risk_platform.current_operational_service_level_objective_status
+risk_platform.current_operational_service_level_objective_exceptions
+```
+
+The status view exposes one row per current objective. The exceptions view
+contains current `missed` and `insufficient` rows; it does not discard the base
+history.
+
+## Reconciliation
+
+`sql/operational_service_level_objectives_consistency_checks.sql` verifies:
+
+- every source report ID and SHA-256 pair references retained source evidence;
+- source policy, schedule, calendar, portfolio, mandate and date-window metadata
+  match the objective report;
+- objective source metrics and units are canonical;
+- success, failure, missing and attainment counts reconcile;
+- objective and overall statuses follow the declared rules;
+- calculation IDs and current grains remain unique;
+- current selection has not chosen a stale correction; and
+- historical, current and exception view row counts match their declared grains.
+
+The live PostgreSQL CI contract also proves deterministic replay, conflicting
+identity rejection, correction ranking and append-only update/delete blocking.
+
 ## Evidence Contract
 
-The report records:
+Each report records:
 
 - deterministic calculation, model and objective-policy identities;
 - exact operational policy, schedule, calendar, portfolio, risk-limit policy and
@@ -131,8 +214,9 @@ Corrections or policy changes therefore produce distinguishable evidence.
 
 ## Current Boundary
 
-This increment writes optional local JSON only. It does not yet persist objective
-attainment in PostgreSQL or expose current attainment views. Append-only history
-and queryable serving are the next separate dependency layer. It also does not
-add a dashboard, paging, automatic gate integration, schedule activation or
-external notification delivery.
+This increment provides calculation, optional local JSON, append-only PostgreSQL
+history, current serving views and reconciliation. It does not add a dashboard,
+paging, automatic readiness-gate integration, schedule activation, external
+notification delivery or automated remediation. A stable dashboard/query
+contract is the next dependency layer; controlled gate integration follows only
+after that evidence is reviewable.

--- a/sql/operational_service_level_objectives_consistency_checks.sql
+++ b/sql/operational_service_level_objectives_consistency_checks.sql
@@ -1,0 +1,352 @@
+-- Reconciliation checks for rolling operational SLO objective history and views.
+-- Run after operational service-level source reports and objective reports exist.
+
+WITH counts AS (
+    SELECT
+        (SELECT COUNT(*)
+         FROM risk_platform.operational_service_level_objective_reports)
+            AS report_rows,
+        (SELECT COUNT(*)
+         FROM risk_platform.latest_operational_service_level_objective_reports)
+            AS latest_rows,
+        (SELECT COUNT(*)
+         FROM risk_platform.operational_service_level_objective_metric_history)
+            AS history_metric_rows,
+        (SELECT COUNT(*)
+         FROM risk_platform.current_operational_service_level_objective_status)
+            AS current_metric_rows,
+        (SELECT COUNT(*)
+         FROM risk_platform.current_operational_service_level_objective_exceptions)
+            AS current_exception_rows,
+        (SELECT COUNT(*)
+         FROM risk_platform.current_operational_service_level_objective_status
+         WHERE objective_status IN ('missed', 'insufficient'))
+            AS expected_exception_rows
+),
+integrity AS (
+    SELECT
+        (
+            SELECT COUNT(*)
+            FROM risk_platform.operational_service_level_objective_reports report
+            CROSS JOIN LATERAL jsonb_array_elements_text(
+                report.input_report_calculation_ids
+            ) WITH ORDINALITY input_id(value, ordinality)
+            JOIN LATERAL jsonb_array_elements_text(
+                report.input_report_document_sha256
+            ) WITH ORDINALITY input_digest(value, ordinality)
+                USING (ordinality)
+            LEFT JOIN risk_platform.operational_service_level_reports source_report
+                ON source_report.calculation_id = input_id.value
+            WHERE
+                source_report.calculation_id IS NULL
+                OR source_report.document_sha256 <> input_digest.value
+        ) AS invalid_source_report_references,
+        (
+            SELECT COUNT(*)
+            FROM risk_platform.operational_service_level_objective_reports report
+            CROSS JOIN LATERAL jsonb_array_elements_text(
+                report.input_report_calculation_ids
+            ) input_id
+            JOIN risk_platform.operational_service_level_reports source_report
+                ON source_report.calculation_id = input_id.value
+            WHERE
+                source_report.policy_id <> report.operational_policy_id
+                OR source_report.policy_fingerprint
+                    <> report.operational_policy_fingerprint
+                OR source_report.schedule_id <> report.schedule_id
+                OR source_report.schedule_fingerprint
+                    <> report.schedule_fingerprint
+                OR source_report.calendar_id <> report.calendar_id
+                OR source_report.portfolio_id <> report.portfolio_id
+                OR source_report.risk_limit_policy_id
+                    <> report.risk_limit_policy_id
+                OR source_report.mandate_fingerprint
+                    <> report.mandate_fingerprint
+                OR source_report.latest_expected_session
+                    < report.window_start_session
+                OR source_report.latest_expected_session
+                    > report.window_end_session
+        ) AS invalid_source_report_contracts,
+        (
+            SELECT COUNT(*)
+            FROM risk_platform.operational_service_level_objective_reports report
+            WHERE
+                jsonb_array_length(report.objectives_json) <> 4
+                OR (
+                    SELECT COUNT(DISTINCT objective.value ->> 'objective_name')
+                    FROM jsonb_array_elements(report.objectives_json) objective
+                ) <> 4
+                OR EXISTS (
+                    SELECT 1
+                    FROM jsonb_array_elements(report.objectives_json) objective
+                    WHERE
+                        (objective.value ->> 'observations_available')::INTEGER
+                            <> report.observations_available
+                        OR
+                        (objective.value ->> 'observations_expected')::INTEGER
+                            <> report.observations_expected
+                        OR
+                        (objective.value ->> 'missing_report_observations')::INTEGER
+                            <> jsonb_array_length(report.missing_report_sessions)
+                        OR
+                        (objective.value ->> 'successful_observations')::INTEGER
+                            +
+                            (objective.value ->> 'failed_observations')::INTEGER
+                            <> report.observations_available
+                        OR ABS(
+                            (objective.value ->> 'attainment_ratio')::DOUBLE PRECISION
+                            - (
+                                (objective.value ->> 'successful_observations')::DOUBLE PRECISION
+                                / report.observations_expected
+                            )
+                        ) > 0.000000000001
+                )
+        ) AS invalid_objective_counts,
+        (
+            SELECT COUNT(*)
+            FROM risk_platform.operational_service_level_objective_reports report
+            WHERE EXISTS (
+                SELECT 1
+                FROM jsonb_array_elements(report.objectives_json) objective
+                WHERE
+                    CASE objective.value ->> 'objective_name'
+                        WHEN 'schedule_completion_attainment'
+                            THEN objective.value ->> 'source_metric_name'
+                                <> 'schedule_lag_sessions'
+                                OR objective.value ->> 'source_unit'
+                                    <> 'sessions'
+                        WHEN 'market_freshness_attainment'
+                            THEN objective.value ->> 'source_metric_name'
+                                <> 'market_freshness_exception_count'
+                                OR objective.value ->> 'source_unit'
+                                    <> 'constituents'
+                        WHEN 'notification_retry_exhaustion_free_attainment'
+                            THEN objective.value ->> 'source_metric_name'
+                                <> 'notification_retry_exhausted_count'
+                                OR objective.value ->> 'source_unit'
+                                    <> 'events'
+                        WHEN 'notification_dead_letter_duration_attainment'
+                            THEN objective.value ->> 'source_metric_name'
+                                <> 'notification_oldest_dead_letter_age_seconds'
+                                OR objective.value ->> 'source_unit'
+                                    <> 'seconds'
+                        ELSE TRUE
+                    END
+            )
+        ) AS invalid_objective_sources,
+        (
+            SELECT COUNT(*)
+            FROM risk_platform.operational_service_level_objective_reports report
+            WHERE EXISTS (
+                SELECT 1
+                FROM jsonb_array_elements(report.objectives_json) objective
+                WHERE
+                    objective.value ->> 'status'
+                    <>
+                    CASE
+                        WHEN report.history_status = 'insufficient'
+                            THEN 'insufficient'
+                        WHEN
+                            (objective.value ->> 'attainment_ratio')::DOUBLE PRECISION
+                            >=
+                            (objective.value ->> 'target_ratio')::DOUBLE PRECISION
+                            THEN 'met'
+                        ELSE 'missed'
+                    END
+            )
+        ) AS invalid_objective_statuses,
+        (
+            SELECT COUNT(*)
+            FROM risk_platform.operational_service_level_objective_reports report
+            WHERE report.overall_status <>
+                CASE
+                    WHEN report.history_status = 'insufficient'
+                        THEN 'insufficient'
+                    WHEN EXISTS (
+                        SELECT 1
+                        FROM jsonb_array_elements(report.objectives_json) objective
+                        WHERE objective.value ->> 'status' = 'missed'
+                    ) THEN 'missed'
+                    ELSE 'met'
+                END
+        ) AS invalid_overall_statuses,
+        (
+            SELECT COUNT(*)
+            FROM (
+                SELECT calculation_id
+                FROM risk_platform.operational_service_level_objective_reports
+                GROUP BY calculation_id
+                HAVING COUNT(*) > 1
+            ) duplicate_ids
+        ) AS duplicate_calculation_ids,
+        (
+            SELECT COUNT(*)
+            FROM (
+                SELECT
+                    model_version,
+                    objective_policy_id,
+                    objective_policy_fingerprint,
+                    operational_policy_id,
+                    operational_policy_fingerprint,
+                    schedule_id,
+                    schedule_fingerprint,
+                    calendar_id,
+                    portfolio_id,
+                    risk_limit_policy_id,
+                    mandate_fingerprint,
+                    through_session
+                FROM risk_platform.latest_operational_service_level_objective_reports
+                GROUP BY
+                    model_version,
+                    objective_policy_id,
+                    objective_policy_fingerprint,
+                    operational_policy_id,
+                    operational_policy_fingerprint,
+                    schedule_id,
+                    schedule_fingerprint,
+                    calendar_id,
+                    portfolio_id,
+                    risk_limit_policy_id,
+                    mandate_fingerprint,
+                    through_session
+                HAVING COUNT(*) > 1
+            ) duplicate_grains
+        ) AS duplicate_latest_grains,
+        (
+            SELECT COUNT(*)
+            FROM risk_platform.latest_operational_service_level_objective_reports latest
+            JOIN risk_platform.operational_service_level_objective_reports candidate
+                ON candidate.model_version = latest.model_version
+                AND candidate.objective_policy_id = latest.objective_policy_id
+                AND candidate.objective_policy_fingerprint
+                    = latest.objective_policy_fingerprint
+                AND candidate.operational_policy_id
+                    = latest.operational_policy_id
+                AND candidate.operational_policy_fingerprint
+                    = latest.operational_policy_fingerprint
+                AND candidate.schedule_id = latest.schedule_id
+                AND candidate.schedule_fingerprint = latest.schedule_fingerprint
+                AND candidate.calendar_id = latest.calendar_id
+                AND candidate.portfolio_id = latest.portfolio_id
+                AND candidate.risk_limit_policy_id
+                    = latest.risk_limit_policy_id
+                AND candidate.mandate_fingerprint = latest.mandate_fingerprint
+                AND candidate.through_session = latest.through_session
+            WHERE
+                (candidate.calculated_at, candidate.calculation_id)
+                    > (latest.calculated_at, latest.calculation_id)
+        ) AS stale_latest_rows
+)
+SELECT
+    'operational_slo_objective_source_report_references_valid' AS check_name,
+    '0' AS expected,
+    invalid_source_report_references::TEXT AS actual,
+    CASE
+        WHEN invalid_source_report_references = 0 THEN 'pass'
+        ELSE 'fail'
+    END AS status
+FROM integrity
+
+UNION ALL
+
+SELECT
+    'operational_slo_objective_source_contracts_align',
+    '0',
+    invalid_source_report_contracts::TEXT,
+    CASE WHEN invalid_source_report_contracts = 0 THEN 'pass' ELSE 'fail' END
+FROM integrity
+
+UNION ALL
+
+SELECT
+    'operational_slo_objective_counts_reconcile',
+    '0',
+    invalid_objective_counts::TEXT,
+    CASE WHEN invalid_objective_counts = 0 THEN 'pass' ELSE 'fail' END
+FROM integrity
+
+UNION ALL
+
+SELECT
+    'operational_slo_objective_sources_align',
+    '0',
+    invalid_objective_sources::TEXT,
+    CASE WHEN invalid_objective_sources = 0 THEN 'pass' ELSE 'fail' END
+FROM integrity
+
+UNION ALL
+
+SELECT
+    'operational_slo_objective_statuses_reconcile',
+    '0',
+    invalid_objective_statuses::TEXT,
+    CASE WHEN invalid_objective_statuses = 0 THEN 'pass' ELSE 'fail' END
+FROM integrity
+
+UNION ALL
+
+SELECT
+    'operational_slo_objective_overall_status_reconciles',
+    '0',
+    invalid_overall_statuses::TEXT,
+    CASE WHEN invalid_overall_statuses = 0 THEN 'pass' ELSE 'fail' END
+FROM integrity
+
+UNION ALL
+
+SELECT
+    'operational_slo_objective_calculation_ids_unique',
+    '0',
+    duplicate_calculation_ids::TEXT,
+    CASE WHEN duplicate_calculation_ids = 0 THEN 'pass' ELSE 'fail' END
+FROM integrity
+
+UNION ALL
+
+SELECT
+    'latest_operational_slo_objective_grain_unique',
+    '0',
+    duplicate_latest_grains::TEXT,
+    CASE WHEN duplicate_latest_grains = 0 THEN 'pass' ELSE 'fail' END
+FROM integrity
+
+UNION ALL
+
+SELECT
+    'latest_operational_slo_objective_selects_current_version',
+    '0',
+    stale_latest_rows::TEXT,
+    CASE WHEN stale_latest_rows = 0 THEN 'pass' ELSE 'fail' END
+FROM integrity
+
+UNION ALL
+
+SELECT
+    'operational_slo_objective_history_rows_match_reports',
+    (report_rows * 4)::TEXT,
+    history_metric_rows::TEXT,
+    CASE WHEN history_metric_rows = report_rows * 4 THEN 'pass' ELSE 'fail' END
+FROM counts
+
+UNION ALL
+
+SELECT
+    'current_operational_slo_objective_rows_match_latest',
+    (latest_rows * 4)::TEXT,
+    current_metric_rows::TEXT,
+    CASE WHEN current_metric_rows = latest_rows * 4 THEN 'pass' ELSE 'fail' END
+FROM counts
+
+UNION ALL
+
+SELECT
+    'current_operational_slo_objective_exceptions_match_status',
+    expected_exception_rows::TEXT,
+    current_exception_rows::TEXT,
+    CASE
+        WHEN current_exception_rows = expected_exception_rows THEN 'pass'
+        ELSE 'fail'
+    END
+FROM counts
+
+ORDER BY check_name;

--- a/sql/operational_service_level_objectives_schema.sql
+++ b/sql/operational_service_level_objectives_schema.sql
@@ -1,0 +1,412 @@
+-- Append-only rolling operational service-level objective history and serving views.
+-- Apply after sql/operational_service_levels_schema.sql so source report evidence exists.
+
+CREATE SCHEMA IF NOT EXISTS risk_platform;
+
+CREATE TABLE IF NOT EXISTS risk_platform.operational_service_level_objective_reports (
+    calculation_id TEXT PRIMARY KEY,
+    model_version TEXT NOT NULL CHECK (
+        model_version = 'operational-slo-attainment-v1'
+    ),
+    objective_policy_id TEXT NOT NULL,
+    objective_policy_fingerprint TEXT NOT NULL,
+    operational_policy_id TEXT NOT NULL,
+    operational_policy_fingerprint TEXT NOT NULL,
+    schedule_id TEXT NOT NULL,
+    schedule_fingerprint TEXT NOT NULL,
+    calendar_id TEXT NOT NULL,
+    portfolio_id TEXT NOT NULL,
+    risk_limit_policy_id TEXT NOT NULL,
+    mandate_id TEXT NOT NULL,
+    mandate_fingerprint TEXT NOT NULL,
+    through_session DATE NOT NULL,
+    window_start_session DATE NOT NULL,
+    window_end_session DATE NOT NULL,
+    window_sessions INTEGER NOT NULL CHECK (
+        window_sessions BETWEEN 2 AND 2520
+    ),
+    minimum_observations INTEGER NOT NULL CHECK (
+        minimum_observations BETWEEN 2 AND window_sessions
+    ),
+    observations_available INTEGER NOT NULL CHECK (
+        observations_available >= 0
+    ),
+    observations_expected INTEGER NOT NULL CHECK (
+        observations_expected BETWEEN 1 AND window_sessions
+    ),
+    missing_report_sessions JSONB NOT NULL,
+    window_complete BOOLEAN NOT NULL,
+    history_status TEXT NOT NULL CHECK (
+        history_status IN ('insufficient', 'ready')
+    ),
+    overall_status TEXT NOT NULL CHECK (
+        overall_status IN ('insufficient', 'met', 'missed')
+    ),
+    calculated_at TIMESTAMPTZ NOT NULL,
+    input_report_calculation_ids JSONB NOT NULL,
+    input_report_document_sha256 JSONB NOT NULL,
+    objectives_json JSONB NOT NULL,
+    input_rows_scanned INTEGER NOT NULL CHECK (
+        input_rows_scanned BETWEEN 0 AND 10000
+    ),
+    provider_request_performed BOOLEAN NOT NULL,
+    external_delivery_performed BOOLEAN NOT NULL,
+    cloud_schedule_activated BOOLEAN NOT NULL,
+    automated_remediation_performed BOOLEAN NOT NULL,
+    report_json JSONB NOT NULL,
+    document_sha256 TEXT NOT NULL,
+    recorded_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    CHECK (
+        calculation_id
+            ~ '^operational-slo-attainment-v1-report-[0-9a-f]{24}$'
+    ),
+    CHECK (
+        objective_policy_id ~ '^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$'
+    ),
+    CHECK (
+        objective_policy_fingerprint
+            ~ '^operational-slo-objective-policy-[0-9a-f]{24}$'
+    ),
+    CHECK (
+        operational_policy_id ~ '^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$'
+    ),
+    CHECK (
+        operational_policy_fingerprint
+            ~ '^operational-slo-policy-[0-9a-f]{24}$'
+    ),
+    CHECK (schedule_id ~ '^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$'),
+    CHECK (schedule_fingerprint <> ''),
+    CHECK (calendar_id ~ '^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$'),
+    CHECK (portfolio_id ~ '^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$'),
+    CHECK (
+        risk_limit_policy_id ~ '^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$'
+    ),
+    CHECK (mandate_id ~ '^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$'),
+    CHECK (mandate_fingerprint <> ''),
+    CHECK (window_start_session <= window_end_session),
+    CHECK (window_end_session = through_session),
+    CHECK (observations_available <= observations_expected),
+    CHECK (input_rows_scanned >= observations_available),
+    CHECK (jsonb_typeof(missing_report_sessions) = 'array'),
+    CHECK (
+        jsonb_array_length(missing_report_sessions)
+            = observations_expected - observations_available
+    ),
+    CHECK (jsonb_typeof(input_report_calculation_ids) = 'array'),
+    CHECK (
+        jsonb_array_length(input_report_calculation_ids)
+            = observations_available
+    ),
+    CHECK (jsonb_typeof(input_report_document_sha256) = 'array'),
+    CHECK (
+        jsonb_array_length(input_report_document_sha256)
+            = observations_available
+    ),
+    CHECK (jsonb_typeof(objectives_json) = 'array'),
+    CHECK (jsonb_array_length(objectives_json) = 4),
+    CHECK (
+        window_complete
+            = (
+                observations_expected = window_sessions
+                AND jsonb_array_length(missing_report_sessions) = 0
+            )
+    ),
+    CHECK (
+        (history_status = 'insufficient'
+            AND observations_available < minimum_observations)
+        OR
+        (history_status = 'ready'
+            AND observations_available >= minimum_observations)
+    ),
+    CHECK (
+        (history_status = 'insufficient'
+            AND overall_status = 'insufficient')
+        OR
+        (history_status = 'ready'
+            AND overall_status IN ('met', 'missed'))
+    ),
+    CHECK (NOT provider_request_performed),
+    CHECK (NOT external_delivery_performed),
+    CHECK (NOT cloud_schedule_activated),
+    CHECK (NOT automated_remediation_performed),
+    CHECK (jsonb_typeof(report_json) = 'object'),
+    CHECK (document_sha256 ~ '^[0-9a-f]{64}$'),
+    CHECK (report_json ->> 'calculation_id' = calculation_id),
+    CHECK (report_json ->> 'model_version' = model_version),
+    CHECK (report_json ->> 'objective_policy_id' = objective_policy_id),
+    CHECK (
+        report_json ->> 'objective_policy_fingerprint'
+            = objective_policy_fingerprint
+    ),
+    CHECK (report_json ->> 'operational_policy_id' = operational_policy_id),
+    CHECK (
+        report_json ->> 'operational_policy_fingerprint'
+            = operational_policy_fingerprint
+    ),
+    CHECK (report_json ->> 'schedule_id' = schedule_id),
+    CHECK (report_json ->> 'schedule_fingerprint' = schedule_fingerprint),
+    CHECK (report_json ->> 'calendar_id' = calendar_id),
+    CHECK (report_json ->> 'portfolio_id' = portfolio_id),
+    CHECK (report_json ->> 'risk_limit_policy_id' = risk_limit_policy_id),
+    CHECK (report_json ->> 'mandate_id' = mandate_id),
+    CHECK (report_json ->> 'mandate_fingerprint' = mandate_fingerprint),
+    CHECK ((report_json ->> 'through_session')::DATE = through_session),
+    CHECK (
+        (report_json ->> 'window_start_session')::DATE
+            = window_start_session
+    ),
+    CHECK (
+        (report_json ->> 'window_end_session')::DATE = window_end_session
+    ),
+    CHECK (
+        (report_json ->> 'window_sessions')::INTEGER = window_sessions
+    ),
+    CHECK (
+        (report_json ->> 'minimum_observations')::INTEGER
+            = minimum_observations
+    ),
+    CHECK (
+        (report_json ->> 'observations_available')::INTEGER
+            = observations_available
+    ),
+    CHECK (
+        (report_json ->> 'observations_expected')::INTEGER
+            = observations_expected
+    ),
+    CHECK (
+        report_json -> 'missing_report_sessions' = missing_report_sessions
+    ),
+    CHECK (
+        (report_json ->> 'window_complete')::BOOLEAN = window_complete
+    ),
+    CHECK (report_json ->> 'history_status' = history_status),
+    CHECK (report_json ->> 'overall_status' = overall_status),
+    CHECK ((report_json ->> 'calculated_at')::TIMESTAMPTZ = calculated_at),
+    CHECK (
+        report_json -> 'input_report_calculation_ids'
+            = input_report_calculation_ids
+    ),
+    CHECK (
+        report_json -> 'input_report_document_sha256'
+            = input_report_document_sha256
+    ),
+    CHECK (report_json -> 'objectives' = objectives_json),
+    CHECK (
+        (report_json ->> 'input_rows_scanned')::INTEGER = input_rows_scanned
+    )
+);
+
+CREATE INDEX IF NOT EXISTS idx_operational_slo_objective_reports_latest
+    ON risk_platform.operational_service_level_objective_reports (
+        objective_policy_id,
+        objective_policy_fingerprint,
+        operational_policy_id,
+        operational_policy_fingerprint,
+        schedule_id,
+        schedule_fingerprint,
+        calendar_id,
+        portfolio_id,
+        risk_limit_policy_id,
+        mandate_fingerprint,
+        through_session DESC,
+        calculated_at DESC,
+        calculation_id DESC
+    );
+
+CREATE INDEX IF NOT EXISTS idx_operational_slo_objective_inputs
+    ON risk_platform.operational_service_level_objective_reports
+    USING GIN (input_report_calculation_ids);
+
+CREATE OR REPLACE FUNCTION
+    risk_platform.prevent_operational_slo_objective_report_mutation()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    RAISE EXCEPTION 'operational SLO objective reports are append-only'
+        USING ERRCODE = '55000';
+END;
+$$;
+
+DROP TRIGGER IF EXISTS prevent_operational_slo_objective_report_update
+    ON risk_platform.operational_service_level_objective_reports;
+CREATE TRIGGER prevent_operational_slo_objective_report_update
+BEFORE UPDATE ON risk_platform.operational_service_level_objective_reports
+FOR EACH ROW
+EXECUTE FUNCTION
+    risk_platform.prevent_operational_slo_objective_report_mutation();
+
+DROP TRIGGER IF EXISTS prevent_operational_slo_objective_report_delete
+    ON risk_platform.operational_service_level_objective_reports;
+CREATE TRIGGER prevent_operational_slo_objective_report_delete
+BEFORE DELETE ON risk_platform.operational_service_level_objective_reports
+FOR EACH ROW
+EXECUTE FUNCTION
+    risk_platform.prevent_operational_slo_objective_report_mutation();
+
+CREATE OR REPLACE VIEW
+    risk_platform.operational_service_level_objective_metric_history AS
+SELECT
+    report.calculation_id AS objective_report_calculation_id,
+    report.model_version,
+    report.objective_policy_id,
+    report.objective_policy_fingerprint,
+    report.operational_policy_id,
+    report.operational_policy_fingerprint,
+    report.schedule_id,
+    report.schedule_fingerprint,
+    report.calendar_id,
+    report.portfolio_id,
+    report.risk_limit_policy_id,
+    report.mandate_id,
+    report.mandate_fingerprint,
+    report.through_session,
+    report.window_start_session,
+    report.window_end_session,
+    report.window_sessions,
+    report.minimum_observations,
+    report.observations_available,
+    report.observations_expected,
+    report.window_complete,
+    report.history_status,
+    report.overall_status,
+    report.calculated_at,
+    objective.ordinality::INTEGER AS objective_ordinal,
+    objective.value ->> 'objective_name' AS objective_name,
+    objective.value ->> 'source_metric_name' AS source_metric_name,
+    objective.value ->> 'source_unit' AS source_unit,
+    (objective.value ->> 'success_threshold')::DOUBLE PRECISION
+        AS success_threshold,
+    (objective.value ->> 'target_ratio')::DOUBLE PRECISION
+        AS target_ratio,
+    (objective.value ->> 'successful_observations')::INTEGER
+        AS successful_observations,
+    (objective.value ->> 'failed_observations')::INTEGER
+        AS failed_observations,
+    (objective.value ->> 'missing_report_observations')::INTEGER
+        AS missing_report_observations,
+    (objective.value ->> 'observations_available')::INTEGER
+        AS objective_observations_available,
+    (objective.value ->> 'observations_expected')::INTEGER
+        AS objective_observations_expected,
+    (objective.value ->> 'attainment_ratio')::DOUBLE PRECISION
+        AS attainment_ratio,
+    objective.value ->> 'status' AS objective_status,
+    report.recorded_at
+FROM risk_platform.operational_service_level_objective_reports report
+CROSS JOIN LATERAL jsonb_array_elements(report.objectives_json)
+    WITH ORDINALITY AS objective(value, ordinality);
+
+CREATE OR REPLACE VIEW
+    risk_platform.latest_operational_service_level_objective_reports AS
+SELECT
+    calculation_id,
+    model_version,
+    objective_policy_id,
+    objective_policy_fingerprint,
+    operational_policy_id,
+    operational_policy_fingerprint,
+    schedule_id,
+    schedule_fingerprint,
+    calendar_id,
+    portfolio_id,
+    risk_limit_policy_id,
+    mandate_id,
+    mandate_fingerprint,
+    through_session,
+    window_start_session,
+    window_end_session,
+    window_sessions,
+    minimum_observations,
+    observations_available,
+    observations_expected,
+    missing_report_sessions,
+    window_complete,
+    history_status,
+    overall_status,
+    calculated_at,
+    input_report_calculation_ids,
+    input_report_document_sha256,
+    objectives_json,
+    input_rows_scanned,
+    report_json,
+    document_sha256,
+    recorded_at
+FROM (
+    SELECT
+        report.*,
+        ROW_NUMBER() OVER (
+            PARTITION BY
+                model_version,
+                objective_policy_id,
+                objective_policy_fingerprint,
+                operational_policy_id,
+                operational_policy_fingerprint,
+                schedule_id,
+                schedule_fingerprint,
+                calendar_id,
+                portfolio_id,
+                risk_limit_policy_id,
+                mandate_fingerprint,
+                through_session
+            ORDER BY calculated_at DESC, calculation_id DESC
+        ) AS report_rank
+    FROM risk_platform.operational_service_level_objective_reports report
+) ranked
+WHERE report_rank = 1;
+
+CREATE OR REPLACE VIEW
+    risk_platform.current_operational_service_level_objective_status AS
+SELECT
+    report.calculation_id AS objective_report_calculation_id,
+    report.model_version,
+    report.objective_policy_id,
+    report.objective_policy_fingerprint,
+    report.operational_policy_id,
+    report.operational_policy_fingerprint,
+    report.schedule_id,
+    report.schedule_fingerprint,
+    report.calendar_id,
+    report.portfolio_id,
+    report.risk_limit_policy_id,
+    report.mandate_id,
+    report.mandate_fingerprint,
+    report.through_session,
+    report.window_start_session,
+    report.window_end_session,
+    report.window_sessions,
+    report.minimum_observations,
+    report.observations_available,
+    report.observations_expected,
+    report.window_complete,
+    report.history_status,
+    report.overall_status,
+    report.calculated_at,
+    objective.ordinality::INTEGER AS objective_ordinal,
+    objective.value ->> 'objective_name' AS objective_name,
+    objective.value ->> 'source_metric_name' AS source_metric_name,
+    objective.value ->> 'source_unit' AS source_unit,
+    (objective.value ->> 'success_threshold')::DOUBLE PRECISION
+        AS success_threshold,
+    (objective.value ->> 'target_ratio')::DOUBLE PRECISION
+        AS target_ratio,
+    (objective.value ->> 'successful_observations')::INTEGER
+        AS successful_observations,
+    (objective.value ->> 'failed_observations')::INTEGER
+        AS failed_observations,
+    (objective.value ->> 'missing_report_observations')::INTEGER
+        AS missing_report_observations,
+    (objective.value ->> 'attainment_ratio')::DOUBLE PRECISION
+        AS attainment_ratio,
+    objective.value ->> 'status' AS objective_status,
+    report.document_sha256,
+    report.recorded_at
+FROM risk_platform.latest_operational_service_level_objective_reports report
+CROSS JOIN LATERAL jsonb_array_elements(report.objectives_json)
+    WITH ORDINALITY AS objective(value, ordinality);
+
+CREATE OR REPLACE VIEW
+    risk_platform.current_operational_service_level_objective_exceptions AS
+SELECT *
+FROM risk_platform.current_operational_service_level_objective_status
+WHERE objective_status IN ('missed', 'insufficient');

--- a/src/warehouse/operational_service_level_contract_check.py
+++ b/src/warehouse/operational_service_level_contract_check.py
@@ -4,6 +4,7 @@ import argparse
 import os
 import sys
 from datetime import date, datetime, timedelta, timezone
+from pathlib import Path
 from typing import Any
 
 from src.analytics.operational_service_levels import (
@@ -11,9 +12,13 @@ from src.analytics.operational_service_levels import (
     parse_operational_service_level_policy,
 )
 from src.common.exceptions import ValidationError
+from src.warehouse.operational_service_level_objective_contract_check import (
+    run_contract_check as run_objective_contract_check,
+)
 from src.warehouse.operational_service_level_recorder import (
     record_operational_service_level_report,
 )
+from src.warehouse.postgres_consistency import run_consistency_checks
 from src.warehouse.postgres_loader import DEFAULT_POSTGRES_DSN
 
 
@@ -223,6 +228,24 @@ def run_contract_check(dsn: str) -> dict[str, Any]:
         else:
             raise AssertionError("operational report delete was not blocked")
 
+    objective_result = run_objective_contract_check(dsn)
+    objective_consistency = run_consistency_checks(
+        dsn=dsn,
+        check_paths=(
+            Path(
+                "sql/operational_service_level_objectives_consistency_checks.sql"
+            ),
+        ),
+    )
+    objective_failures = [
+        result for result in objective_consistency if result.status != "pass"
+    ]
+    if objective_failures:
+        names = ", ".join(result.check_name for result in objective_failures)
+        raise AssertionError(
+            "operational objective reconciliation failed: " + names
+        )
+
     return {
         "first_calculation_id": first_report["calculation_id"],
         "second_calculation_id": second_report["calculation_id"],
@@ -232,6 +255,8 @@ def run_contract_check(dsn: str) -> dict[str, Any]:
         "append_only_verified": True,
         "replay_verified": True,
         "conflict_verified": True,
+        "objective_contract": objective_result,
+        "objective_consistency_checks": len(objective_consistency),
     }
 
 
@@ -258,7 +283,8 @@ def main() -> int:
         return 1
     print(
         "Operational service-level PostgreSQL contract passed: "
-        f"{result['report_rows']} reports, {result['metric_rows']} metrics"
+        f"{result['report_rows']} reports, {result['metric_rows']} metrics, "
+        f"{result['objective_consistency_checks']} objective checks"
     )
     return 0
 

--- a/src/warehouse/operational_service_level_objective_contract_check.py
+++ b/src/warehouse/operational_service_level_objective_contract_check.py
@@ -1,0 +1,357 @@
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from datetime import date, datetime, timezone
+from typing import Any
+
+from src.analytics.operational_service_level_objectives import (
+    evaluate_operational_objectives,
+    parse_operational_objective_policy,
+)
+from src.analytics.operational_service_levels import (
+    evaluate_operational_service_levels,
+    parse_operational_service_level_policy,
+)
+from src.common.exceptions import ValidationError
+from src.warehouse.operational_service_level_objective_recorder import (
+    record_operational_objective_report,
+)
+from src.warehouse.operational_service_level_recorder import (
+    record_operational_service_level_report,
+)
+from src.warehouse.postgres_loader import DEFAULT_POSTGRES_DSN
+
+SESSIONS = (
+    date(2026, 3, 27),
+    date(2026, 3, 30),
+    date(2026, 3, 31),
+)
+
+
+def _operational_policy():
+    return parse_operational_service_level_policy(
+        {
+            "policies": {
+                "us-tech-local": {
+                    "schedule_id": "us-tech-local",
+                    "metrics": {
+                        "schedule_lag_sessions": {
+                            "warning": 1,
+                            "critical": 2,
+                        },
+                        "market_freshness_exception_count": {
+                            "warning": 1,
+                            "critical": 2,
+                        },
+                        "notification_retry_exhausted_count": {
+                            "warning": 1,
+                            "critical": 2,
+                        },
+                        "notification_oldest_dead_letter_age_seconds": {
+                            "warning": 900,
+                            "critical": 3600,
+                        },
+                    },
+                }
+            }
+        },
+        "us-tech-local",
+    )
+
+
+def _objective_policy():
+    return parse_operational_objective_policy(
+        {
+            "objective_policies": {
+                "us-tech-three-session": {
+                    "operational_policy_id": "us-tech-local",
+                    "window_sessions": 3,
+                    "minimum_observations": 2,
+                    "targets": {
+                        "schedule_completion_attainment": {
+                            "source_metric_name": "schedule_lag_sessions",
+                            "success_threshold": 0,
+                            "target_ratio": 1.0,
+                        },
+                        "market_freshness_attainment": {
+                            "source_metric_name": (
+                                "market_freshness_exception_count"
+                            ),
+                            "success_threshold": 0,
+                            "target_ratio": 1.0,
+                        },
+                        "notification_retry_exhaustion_free_attainment": {
+                            "source_metric_name": (
+                                "notification_retry_exhausted_count"
+                            ),
+                            "success_threshold": 0,
+                            "target_ratio": 1.0,
+                        },
+                        "notification_dead_letter_duration_attainment": {
+                            "source_metric_name": (
+                                "notification_oldest_dead_letter_age_seconds"
+                            ),
+                            "success_threshold": 900,
+                            "target_ratio": 1.0,
+                        },
+                    },
+                }
+            }
+        },
+        "us-tech-three-session",
+    )
+
+
+def _source_report(
+    *,
+    session: date,
+    as_of: datetime,
+    lag: int,
+) -> dict[str, Any]:
+    freshness = [
+        {
+            "source": "alpha_vantage",
+            "symbol": symbol,
+            "calendar_id": "XNYS",
+            "as_of_date": session,
+            "freshness_status": "current",
+            "trailing_missing_session_count": 0,
+        }
+        for symbol in ("AAPL", "MSFT")
+    ]
+    output = evaluate_operational_service_levels(
+        policy=_operational_policy(),
+        as_of=as_of,
+        schedule_fingerprint="local-portfolio-schedule-v1-example",
+        latest_expected_session=session,
+        schedule_checkpoint=session,
+        schedule_lag_sessions=lag,
+        expected_constituents=(
+            "alpha_vantage:AAPL",
+            "alpha_vantage:MSFT",
+        ),
+        calendar_id="XNYS",
+        freshness_records=freshness,
+        notification_records=[],
+        maximum_notification_attempts=3,
+    )
+    return {
+        **dict(output.report),
+        "portfolio_id": "us-tech-equal",
+        "risk_limit_policy_id": "us-tech-standard",
+        "mandate_id": "us-tech-2026",
+        "mandate_fingerprint": "portfolio-mandate-v1-example",
+        "provider_request_performed": False,
+        "external_delivery_performed": False,
+        "cloud_schedule_activated": False,
+    }
+
+
+def _record_source(
+    dsn: str,
+    *,
+    session: date,
+    as_of: datetime,
+    lag: int,
+) -> dict[str, Any]:
+    report = _source_report(session=session, as_of=as_of, lag=lag)
+    recorded = record_operational_service_level_report(
+        dsn=dsn,
+        report=report,
+    )
+    return {
+        "calculation_id": report["calculation_id"],
+        "policy_id": report["policy_id"],
+        "policy_fingerprint": report["policy_fingerprint"],
+        "schedule_id": report["schedule_id"],
+        "schedule_fingerprint": report["schedule_fingerprint"],
+        "calendar_id": report["calendar_id"],
+        "portfolio_id": report["portfolio_id"],
+        "risk_limit_policy_id": report["risk_limit_policy_id"],
+        "mandate_fingerprint": report["mandate_fingerprint"],
+        "as_of": datetime.fromisoformat(report["as_of"]),
+        "latest_expected_session": date.fromisoformat(
+            report["latest_expected_session"]
+        ),
+        "metrics_json": report["metrics"],
+        "document_sha256": recorded["document_sha256"],
+    }
+
+
+def _objective_report(source_reports: list[dict[str, Any]]) -> dict[str, Any]:
+    output = evaluate_operational_objectives(
+        objective_policy=_objective_policy(),
+        through_session=SESSIONS[-1],
+        expected_sessions=SESSIONS,
+        operational_policy_fingerprint=_operational_policy().fingerprint,
+        schedule_id="us-tech-local",
+        schedule_fingerprint="local-portfolio-schedule-v1-example",
+        calendar_id="XNYS",
+        portfolio_id="us-tech-equal",
+        risk_limit_policy_id="us-tech-standard",
+        mandate_id="us-tech-2026",
+        mandate_fingerprint="portfolio-mandate-v1-example",
+        reports=source_reports,
+    )
+    return dict(output.report)
+
+
+def run_contract_check(dsn: str) -> dict[str, Any]:
+    source_reports = [
+        _record_source(
+            dsn,
+            session=session,
+            as_of=datetime(
+                2026,
+                4,
+                index,
+                12,
+                tzinfo=timezone.utc,
+            ),
+            lag=0,
+        )
+        for index, session in enumerate(SESSIONS, start=1)
+    ]
+    first_report = _objective_report(source_reports)
+    first = record_operational_objective_report(
+        dsn=dsn,
+        report=first_report,
+    )
+    replay = record_operational_objective_report(
+        dsn=dsn,
+        report=first_report,
+    )
+    if first["created"] is not True or replay["created"] is not False:
+        raise AssertionError("operational objective retry did not converge")
+
+    conflicting = dict(first_report)
+    conflicting["input_rows_scanned"] = first_report["input_rows_scanned"] + 1
+    try:
+        record_operational_objective_report(
+            dsn=dsn,
+            report=conflicting,
+        )
+    except ValidationError:
+        pass
+    else:
+        raise AssertionError("conflicting objective calculation identity was accepted")
+
+    corrected = _record_source(
+        dsn,
+        session=SESSIONS[-1],
+        as_of=datetime(2026, 4, 4, 12, tzinfo=timezone.utc),
+        lag=1,
+    )
+    second_report = _objective_report([*source_reports[:-1], corrected])
+    second = record_operational_objective_report(
+        dsn=dsn,
+        report=second_report,
+    )
+    if second["created"] is not True:
+        raise AssertionError("corrected operational objective report was not appended")
+
+    try:
+        import psycopg
+    except ImportError as exc:  # pragma: no cover - dependency is required in CI.
+        raise RuntimeError("Operational objective contract check requires psycopg") from exc
+
+    with psycopg.connect(dsn) as connection:
+        with connection.cursor() as cursor:
+            cursor.execute(
+                """
+                SELECT
+                    (SELECT COUNT(*)
+                     FROM risk_platform.operational_service_level_objective_reports),
+                    (SELECT COUNT(*)
+                     FROM risk_platform.operational_service_level_objective_metric_history),
+                    (SELECT COUNT(*)
+                     FROM risk_platform.latest_operational_service_level_objective_reports),
+                    (SELECT COUNT(*)
+                     FROM risk_platform.current_operational_service_level_objective_status),
+                    (SELECT COUNT(*)
+                     FROM risk_platform.current_operational_service_level_objective_exceptions),
+                    (SELECT overall_status
+                     FROM risk_platform.latest_operational_service_level_objective_reports)
+                """
+            )
+            counts = cursor.fetchone()
+            if counts != (2, 8, 1, 4, 1, "missed"):
+                raise AssertionError(
+                    f"operational objective serving views are incompatible: {counts!r}"
+                )
+
+    with psycopg.connect(dsn) as connection:
+        try:
+            with connection.cursor() as cursor:
+                cursor.execute(
+                    """
+                    UPDATE risk_platform.operational_service_level_objective_reports
+                    SET recorded_at = recorded_at
+                    WHERE calculation_id = %s
+                    """,
+                    (first_report["calculation_id"],),
+                )
+        except psycopg.Error:
+            connection.rollback()
+        else:
+            raise AssertionError("operational objective update was not blocked")
+
+    with psycopg.connect(dsn) as connection:
+        try:
+            with connection.cursor() as cursor:
+                cursor.execute(
+                    """
+                    DELETE FROM risk_platform.operational_service_level_objective_reports
+                    WHERE calculation_id = %s
+                    """,
+                    (first_report["calculation_id"],),
+                )
+        except psycopg.Error:
+            connection.rollback()
+        else:
+            raise AssertionError("operational objective delete was not blocked")
+
+    return {
+        "first_calculation_id": first_report["calculation_id"],
+        "second_calculation_id": second_report["calculation_id"],
+        "report_rows": 2,
+        "objective_rows": 8,
+        "latest_status": "missed",
+        "append_only_verified": True,
+        "replay_verified": True,
+        "conflict_verified": True,
+    }
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Exercise the operational SLO objective PostgreSQL contract."
+    )
+    parser.add_argument(
+        "--dsn",
+        default=os.environ.get("WAREHOUSE_POSTGRES_DSN", DEFAULT_POSTGRES_DSN),
+    )
+    return parser
+
+
+def main() -> int:
+    args = _build_parser().parse_args()
+    try:
+        result = run_contract_check(args.dsn)
+    except Exception as exc:
+        print(
+            f"Operational SLO objective contract check failed: {exc}",
+            file=sys.stderr,
+        )
+        return 1
+    print(
+        "Operational SLO objective PostgreSQL contract passed: "
+        f"{result['report_rows']} reports, {result['objective_rows']} objectives"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/warehouse/operational_service_level_objective_recorder.py
+++ b/src/warehouse/operational_service_level_objective_recorder.py
@@ -1,0 +1,680 @@
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+import os
+import re
+import sys
+from collections.abc import Mapping, Sequence
+from datetime import date, datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from src.analytics.operational_service_level_objectives import (
+    MAX_REPORT_ROWS,
+    MODEL_VERSION,
+    OBJECTIVE_NAMES,
+)
+from src.analytics.operational_service_level_objective_policy import (
+    EXPECTED_UNITS,
+    OBJECTIVE_SOURCE_METRICS,
+)
+from src.common.exceptions import StorageError, ValidationError
+from src.warehouse.postgres_loader import DEFAULT_POSTGRES_DSN
+
+MAX_REPORT_BYTES = 2_000_000
+CALCULATION_ID_PATTERN = re.compile(
+    r"^operational-slo-attainment-v1-report-[0-9a-f]{24}$"
+)
+OBJECTIVE_POLICY_FINGERPRINT_PATTERN = re.compile(
+    r"^operational-slo-objective-policy-[0-9a-f]{24}$"
+)
+OPERATIONAL_POLICY_FINGERPRINT_PATTERN = re.compile(
+    r"^operational-slo-policy-[0-9a-f]{24}$"
+)
+REPORT_ID_PATTERN = re.compile(
+    r"^operational-service-levels-v1-report-[0-9a-f]{24}$"
+)
+SHA256_PATTERN = re.compile(r"^[0-9a-f]{64}$")
+SAFE_SEGMENT_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$")
+REPORT_KEYS = frozenset(
+    {
+        "calculation_id",
+        "model_version",
+        "objective_policy_id",
+        "objective_policy_fingerprint",
+        "operational_policy_id",
+        "operational_policy_fingerprint",
+        "schedule_id",
+        "schedule_fingerprint",
+        "calendar_id",
+        "portfolio_id",
+        "risk_limit_policy_id",
+        "mandate_id",
+        "mandate_fingerprint",
+        "through_session",
+        "window_start_session",
+        "window_end_session",
+        "window_sessions",
+        "minimum_observations",
+        "observations_available",
+        "observations_expected",
+        "missing_report_sessions",
+        "window_complete",
+        "history_status",
+        "overall_status",
+        "calculated_at",
+        "input_report_calculation_ids",
+        "input_report_document_sha256",
+        "objectives",
+        "input_rows_scanned",
+        "provider_request_performed",
+        "external_delivery_performed",
+        "cloud_schedule_activated",
+        "automated_remediation_performed",
+    }
+)
+OBJECTIVE_KEYS = frozenset(
+    {
+        "objective_name",
+        "source_metric_name",
+        "source_unit",
+        "success_threshold",
+        "target_ratio",
+        "successful_observations",
+        "failed_observations",
+        "missing_report_observations",
+        "observations_available",
+        "observations_expected",
+        "attainment_ratio",
+        "status",
+    }
+)
+
+
+def _safe_segment(value: Any, label: str) -> str:
+    if not isinstance(value, str) or not SAFE_SEGMENT_PATTERN.fullmatch(value):
+        raise ValidationError(f"{label} must be one safe text segment")
+    return value
+
+
+def _fingerprint(value: Any, label: str, pattern: re.Pattern[str] | None = None) -> str:
+    if not isinstance(value, str) or not value or len(value) > 256:
+        raise ValidationError(f"{label} must be non-empty bounded text")
+    if value != value.strip() or any(ord(character) < 32 for character in value):
+        raise ValidationError(f"{label} must be canonical bounded text")
+    if pattern is not None and not pattern.fullmatch(value):
+        raise ValidationError(f"{label} is incompatible")
+    return value
+
+
+def _calendar_date(value: Any, label: str) -> date:
+    if isinstance(value, datetime):
+        raise ValidationError(f"{label} must be a calendar date")
+    if isinstance(value, date):
+        return value
+    if not isinstance(value, str):
+        raise ValidationError(f"{label} must use YYYY-MM-DD")
+    try:
+        parsed = date.fromisoformat(value)
+    except ValueError:
+        raise ValidationError(f"{label} must use YYYY-MM-DD") from None
+    if value != parsed.isoformat():
+        raise ValidationError(f"{label} must use YYYY-MM-DD")
+    return parsed
+
+
+def _aware_utc(value: Any, label: str) -> datetime:
+    if isinstance(value, datetime):
+        parsed = value
+    elif isinstance(value, str):
+        try:
+            parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        except ValueError:
+            raise ValidationError(f"{label} must be ISO-8601") from None
+    else:
+        raise ValidationError(f"{label} must be timezone-aware")
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise ValidationError(f"{label} must be timezone-aware")
+    return parsed.astimezone(timezone.utc)
+
+
+def _bounded_int(
+    value: Any,
+    label: str,
+    *,
+    minimum: int,
+    maximum: int,
+) -> int:
+    if type(value) is not int or not minimum <= value <= maximum:
+        raise ValidationError(
+            f"{label} must be an integer between {minimum} and {maximum}"
+        )
+    return value
+
+
+def _finite_nonnegative(value: Any, label: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ValidationError(f"{label} must be a finite non-negative number")
+    parsed = float(value)
+    if not math.isfinite(parsed) or parsed < 0:
+        raise ValidationError(f"{label} must be a finite non-negative number")
+    return parsed
+
+
+def _date_array(value: Any, label: str) -> list[str]:
+    if not isinstance(value, list):
+        raise ValidationError(f"{label} must be an array")
+    parsed = [_calendar_date(item, label).isoformat() for item in value]
+    if parsed != sorted(set(parsed)):
+        raise ValidationError(f"{label} must be unique and ordered")
+    return parsed
+
+
+def _text_array(
+    value: Any,
+    label: str,
+    *,
+    pattern: re.Pattern[str],
+) -> list[str]:
+    if not isinstance(value, list):
+        raise ValidationError(f"{label} must be an array")
+    parsed: list[str] = []
+    for item in value:
+        if not isinstance(item, str) or not pattern.fullmatch(item):
+            raise ValidationError(f"{label} contains an incompatible value")
+        parsed.append(item)
+    if len(parsed) != len(set(parsed)):
+        raise ValidationError(f"{label} must not contain duplicates")
+    return parsed
+
+
+def _objectives(
+    value: Any,
+    *,
+    history_status: str,
+    observations_available: int,
+    observations_expected: int,
+    missing_count: int,
+) -> tuple[list[dict[str, Any]], str]:
+    if not isinstance(value, list) or len(value) != len(OBJECTIVE_NAMES):
+        raise ValidationError("objectives must contain the four supported rows")
+    rows: list[dict[str, Any]] = []
+    statuses: list[str] = []
+    names: list[str] = []
+    for raw in value:
+        if not isinstance(raw, Mapping) or set(raw) != OBJECTIVE_KEYS:
+            raise ValidationError("each objective must match the strict contract")
+        name = raw.get("objective_name")
+        if name not in OBJECTIVE_NAMES or not isinstance(name, str):
+            raise ValidationError("objective_name is unsupported")
+        metric_name = OBJECTIVE_SOURCE_METRICS[name]
+        if raw.get("source_metric_name") != metric_name:
+            raise ValidationError("objective source metric is incompatible")
+        if raw.get("source_unit") != EXPECTED_UNITS[metric_name]:
+            raise ValidationError("objective source unit is incompatible")
+        threshold = _finite_nonnegative(
+            raw.get("success_threshold"),
+            f"{name}.success_threshold",
+        )
+        target_ratio = _finite_nonnegative(
+            raw.get("target_ratio"),
+            f"{name}.target_ratio",
+        )
+        if not 0 < target_ratio <= 1:
+            raise ValidationError("objective target_ratio must be in (0, 1]")
+        successful = _bounded_int(
+            raw.get("successful_observations"),
+            f"{name}.successful_observations",
+            minimum=0,
+            maximum=observations_available,
+        )
+        failed = _bounded_int(
+            raw.get("failed_observations"),
+            f"{name}.failed_observations",
+            minimum=0,
+            maximum=observations_available,
+        )
+        if successful + failed != observations_available:
+            raise ValidationError("objective success and failure counts do not reconcile")
+        if raw.get("missing_report_observations") != missing_count:
+            raise ValidationError("objective missing-report count does not reconcile")
+        if raw.get("observations_available") != observations_available:
+            raise ValidationError("objective available count does not reconcile")
+        if raw.get("observations_expected") != observations_expected:
+            raise ValidationError("objective expected count does not reconcile")
+        attainment_ratio = _finite_nonnegative(
+            raw.get("attainment_ratio"),
+            f"{name}.attainment_ratio",
+        )
+        expected_ratio = successful / observations_expected
+        if not math.isclose(
+            attainment_ratio,
+            expected_ratio,
+            rel_tol=0.0,
+            abs_tol=1e-12,
+        ):
+            raise ValidationError("objective attainment ratio does not reconcile")
+        expected_status = (
+            "insufficient"
+            if history_status == "insufficient"
+            else ("met" if attainment_ratio >= target_ratio else "missed")
+        )
+        if raw.get("status") != expected_status:
+            raise ValidationError("objective status does not match attainment")
+        rows.append(
+            {
+                "objective_name": name,
+                "source_metric_name": metric_name,
+                "source_unit": EXPECTED_UNITS[metric_name],
+                "success_threshold": threshold,
+                "target_ratio": target_ratio,
+                "successful_observations": successful,
+                "failed_observations": failed,
+                "missing_report_observations": missing_count,
+                "observations_available": observations_available,
+                "observations_expected": observations_expected,
+                "attainment_ratio": attainment_ratio,
+                "status": expected_status,
+            }
+        )
+        names.append(name)
+        statuses.append(expected_status)
+    if tuple(names) != OBJECTIVE_NAMES:
+        raise ValidationError("objectives must use the canonical order")
+    overall = (
+        "insufficient"
+        if history_status == "insufficient"
+        else ("missed" if "missed" in statuses else "met")
+    )
+    return rows, overall
+
+
+def validate_operational_objective_report(
+    payload: Mapping[str, Any],
+) -> dict[str, Any]:
+    if not isinstance(payload, Mapping) or set(payload) != REPORT_KEYS:
+        raise ValidationError("operational objective report has an invalid shape")
+    calculation_id = payload.get("calculation_id")
+    if not isinstance(calculation_id, str) or not CALCULATION_ID_PATTERN.fullmatch(
+        calculation_id
+    ):
+        raise ValidationError("calculation_id is incompatible")
+    if payload.get("model_version") != MODEL_VERSION:
+        raise ValidationError("operational objective model version is unsupported")
+    through_session = _calendar_date(payload.get("through_session"), "through_session")
+    window_start = _calendar_date(
+        payload.get("window_start_session"),
+        "window_start_session",
+    )
+    window_end = _calendar_date(
+        payload.get("window_end_session"),
+        "window_end_session",
+    )
+    if window_start > window_end or window_end != through_session:
+        raise ValidationError("objective report window boundaries are inconsistent")
+    window_sessions = _bounded_int(
+        payload.get("window_sessions"),
+        "window_sessions",
+        minimum=2,
+        maximum=2520,
+    )
+    minimum_observations = _bounded_int(
+        payload.get("minimum_observations"),
+        "minimum_observations",
+        minimum=2,
+        maximum=window_sessions,
+    )
+    observations_expected = _bounded_int(
+        payload.get("observations_expected"),
+        "observations_expected",
+        minimum=1,
+        maximum=window_sessions,
+    )
+    observations_available = _bounded_int(
+        payload.get("observations_available"),
+        "observations_available",
+        minimum=0,
+        maximum=observations_expected,
+    )
+    missing_sessions = _date_array(
+        payload.get("missing_report_sessions"),
+        "missing_report_sessions",
+    )
+    if len(missing_sessions) != observations_expected - observations_available:
+        raise ValidationError("missing report sessions do not reconcile")
+    input_ids = _text_array(
+        payload.get("input_report_calculation_ids"),
+        "input_report_calculation_ids",
+        pattern=REPORT_ID_PATTERN,
+    )
+    input_digests = _text_array(
+        payload.get("input_report_document_sha256"),
+        "input_report_document_sha256",
+        pattern=SHA256_PATTERN,
+    )
+    if len(input_ids) != observations_available or len(input_digests) != observations_available:
+        raise ValidationError("input report evidence does not reconcile")
+    history_status = payload.get("history_status")
+    expected_history = (
+        "ready"
+        if observations_available >= minimum_observations
+        else "insufficient"
+    )
+    if history_status != expected_history:
+        raise ValidationError("history_status does not match observation count")
+    objectives, expected_overall = _objectives(
+        payload.get("objectives"),
+        history_status=expected_history,
+        observations_available=observations_available,
+        observations_expected=observations_expected,
+        missing_count=len(missing_sessions),
+    )
+    if payload.get("overall_status") != expected_overall:
+        raise ValidationError("overall_status does not match objectives")
+    expected_complete = (
+        observations_expected == window_sessions and not missing_sessions
+    )
+    if payload.get("window_complete") is not expected_complete:
+        raise ValidationError("window_complete does not match the window evidence")
+    input_rows_scanned = _bounded_int(
+        payload.get("input_rows_scanned"),
+        "input_rows_scanned",
+        minimum=observations_available,
+        maximum=MAX_REPORT_ROWS,
+    )
+    for flag in (
+        "provider_request_performed",
+        "external_delivery_performed",
+        "cloud_schedule_activated",
+        "automated_remediation_performed",
+    ):
+        if payload.get(flag) is not False:
+            raise ValidationError(f"{flag} must be false for report-only evidence")
+    report = {
+        "calculation_id": calculation_id,
+        "model_version": MODEL_VERSION,
+        "objective_policy_id": _safe_segment(
+            payload.get("objective_policy_id"),
+            "objective_policy_id",
+        ),
+        "objective_policy_fingerprint": _fingerprint(
+            payload.get("objective_policy_fingerprint"),
+            "objective_policy_fingerprint",
+            OBJECTIVE_POLICY_FINGERPRINT_PATTERN,
+        ),
+        "operational_policy_id": _safe_segment(
+            payload.get("operational_policy_id"),
+            "operational_policy_id",
+        ),
+        "operational_policy_fingerprint": _fingerprint(
+            payload.get("operational_policy_fingerprint"),
+            "operational_policy_fingerprint",
+            OPERATIONAL_POLICY_FINGERPRINT_PATTERN,
+        ),
+        "schedule_id": _safe_segment(payload.get("schedule_id"), "schedule_id"),
+        "schedule_fingerprint": _fingerprint(
+            payload.get("schedule_fingerprint"),
+            "schedule_fingerprint",
+        ),
+        "calendar_id": _safe_segment(payload.get("calendar_id"), "calendar_id"),
+        "portfolio_id": _safe_segment(payload.get("portfolio_id"), "portfolio_id"),
+        "risk_limit_policy_id": _safe_segment(
+            payload.get("risk_limit_policy_id"),
+            "risk_limit_policy_id",
+        ),
+        "mandate_id": _safe_segment(payload.get("mandate_id"), "mandate_id"),
+        "mandate_fingerprint": _fingerprint(
+            payload.get("mandate_fingerprint"),
+            "mandate_fingerprint",
+        ),
+        "through_session": through_session.isoformat(),
+        "window_start_session": window_start.isoformat(),
+        "window_end_session": window_end.isoformat(),
+        "window_sessions": window_sessions,
+        "minimum_observations": minimum_observations,
+        "observations_available": observations_available,
+        "observations_expected": observations_expected,
+        "missing_report_sessions": missing_sessions,
+        "window_complete": expected_complete,
+        "history_status": expected_history,
+        "overall_status": expected_overall,
+        "calculated_at": _aware_utc(
+            payload.get("calculated_at"),
+            "calculated_at",
+        ).isoformat(),
+        "input_report_calculation_ids": input_ids,
+        "input_report_document_sha256": input_digests,
+        "objectives": objectives,
+        "input_rows_scanned": input_rows_scanned,
+        "provider_request_performed": False,
+        "external_delivery_performed": False,
+        "cloud_schedule_activated": False,
+        "automated_remediation_performed": False,
+    }
+    return report
+
+
+def canonical_objective_report_bytes(report: Mapping[str, Any]) -> bytes:
+    try:
+        return json.dumps(
+            report,
+            sort_keys=True,
+            separators=(",", ":"),
+            allow_nan=False,
+        ).encode("utf-8")
+    except (TypeError, ValueError):
+        raise ValidationError("operational objective report is not canonical JSON") from None
+
+
+def read_objective_report(path: Path) -> dict[str, Any]:
+    if path.is_symlink():
+        raise StorageError("operational objective report must not be a symbolic link")
+    if not path.is_file():
+        raise StorageError("operational objective report must be a regular file")
+    try:
+        if path.stat().st_size > MAX_REPORT_BYTES:
+            raise StorageError("operational objective report exceeds the byte limit")
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except StorageError:
+        raise
+    except (OSError, ValueError):
+        raise StorageError("operational objective report could not be read") from None
+    if not isinstance(payload, Mapping):
+        raise ValidationError("operational objective report must be a JSON object")
+    return validate_operational_objective_report(payload)
+
+
+def record_operational_objective_report(
+    *,
+    dsn: str,
+    report: Mapping[str, Any],
+) -> dict[str, Any]:
+    validated = validate_operational_objective_report(report)
+    canonical = canonical_objective_report_bytes(validated)
+    document_sha256 = hashlib.sha256(canonical).hexdigest()
+    try:
+        import psycopg
+        from psycopg.types.json import Jsonb
+    except ImportError as exc:  # pragma: no cover - dependency is required in CI.
+        raise RuntimeError("Operational objective recording requires psycopg") from exc
+
+    created = False
+    recorded_at: datetime | None = None
+    try:
+        with psycopg.connect(dsn) as connection:
+            with connection.cursor() as cursor:
+                cursor.execute(
+                    """
+                    INSERT INTO risk_platform.operational_service_level_objective_reports (
+                        calculation_id,
+                        model_version,
+                        objective_policy_id,
+                        objective_policy_fingerprint,
+                        operational_policy_id,
+                        operational_policy_fingerprint,
+                        schedule_id,
+                        schedule_fingerprint,
+                        calendar_id,
+                        portfolio_id,
+                        risk_limit_policy_id,
+                        mandate_id,
+                        mandate_fingerprint,
+                        through_session,
+                        window_start_session,
+                        window_end_session,
+                        window_sessions,
+                        minimum_observations,
+                        observations_available,
+                        observations_expected,
+                        missing_report_sessions,
+                        window_complete,
+                        history_status,
+                        overall_status,
+                        calculated_at,
+                        input_report_calculation_ids,
+                        input_report_document_sha256,
+                        objectives_json,
+                        input_rows_scanned,
+                        provider_request_performed,
+                        external_delivery_performed,
+                        cloud_schedule_activated,
+                        automated_remediation_performed,
+                        report_json,
+                        document_sha256
+                    ) VALUES (
+                        %s, %s, %s, %s, %s, %s, %s, %s, %s, %s,
+                        %s, %s, %s, %s, %s, %s, %s, %s, %s, %s,
+                        %s, %s, %s, %s, %s, %s, %s, %s, %s, %s,
+                        %s, %s, %s, %s, %s
+                    )
+                    ON CONFLICT (calculation_id) DO NOTHING
+                    RETURNING recorded_at
+                    """,
+                    (
+                        validated["calculation_id"],
+                        validated["model_version"],
+                        validated["objective_policy_id"],
+                        validated["objective_policy_fingerprint"],
+                        validated["operational_policy_id"],
+                        validated["operational_policy_fingerprint"],
+                        validated["schedule_id"],
+                        validated["schedule_fingerprint"],
+                        validated["calendar_id"],
+                        validated["portfolio_id"],
+                        validated["risk_limit_policy_id"],
+                        validated["mandate_id"],
+                        validated["mandate_fingerprint"],
+                        date.fromisoformat(validated["through_session"]),
+                        date.fromisoformat(validated["window_start_session"]),
+                        date.fromisoformat(validated["window_end_session"]),
+                        validated["window_sessions"],
+                        validated["minimum_observations"],
+                        validated["observations_available"],
+                        validated["observations_expected"],
+                        Jsonb(validated["missing_report_sessions"]),
+                        validated["window_complete"],
+                        validated["history_status"],
+                        validated["overall_status"],
+                        datetime.fromisoformat(validated["calculated_at"]),
+                        Jsonb(validated["input_report_calculation_ids"]),
+                        Jsonb(validated["input_report_document_sha256"]),
+                        Jsonb(validated["objectives"]),
+                        validated["input_rows_scanned"],
+                        False,
+                        False,
+                        False,
+                        False,
+                        Jsonb(validated),
+                        document_sha256,
+                    ),
+                )
+                inserted = cursor.fetchone()
+                created = inserted is not None
+                cursor.execute(
+                    """
+                    SELECT document_sha256, recorded_at
+                    FROM risk_platform.operational_service_level_objective_reports
+                    WHERE calculation_id = %s
+                    """,
+                    (validated["calculation_id"],),
+                )
+                stored = cursor.fetchone()
+                if stored is None:
+                    raise StorageError(
+                        "operational objective report is unavailable after insert"
+                    )
+                if stored[0] != document_sha256:
+                    raise ValidationError(
+                        "calculation_id already exists with different objective content"
+                    )
+                if not isinstance(stored[1], datetime):
+                    raise StorageError(
+                        "stored operational objective timestamp is incompatible"
+                    )
+                recorded_at = stored[1].astimezone(timezone.utc)
+            connection.commit()
+    except (ValidationError, StorageError):
+        raise
+    except Exception:
+        raise StorageError("operational objective database operation failed") from None
+    if recorded_at is None:  # pragma: no cover - guarded above.
+        raise StorageError("operational objective record result is unavailable")
+    return {
+        "calculation_id": validated["calculation_id"],
+        "model_version": MODEL_VERSION,
+        "objective_policy_id": validated["objective_policy_id"],
+        "through_session": validated["through_session"],
+        "history_status": validated["history_status"],
+        "overall_status": validated["overall_status"],
+        "document_sha256": document_sha256,
+        "recorded_at": recorded_at.isoformat(),
+        "created": created,
+    }
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Record one append-only operational SLO objective report."
+    )
+    parser.add_argument("--report", type=Path, required=True)
+    parser.add_argument(
+        "--dsn",
+        default=os.environ.get("WAREHOUSE_POSTGRES_DSN", DEFAULT_POSTGRES_DSN),
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    try:
+        summary = record_operational_objective_report(
+            dsn=args.dsn,
+            report=read_objective_report(args.report),
+        )
+    except ValidationError:
+        print(
+            "Operational objective recording failed: report evidence was invalid",
+            file=sys.stderr,
+        )
+        return 1
+    except StorageError:
+        print(
+            "Operational objective recording failed: file or PostgreSQL operation failed",
+            file=sys.stderr,
+        )
+        return 1
+    except Exception:
+        print(
+            "Operational objective recording failed: unexpected local failure",
+            file=sys.stderr,
+        )
+        return 1
+    print(json.dumps(summary, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/test_docker_compose_contract.py
+++ b/tests/unit/test_docker_compose_contract.py
@@ -38,6 +38,7 @@ def test_local_database_seed_mounts_are_read_only_and_ordered() -> None:
         "./sql/portfolio_risk_limits_method_schema.sql:/docker-entrypoint-initdb.d/11_portfolio_risk_limits_method_schema.sql:ro",
         "./sql/model_approval_schema.sql:/docker-entrypoint-initdb.d/12_model_approval_schema.sql:ro",
         "./sql/operational_service_levels_schema.sql:/docker-entrypoint-initdb.d/13_operational_service_levels_schema.sql:ro",
+        "./sql/operational_service_level_objectives_schema.sql:/docker-entrypoint-initdb.d/14_operational_service_level_objectives_schema.sql:ro",
     ]
     assert services["mongo"]["volumes"] == [
         "./mongo/init:/docker-entrypoint-initdb.d:ro"

--- a/tests/unit/test_operational_service_level_objective_recorder.py
+++ b/tests/unit/test_operational_service_level_objective_recorder.py
@@ -1,0 +1,159 @@
+from __future__ import annotations
+
+from datetime import date, datetime, timezone
+
+import pytest
+
+from src.analytics.operational_service_level_objectives import (
+    evaluate_operational_objectives,
+    parse_operational_objective_policy,
+)
+from src.common.exceptions import ValidationError
+from src.warehouse.operational_service_level_objective_recorder import (
+    canonical_objective_report_bytes,
+    validate_operational_objective_report,
+)
+
+
+def _policy():
+    return parse_operational_objective_policy(
+        {
+            "objective_policies": {
+                "demo": {
+                    "operational_policy_id": "operations",
+                    "window_sessions": 2,
+                    "minimum_observations": 2,
+                    "targets": {
+                        "schedule_completion_attainment": {
+                            "source_metric_name": "schedule_lag_sessions",
+                            "success_threshold": 0,
+                            "target_ratio": 1,
+                        },
+                        "market_freshness_attainment": {
+                            "source_metric_name": (
+                                "market_freshness_exception_count"
+                            ),
+                            "success_threshold": 0,
+                            "target_ratio": 1,
+                        },
+                        "notification_retry_exhaustion_free_attainment": {
+                            "source_metric_name": (
+                                "notification_retry_exhausted_count"
+                            ),
+                            "success_threshold": 0,
+                            "target_ratio": 1,
+                        },
+                        "notification_dead_letter_duration_attainment": {
+                            "source_metric_name": (
+                                "notification_oldest_dead_letter_age_seconds"
+                            ),
+                            "success_threshold": 900,
+                            "target_ratio": 1,
+                        },
+                    },
+                }
+            }
+        },
+        "demo",
+    )
+
+
+def _source_report(day: int) -> dict[str, object]:
+    names = (
+        "schedule_lag_sessions",
+        "market_freshness_exception_count",
+        "notification_retry_exhausted_count",
+        "notification_oldest_dead_letter_age_seconds",
+    )
+    units = ("sessions", "constituents", "events", "seconds")
+    return {
+        "calculation_id": (
+            f"operational-service-levels-v1-report-{day:024x}"
+        ),
+        "policy_id": "operations",
+        "policy_fingerprint": "operational-slo-policy-" + "a" * 24,
+        "schedule_id": "schedule",
+        "schedule_fingerprint": "schedule-fingerprint",
+        "calendar_id": "XNYS",
+        "portfolio_id": "portfolio",
+        "risk_limit_policy_id": "risk-policy",
+        "mandate_fingerprint": "mandate-fingerprint",
+        "as_of": datetime(2026, 1, day, 12, tzinfo=timezone.utc),
+        "latest_expected_session": date(2026, 1, day),
+        "metrics_json": [
+            {
+                "metric_name": name,
+                "observed_value": 0,
+                "unit": unit,
+                "warning_threshold": 1,
+                "critical_threshold": 2,
+                "status": "ok",
+                "reason": None,
+            }
+            for name, unit in zip(names, units, strict=True)
+        ],
+        "document_sha256": f"{day:064x}",
+    }
+
+
+def _report() -> dict[str, object]:
+    output = evaluate_operational_objectives(
+        objective_policy=_policy(),
+        through_session=date(2026, 1, 2),
+        expected_sessions=(date(2026, 1, 1), date(2026, 1, 2)),
+        operational_policy_fingerprint=(
+            "operational-slo-policy-" + "a" * 24
+        ),
+        schedule_id="schedule",
+        schedule_fingerprint="schedule-fingerprint",
+        calendar_id="XNYS",
+        portfolio_id="portfolio",
+        risk_limit_policy_id="risk-policy",
+        mandate_id="mandate",
+        mandate_fingerprint="mandate-fingerprint",
+        reports=[_source_report(1), _source_report(2)],
+    )
+    return dict(output.report)
+
+
+def test_valid_report_is_canonical_and_deterministic() -> None:
+    first = validate_operational_objective_report(_report())
+    second = validate_operational_objective_report(dict(reversed(list(_report().items()))))
+
+    assert first == second
+    assert canonical_objective_report_bytes(first) == canonical_objective_report_bytes(
+        second
+    )
+    assert first["history_status"] == "ready"
+    assert first["overall_status"] == "met"
+    assert len(first["objectives"]) == 4
+
+
+def test_report_side_effect_flags_fail_closed() -> None:
+    report = _report()
+    report["automated_remediation_performed"] = True
+
+    with pytest.raises(ValidationError, match="must be false"):
+        validate_operational_objective_report(report)
+
+
+def test_report_objective_ratio_must_reconcile() -> None:
+    report = _report()
+    objectives = [dict(row) for row in report["objectives"]]
+    objectives[0]["attainment_ratio"] = 0.5
+    report["objectives"] = objectives
+
+    with pytest.raises(ValidationError, match="ratio does not reconcile"):
+        validate_operational_objective_report(report)
+
+
+def test_report_shape_and_input_evidence_are_strict() -> None:
+    report = _report()
+    report["unexpected"] = True
+    with pytest.raises(ValidationError, match="invalid shape"):
+        validate_operational_objective_report(report)
+
+    report = _report()
+    report["input_report_document_sha256"] = []
+    with pytest.raises(ValidationError, match="input report evidence"):
+        validate_operational_objective_report(report)

--- a/tests/unit/test_operational_service_level_objective_reporting_sql_contract.py
+++ b/tests/unit/test_operational_service_level_objective_reporting_sql_contract.py
@@ -1,0 +1,45 @@
+from pathlib import Path
+
+
+def test_operational_objective_schema_exposes_append_only_serving_contract() -> None:
+    schema = Path(
+        "sql/operational_service_level_objectives_schema.sql"
+    ).read_text(encoding="utf-8")
+
+    for required in (
+        "CREATE TABLE IF NOT EXISTS risk_platform.operational_service_level_objective_reports",
+        "operational-slo-attainment-v1",
+        "operational-slo-objective-policy-",
+        "prevent_operational_slo_objective_report_update",
+        "prevent_operational_slo_objective_report_delete",
+        "operational_service_level_objective_metric_history",
+        "latest_operational_service_level_objective_reports",
+        "current_operational_service_level_objective_status",
+        "current_operational_service_level_objective_exceptions",
+        "ORDER BY calculated_at DESC, calculation_id DESC",
+        "jsonb_array_length(objectives_json) = 4",
+        "NOT automated_remediation_performed",
+    ):
+        assert required in schema
+
+
+def test_operational_objective_consistency_checks_cover_current_contract() -> None:
+    checks = Path(
+        "sql/operational_service_level_objectives_consistency_checks.sql"
+    ).read_text(encoding="utf-8")
+
+    for check_name in (
+        "operational_slo_objective_source_report_references_valid",
+        "operational_slo_objective_source_contracts_align",
+        "operational_slo_objective_counts_reconcile",
+        "operational_slo_objective_sources_align",
+        "operational_slo_objective_statuses_reconcile",
+        "operational_slo_objective_overall_status_reconciles",
+        "operational_slo_objective_calculation_ids_unique",
+        "latest_operational_slo_objective_grain_unique",
+        "latest_operational_slo_objective_selects_current_version",
+        "operational_slo_objective_history_rows_match_reports",
+        "current_operational_slo_objective_rows_match_latest",
+        "current_operational_slo_objective_exceptions_match_status",
+    ):
+        assert check_name in checks

--- a/tests/unit/test_operational_service_level_objectives_architecture_contract.py
+++ b/tests/unit/test_operational_service_level_objectives_architecture_contract.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 
 
-def test_operational_objective_documentation_matches_report_only_contract() -> None:
+def test_operational_objective_documentation_matches_persistent_contract() -> None:
     documentation = " ".join(
         Path("docs/operational-service-level-objectives.md")
         .read_text(encoding="utf-8")
@@ -17,8 +17,17 @@ def test_operational_objective_documentation_matches_report_only_contract() -> N
         "as_of DESC",
         "calculation_id DESC",
         "run_operational_service_level_objectives",
+        "operational_service_level_objective_recorder",
+        "operational_service_level_objective_reports",
+        "current_operational_service_level_objective_status",
+        "current_operational_service_level_objective_exceptions",
         "provider",
         "automated remediation",
-        "does not yet persist objective attainment in PostgreSQL",
+        "append-only PostgreSQL history",
     ):
         assert required.lower() in documentation.lower()
+
+    assert (
+        "does not yet persist objective attainment in PostgreSQL"
+        not in documentation.lower()
+    )


### PR DESCRIPTION
## Outcome

Persist the rolling objective-attainment evidence introduced by PR #97 as an append-only PostgreSQL contract:

```text
operational SLO attainment JSON
  -> strict canonical validation
  -> append-only PostgreSQL report history
  -> current report ranking
  -> one current row per objective
  -> current missed/insufficient exceptions
  -> source-to-objective reconciliation
```

Primary arc42 block: `warehouse`, with an explicit interface to the retained operational service-level reports.

## Recorder

Add `src.warehouse.operational_service_level_objective_recorder`.

The recorder validates the exact report and objective shapes, rechecks observation counts, missing sessions, attainment ratios and statuses, requires every report-only side-effect flag to remain false, serialises canonical JSON and records its SHA-256 digest.

`calculation_id` is the append-only identity. Identical retries converge when the stored digest matches; conflicting content under the same identity fails closed. PostgreSQL triggers reject updates and deletes.

## Serving contract

Add `risk_platform.operational_service_level_objective_reports` plus:

- `operational_service_level_objective_metric_history`;
- `latest_operational_service_level_objective_reports`;
- `current_operational_service_level_objective_status`; and
- `current_operational_service_level_objective_exceptions`.

The current report grain preserves model, objective-policy, operational-policy, schedule, calendar, portfolio, risk-limit policy, mandate and through-session identity. Corrections rank by:

```text
calculated_at DESC
calculation_id DESC
```

The current status view exposes one row per objective. The exception view contains current `missed` and `insufficient` rows while all versions remain in the base table.

## Reconciliation

`sql/operational_service_level_objectives_consistency_checks.sql` verifies:

- source report IDs and SHA-256 values;
- source policy, schedule, calendar, portfolio, mandate and expected-session alignment;
- canonical objective source metrics and units;
- success, failure, missing and attainment counts;
- objective and overall statuses;
- unique identities and current grains;
- current correction selection; and
- history, current and exception row counts.

The expected-session window is checked against `latest_expected_session`, not the later report-generation timestamp. The query also conforms to the shared `check_name / expected / actual / status` result contract.

## Live PostgreSQL contract

The protected workflow remains unchanged. Its existing operational service-level contract entry point invokes the new objective contract and reconciliation after completing the original fixed-count assertions.

The live check records source operational reports, proves deterministic objective replay, rejects conflicting identity reuse, appends a corrected report, verifies current ranking and blocks update/delete mutations.

## Validation

GitHub Actions run `32670332380` passed on exact head `c47a111393519685b82c78e450fcd2389891d98d`:

- Security guardrails: passed.
- Python readiness: passed, including Ruff, mypy, the complete test suite, dependency integrity and readiness replay.
- PostgreSQL contract: passed, including the original operational contract, objective append-only contract and objective reconciliation SQL.
- Infrastructure validation: passed, including Kubernetes rendering and Terraform format/init/validate without apply.

The first live-database attempt exposed two real integration defects: session-window reconciliation used report-generation dates, and the SQL result used `observed` instead of the shared `actual` column. Both were corrected without weakening any validation. The branch was rebuilt as one clean commit directly on `main`.

No unresolved review threads or requested changes are present.

## Scope

The branch is one commit ahead of `main` and zero behind. It changes 11 files as one persistence-and-serving layer.

No dashboard, paging, readiness-gate integration, scheduled execution, external delivery, provider request, cloud mutation, deployment or `terraform apply` is included. Plan-only readiness-gate integration is the next dependency layer.

## Acceptance boundary

This PR is validated and ready for squash merge.