### PR TITLE
Persist operational readiness decision history

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,7 @@ services:
       - ./sql/model_approval_schema.sql:/docker-entrypoint-initdb.d/12_model_approval_schema.sql:ro
       - ./sql/operational_service_levels_schema.sql:/docker-entrypoint-initdb.d/13_operational_service_levels_schema.sql:ro
       - ./sql/operational_service_level_objectives_schema.sql:/docker-entrypoint-initdb.d/14_operational_service_level_objectives_schema.sql:ro
+      - ./sql/operational_readiness_decisions_schema.sql:/docker-entrypoint-initdb.d/15_operational_readiness_decisions_schema.sql:ro
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U risk_user -d risk_platform"]
       interval: 5s

--- a/docs/operational-readiness-decisions.md
+++ b/docs/operational-readiness-decisions.md
@@ -1,0 +1,133 @@
+# Operational Readiness Decision History
+
+## Outcome
+
+The read-only `operational-readiness-gate-v1` output can be retained as immutable
+PostgreSQL evidence without changing the gate decision or executing a schedule:
+
+```text
+current operational service-level report
+  + current gate, schedule, calendar and mandate contract
+  -> deterministic allow or block decision
+  -> strict canonical validation
+  -> append-only PostgreSQL history
+  -> current allowed and blocked views
+```
+
+The gate remains responsible for evaluating evidence. The recorder only validates
+and persists the exact decision document; it does not recalculate operational
+metrics or reinterpret a block as an allow.
+
+## Operator Flow
+
+Generate a decision:
+
+```bash
+.venv/bin/python -m src.warehouse.operational_readiness_gate \
+  --gate-id us-tech-local \
+  --evaluated-at 2026-04-01T12:00:00Z \
+  --summary-json .demo/operational-readiness-gate.json
+```
+
+Record the decision:
+
+```bash
+.venv/bin/python -m src.warehouse.operational_readiness_decision_recorder \
+  --decision .demo/operational-readiness-gate.json
+```
+
+The recorder accepts one regular JSON file no larger than 1 MB. Symbolic links,
+unknown fields, non-canonical timestamps, incompatible identities, inconsistent
+age arithmetic, incorrect reason ordering and any side-effect flag set to true
+fail before PostgreSQL mutation.
+
+## Decision Contract
+
+The deterministic decision identity binds:
+
+- gate fingerprint;
+- operational policy fingerprint;
+- schedule and schedule fingerprint;
+- calendar, portfolio, risk-limit policy and mandate fingerprint;
+- latest expected market session;
+- evaluation timestamp;
+- retained report identity and SHA-256 when present;
+- ordered blocking reasons; and
+- final `allow` or `block` decision.
+
+The recorder reconstructs the same identity and requires the supplied
+`decision_id` to match. Report age and future-offset values are recomputed from
+`evaluated_at` and `report_as_of`. Reasons are reconstructed in canonical order:
+
+```text
+report_missing
+report_timestamp_future
+report_age_exceeds_limit
+report_session_mismatch
+report_status_critical
+report_status_warning
+```
+
+An allow decision has no reasons. A block decision has at least one reason.
+Missing-report evidence uses exactly `report_missing` and null report fields.
+
+## PostgreSQL Contract
+
+Every version is retained in:
+
+```text
+risk_platform.operational_readiness_decisions
+```
+
+`decision_id` is the append-only identity. An exact retry converges on the
+existing row when the canonical document SHA-256 matches. Reusing one decision ID
+with different content fails closed. PostgreSQL triggers reject UPDATE and DELETE.
+
+History and reason-level evidence are exposed through:
+
+```text
+risk_platform.operational_readiness_decision_history
+risk_platform.operational_readiness_reason_history
+```
+
+The current grain preserves the complete current gate, operational-policy,
+schedule, calendar, portfolio, risk-limit-policy, mandate and expected-session
+contract. Corrections rank by:
+
+```text
+evaluated_at DESC
+decision_id DESC
+```
+
+Current results are exposed through:
+
+```text
+risk_platform.latest_operational_readiness_decisions
+risk_platform.current_allowed_operational_readiness_decisions
+risk_platform.current_blocked_operational_readiness_decisions
+```
+
+The original operational report remains referenced by calculation ID and document
+digest. Missing-report blocks retain no fabricated report reference.
+
+## Reconciliation
+
+`sql/operational_readiness_decisions_consistency_checks.sql` verifies:
+
+- report references and digests;
+- report, schedule, calendar, portfolio and mandate metadata;
+- report age and future-offset arithmetic;
+- blocking-reason semantics;
+- decision and latest-grain uniqueness;
+- newest-decision selection;
+- allowed/blocked partitioning;
+- reason-row expansion; and
+- both append-only triggers.
+
+## Boundary
+
+No schedule command is executed. No provider request, notification delivery,
+checkpoint update, cloud schedule activation, deployment or Terraform apply is
+performed by the gate or recorder. Persisted readiness evidence becomes an audit
+foundation for later plan-only schedule integration and reviewed override
+semantics; it is not execution authority by itself.

--- a/sql/operational_readiness_decisions_consistency_checks.sql
+++ b/sql/operational_readiness_decisions_consistency_checks.sql
@@ -1,0 +1,294 @@
+-- Reconciliation checks for append-only operational readiness decisions.
+
+WITH counts AS (
+    SELECT
+        (SELECT COUNT(*)
+         FROM risk_platform.operational_readiness_decisions) AS decision_rows,
+        (SELECT COUNT(*)
+         FROM risk_platform.operational_readiness_decision_history) AS history_rows,
+        (SELECT COUNT(*)
+         FROM risk_platform.operational_readiness_reason_history) AS reason_rows,
+        (SELECT COALESCE(SUM(jsonb_array_length(reasons)), 0)
+         FROM risk_platform.operational_readiness_decisions) AS expected_reason_rows,
+        (SELECT COUNT(*)
+         FROM risk_platform.latest_operational_readiness_decisions) AS latest_rows,
+        (SELECT COUNT(*)
+         FROM risk_platform.current_allowed_operational_readiness_decisions)
+            AS allowed_rows,
+        (SELECT COUNT(*)
+         FROM risk_platform.current_blocked_operational_readiness_decisions)
+            AS blocked_rows
+),
+integrity AS (
+    SELECT
+        (
+            SELECT COUNT(*)
+            FROM risk_platform.operational_readiness_decisions decision
+            LEFT JOIN risk_platform.operational_service_level_reports report
+                ON report.calculation_id = decision.report_calculation_id
+            WHERE decision.report_calculation_id IS NOT NULL
+              AND report.calculation_id IS NULL
+        ) AS orphan_report_references,
+        (
+            SELECT COUNT(*)
+            FROM risk_platform.operational_readiness_decisions decision
+            JOIN risk_platform.operational_service_level_reports report
+                ON report.calculation_id = decision.report_calculation_id
+            WHERE decision.report_document_sha256 <> report.document_sha256
+               OR decision.operational_policy_id <> report.policy_id
+               OR decision.operational_policy_fingerprint <> report.policy_fingerprint
+               OR decision.schedule_id <> report.schedule_id
+               OR decision.schedule_fingerprint <> report.schedule_fingerprint
+               OR decision.calendar_id <> report.calendar_id
+               OR decision.portfolio_id <> report.portfolio_id
+               OR decision.risk_limit_policy_id <> report.risk_limit_policy_id
+               OR decision.mandate_fingerprint <> report.mandate_fingerprint
+               OR decision.report_as_of <> report.as_of
+               OR decision.report_latest_expected_session
+                    <> report.latest_expected_session
+               OR decision.report_status <> report.overall_status
+        ) AS mismatched_report_evidence,
+        (
+            SELECT COUNT(*)
+            FROM risk_platform.operational_readiness_decisions decision
+            WHERE decision.report_calculation_id IS NOT NULL
+              AND (
+                    ABS(
+                        decision.report_age_seconds
+                        - GREATEST(
+                            0,
+                            EXTRACT(EPOCH FROM (
+                                decision.evaluated_at - decision.report_as_of
+                            ))
+                        )
+                    ) > 0.000001
+                    OR ABS(
+                        decision.report_future_seconds
+                        - GREATEST(
+                            0,
+                            EXTRACT(EPOCH FROM (
+                                decision.report_as_of - decision.evaluated_at
+                            ))
+                        )
+                    ) > 0.000001
+              )
+        ) AS invalid_report_age_evidence,
+        (
+            SELECT COUNT(*)
+            FROM risk_platform.operational_readiness_decisions decision
+            WHERE
+                (decision.report_calculation_id IS NULL)
+                    <> (decision.reasons = '["report_missing"]'::JSONB)
+                OR (
+                    decision.report_calculation_id IS NOT NULL
+                    AND (
+                        (decision.report_future_seconds > 0)
+                            <> (decision.reasons ? 'report_timestamp_future')
+                        OR (
+                            decision.report_future_seconds = 0
+                            AND decision.report_age_seconds
+                                > decision.max_report_age_seconds
+                        ) <> (decision.reasons ? 'report_age_exceeds_limit')
+                        OR (
+                            decision.report_latest_expected_session
+                                <> decision.latest_expected_session
+                        ) <> (decision.reasons ? 'report_session_mismatch')
+                        OR (decision.report_status = 'critical')
+                            <> (decision.reasons ? 'report_status_critical')
+                        OR (
+                            decision.report_status = 'warning'
+                            AND NOT decision.allow_warning
+                        ) <> (decision.reasons ? 'report_status_warning')
+                    )
+                )
+                OR (decision.decision = 'allow')
+                    <> (jsonb_array_length(decision.reasons) = 0)
+        ) AS invalid_reason_semantics,
+        (
+            SELECT COUNT(*)
+            FROM (
+                SELECT decision_id
+                FROM risk_platform.operational_readiness_decisions
+                GROUP BY decision_id
+                HAVING COUNT(*) > 1
+            ) duplicates
+        ) AS duplicate_decision_ids,
+        (
+            SELECT COUNT(*)
+            FROM (
+                SELECT
+                    model_version,
+                    gate_id,
+                    gate_fingerprint,
+                    operational_policy_id,
+                    operational_policy_fingerprint,
+                    schedule_id,
+                    schedule_fingerprint,
+                    calendar_id,
+                    portfolio_id,
+                    risk_limit_policy_id,
+                    mandate_fingerprint,
+                    latest_expected_session
+                FROM risk_platform.latest_operational_readiness_decisions
+                GROUP BY
+                    model_version,
+                    gate_id,
+                    gate_fingerprint,
+                    operational_policy_id,
+                    operational_policy_fingerprint,
+                    schedule_id,
+                    schedule_fingerprint,
+                    calendar_id,
+                    portfolio_id,
+                    risk_limit_policy_id,
+                    mandate_fingerprint,
+                    latest_expected_session
+                HAVING COUNT(*) > 1
+            ) duplicates
+        ) AS duplicate_latest_grains,
+        (
+            SELECT COUNT(*)
+            FROM risk_platform.latest_operational_readiness_decisions latest
+            WHERE EXISTS (
+                SELECT 1
+                FROM risk_platform.operational_readiness_decisions candidate
+                WHERE candidate.model_version = latest.model_version
+                  AND candidate.gate_id = latest.gate_id
+                  AND candidate.gate_fingerprint = latest.gate_fingerprint
+                  AND candidate.operational_policy_id
+                        = latest.operational_policy_id
+                  AND candidate.operational_policy_fingerprint
+                        = latest.operational_policy_fingerprint
+                  AND candidate.schedule_id = latest.schedule_id
+                  AND candidate.schedule_fingerprint
+                        = latest.schedule_fingerprint
+                  AND candidate.calendar_id = latest.calendar_id
+                  AND candidate.portfolio_id = latest.portfolio_id
+                  AND candidate.risk_limit_policy_id
+                        = latest.risk_limit_policy_id
+                  AND candidate.mandate_fingerprint
+                        = latest.mandate_fingerprint
+                  AND candidate.latest_expected_session
+                        = latest.latest_expected_session
+                  AND (
+                        candidate.evaluated_at,
+                        candidate.decision_id
+                  ) > (
+                        latest.evaluated_at,
+                        latest.decision_id
+                  )
+            )
+        ) AS stale_latest_rows,
+        (
+            SELECT COUNT(*)
+            FROM pg_trigger trigger
+            JOIN pg_class table_ref ON table_ref.oid = trigger.tgrelid
+            JOIN pg_namespace namespace_ref
+                ON namespace_ref.oid = table_ref.relnamespace
+            WHERE namespace_ref.nspname = 'risk_platform'
+              AND table_ref.relname = 'operational_readiness_decisions'
+              AND trigger.tgname IN (
+                    'prevent_operational_readiness_decision_update',
+                    'prevent_operational_readiness_decision_delete'
+              )
+              AND NOT trigger.tgisinternal
+        ) AS append_only_trigger_count
+)
+SELECT
+    'operational_readiness_history_rows_match' AS check_name,
+    decision_rows::TEXT AS expected,
+    history_rows::TEXT AS actual,
+    CASE WHEN decision_rows = history_rows THEN 'pass' ELSE 'fail' END AS status
+FROM counts
+
+UNION ALL
+
+SELECT
+    'operational_readiness_reason_rows_match',
+    expected_reason_rows::TEXT,
+    reason_rows::TEXT,
+    CASE WHEN expected_reason_rows = reason_rows THEN 'pass' ELSE 'fail' END
+FROM counts
+
+UNION ALL
+
+SELECT
+    'operational_readiness_current_views_partition_latest',
+    latest_rows::TEXT,
+    (allowed_rows + blocked_rows)::TEXT,
+    CASE WHEN latest_rows = allowed_rows + blocked_rows THEN 'pass' ELSE 'fail' END
+FROM counts
+
+UNION ALL
+
+SELECT
+    'operational_readiness_report_references_exist',
+    '0',
+    orphan_report_references::TEXT,
+    CASE WHEN orphan_report_references = 0 THEN 'pass' ELSE 'fail' END
+FROM integrity
+
+UNION ALL
+
+SELECT
+    'operational_readiness_report_evidence_matches_source',
+    '0',
+    mismatched_report_evidence::TEXT,
+    CASE WHEN mismatched_report_evidence = 0 THEN 'pass' ELSE 'fail' END
+FROM integrity
+
+UNION ALL
+
+SELECT
+    'operational_readiness_report_age_reconciles',
+    '0',
+    invalid_report_age_evidence::TEXT,
+    CASE WHEN invalid_report_age_evidence = 0 THEN 'pass' ELSE 'fail' END
+FROM integrity
+
+UNION ALL
+
+SELECT
+    'operational_readiness_reason_semantics_reconcile',
+    '0',
+    invalid_reason_semantics::TEXT,
+    CASE WHEN invalid_reason_semantics = 0 THEN 'pass' ELSE 'fail' END
+FROM integrity
+
+UNION ALL
+
+SELECT
+    'operational_readiness_decision_ids_unique',
+    '0',
+    duplicate_decision_ids::TEXT,
+    CASE WHEN duplicate_decision_ids = 0 THEN 'pass' ELSE 'fail' END
+FROM integrity
+
+UNION ALL
+
+SELECT
+    'latest_operational_readiness_grain_unique',
+    '0',
+    duplicate_latest_grains::TEXT,
+    CASE WHEN duplicate_latest_grains = 0 THEN 'pass' ELSE 'fail' END
+FROM integrity
+
+UNION ALL
+
+SELECT
+    'latest_operational_readiness_selects_current_decision',
+    '0',
+    stale_latest_rows::TEXT,
+    CASE WHEN stale_latest_rows = 0 THEN 'pass' ELSE 'fail' END
+FROM integrity
+
+UNION ALL
+
+SELECT
+    'operational_readiness_append_only_triggers_present',
+    '2',
+    append_only_trigger_count::TEXT,
+    CASE WHEN append_only_trigger_count = 2 THEN 'pass' ELSE 'fail' END
+FROM integrity
+
+ORDER BY check_name;

--- a/sql/operational_readiness_decisions_schema.sql
+++ b/sql/operational_readiness_decisions_schema.sql
@@ -1,0 +1,341 @@
+-- Append-only operational readiness decision history and current serving views.
+-- Apply after sql/operational_service_levels_schema.sql so retained report evidence exists.
+
+CREATE SCHEMA IF NOT EXISTS risk_platform;
+
+CREATE TABLE IF NOT EXISTS risk_platform.operational_readiness_decisions (
+    decision_id TEXT PRIMARY KEY,
+    model_version TEXT NOT NULL CHECK (
+        model_version = 'operational-readiness-gate-v1'
+    ),
+    gate_id TEXT NOT NULL,
+    gate_fingerprint TEXT NOT NULL,
+    operational_policy_id TEXT NOT NULL,
+    operational_policy_fingerprint TEXT NOT NULL,
+    schedule_id TEXT NOT NULL,
+    schedule_fingerprint TEXT NOT NULL,
+    calendar_id TEXT NOT NULL,
+    portfolio_id TEXT NOT NULL,
+    risk_limit_policy_id TEXT NOT NULL,
+    mandate_fingerprint TEXT NOT NULL,
+    evaluated_at TIMESTAMPTZ NOT NULL,
+    latest_expected_session DATE NOT NULL,
+    max_report_age_seconds INTEGER NOT NULL CHECK (
+        max_report_age_seconds BETWEEN 1 AND 604800
+    ),
+    allow_warning BOOLEAN NOT NULL,
+    report_calculation_id TEXT REFERENCES
+        risk_platform.operational_service_level_reports (calculation_id),
+    report_document_sha256 TEXT,
+    report_as_of TIMESTAMPTZ,
+    report_latest_expected_session DATE,
+    report_status TEXT CHECK (
+        report_status IS NULL OR report_status IN ('ok', 'warning', 'critical')
+    ),
+    report_age_seconds DOUBLE PRECISION CHECK (
+        report_age_seconds IS NULL
+        OR (
+            report_age_seconds >= 0
+            AND report_age_seconds < 'Infinity'::DOUBLE PRECISION
+        )
+    ),
+    report_future_seconds DOUBLE PRECISION CHECK (
+        report_future_seconds IS NULL
+        OR (
+            report_future_seconds >= 0
+            AND report_future_seconds < 'Infinity'::DOUBLE PRECISION
+        )
+    ),
+    decision TEXT NOT NULL CHECK (decision IN ('allow', 'block')),
+    reasons JSONB NOT NULL,
+    schedule_executed BOOLEAN NOT NULL,
+    provider_request_performed BOOLEAN NOT NULL,
+    notification_delivery_performed BOOLEAN NOT NULL,
+    cloud_schedule_activated BOOLEAN NOT NULL,
+    decision_json JSONB NOT NULL,
+    document_sha256 TEXT NOT NULL,
+    recorded_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    CHECK (
+        decision_id
+            ~ '^operational-readiness-gate-v1-decision-[0-9a-f]{24}$'
+    ),
+    CHECK (gate_id ~ '^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$'),
+    CHECK (
+        gate_fingerprint ~ '^operational-readiness-gate-[0-9a-f]{24}$'
+    ),
+    CHECK (
+        operational_policy_id ~ '^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$'
+    ),
+    CHECK (
+        operational_policy_fingerprint
+            ~ '^operational-slo-policy-[0-9a-f]{24}$'
+    ),
+    CHECK (schedule_id ~ '^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$'),
+    CHECK (schedule_fingerprint <> ''),
+    CHECK (calendar_id ~ '^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$'),
+    CHECK (portfolio_id ~ '^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$'),
+    CHECK (
+        risk_limit_policy_id ~ '^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$'
+    ),
+    CHECK (mandate_fingerprint <> ''),
+    CHECK (jsonb_typeof(reasons) = 'array'),
+    CHECK (
+        (decision = 'allow' AND jsonb_array_length(reasons) = 0)
+        OR (decision = 'block' AND jsonb_array_length(reasons) > 0)
+    ),
+    CHECK (
+        (
+            report_calculation_id IS NULL
+            AND report_document_sha256 IS NULL
+            AND report_as_of IS NULL
+            AND report_latest_expected_session IS NULL
+            AND report_status IS NULL
+            AND report_age_seconds IS NULL
+            AND report_future_seconds IS NULL
+            AND reasons = '["report_missing"]'::JSONB
+        )
+        OR (
+            report_calculation_id IS NOT NULL
+            AND report_document_sha256 IS NOT NULL
+            AND report_as_of IS NOT NULL
+            AND report_latest_expected_session IS NOT NULL
+            AND report_status IS NOT NULL
+            AND report_age_seconds IS NOT NULL
+            AND report_future_seconds IS NOT NULL
+        )
+    ),
+    CHECK (
+        report_document_sha256 IS NULL
+        OR report_document_sha256 ~ '^[0-9a-f]{64}$'
+    ),
+    CHECK (NOT schedule_executed),
+    CHECK (NOT provider_request_performed),
+    CHECK (NOT notification_delivery_performed),
+    CHECK (NOT cloud_schedule_activated),
+    CHECK (jsonb_typeof(decision_json) = 'object'),
+    CHECK (document_sha256 ~ '^[0-9a-f]{64}$'),
+    CHECK (decision_json ->> 'decision_id' = decision_id),
+    CHECK (decision_json ->> 'model_version' = model_version),
+    CHECK (decision_json ->> 'gate_id' = gate_id),
+    CHECK (decision_json ->> 'gate_fingerprint' = gate_fingerprint),
+    CHECK (
+        decision_json ->> 'operational_policy_id' = operational_policy_id
+    ),
+    CHECK (
+        decision_json ->> 'operational_policy_fingerprint'
+            = operational_policy_fingerprint
+    ),
+    CHECK (decision_json ->> 'schedule_id' = schedule_id),
+    CHECK (
+        decision_json ->> 'schedule_fingerprint' = schedule_fingerprint
+    ),
+    CHECK (decision_json ->> 'calendar_id' = calendar_id),
+    CHECK (decision_json ->> 'portfolio_id' = portfolio_id),
+    CHECK (
+        decision_json ->> 'risk_limit_policy_id' = risk_limit_policy_id
+    ),
+    CHECK (
+        decision_json ->> 'mandate_fingerprint' = mandate_fingerprint
+    ),
+    CHECK (
+        (decision_json ->> 'evaluated_at')::TIMESTAMPTZ = evaluated_at
+    ),
+    CHECK (
+        (decision_json ->> 'latest_expected_session')::DATE
+            = latest_expected_session
+    ),
+    CHECK (
+        (decision_json ->> 'max_report_age_seconds')::INTEGER
+            = max_report_age_seconds
+    ),
+    CHECK ((decision_json ->> 'allow_warning')::BOOLEAN = allow_warning),
+    CHECK (
+        decision_json ->> 'report_calculation_id'
+            IS NOT DISTINCT FROM report_calculation_id
+    ),
+    CHECK (
+        decision_json ->> 'report_document_sha256'
+            IS NOT DISTINCT FROM report_document_sha256
+    ),
+    CHECK (
+        (decision_json ->> 'report_as_of')::TIMESTAMPTZ
+            IS NOT DISTINCT FROM report_as_of
+    ),
+    CHECK (
+        (decision_json ->> 'report_latest_expected_session')::DATE
+            IS NOT DISTINCT FROM report_latest_expected_session
+    ),
+    CHECK (
+        decision_json ->> 'report_status' IS NOT DISTINCT FROM report_status
+    ),
+    CHECK (
+        (decision_json ->> 'report_age_seconds')::DOUBLE PRECISION
+            IS NOT DISTINCT FROM report_age_seconds
+    ),
+    CHECK (
+        (decision_json ->> 'report_future_seconds')::DOUBLE PRECISION
+            IS NOT DISTINCT FROM report_future_seconds
+    ),
+    CHECK (decision_json ->> 'decision' = decision),
+    CHECK (decision_json -> 'reasons' = reasons)
+);
+
+CREATE INDEX IF NOT EXISTS idx_operational_readiness_decisions_latest
+    ON risk_platform.operational_readiness_decisions (
+        model_version,
+        gate_id,
+        gate_fingerprint,
+        operational_policy_id,
+        operational_policy_fingerprint,
+        schedule_id,
+        schedule_fingerprint,
+        calendar_id,
+        portfolio_id,
+        risk_limit_policy_id,
+        mandate_fingerprint,
+        latest_expected_session DESC,
+        evaluated_at DESC,
+        decision_id DESC
+    );
+
+CREATE INDEX IF NOT EXISTS idx_operational_readiness_report_reference
+    ON risk_platform.operational_readiness_decisions (report_calculation_id)
+    WHERE report_calculation_id IS NOT NULL;
+
+CREATE OR REPLACE FUNCTION
+    risk_platform.prevent_operational_readiness_decision_mutation()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    RAISE EXCEPTION 'operational readiness decisions are append-only'
+        USING ERRCODE = '55000';
+END;
+$$;
+
+DROP TRIGGER IF EXISTS prevent_operational_readiness_decision_update
+    ON risk_platform.operational_readiness_decisions;
+CREATE TRIGGER prevent_operational_readiness_decision_update
+BEFORE UPDATE ON risk_platform.operational_readiness_decisions
+FOR EACH ROW
+EXECUTE FUNCTION risk_platform.prevent_operational_readiness_decision_mutation();
+
+DROP TRIGGER IF EXISTS prevent_operational_readiness_decision_delete
+    ON risk_platform.operational_readiness_decisions;
+CREATE TRIGGER prevent_operational_readiness_decision_delete
+BEFORE DELETE ON risk_platform.operational_readiness_decisions
+FOR EACH ROW
+EXECUTE FUNCTION risk_platform.prevent_operational_readiness_decision_mutation();
+
+CREATE OR REPLACE VIEW risk_platform.operational_readiness_decision_history AS
+SELECT
+    decision_id,
+    model_version,
+    gate_id,
+    gate_fingerprint,
+    operational_policy_id,
+    operational_policy_fingerprint,
+    schedule_id,
+    schedule_fingerprint,
+    calendar_id,
+    portfolio_id,
+    risk_limit_policy_id,
+    mandate_fingerprint,
+    evaluated_at,
+    latest_expected_session,
+    max_report_age_seconds,
+    allow_warning,
+    report_calculation_id,
+    report_document_sha256,
+    report_as_of,
+    report_latest_expected_session,
+    report_status,
+    report_age_seconds,
+    report_future_seconds,
+    decision,
+    reasons,
+    jsonb_array_length(reasons) AS reason_count,
+    document_sha256,
+    recorded_at
+FROM risk_platform.operational_readiness_decisions;
+
+CREATE OR REPLACE VIEW risk_platform.operational_readiness_reason_history AS
+SELECT
+    decision.decision_id,
+    decision.model_version,
+    decision.gate_id,
+    decision.gate_fingerprint,
+    decision.schedule_id,
+    decision.schedule_fingerprint,
+    decision.portfolio_id,
+    decision.latest_expected_session,
+    decision.evaluated_at,
+    reason.ordinality::INTEGER AS reason_ordinal,
+    reason.value AS reason
+FROM risk_platform.operational_readiness_decisions decision
+CROSS JOIN LATERAL jsonb_array_elements_text(decision.reasons)
+    WITH ORDINALITY AS reason(value, ordinality);
+
+CREATE OR REPLACE VIEW risk_platform.latest_operational_readiness_decisions AS
+SELECT
+    decision_id,
+    model_version,
+    gate_id,
+    gate_fingerprint,
+    operational_policy_id,
+    operational_policy_fingerprint,
+    schedule_id,
+    schedule_fingerprint,
+    calendar_id,
+    portfolio_id,
+    risk_limit_policy_id,
+    mandate_fingerprint,
+    evaluated_at,
+    latest_expected_session,
+    max_report_age_seconds,
+    allow_warning,
+    report_calculation_id,
+    report_document_sha256,
+    report_as_of,
+    report_latest_expected_session,
+    report_status,
+    report_age_seconds,
+    report_future_seconds,
+    decision,
+    reasons,
+    document_sha256,
+    recorded_at
+FROM (
+    SELECT
+        readiness.*,
+        ROW_NUMBER() OVER (
+            PARTITION BY
+                model_version,
+                gate_id,
+                gate_fingerprint,
+                operational_policy_id,
+                operational_policy_fingerprint,
+                schedule_id,
+                schedule_fingerprint,
+                calendar_id,
+                portfolio_id,
+                risk_limit_policy_id,
+                mandate_fingerprint,
+                latest_expected_session
+            ORDER BY evaluated_at DESC, decision_id DESC
+        ) AS decision_rank
+    FROM risk_platform.operational_readiness_decisions readiness
+) ranked
+WHERE decision_rank = 1;
+
+CREATE OR REPLACE VIEW
+    risk_platform.current_allowed_operational_readiness_decisions AS
+SELECT *
+FROM risk_platform.latest_operational_readiness_decisions
+WHERE decision = 'allow';
+
+CREATE OR REPLACE VIEW
+    risk_platform.current_blocked_operational_readiness_decisions AS
+SELECT *
+FROM risk_platform.latest_operational_readiness_decisions
+WHERE decision = 'block';

--- a/src/warehouse/operational_readiness_decision_contract_check.py
+++ b/src/warehouse/operational_readiness_decision_contract_check.py
@@ -1,0 +1,208 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from datetime import date, datetime, timedelta
+from pathlib import Path
+from typing import Any
+
+from src.common.exceptions import ValidationError
+from src.warehouse.operational_readiness_decision_recorder import (
+    record_operational_readiness_decision,
+)
+from src.warehouse.operational_readiness_gate import (
+    OperationalReadinessGatePolicy,
+    evaluate_operational_readiness,
+)
+from src.warehouse.postgres_consistency import run_consistency_checks
+
+
+def _report_row(
+    report: Mapping[str, Any],
+    document_sha256: str,
+) -> dict[str, Any]:
+    return {
+        "calculation_id": report["calculation_id"],
+        "policy_id": report["policy_id"],
+        "policy_fingerprint": report["policy_fingerprint"],
+        "schedule_id": report["schedule_id"],
+        "schedule_fingerprint": report["schedule_fingerprint"],
+        "calendar_id": report["calendar_id"],
+        "portfolio_id": report["portfolio_id"],
+        "risk_limit_policy_id": report["risk_limit_policy_id"],
+        "mandate_fingerprint": report["mandate_fingerprint"],
+        "as_of": report["as_of"],
+        "latest_expected_session": report["latest_expected_session"],
+        "overall_status": report["overall_status"],
+        "document_sha256": document_sha256,
+    }
+
+
+def _decision(
+    *,
+    report: Mapping[str, Any],
+    document_sha256: str,
+    evaluated_at: datetime,
+) -> dict[str, Any]:
+    gate = OperationalReadinessGatePolicy(
+        gate_id="us-tech-local",
+        operational_policy_id=str(report["policy_id"]),
+        max_report_age_seconds=3600,
+        allow_warning=True,
+    )
+    latest_session = report["latest_expected_session"]
+    if not isinstance(latest_session, str):
+        raise AssertionError("contract fixture latest session is incompatible")
+    return evaluate_operational_readiness(
+        gate_policy=gate,
+        evaluated_at=evaluated_at,
+        latest_expected_session=date.fromisoformat(latest_session),
+        operational_policy_fingerprint=str(report["policy_fingerprint"]),
+        schedule_id=str(report["schedule_id"]),
+        schedule_fingerprint=str(report["schedule_fingerprint"]),
+        calendar_id=str(report["calendar_id"]),
+        portfolio_id=str(report["portfolio_id"]),
+        risk_limit_policy_id=str(report["risk_limit_policy_id"]),
+        mandate_fingerprint=str(report["mandate_fingerprint"]),
+        report=_report_row(report, document_sha256),
+    )
+
+
+def run_contract_check(
+    *,
+    dsn: str,
+    first_report: Mapping[str, Any],
+    first_document_sha256: str,
+    second_report: Mapping[str, Any],
+    second_document_sha256: str,
+) -> dict[str, Any]:
+    first_as_of = datetime.fromisoformat(str(first_report["as_of"]))
+    second_as_of = datetime.fromisoformat(str(second_report["as_of"]))
+    first_decision = _decision(
+        report=first_report,
+        document_sha256=first_document_sha256,
+        evaluated_at=first_as_of + timedelta(minutes=5),
+    )
+    second_decision = _decision(
+        report=second_report,
+        document_sha256=second_document_sha256,
+        evaluated_at=second_as_of + timedelta(minutes=5),
+    )
+    if first_decision["decision"] != "allow":
+        raise AssertionError("warning-allowed readiness fixture did not allow")
+    if second_decision["decision"] != "block":
+        raise AssertionError("critical readiness fixture did not block")
+
+    first = record_operational_readiness_decision(
+        dsn=dsn,
+        decision=first_decision,
+    )
+    replay = record_operational_readiness_decision(
+        dsn=dsn,
+        decision=first_decision,
+    )
+    if first["created"] is not True or replay["created"] is not False:
+        raise AssertionError("operational readiness retry did not converge")
+
+    conflicting = dict(first_decision)
+    conflicting["report_status"] = "ok"
+    try:
+        record_operational_readiness_decision(
+            dsn=dsn,
+            decision=conflicting,
+        )
+    except ValidationError:
+        pass
+    else:
+        raise AssertionError("conflicting readiness decision identity was accepted")
+
+    second = record_operational_readiness_decision(
+        dsn=dsn,
+        decision=second_decision,
+    )
+    if second["created"] is not True:
+        raise AssertionError("second operational readiness decision was not appended")
+
+    try:
+        import psycopg
+    except ImportError as exc:  # pragma: no cover - dependency is required in CI.
+        raise RuntimeError("Operational readiness contract requires psycopg") from exc
+
+    with psycopg.connect(dsn) as connection:
+        with connection.cursor() as cursor:
+            cursor.execute(
+                """
+                SELECT
+                    (SELECT COUNT(*)
+                     FROM risk_platform.operational_readiness_decisions),
+                    (SELECT COUNT(*)
+                     FROM risk_platform.operational_readiness_decision_history),
+                    (SELECT COUNT(*)
+                     FROM risk_platform.operational_readiness_reason_history),
+                    (SELECT COUNT(*)
+                     FROM risk_platform.latest_operational_readiness_decisions),
+                    (SELECT COUNT(*)
+                     FROM risk_platform.current_allowed_operational_readiness_decisions),
+                    (SELECT COUNT(*)
+                     FROM risk_platform.current_blocked_operational_readiness_decisions),
+                    (SELECT decision
+                     FROM risk_platform.latest_operational_readiness_decisions)
+                """
+            )
+            counts = cursor.fetchone()
+            if counts != (2, 2, 1, 1, 0, 1, "block"):
+                raise AssertionError(
+                    f"operational readiness serving views are incompatible: {counts!r}"
+                )
+
+    with psycopg.connect(dsn) as connection:
+        try:
+            with connection.cursor() as cursor:
+                cursor.execute(
+                    """
+                    UPDATE risk_platform.operational_readiness_decisions
+                    SET recorded_at = recorded_at
+                    WHERE decision_id = %s
+                    """,
+                    (first_decision["decision_id"],),
+                )
+        except psycopg.Error:
+            connection.rollback()
+        else:
+            raise AssertionError("operational readiness update was not blocked")
+
+    with psycopg.connect(dsn) as connection:
+        try:
+            with connection.cursor() as cursor:
+                cursor.execute(
+                    """
+                    DELETE FROM risk_platform.operational_readiness_decisions
+                    WHERE decision_id = %s
+                    """,
+                    (first_decision["decision_id"],),
+                )
+        except psycopg.Error:
+            connection.rollback()
+        else:
+            raise AssertionError("operational readiness delete was not blocked")
+
+    consistency = run_consistency_checks(
+        dsn=dsn,
+        check_paths=(
+            Path("sql/operational_readiness_decisions_consistency_checks.sql"),
+        ),
+    )
+    failures = [result for result in consistency if result.status != "pass"]
+    if failures:
+        names = ", ".join(result.check_name for result in failures)
+        raise AssertionError("operational readiness reconciliation failed: " + names)
+
+    return {
+        "first_decision_id": first_decision["decision_id"],
+        "second_decision_id": second_decision["decision_id"],
+        "decision_rows": 2,
+        "latest_decision": "block",
+        "append_only_verified": True,
+        "replay_verified": True,
+        "conflict_verified": True,
+        "consistency_checks": len(consistency),
+    }

--- a/src/warehouse/operational_readiness_decision_recorder.py
+++ b/src/warehouse/operational_readiness_decision_recorder.py
@@ -1,0 +1,605 @@
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+import os
+import re
+import sys
+from collections.abc import Mapping, Sequence
+from datetime import date, datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from src.common.exceptions import StorageError, ValidationError
+from src.warehouse.operational_readiness_gate import MODEL_VERSION
+from src.warehouse.postgres_loader import DEFAULT_POSTGRES_DSN
+
+MAX_DECISION_BYTES = 1_000_000
+MAX_REPORT_AGE_SECONDS = 7 * 24 * 60 * 60
+DECISION_ID_PATTERN = re.compile(
+    r"^operational-readiness-gate-v1-decision-[0-9a-f]{24}$"
+)
+GATE_FINGERPRINT_PATTERN = re.compile(
+    r"^operational-readiness-gate-[0-9a-f]{24}$"
+)
+OPERATIONAL_POLICY_FINGERPRINT_PATTERN = re.compile(
+    r"^operational-slo-policy-[0-9a-f]{24}$"
+)
+REPORT_ID_PATTERN = re.compile(
+    r"^operational-service-levels-v1-report-[0-9a-f]{24}$"
+)
+SHA256_PATTERN = re.compile(r"^[0-9a-f]{64}$")
+SAFE_SEGMENT_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$")
+REASON_ORDER = (
+    "report_missing",
+    "report_timestamp_future",
+    "report_age_exceeds_limit",
+    "report_session_mismatch",
+    "report_status_critical",
+    "report_status_warning",
+)
+DECISION_KEYS = frozenset(
+    {
+        "decision_id",
+        "model_version",
+        "gate_id",
+        "gate_fingerprint",
+        "operational_policy_id",
+        "operational_policy_fingerprint",
+        "schedule_id",
+        "schedule_fingerprint",
+        "calendar_id",
+        "portfolio_id",
+        "risk_limit_policy_id",
+        "mandate_fingerprint",
+        "evaluated_at",
+        "latest_expected_session",
+        "max_report_age_seconds",
+        "allow_warning",
+        "report_calculation_id",
+        "report_document_sha256",
+        "report_as_of",
+        "report_latest_expected_session",
+        "report_status",
+        "report_age_seconds",
+        "report_future_seconds",
+        "decision",
+        "reasons",
+        "schedule_executed",
+        "provider_request_performed",
+        "notification_delivery_performed",
+        "cloud_schedule_activated",
+    }
+)
+
+
+def _safe_segment(value: Any, label: str) -> str:
+    if not isinstance(value, str) or not SAFE_SEGMENT_PATTERN.fullmatch(value):
+        raise ValidationError(f"{label} must be one safe text segment")
+    return value
+
+
+def _fingerprint(
+    value: Any,
+    label: str,
+    pattern: re.Pattern[str] | None = None,
+) -> str:
+    if not isinstance(value, str) or not value or len(value) > 256:
+        raise ValidationError(f"{label} must be non-empty bounded text")
+    if value != value.strip() or any(ord(character) < 32 for character in value):
+        raise ValidationError(f"{label} must be canonical bounded text")
+    if pattern is not None and not pattern.fullmatch(value):
+        raise ValidationError(f"{label} is incompatible")
+    return value
+
+
+def _aware_utc(value: Any, label: str) -> datetime:
+    if isinstance(value, datetime):
+        parsed = value
+    elif isinstance(value, str):
+        try:
+            parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        except ValueError:
+            raise ValidationError(f"{label} must be ISO-8601") from None
+    else:
+        raise ValidationError(f"{label} must be timezone-aware")
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise ValidationError(f"{label} must be timezone-aware")
+    return parsed.astimezone(timezone.utc)
+
+
+def _calendar_date(value: Any, label: str) -> date:
+    if isinstance(value, datetime):
+        raise ValidationError(f"{label} must be a calendar date")
+    if isinstance(value, date):
+        return value
+    if not isinstance(value, str):
+        raise ValidationError(f"{label} must use YYYY-MM-DD")
+    try:
+        parsed = date.fromisoformat(value)
+    except ValueError:
+        raise ValidationError(f"{label} must use YYYY-MM-DD") from None
+    if value != parsed.isoformat():
+        raise ValidationError(f"{label} must use YYYY-MM-DD")
+    return parsed
+
+
+def _optional_timestamp(value: Any, label: str) -> datetime | None:
+    return None if value is None else _aware_utc(value, label)
+
+
+def _optional_date(value: Any, label: str) -> date | None:
+    return None if value is None else _calendar_date(value, label)
+
+
+def _optional_pattern(
+    value: Any,
+    label: str,
+    pattern: re.Pattern[str],
+) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str) or not pattern.fullmatch(value):
+        raise ValidationError(f"{label} is incompatible")
+    return value
+
+
+def _optional_nonnegative(value: Any, label: str) -> float | None:
+    if value is None:
+        return None
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ValidationError(f"{label} must be a finite non-negative number")
+    parsed = float(value)
+    if not math.isfinite(parsed) or parsed < 0:
+        raise ValidationError(f"{label} must be a finite non-negative number")
+    return parsed
+
+
+def _reasons(value: Any) -> list[str]:
+    if not isinstance(value, list):
+        raise ValidationError("reasons must be an array")
+    if any(not isinstance(item, str) or item not in REASON_ORDER for item in value):
+        raise ValidationError("reasons contains an unsupported value")
+    if len(value) != len(set(value)):
+        raise ValidationError("reasons must not contain duplicates")
+    expected = [reason for reason in REASON_ORDER if reason in value]
+    if value != expected:
+        raise ValidationError("reasons must use canonical order")
+    return list(value)
+
+
+def _decision_id_payload(decision: Mapping[str, Any]) -> dict[str, Any]:
+    return {
+        "calendar_id": decision["calendar_id"],
+        "decision": decision["decision"],
+        "evaluated_at": decision["evaluated_at"],
+        "gate_fingerprint": decision["gate_fingerprint"],
+        "latest_expected_session": decision["latest_expected_session"],
+        "mandate_fingerprint": decision["mandate_fingerprint"],
+        "operational_policy_fingerprint": decision[
+            "operational_policy_fingerprint"
+        ],
+        "portfolio_id": decision["portfolio_id"],
+        "reasons": decision["reasons"],
+        "report_calculation_id": decision["report_calculation_id"],
+        "report_document_sha256": decision["report_document_sha256"],
+        "risk_limit_policy_id": decision["risk_limit_policy_id"],
+        "schedule_fingerprint": decision["schedule_fingerprint"],
+        "schedule_id": decision["schedule_id"],
+    }
+
+
+def _expected_decision_id(decision: Mapping[str, Any]) -> str:
+    digest = hashlib.sha256(
+        json.dumps(
+            _decision_id_payload(decision),
+            sort_keys=True,
+            separators=(",", ":"),
+            allow_nan=False,
+        ).encode("utf-8")
+    ).hexdigest()[:24]
+    return f"{MODEL_VERSION}-decision-{digest}"
+
+
+def validate_operational_readiness_decision(
+    payload: Mapping[str, Any],
+) -> dict[str, Any]:
+    if not isinstance(payload, Mapping) or set(payload) != DECISION_KEYS:
+        raise ValidationError("operational readiness decision has an invalid shape")
+    if payload.get("model_version") != MODEL_VERSION:
+        raise ValidationError("operational readiness model version is unsupported")
+    decision_id = payload.get("decision_id")
+    if not isinstance(decision_id, str) or not DECISION_ID_PATTERN.fullmatch(
+        decision_id
+    ):
+        raise ValidationError("decision_id is incompatible")
+
+    evaluated_at = _aware_utc(payload.get("evaluated_at"), "evaluated_at")
+    expected_session = _calendar_date(
+        payload.get("latest_expected_session"),
+        "latest_expected_session",
+    )
+    max_age = payload.get("max_report_age_seconds")
+    if type(max_age) is not int or not 1 <= max_age <= MAX_REPORT_AGE_SECONDS:
+        raise ValidationError("max_report_age_seconds is outside the supported range")
+    allow_warning = payload.get("allow_warning")
+    if type(allow_warning) is not bool:
+        raise ValidationError("allow_warning must be boolean")
+    decision = payload.get("decision")
+    if decision not in {"allow", "block"}:
+        raise ValidationError("decision must be allow or block")
+    reasons = _reasons(payload.get("reasons"))
+
+    report_calculation_id = _optional_pattern(
+        payload.get("report_calculation_id"),
+        "report_calculation_id",
+        REPORT_ID_PATTERN,
+    )
+    report_document_sha256 = _optional_pattern(
+        payload.get("report_document_sha256"),
+        "report_document_sha256",
+        SHA256_PATTERN,
+    )
+    report_as_of = _optional_timestamp(payload.get("report_as_of"), "report_as_of")
+    report_session = _optional_date(
+        payload.get("report_latest_expected_session"),
+        "report_latest_expected_session",
+    )
+    report_status = payload.get("report_status")
+    if report_status is not None and report_status not in {"ok", "warning", "critical"}:
+        raise ValidationError("report_status is incompatible")
+    report_age_seconds = _optional_nonnegative(
+        payload.get("report_age_seconds"),
+        "report_age_seconds",
+    )
+    report_future_seconds = _optional_nonnegative(
+        payload.get("report_future_seconds"),
+        "report_future_seconds",
+    )
+
+    report_fields = (
+        report_calculation_id,
+        report_document_sha256,
+        report_as_of,
+        report_session,
+        report_status,
+        report_age_seconds,
+        report_future_seconds,
+    )
+    expected_reasons: list[str] = []
+    if report_calculation_id is None:
+        if any(value is not None for value in report_fields[1:]):
+            raise ValidationError("missing report evidence must use null report fields")
+        expected_reasons.append("report_missing")
+    else:
+        if any(value is None for value in report_fields[1:]):
+            raise ValidationError("retained report evidence must be complete")
+        assert report_as_of is not None
+        assert report_session is not None
+        assert report_age_seconds is not None
+        assert report_future_seconds is not None
+        delta_seconds = (evaluated_at - report_as_of).total_seconds()
+        expected_age = max(0.0, delta_seconds)
+        expected_future = max(0.0, -delta_seconds)
+        if not math.isclose(
+            report_age_seconds,
+            expected_age,
+            rel_tol=0.0,
+            abs_tol=1e-9,
+        ) or not math.isclose(
+            report_future_seconds,
+            expected_future,
+            rel_tol=0.0,
+            abs_tol=1e-9,
+        ):
+            raise ValidationError("report age evidence does not reconcile")
+        if delta_seconds < 0:
+            expected_reasons.append("report_timestamp_future")
+        elif expected_age > max_age:
+            expected_reasons.append("report_age_exceeds_limit")
+        if report_session != expected_session:
+            expected_reasons.append("report_session_mismatch")
+        if report_status == "critical":
+            expected_reasons.append("report_status_critical")
+        elif report_status == "warning" and not allow_warning:
+            expected_reasons.append("report_status_warning")
+
+    if reasons != expected_reasons:
+        raise ValidationError("reasons do not match retained readiness evidence")
+    expected_decision = "allow" if not expected_reasons else "block"
+    if decision != expected_decision:
+        raise ValidationError("decision does not match readiness reasons")
+    for flag in (
+        "schedule_executed",
+        "provider_request_performed",
+        "notification_delivery_performed",
+        "cloud_schedule_activated",
+    ):
+        if payload.get(flag) is not False:
+            raise ValidationError(f"{flag} must be false for read-only evidence")
+
+    validated = {
+        "decision_id": decision_id,
+        "model_version": MODEL_VERSION,
+        "gate_id": _safe_segment(payload.get("gate_id"), "gate_id"),
+        "gate_fingerprint": _fingerprint(
+            payload.get("gate_fingerprint"),
+            "gate_fingerprint",
+            GATE_FINGERPRINT_PATTERN,
+        ),
+        "operational_policy_id": _safe_segment(
+            payload.get("operational_policy_id"),
+            "operational_policy_id",
+        ),
+        "operational_policy_fingerprint": _fingerprint(
+            payload.get("operational_policy_fingerprint"),
+            "operational_policy_fingerprint",
+            OPERATIONAL_POLICY_FINGERPRINT_PATTERN,
+        ),
+        "schedule_id": _safe_segment(payload.get("schedule_id"), "schedule_id"),
+        "schedule_fingerprint": _fingerprint(
+            payload.get("schedule_fingerprint"),
+            "schedule_fingerprint",
+        ),
+        "calendar_id": _safe_segment(payload.get("calendar_id"), "calendar_id"),
+        "portfolio_id": _safe_segment(payload.get("portfolio_id"), "portfolio_id"),
+        "risk_limit_policy_id": _safe_segment(
+            payload.get("risk_limit_policy_id"),
+            "risk_limit_policy_id",
+        ),
+        "mandate_fingerprint": _fingerprint(
+            payload.get("mandate_fingerprint"),
+            "mandate_fingerprint",
+        ),
+        "evaluated_at": evaluated_at.isoformat(),
+        "latest_expected_session": expected_session.isoformat(),
+        "max_report_age_seconds": max_age,
+        "allow_warning": allow_warning,
+        "report_calculation_id": report_calculation_id,
+        "report_document_sha256": report_document_sha256,
+        "report_as_of": report_as_of.isoformat() if report_as_of is not None else None,
+        "report_latest_expected_session": (
+            report_session.isoformat() if report_session is not None else None
+        ),
+        "report_status": report_status,
+        "report_age_seconds": report_age_seconds,
+        "report_future_seconds": report_future_seconds,
+        "decision": expected_decision,
+        "reasons": expected_reasons,
+        "schedule_executed": False,
+        "provider_request_performed": False,
+        "notification_delivery_performed": False,
+        "cloud_schedule_activated": False,
+    }
+    if validated["decision_id"] != _expected_decision_id(validated):
+        raise ValidationError("decision_id does not match canonical readiness evidence")
+    return validated
+
+
+def canonical_operational_readiness_decision_bytes(
+    decision: Mapping[str, Any],
+) -> bytes:
+    try:
+        return json.dumps(
+            decision,
+            sort_keys=True,
+            separators=(",", ":"),
+            allow_nan=False,
+        ).encode("utf-8")
+    except (TypeError, ValueError):
+        raise ValidationError("operational readiness decision is not canonical JSON") from None
+
+
+def read_operational_readiness_decision(path: Path) -> dict[str, Any]:
+    if path.is_symlink():
+        raise StorageError("operational readiness decision must not be a symbolic link")
+    if not path.is_file():
+        raise StorageError("operational readiness decision must be a regular file")
+    try:
+        if path.stat().st_size > MAX_DECISION_BYTES:
+            raise StorageError("operational readiness decision exceeds the byte limit")
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except StorageError:
+        raise
+    except (OSError, ValueError):
+        raise StorageError("operational readiness decision could not be read") from None
+    if not isinstance(payload, Mapping):
+        raise ValidationError("operational readiness decision must be a JSON object")
+    return validate_operational_readiness_decision(payload)
+
+
+def record_operational_readiness_decision(
+    *,
+    dsn: str,
+    decision: Mapping[str, Any],
+) -> dict[str, Any]:
+    validated = validate_operational_readiness_decision(decision)
+    canonical = canonical_operational_readiness_decision_bytes(validated)
+    document_sha256 = hashlib.sha256(canonical).hexdigest()
+    try:
+        import psycopg
+        from psycopg.types.json import Jsonb
+    except ImportError as exc:  # pragma: no cover - dependency is required in CI.
+        raise RuntimeError("Operational readiness recording requires psycopg") from exc
+
+    created = False
+    recorded_at: datetime | None = None
+    try:
+        with psycopg.connect(dsn) as connection:
+            with connection.cursor() as cursor:
+                cursor.execute(
+                    """
+                    INSERT INTO risk_platform.operational_readiness_decisions (
+                        decision_id,
+                        model_version,
+                        gate_id,
+                        gate_fingerprint,
+                        operational_policy_id,
+                        operational_policy_fingerprint,
+                        schedule_id,
+                        schedule_fingerprint,
+                        calendar_id,
+                        portfolio_id,
+                        risk_limit_policy_id,
+                        mandate_fingerprint,
+                        evaluated_at,
+                        latest_expected_session,
+                        max_report_age_seconds,
+                        allow_warning,
+                        report_calculation_id,
+                        report_document_sha256,
+                        report_as_of,
+                        report_latest_expected_session,
+                        report_status,
+                        report_age_seconds,
+                        report_future_seconds,
+                        decision,
+                        reasons,
+                        schedule_executed,
+                        provider_request_performed,
+                        notification_delivery_performed,
+                        cloud_schedule_activated,
+                        decision_json,
+                        document_sha256
+                    ) VALUES (
+                        %s, %s, %s, %s, %s, %s, %s, %s, %s, %s,
+                        %s, %s, %s, %s, %s, %s, %s, %s, %s, %s,
+                        %s, %s, %s, %s, %s, %s, %s, %s, %s, %s,
+                        %s
+                    )
+                    ON CONFLICT (decision_id) DO NOTHING
+                    RETURNING recorded_at
+                    """,
+                    (
+                        validated["decision_id"],
+                        validated["model_version"],
+                        validated["gate_id"],
+                        validated["gate_fingerprint"],
+                        validated["operational_policy_id"],
+                        validated["operational_policy_fingerprint"],
+                        validated["schedule_id"],
+                        validated["schedule_fingerprint"],
+                        validated["calendar_id"],
+                        validated["portfolio_id"],
+                        validated["risk_limit_policy_id"],
+                        validated["mandate_fingerprint"],
+                        datetime.fromisoformat(validated["evaluated_at"]),
+                        date.fromisoformat(validated["latest_expected_session"]),
+                        validated["max_report_age_seconds"],
+                        validated["allow_warning"],
+                        validated["report_calculation_id"],
+                        validated["report_document_sha256"],
+                        (
+                            datetime.fromisoformat(validated["report_as_of"])
+                            if validated["report_as_of"] is not None
+                            else None
+                        ),
+                        (
+                            date.fromisoformat(
+                                validated["report_latest_expected_session"]
+                            )
+                            if validated["report_latest_expected_session"] is not None
+                            else None
+                        ),
+                        validated["report_status"],
+                        validated["report_age_seconds"],
+                        validated["report_future_seconds"],
+                        validated["decision"],
+                        Jsonb(validated["reasons"]),
+                        False,
+                        False,
+                        False,
+                        False,
+                        Jsonb(validated),
+                        document_sha256,
+                    ),
+                )
+                inserted = cursor.fetchone()
+                created = inserted is not None
+                cursor.execute(
+                    """
+                    SELECT document_sha256, recorded_at
+                    FROM risk_platform.operational_readiness_decisions
+                    WHERE decision_id = %s
+                    """,
+                    (validated["decision_id"],),
+                )
+                stored = cursor.fetchone()
+                if stored is None:
+                    raise StorageError(
+                        "operational readiness decision is unavailable after insert"
+                    )
+                if stored[0] != document_sha256:
+                    raise ValidationError(
+                        "decision_id already exists with different readiness content"
+                    )
+                if not isinstance(stored[1], datetime):
+                    raise StorageError(
+                        "stored operational readiness timestamp is incompatible"
+                    )
+                recorded_at = stored[1].astimezone(timezone.utc)
+            connection.commit()
+    except (ValidationError, StorageError):
+        raise
+    except Exception:
+        raise StorageError("operational readiness database operation failed") from None
+    if recorded_at is None:  # pragma: no cover - guarded above.
+        raise StorageError("operational readiness record result is unavailable")
+    return {
+        "decision_id": validated["decision_id"],
+        "model_version": MODEL_VERSION,
+        "gate_id": validated["gate_id"],
+        "latest_expected_session": validated["latest_expected_session"],
+        "decision": validated["decision"],
+        "reason_count": len(validated["reasons"]),
+        "document_sha256": document_sha256,
+        "recorded_at": recorded_at.isoformat(),
+        "created": created,
+    }
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Record one append-only operational readiness decision."
+    )
+    parser.add_argument("--decision", type=Path, required=True)
+    parser.add_argument(
+        "--dsn",
+        default=os.environ.get("WAREHOUSE_POSTGRES_DSN", DEFAULT_POSTGRES_DSN),
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    try:
+        summary = record_operational_readiness_decision(
+            dsn=args.dsn,
+            decision=read_operational_readiness_decision(args.decision),
+        )
+    except ValidationError:
+        print(
+            "Operational readiness recording failed: decision evidence was invalid",
+            file=sys.stderr,
+        )
+        return 1
+    except StorageError:
+        print(
+            "Operational readiness recording failed: file or PostgreSQL operation failed",
+            file=sys.stderr,
+        )
+        return 1
+    except Exception:
+        print(
+            "Operational readiness recording failed: unexpected local failure",
+            file=sys.stderr,
+        )
+        return 1
+    print(json.dumps(summary, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/warehouse/operational_service_level_contract_check.py
+++ b/src/warehouse/operational_service_level_contract_check.py
@@ -12,6 +12,9 @@ from src.analytics.operational_service_levels import (
     parse_operational_service_level_policy,
 )
 from src.common.exceptions import ValidationError
+from src.warehouse.operational_readiness_decision_contract_check import (
+    run_contract_check as run_readiness_contract_check,
+)
 from src.warehouse.operational_service_level_objective_contract_check import (
     run_contract_check as run_objective_contract_check,
 )
@@ -246,6 +249,14 @@ def run_contract_check(dsn: str) -> dict[str, Any]:
             "operational objective reconciliation failed: " + names
         )
 
+    readiness_result = run_readiness_contract_check(
+        dsn=dsn,
+        first_report=first_report,
+        first_document_sha256=str(first["document_sha256"]),
+        second_report=second_report,
+        second_document_sha256=str(second["document_sha256"]),
+    )
+
     return {
         "first_calculation_id": first_report["calculation_id"],
         "second_calculation_id": second_report["calculation_id"],
@@ -257,6 +268,7 @@ def run_contract_check(dsn: str) -> dict[str, Any]:
         "conflict_verified": True,
         "objective_contract": objective_result,
         "objective_consistency_checks": len(objective_consistency),
+        "readiness_contract": readiness_result,
     }
 
 
@@ -281,10 +293,12 @@ def main() -> int:
             file=sys.stderr,
         )
         return 1
+    readiness = result["readiness_contract"]
     print(
         "Operational service-level PostgreSQL contract passed: "
         f"{result['report_rows']} reports, {result['metric_rows']} metrics, "
-        f"{result['objective_consistency_checks']} objective checks"
+        f"{result['objective_consistency_checks']} objective checks, "
+        f"{readiness['consistency_checks']} readiness checks"
     )
     return 0
 

--- a/tests/unit/test_docker_compose_contract.py
+++ b/tests/unit/test_docker_compose_contract.py
@@ -39,6 +39,7 @@ def test_local_database_seed_mounts_are_read_only_and_ordered() -> None:
         "./sql/model_approval_schema.sql:/docker-entrypoint-initdb.d/12_model_approval_schema.sql:ro",
         "./sql/operational_service_levels_schema.sql:/docker-entrypoint-initdb.d/13_operational_service_levels_schema.sql:ro",
         "./sql/operational_service_level_objectives_schema.sql:/docker-entrypoint-initdb.d/14_operational_service_level_objectives_schema.sql:ro",
+        "./sql/operational_readiness_decisions_schema.sql:/docker-entrypoint-initdb.d/15_operational_readiness_decisions_schema.sql:ro",
     ]
     assert services["mongo"]["volumes"] == [
         "./mongo/init:/docker-entrypoint-initdb.d:ro"

--- a/tests/unit/test_operational_readiness_decision_architecture_contract.py
+++ b/tests/unit/test_operational_readiness_decision_architecture_contract.py
@@ -1,0 +1,20 @@
+from pathlib import Path
+
+
+def test_operational_readiness_decision_documentation_matches_runtime() -> None:
+    documentation = Path("docs/operational-readiness-decisions.md").read_text(
+        encoding="utf-8"
+    )
+
+    for required in (
+        "operational-readiness-gate-v1",
+        "risk_platform.operational_readiness_decisions",
+        "latest_operational_readiness_decisions",
+        "current_allowed_operational_readiness_decisions",
+        "current_blocked_operational_readiness_decisions",
+        "evaluated_at DESC",
+        "decision_id DESC",
+        "append-only",
+        "No schedule command is executed",
+    ):
+        assert required in documentation

--- a/tests/unit/test_operational_readiness_decision_recorder.py
+++ b/tests/unit/test_operational_readiness_decision_recorder.py
@@ -1,0 +1,170 @@
+from __future__ import annotations
+
+from datetime import date, datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+from src.common.exceptions import StorageError, ValidationError
+from src.warehouse.operational_readiness_decision_recorder import (
+    canonical_operational_readiness_decision_bytes,
+    read_operational_readiness_decision,
+    validate_operational_readiness_decision,
+)
+from src.warehouse.operational_readiness_gate import (
+    OperationalReadinessGatePolicy,
+    evaluate_operational_readiness,
+)
+
+
+def _policy(*, allow_warning: bool = True) -> OperationalReadinessGatePolicy:
+    return OperationalReadinessGatePolicy(
+        gate_id="us-tech-local",
+        operational_policy_id="us-tech-local",
+        max_report_age_seconds=3600,
+        allow_warning=allow_warning,
+    )
+
+
+def _report(
+    *,
+    as_of: datetime,
+    status: str = "ok",
+    latest_session: date = date(2026, 3, 31),
+) -> dict[str, object]:
+    return {
+        "calculation_id": "operational-service-levels-v1-report-" + "a" * 24,
+        "policy_id": "us-tech-local",
+        "policy_fingerprint": "operational-slo-policy-" + "b" * 24,
+        "schedule_id": "us-tech-local",
+        "schedule_fingerprint": "local-portfolio-schedule-v1-example",
+        "calendar_id": "XNYS",
+        "portfolio_id": "us-tech-equal",
+        "risk_limit_policy_id": "us-tech-standard",
+        "mandate_fingerprint": "portfolio-mandate-v1-example",
+        "as_of": as_of,
+        "latest_expected_session": latest_session,
+        "overall_status": status,
+        "document_sha256": "c" * 64,
+    }
+
+
+def _decision(
+    *,
+    evaluated_at: datetime,
+    report: dict[str, object] | None,
+    allow_warning: bool = True,
+    expected_session: date = date(2026, 3, 31),
+) -> dict[str, object]:
+    return evaluate_operational_readiness(
+        gate_policy=_policy(allow_warning=allow_warning),
+        evaluated_at=evaluated_at,
+        latest_expected_session=expected_session,
+        operational_policy_fingerprint="operational-slo-policy-" + "b" * 24,
+        schedule_id="us-tech-local",
+        schedule_fingerprint="local-portfolio-schedule-v1-example",
+        calendar_id="XNYS",
+        portfolio_id="us-tech-equal",
+        risk_limit_policy_id="us-tech-standard",
+        mandate_fingerprint="portfolio-mandate-v1-example",
+        report=report,
+    )
+
+
+def test_validate_allow_decision_preserves_canonical_identity() -> None:
+    evaluated_at = datetime(2026, 4, 1, 12, tzinfo=timezone.utc)
+    decision = _decision(
+        evaluated_at=evaluated_at,
+        report=_report(as_of=evaluated_at - timedelta(minutes=5)),
+    )
+
+    validated = validate_operational_readiness_decision(decision)
+
+    assert validated["decision"] == "allow"
+    assert validated["reasons"] == []
+    assert validated["decision_id"] == decision["decision_id"]
+    assert canonical_operational_readiness_decision_bytes(validated).startswith(b'{"')
+
+
+def test_validate_missing_report_and_critical_report_block() -> None:
+    evaluated_at = datetime(2026, 4, 1, 12, tzinfo=timezone.utc)
+    missing = validate_operational_readiness_decision(
+        _decision(evaluated_at=evaluated_at, report=None)
+    )
+    critical = validate_operational_readiness_decision(
+        _decision(
+            evaluated_at=evaluated_at,
+            report=_report(
+                as_of=evaluated_at - timedelta(minutes=5),
+                status="critical",
+            ),
+        )
+    )
+
+    assert missing["decision"] == "block"
+    assert missing["reasons"] == ["report_missing"]
+    assert critical["decision"] == "block"
+    assert critical["reasons"] == ["report_status_critical"]
+
+
+def test_warning_policy_and_report_age_are_recomputed() -> None:
+    evaluated_at = datetime(2026, 4, 1, 12, tzinfo=timezone.utc)
+    warning = _decision(
+        evaluated_at=evaluated_at,
+        report=_report(
+            as_of=evaluated_at - timedelta(minutes=5),
+            status="warning",
+        ),
+        allow_warning=False,
+    )
+    stale = _decision(
+        evaluated_at=evaluated_at,
+        report=_report(as_of=evaluated_at - timedelta(hours=2)),
+    )
+
+    assert validate_operational_readiness_decision(warning)["reasons"] == [
+        "report_status_warning"
+    ]
+    assert validate_operational_readiness_decision(stale)["reasons"] == [
+        "report_age_exceeds_limit"
+    ]
+
+    stale["report_age_seconds"] = 1.0
+    with pytest.raises(ValidationError, match="age evidence"):
+        validate_operational_readiness_decision(stale)
+
+
+def test_noncanonical_reason_order_and_side_effects_fail_closed() -> None:
+    evaluated_at = datetime(2026, 4, 1, 12, tzinfo=timezone.utc)
+    decision = _decision(
+        evaluated_at=evaluated_at,
+        expected_session=date(2026, 4, 1),
+        report=_report(
+            as_of=evaluated_at + timedelta(minutes=5),
+            status="critical",
+        ),
+    )
+    assert decision["reasons"] == [
+        "report_timestamp_future",
+        "report_session_mismatch",
+        "report_status_critical",
+    ]
+
+    decision["reasons"] = list(reversed(decision["reasons"]))
+    with pytest.raises(ValidationError, match="canonical order"):
+        validate_operational_readiness_decision(decision)
+
+    valid = _decision(evaluated_at=evaluated_at, report=None)
+    valid["schedule_executed"] = True
+    with pytest.raises(ValidationError, match="must be false"):
+        validate_operational_readiness_decision(valid)
+
+
+def test_read_decision_rejects_symbolic_links(tmp_path: Path) -> None:
+    target = tmp_path / "decision.json"
+    target.write_text("{}", encoding="utf-8")
+    link = tmp_path / "decision-link.json"
+    link.symlink_to(target)
+
+    with pytest.raises(StorageError, match="symbolic link"):
+        read_operational_readiness_decision(link)

--- a/tests/unit/test_operational_readiness_decision_sql_contract.py
+++ b/tests/unit/test_operational_readiness_decision_sql_contract.py
@@ -1,0 +1,50 @@
+from pathlib import Path
+
+
+def test_operational_readiness_schema_exposes_append_only_serving_contract() -> None:
+    sql = Path("sql/operational_readiness_decisions_schema.sql").read_text(
+        encoding="utf-8"
+    )
+
+    assert (
+        "CREATE TABLE IF NOT EXISTS risk_platform.operational_readiness_decisions"
+        in sql
+    )
+    assert "REFERENCES\n        risk_platform.operational_service_level_reports" in sql
+    for view in (
+        "operational_readiness_decision_history",
+        "operational_readiness_reason_history",
+        "latest_operational_readiness_decisions",
+        "current_allowed_operational_readiness_decisions",
+        "current_blocked_operational_readiness_decisions",
+    ):
+        assert f"risk_platform.{view}" in sql
+    assert "ORDER BY evaluated_at DESC, decision_id DESC" in sql
+    assert "operational readiness decisions are append-only" in sql
+    assert "prevent_operational_readiness_decision_update" in sql
+    assert "prevent_operational_readiness_decision_delete" in sql
+
+
+def test_operational_readiness_consistency_checks_cover_identity_and_views() -> None:
+    sql = Path(
+        "sql/operational_readiness_decisions_consistency_checks.sql"
+    ).read_text(encoding="utf-8")
+
+    for check_name in (
+        "operational_readiness_history_rows_match",
+        "operational_readiness_reason_rows_match",
+        "operational_readiness_current_views_partition_latest",
+        "operational_readiness_report_references_exist",
+        "operational_readiness_report_evidence_matches_source",
+        "operational_readiness_report_age_reconciles",
+        "operational_readiness_reason_semantics_reconcile",
+        "operational_readiness_decision_ids_unique",
+        "latest_operational_readiness_grain_unique",
+        "latest_operational_readiness_selects_current_decision",
+        "operational_readiness_append_only_triggers_present",
+    ):
+        assert check_name in sql
+    assert "check_name" in sql
+    assert "expected" in sql
+    assert "actual" in sql
+    assert "status" in sql


### PR DESCRIPTION
## Outcome

Persist the existing read-only operational readiness gate as strict append-only PostgreSQL evidence:

```text
current operational report
  + current gate, schedule, calendar and mandate contract
  -> deterministic allow or block decision
  -> canonical JSON and SHA-256 validation
  -> append-only PostgreSQL history
  -> current allowed and blocked views
```

Primary arc42 block: `warehouse`, with a bounded interface to `operational-readiness-gate-v1` and retained operational service-level reports.

## Recorder

Add `src.warehouse.operational_readiness_decision_recorder`.

The recorder validates the exact gate-document shape, recomputes report-age and future-offset arithmetic, reconstructs blocking reasons in canonical order, verifies the deterministic decision ID and requires all schedule/provider/delivery/cloud side-effect flags to remain false.

It accepts one regular JSON file up to 1 MB and rejects symbolic links, unknown fields, incomplete report evidence, non-canonical reasons and incompatible identities before PostgreSQL mutation.

`decision_id` is the append-only identity:

- an exact retry converges when the canonical document SHA-256 matches;
- conflicting content under the same identity fails closed; and
- UPDATE and DELETE are blocked by PostgreSQL triggers.

## Serving contract

Add:

- `risk_platform.operational_readiness_decisions`;
- `operational_readiness_decision_history`;
- `operational_readiness_reason_history`;
- `latest_operational_readiness_decisions`;
- `current_allowed_operational_readiness_decisions`; and
- `current_blocked_operational_readiness_decisions`.

The current grain retains the complete gate, operational-policy, schedule, calendar, portfolio, risk-limit-policy, mandate and expected-session contract. Corrections rank by:

```text
evaluated_at DESC
decision_id DESC
```

Missing-report blocks remain first-class evidence with no fabricated report reference.

## Reconciliation and live PostgreSQL evidence

`sql/operational_readiness_decisions_consistency_checks.sql` verifies report references and digests, source metadata, report-age arithmetic, reason semantics, identity/current-grain uniqueness, newest decision selection, allowed/blocked partitioning, reason expansion and append-only triggers.

The existing operational PostgreSQL contract exercises warning-allowed `allow` evidence, exact retry convergence, conflicting identity rejection, a later current `block` decision, current/history/reason view counts, UPDATE/DELETE rejection and all readiness reconciliation queries.

## Validation

GitHub Actions run `32711945377` (`ci` run 292) passed on exact head `be879dc6358da039467d02f3e9cf9dd5d53186e9`:

- Security guardrails: passed.
- Python readiness: passed.
  - locked dependencies resolved;
  - Ruff passed;
  - mypy passed across 96 source files;
  - 720 tests passed in both quality and readiness runs;
  - `pip check` passed;
  - the standard readiness replay passed.
- PostgreSQL contract: passed against PostgreSQL 16.
  - source-to-serving replay passed;
  - model-approval contract passed;
  - operational reports and rolling objectives passed;
  - two readiness decisions, exact retry, conflict rejection and append-only mutation rejection passed;
  - 11 readiness reconciliation checks passed.
- Infrastructure validation: passed.
  - Kubernetes overlays rendered;
  - Terraform format/init/validate passed without apply.

No unresolved review threads or requested changes are present.

## Scope

The branch is directly based on current `main`, is zero commits behind and changes 11 files with 1,838 additions and one deletion as one persistence-and-serving layer. The browser contents API produced 11 working commits; this PR is intended for squash merge as one increment.

No schedule command, provider request, notification delivery, checkpoint mutation, override, cloud activation, deployment or `terraform apply` is included.

## Acceptance boundary

Validated and ready for squash merge as the audit foundation for readiness-aware planning.