### PR TITLE
Add operational review query contract

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,7 @@ services:
       - ./sql/operational_service_levels_schema.sql:/docker-entrypoint-initdb.d/13_operational_service_levels_schema.sql:ro
       - ./sql/operational_service_level_objectives_schema.sql:/docker-entrypoint-initdb.d/14_operational_service_level_objectives_schema.sql:ro
       - ./sql/operational_readiness_decisions_schema.sql:/docker-entrypoint-initdb.d/15_operational_readiness_decisions_schema.sql:ro
+      - ./sql/operational_review_schema.sql:/docker-entrypoint-initdb.d/16_operational_review_schema.sql:ro
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U risk_user -d risk_platform"]
       interval: 5s

--- a/docs/operational-review-queries.md
+++ b/docs/operational-review-queries.md
@@ -1,0 +1,134 @@
+# Operational Review Query Contract
+
+## Outcome
+
+This SQL layer turns retained operational service-level, rolling-objective and
+readiness evidence into dashboard-ready grains without deploying or claiming a
+dashboard:
+
+```text
+append-only SLI reports
+  + append-only rolling SLO reports
+  + append-only readiness decisions
+  -> one current health row per exact operating contract and market session
+  -> one current exception row per metric, objective or blocking reason
+  -> readiness decision recency
+  -> rolling objective trends
+  -> evidence drill-through identities
+```
+
+## Current Health Card Grain
+
+`risk_platform.current_operational_health_summary` contains one row per:
+
+```text
+operational policy and fingerprint
++ schedule and fingerprint
++ calendar
++ portfolio and risk-limit policy
++ mandate fingerprint
++ latest expected market session
+```
+
+It exposes the current SLI report, all current objective-report identities, the
+current readiness decision, evidence timestamps and one deterministic health
+status. Status precedence is:
+
+```text
+blocked
+critical
+missed
+readiness_missing
+service_level_missing
+objective_missing
+warning
+insufficient
+ok
+```
+
+Missing evidence remains explicit. It is not removed through an inner join.
+`current_exception_count` combines current SLI exceptions, current SLO exceptions
+and current readiness blocking reasons.
+
+## Current Exception Table Grain
+
+`risk_platform.current_operational_exception_summary` contains one row per:
+
+```text
+exception type + evidence identity + metric/objective/reason name
+```
+
+The three exception types are:
+
+- `service_level_metric`;
+- `service_level_objective`; and
+- `readiness_reason`.
+
+The common contract carries exact policy, schedule, portfolio, mandate and market
+session identities plus observed values and thresholds where those concepts
+exist. Readiness reasons retain the source operational report ID as their parent
+evidence when one exists.
+
+## Recent Decisions
+
+`risk_platform.recent_operational_readiness_decisions` retains all decision
+history and adds `decision_recency_rank` within the exact current serving grain.
+Consumers can filter `decision_recency_rank <= 20` without changing the durable
+view contract. Rank one matches `latest_operational_readiness_decisions`.
+
+## Rolling Objective Trend Grain
+
+`risk_platform.rolling_operational_objective_attainment` contains one row per:
+
+```text
+objective report + objective name
+```
+
+It retains observation counts, missing sessions, success/failure counts,
+attainment and target ratios, `insufficient`/`met`/`missed` status, an attainment
+gap and a numeric status rank. `through_session` is the business-session axis;
+`calculated_at` is the evidence-generation timestamp.
+
+## Drill-through Grain
+
+`risk_platform.operational_evidence_drillthrough` contains one row per retained:
+
+- operational service-level report;
+- operational objective report; or
+- readiness decision.
+
+Every row carries an evidence type, model, stable evidence ID, document SHA-256,
+business session, evidence timestamp and parent report IDs. Objective reports
+retain all input report IDs; readiness decisions retain their exact source report
+ID or an empty parent array for missing-report blocks.
+
+## Suggested Dashboard Mapping
+
+A reporting tool can map the views without additional semantic joins:
+
+| Visual | View | Grain |
+| --- | --- | --- |
+| Current health card | `current_operational_health_summary` | operating contract/session |
+| Current exception table | `current_operational_exception_summary` | exception/evidence |
+| Readiness decision timeline | `recent_operational_readiness_decisions` | decision |
+| Objective attainment trend | `rolling_operational_objective_attainment` | report/objective |
+| Drill-through page | `operational_evidence_drillthrough` | retained evidence |
+
+Filters should preserve the exact policy and fingerprint columns. A consumer
+must not combine different schedule, mandate, policy or objective fingerprints
+under one unlabelled series.
+
+## Reconciliation
+
+`sql/operational_review_consistency_checks.sql` verifies current-health grain and
+status, exception counts and identities, readiness ranks, objective trend
+arithmetic, drill-through row counts, parent references and evidence uniqueness.
+The live PostgreSQL contract executes this query pack against real retained
+reports, objective corrections and readiness corrections.
+
+## Boundary
+
+These are read-only PostgreSQL views. No dashboard is deployed. No alert is sent,
+no schedule is executed, no checkpoint is changed, and no cloud resource is
+created. The contract prepares the review surface required before readiness is
+allowed to affect schedule planning.

--- a/sql/operational_review_consistency_checks.sql
+++ b/sql/operational_review_consistency_checks.sql
@@ -1,0 +1,317 @@
+-- Reconciliation for dashboard-ready operational review views.
+
+WITH contract_keys AS (
+    SELECT DISTINCT
+        policy_id AS operational_policy_id,
+        policy_fingerprint AS operational_policy_fingerprint,
+        schedule_id,
+        schedule_fingerprint,
+        calendar_id,
+        portfolio_id,
+        risk_limit_policy_id,
+        mandate_fingerprint,
+        latest_expected_session
+    FROM risk_platform.latest_operational_service_level_reports
+    UNION
+    SELECT DISTINCT
+        operational_policy_id,
+        operational_policy_fingerprint,
+        schedule_id,
+        schedule_fingerprint,
+        calendar_id,
+        portfolio_id,
+        risk_limit_policy_id,
+        mandate_fingerprint,
+        through_session
+    FROM risk_platform.latest_operational_service_level_objective_reports
+    UNION
+    SELECT DISTINCT
+        operational_policy_id,
+        operational_policy_fingerprint,
+        schedule_id,
+        schedule_fingerprint,
+        calendar_id,
+        portfolio_id,
+        risk_limit_policy_id,
+        mandate_fingerprint,
+        latest_expected_session
+    FROM risk_platform.latest_operational_readiness_decisions
+),
+counts AS (
+    SELECT
+        (SELECT COUNT(*) FROM contract_keys) AS expected_health_rows,
+        (SELECT COUNT(*) FROM risk_platform.current_operational_health_summary)
+            AS health_rows,
+        (
+            SELECT COUNT(*)
+            FROM risk_platform.current_operational_service_level_exceptions
+        ) + (
+            SELECT COUNT(*)
+            FROM risk_platform.current_operational_service_level_objective_exceptions
+        ) + (
+            SELECT COALESCE(SUM(jsonb_array_length(reasons)), 0)
+            FROM risk_platform.current_blocked_operational_readiness_decisions
+        ) AS expected_exception_rows,
+        (
+            SELECT COUNT(*)
+            FROM risk_platform.current_operational_exception_summary
+        ) AS exception_rows,
+        (
+            SELECT COUNT(*)
+            FROM risk_platform.operational_readiness_decision_history
+        ) AS expected_recent_decision_rows,
+        (
+            SELECT COUNT(*)
+            FROM risk_platform.recent_operational_readiness_decisions
+        ) AS recent_decision_rows,
+        (
+            SELECT COUNT(*)
+            FROM risk_platform.operational_service_level_objective_metric_history
+        ) AS expected_objective_trend_rows,
+        (
+            SELECT COUNT(*)
+            FROM risk_platform.rolling_operational_objective_attainment
+        ) AS objective_trend_rows,
+        (
+            SELECT COUNT(*) FROM risk_platform.operational_service_level_reports
+        ) + (
+            SELECT COUNT(*)
+            FROM risk_platform.operational_service_level_objective_reports
+        ) + (
+            SELECT COUNT(*)
+            FROM risk_platform.operational_readiness_decisions
+        ) AS expected_drillthrough_rows,
+        (
+            SELECT COUNT(*)
+            FROM risk_platform.operational_evidence_drillthrough
+        ) AS drillthrough_rows
+),
+integrity AS (
+    SELECT
+        (
+            SELECT COUNT(*)
+            FROM (
+                SELECT
+                    operational_policy_id,
+                    operational_policy_fingerprint,
+                    schedule_id,
+                    schedule_fingerprint,
+                    calendar_id,
+                    portfolio_id,
+                    risk_limit_policy_id,
+                    mandate_fingerprint,
+                    latest_expected_session
+                FROM risk_platform.current_operational_health_summary
+                GROUP BY
+                    operational_policy_id,
+                    operational_policy_fingerprint,
+                    schedule_id,
+                    schedule_fingerprint,
+                    calendar_id,
+                    portfolio_id,
+                    risk_limit_policy_id,
+                    mandate_fingerprint,
+                    latest_expected_session
+                HAVING COUNT(*) > 1
+            ) duplicates
+        ) AS duplicate_health_grains,
+        (
+            SELECT COUNT(*)
+            FROM risk_platform.current_operational_health_summary health
+            WHERE health.health_status <> CASE
+                WHEN health.readiness_decision = 'block' THEN 'blocked'
+                WHEN health.service_level_status = 'critical' THEN 'critical'
+                WHEN health.objective_overall_status = 'missed' THEN 'missed'
+                WHEN health.readiness_decision IS NULL THEN 'readiness_missing'
+                WHEN health.service_level_report_calculation_id IS NULL
+                    THEN 'service_level_missing'
+                WHEN health.objective_policy_count IS NULL
+                    THEN 'objective_missing'
+                WHEN health.service_level_status = 'warning' THEN 'warning'
+                WHEN health.objective_overall_status = 'insufficient'
+                    THEN 'insufficient'
+                ELSE 'ok'
+            END
+        ) AS invalid_health_statuses,
+        (
+            SELECT COUNT(*)
+            FROM (
+                SELECT exception_type, evidence_id, exception_name
+                FROM risk_platform.current_operational_exception_summary
+                GROUP BY exception_type, evidence_id, exception_name
+                HAVING COUNT(*) > 1
+            ) duplicates
+        ) AS duplicate_exception_rows,
+        (
+            SELECT COUNT(*)
+            FROM risk_platform.recent_operational_readiness_decisions recent
+            WHERE recent.decision_recency_rank = 1
+              AND NOT EXISTS (
+                    SELECT 1
+                    FROM risk_platform.latest_operational_readiness_decisions latest
+                    WHERE latest.decision_id = recent.decision_id
+              )
+        ) + (
+            SELECT COUNT(*)
+            FROM risk_platform.latest_operational_readiness_decisions latest
+            WHERE NOT EXISTS (
+                    SELECT 1
+                    FROM risk_platform.recent_operational_readiness_decisions recent
+                    WHERE recent.decision_id = latest.decision_id
+                      AND recent.decision_recency_rank = 1
+              )
+        ) AS invalid_readiness_ranks,
+        (
+            SELECT COUNT(*)
+            FROM risk_platform.rolling_operational_objective_attainment objective
+            WHERE ABS(
+                objective.attainment_gap
+                - (objective.attainment_ratio - objective.target_ratio)
+            ) > 0.000000001
+               OR objective.objective_status_rank <> CASE objective.objective_status
+                    WHEN 'missed' THEN 2
+                    WHEN 'insufficient' THEN 1
+                    ELSE 0
+                  END
+        ) AS invalid_objective_trends,
+        (
+            SELECT COUNT(*)
+            FROM (
+                SELECT evidence_type, evidence_id
+                FROM risk_platform.operational_evidence_drillthrough
+                GROUP BY evidence_type, evidence_id
+                HAVING COUNT(*) > 1
+            ) duplicates
+        ) AS duplicate_drillthrough_evidence,
+        (
+            SELECT COUNT(*)
+            FROM risk_platform.operational_evidence_drillthrough evidence
+            CROSS JOIN LATERAL jsonb_array_elements_text(
+                evidence.parent_evidence_ids
+            ) parent(parent_id)
+            LEFT JOIN risk_platform.operational_service_level_reports source
+                ON source.calculation_id = parent.parent_id
+            WHERE evidence.evidence_type IN (
+                    'service_level_objective_report',
+                    'readiness_decision'
+                  )
+              AND source.calculation_id IS NULL
+        ) AS orphan_drillthrough_parents
+)
+SELECT
+    'operational_review_health_rows_match_contracts' AS check_name,
+    expected_health_rows::TEXT AS expected,
+    health_rows::TEXT AS actual,
+    CASE WHEN expected_health_rows = health_rows THEN 'pass' ELSE 'fail' END
+        AS status
+FROM counts
+
+UNION ALL
+
+SELECT
+    'operational_review_health_grain_unique',
+    '0',
+    duplicate_health_grains::TEXT,
+    CASE WHEN duplicate_health_grains = 0 THEN 'pass' ELSE 'fail' END
+FROM integrity
+
+UNION ALL
+
+SELECT
+    'operational_review_health_status_reconciles',
+    '0',
+    invalid_health_statuses::TEXT,
+    CASE WHEN invalid_health_statuses = 0 THEN 'pass' ELSE 'fail' END
+FROM integrity
+
+UNION ALL
+
+SELECT
+    'operational_review_exception_rows_match_sources',
+    expected_exception_rows::TEXT,
+    exception_rows::TEXT,
+    CASE WHEN expected_exception_rows = exception_rows THEN 'pass' ELSE 'fail' END
+FROM counts
+
+UNION ALL
+
+SELECT
+    'operational_review_exception_identity_unique',
+    '0',
+    duplicate_exception_rows::TEXT,
+    CASE WHEN duplicate_exception_rows = 0 THEN 'pass' ELSE 'fail' END
+FROM integrity
+
+UNION ALL
+
+SELECT
+    'operational_review_recent_decisions_match_history',
+    expected_recent_decision_rows::TEXT,
+    recent_decision_rows::TEXT,
+    CASE
+        WHEN expected_recent_decision_rows = recent_decision_rows THEN 'pass'
+        ELSE 'fail'
+    END
+FROM counts
+
+UNION ALL
+
+SELECT
+    'operational_review_recent_decision_rank_matches_latest',
+    '0',
+    invalid_readiness_ranks::TEXT,
+    CASE WHEN invalid_readiness_ranks = 0 THEN 'pass' ELSE 'fail' END
+FROM integrity
+
+UNION ALL
+
+SELECT
+    'operational_review_objective_trend_rows_match_history',
+    expected_objective_trend_rows::TEXT,
+    objective_trend_rows::TEXT,
+    CASE
+        WHEN expected_objective_trend_rows = objective_trend_rows THEN 'pass'
+        ELSE 'fail'
+    END
+FROM counts
+
+UNION ALL
+
+SELECT
+    'operational_review_objective_trend_arithmetic_reconciles',
+    '0',
+    invalid_objective_trends::TEXT,
+    CASE WHEN invalid_objective_trends = 0 THEN 'pass' ELSE 'fail' END
+FROM integrity
+
+UNION ALL
+
+SELECT
+    'operational_review_drillthrough_rows_match_evidence',
+    expected_drillthrough_rows::TEXT,
+    drillthrough_rows::TEXT,
+    CASE
+        WHEN expected_drillthrough_rows = drillthrough_rows THEN 'pass'
+        ELSE 'fail'
+    END
+FROM counts
+
+UNION ALL
+
+SELECT
+    'operational_review_drillthrough_identity_unique',
+    '0',
+    duplicate_drillthrough_evidence::TEXT,
+    CASE WHEN duplicate_drillthrough_evidence = 0 THEN 'pass' ELSE 'fail' END
+FROM integrity
+
+UNION ALL
+
+SELECT
+    'operational_review_drillthrough_parents_exist',
+    '0',
+    orphan_drillthrough_parents::TEXT,
+    CASE WHEN orphan_drillthrough_parents = 0 THEN 'pass' ELSE 'fail' END
+FROM integrity
+
+ORDER BY check_name;

--- a/sql/operational_review_schema.sql
+++ b/sql/operational_review_schema.sql
@@ -1,0 +1,466 @@
+-- Dashboard-ready, read-only operational review views.
+-- Apply after operational service-level, objective and readiness decision schemas.
+
+CREATE SCHEMA IF NOT EXISTS risk_platform;
+
+CREATE OR REPLACE VIEW risk_platform.current_operational_health_summary AS
+WITH contract_keys AS (
+    SELECT DISTINCT
+        policy_id AS operational_policy_id,
+        policy_fingerprint AS operational_policy_fingerprint,
+        schedule_id,
+        schedule_fingerprint,
+        calendar_id,
+        portfolio_id,
+        risk_limit_policy_id,
+        mandate_fingerprint,
+        latest_expected_session
+    FROM risk_platform.latest_operational_service_level_reports
+    UNION
+    SELECT DISTINCT
+        operational_policy_id,
+        operational_policy_fingerprint,
+        schedule_id,
+        schedule_fingerprint,
+        calendar_id,
+        portfolio_id,
+        risk_limit_policy_id,
+        mandate_fingerprint,
+        through_session AS latest_expected_session
+    FROM risk_platform.latest_operational_service_level_objective_reports
+    UNION
+    SELECT DISTINCT
+        operational_policy_id,
+        operational_policy_fingerprint,
+        schedule_id,
+        schedule_fingerprint,
+        calendar_id,
+        portfolio_id,
+        risk_limit_policy_id,
+        mandate_fingerprint,
+        latest_expected_session
+    FROM risk_platform.latest_operational_readiness_decisions
+),
+objective_rollup AS (
+    SELECT
+        operational_policy_id,
+        operational_policy_fingerprint,
+        schedule_id,
+        schedule_fingerprint,
+        calendar_id,
+        portfolio_id,
+        risk_limit_policy_id,
+        mandate_fingerprint,
+        through_session AS latest_expected_session,
+        MIN(mandate_id) AS mandate_id,
+        COUNT(*)::INTEGER AS objective_policy_count,
+        jsonb_agg(
+            calculation_id
+            ORDER BY objective_policy_id, objective_policy_fingerprint
+        ) AS objective_report_calculation_ids,
+        MAX(calculated_at) AS latest_objective_calculated_at,
+        CASE MAX(
+            CASE overall_status
+                WHEN 'missed' THEN 2
+                WHEN 'insufficient' THEN 1
+                ELSE 0
+            END
+        )
+            WHEN 2 THEN 'missed'
+            WHEN 1 THEN 'insufficient'
+            ELSE 'met'
+        END AS objective_overall_status
+    FROM risk_platform.latest_operational_service_level_objective_reports
+    GROUP BY
+        operational_policy_id,
+        operational_policy_fingerprint,
+        schedule_id,
+        schedule_fingerprint,
+        calendar_id,
+        portfolio_id,
+        risk_limit_policy_id,
+        mandate_fingerprint,
+        through_session
+),
+metric_exceptions AS (
+    SELECT
+        policy_id AS operational_policy_id,
+        policy_fingerprint AS operational_policy_fingerprint,
+        schedule_id,
+        schedule_fingerprint,
+        calendar_id,
+        portfolio_id,
+        risk_limit_policy_id,
+        mandate_fingerprint,
+        latest_expected_session,
+        COUNT(*)::INTEGER AS exception_count
+    FROM risk_platform.current_operational_service_level_exceptions
+    GROUP BY
+        policy_id,
+        policy_fingerprint,
+        schedule_id,
+        schedule_fingerprint,
+        calendar_id,
+        portfolio_id,
+        risk_limit_policy_id,
+        mandate_fingerprint,
+        latest_expected_session
+),
+objective_exceptions AS (
+    SELECT
+        operational_policy_id,
+        operational_policy_fingerprint,
+        schedule_id,
+        schedule_fingerprint,
+        calendar_id,
+        portfolio_id,
+        risk_limit_policy_id,
+        mandate_fingerprint,
+        through_session AS latest_expected_session,
+        COUNT(*)::INTEGER AS exception_count
+    FROM risk_platform.current_operational_service_level_objective_exceptions
+    GROUP BY
+        operational_policy_id,
+        operational_policy_fingerprint,
+        schedule_id,
+        schedule_fingerprint,
+        calendar_id,
+        portfolio_id,
+        risk_limit_policy_id,
+        mandate_fingerprint,
+        through_session
+)
+SELECT
+    contract.operational_policy_id,
+    contract.operational_policy_fingerprint,
+    contract.schedule_id,
+    contract.schedule_fingerprint,
+    contract.calendar_id,
+    contract.portfolio_id,
+    contract.risk_limit_policy_id,
+    COALESCE(report.mandate_id, objective.mandate_id) AS mandate_id,
+    contract.mandate_fingerprint,
+    contract.latest_expected_session,
+    report.calculation_id AS service_level_report_calculation_id,
+    report.document_sha256 AS service_level_report_document_sha256,
+    report.as_of AS service_level_report_as_of,
+    report.overall_status AS service_level_status,
+    objective.objective_policy_count,
+    objective.objective_report_calculation_ids,
+    objective.latest_objective_calculated_at,
+    objective.objective_overall_status,
+    readiness.decision_id AS readiness_decision_id,
+    readiness.document_sha256 AS readiness_document_sha256,
+    readiness.evaluated_at AS readiness_evaluated_at,
+    readiness.decision AS readiness_decision,
+    readiness.reasons AS readiness_reasons,
+    readiness.report_age_seconds AS gate_report_age_seconds,
+    COALESCE(metric_exception.exception_count, 0)
+        + COALESCE(objective_exception.exception_count, 0)
+        + CASE
+            WHEN readiness.decision = 'block'
+                THEN jsonb_array_length(readiness.reasons)
+            ELSE 0
+          END AS current_exception_count,
+    CASE
+        WHEN readiness.decision = 'block' THEN 'blocked'
+        WHEN report.overall_status = 'critical' THEN 'critical'
+        WHEN objective.objective_overall_status = 'missed' THEN 'missed'
+        WHEN readiness.decision IS NULL THEN 'readiness_missing'
+        WHEN report.calculation_id IS NULL THEN 'service_level_missing'
+        WHEN objective.objective_policy_count IS NULL THEN 'objective_missing'
+        WHEN report.overall_status = 'warning' THEN 'warning'
+        WHEN objective.objective_overall_status = 'insufficient'
+            THEN 'insufficient'
+        ELSE 'ok'
+    END AS health_status
+FROM contract_keys contract
+LEFT JOIN risk_platform.latest_operational_service_level_reports report
+    ON report.policy_id = contract.operational_policy_id
+   AND report.policy_fingerprint = contract.operational_policy_fingerprint
+   AND report.schedule_id = contract.schedule_id
+   AND report.schedule_fingerprint = contract.schedule_fingerprint
+   AND report.calendar_id = contract.calendar_id
+   AND report.portfolio_id = contract.portfolio_id
+   AND report.risk_limit_policy_id = contract.risk_limit_policy_id
+   AND report.mandate_fingerprint = contract.mandate_fingerprint
+   AND report.latest_expected_session = contract.latest_expected_session
+LEFT JOIN objective_rollup objective
+    ON objective.operational_policy_id = contract.operational_policy_id
+   AND objective.operational_policy_fingerprint
+        = contract.operational_policy_fingerprint
+   AND objective.schedule_id = contract.schedule_id
+   AND objective.schedule_fingerprint = contract.schedule_fingerprint
+   AND objective.calendar_id = contract.calendar_id
+   AND objective.portfolio_id = contract.portfolio_id
+   AND objective.risk_limit_policy_id = contract.risk_limit_policy_id
+   AND objective.mandate_fingerprint = contract.mandate_fingerprint
+   AND objective.latest_expected_session = contract.latest_expected_session
+LEFT JOIN risk_platform.latest_operational_readiness_decisions readiness
+    ON readiness.operational_policy_id = contract.operational_policy_id
+   AND readiness.operational_policy_fingerprint
+        = contract.operational_policy_fingerprint
+   AND readiness.schedule_id = contract.schedule_id
+   AND readiness.schedule_fingerprint = contract.schedule_fingerprint
+   AND readiness.calendar_id = contract.calendar_id
+   AND readiness.portfolio_id = contract.portfolio_id
+   AND readiness.risk_limit_policy_id = contract.risk_limit_policy_id
+   AND readiness.mandate_fingerprint = contract.mandate_fingerprint
+   AND readiness.latest_expected_session = contract.latest_expected_session
+LEFT JOIN metric_exceptions metric_exception
+    ON metric_exception.operational_policy_id = contract.operational_policy_id
+   AND metric_exception.operational_policy_fingerprint
+        = contract.operational_policy_fingerprint
+   AND metric_exception.schedule_id = contract.schedule_id
+   AND metric_exception.schedule_fingerprint = contract.schedule_fingerprint
+   AND metric_exception.calendar_id = contract.calendar_id
+   AND metric_exception.portfolio_id = contract.portfolio_id
+   AND metric_exception.risk_limit_policy_id = contract.risk_limit_policy_id
+   AND metric_exception.mandate_fingerprint = contract.mandate_fingerprint
+   AND metric_exception.latest_expected_session
+        = contract.latest_expected_session
+LEFT JOIN objective_exceptions objective_exception
+    ON objective_exception.operational_policy_id
+        = contract.operational_policy_id
+   AND objective_exception.operational_policy_fingerprint
+        = contract.operational_policy_fingerprint
+   AND objective_exception.schedule_id = contract.schedule_id
+   AND objective_exception.schedule_fingerprint = contract.schedule_fingerprint
+   AND objective_exception.calendar_id = contract.calendar_id
+   AND objective_exception.portfolio_id = contract.portfolio_id
+   AND objective_exception.risk_limit_policy_id
+        = contract.risk_limit_policy_id
+   AND objective_exception.mandate_fingerprint = contract.mandate_fingerprint
+   AND objective_exception.latest_expected_session
+        = contract.latest_expected_session;
+
+CREATE OR REPLACE VIEW risk_platform.current_operational_exception_summary AS
+SELECT
+    'service_level_metric'::TEXT AS exception_type,
+    metric.metric_name AS exception_name,
+    metric.metric_status AS exception_status,
+    CASE metric.metric_status WHEN 'critical' THEN 3 ELSE 2 END
+        AS severity_rank,
+    metric.policy_id AS operational_policy_id,
+    metric.policy_fingerprint AS operational_policy_fingerprint,
+    NULL::TEXT AS objective_policy_id,
+    NULL::TEXT AS objective_policy_fingerprint,
+    metric.schedule_id,
+    metric.schedule_fingerprint,
+    metric.calendar_id,
+    metric.portfolio_id,
+    metric.risk_limit_policy_id,
+    metric.mandate_id,
+    metric.mandate_fingerprint,
+    metric.latest_expected_session AS event_session,
+    metric.report_calculation_id AS evidence_id,
+    metric.as_of AS evidence_ts,
+    NULL::TEXT AS parent_evidence_id,
+    metric.observed_value,
+    metric.warning_threshold,
+    metric.critical_threshold AS target_or_critical_threshold,
+    metric.unit,
+    metric.reason
+FROM risk_platform.current_operational_service_level_exceptions metric
+
+UNION ALL
+
+SELECT
+    'service_level_objective',
+    objective.objective_name,
+    objective.objective_status,
+    CASE objective.objective_status WHEN 'missed' THEN 3 ELSE 1 END,
+    objective.operational_policy_id,
+    objective.operational_policy_fingerprint,
+    objective.objective_policy_id,
+    objective.objective_policy_fingerprint,
+    objective.schedule_id,
+    objective.schedule_fingerprint,
+    objective.calendar_id,
+    objective.portfolio_id,
+    objective.risk_limit_policy_id,
+    objective.mandate_id,
+    objective.mandate_fingerprint,
+    objective.through_session,
+    objective.objective_report_calculation_id,
+    objective.calculated_at,
+    NULL::TEXT,
+    objective.attainment_ratio,
+    NULL::DOUBLE PRECISION,
+    objective.target_ratio,
+    'ratio'::TEXT,
+    NULL::TEXT
+FROM risk_platform.current_operational_service_level_objective_exceptions objective
+
+UNION ALL
+
+SELECT
+    'readiness_reason',
+    reason.value,
+    'block',
+    4,
+    readiness.operational_policy_id,
+    readiness.operational_policy_fingerprint,
+    NULL::TEXT,
+    NULL::TEXT,
+    readiness.schedule_id,
+    readiness.schedule_fingerprint,
+    readiness.calendar_id,
+    readiness.portfolio_id,
+    readiness.risk_limit_policy_id,
+    NULL::TEXT,
+    readiness.mandate_fingerprint,
+    readiness.latest_expected_session,
+    readiness.decision_id,
+    readiness.evaluated_at,
+    readiness.report_calculation_id,
+    NULL::DOUBLE PRECISION,
+    NULL::DOUBLE PRECISION,
+    NULL::DOUBLE PRECISION,
+    'decision'::TEXT,
+    reason.value
+FROM risk_platform.current_blocked_operational_readiness_decisions readiness
+CROSS JOIN LATERAL jsonb_array_elements_text(readiness.reasons) reason(value);
+
+CREATE OR REPLACE VIEW risk_platform.recent_operational_readiness_decisions AS
+SELECT
+    history.*,
+    ROW_NUMBER() OVER (
+        PARTITION BY
+            model_version,
+            gate_id,
+            gate_fingerprint,
+            operational_policy_id,
+            operational_policy_fingerprint,
+            schedule_id,
+            schedule_fingerprint,
+            calendar_id,
+            portfolio_id,
+            risk_limit_policy_id,
+            mandate_fingerprint,
+            latest_expected_session
+        ORDER BY evaluated_at DESC, decision_id DESC
+    ) AS decision_recency_rank
+FROM risk_platform.operational_readiness_decision_history history;
+
+CREATE OR REPLACE VIEW risk_platform.rolling_operational_objective_attainment AS
+SELECT
+    objective_report_calculation_id,
+    model_version,
+    objective_policy_id,
+    objective_policy_fingerprint,
+    operational_policy_id,
+    operational_policy_fingerprint,
+    schedule_id,
+    schedule_fingerprint,
+    calendar_id,
+    portfolio_id,
+    risk_limit_policy_id,
+    mandate_id,
+    mandate_fingerprint,
+    through_session,
+    window_start_session,
+    window_end_session,
+    window_sessions,
+    minimum_observations,
+    observations_available,
+    observations_expected,
+    window_complete,
+    history_status,
+    overall_status,
+    calculated_at,
+    objective_ordinal,
+    objective_name,
+    source_metric_name,
+    source_unit,
+    success_threshold,
+    target_ratio,
+    successful_observations,
+    failed_observations,
+    missing_report_observations,
+    objective_observations_available,
+    objective_observations_expected,
+    attainment_ratio,
+    attainment_ratio - target_ratio AS attainment_gap,
+    CASE objective_status
+        WHEN 'missed' THEN 2
+        WHEN 'insufficient' THEN 1
+        ELSE 0
+    END AS objective_status_rank,
+    objective_status,
+    recorded_at
+FROM risk_platform.operational_service_level_objective_metric_history;
+
+CREATE OR REPLACE VIEW risk_platform.operational_evidence_drillthrough AS
+SELECT
+    'service_level_report'::TEXT AS evidence_type,
+    report.model_version,
+    report.calculation_id AS evidence_id,
+    '[]'::JSONB AS parent_evidence_ids,
+    report.latest_expected_session AS event_session,
+    report.as_of AS evidence_ts,
+    report.overall_status AS status,
+    report.policy_id AS operational_policy_id,
+    report.policy_fingerprint AS operational_policy_fingerprint,
+    NULL::TEXT AS objective_policy_id,
+    NULL::TEXT AS objective_policy_fingerprint,
+    report.schedule_id,
+    report.schedule_fingerprint,
+    report.calendar_id,
+    report.portfolio_id,
+    report.risk_limit_policy_id,
+    report.mandate_id,
+    report.mandate_fingerprint,
+    report.document_sha256
+FROM risk_platform.operational_service_level_reports report
+
+UNION ALL
+
+SELECT
+    'service_level_objective_report',
+    report.model_version,
+    report.calculation_id,
+    report.input_report_calculation_ids,
+    report.through_session,
+    report.calculated_at,
+    report.overall_status,
+    report.operational_policy_id,
+    report.operational_policy_fingerprint,
+    report.objective_policy_id,
+    report.objective_policy_fingerprint,
+    report.schedule_id,
+    report.schedule_fingerprint,
+    report.calendar_id,
+    report.portfolio_id,
+    report.risk_limit_policy_id,
+    report.mandate_id,
+    report.mandate_fingerprint,
+    report.document_sha256
+FROM risk_platform.operational_service_level_objective_reports report
+
+UNION ALL
+
+SELECT
+    'readiness_decision',
+    decision.model_version,
+    decision.decision_id,
+    CASE
+        WHEN decision.report_calculation_id IS NULL THEN '[]'::JSONB
+        ELSE jsonb_build_array(decision.report_calculation_id)
+    END,
+    decision.latest_expected_session,
+    decision.evaluated_at,
+    decision.decision,
+    decision.operational_policy_id,
+    decision.operational_policy_fingerprint,
+    NULL::TEXT,
+    NULL::TEXT,
+    decision.schedule_id,
+    decision.schedule_fingerprint,
+    decision.calendar_id,
+    decision.portfolio_id,
+    decision.risk_limit_policy_id,
+    NULL::TEXT,
+    decision.mandate_fingerprint,
+    decision.document_sha256
+FROM risk_platform.operational_readiness_decisions decision;

--- a/src/warehouse/operational_readiness_decision_contract_check.py
+++ b/src/warehouse/operational_readiness_decision_contract_check.py
@@ -196,6 +196,45 @@ def run_contract_check(
         names = ", ".join(result.check_name for result in failures)
         raise AssertionError("operational readiness reconciliation failed: " + names)
 
+    with psycopg.connect(dsn) as connection:
+        with connection.cursor() as cursor:
+            cursor.execute(
+                """
+                SELECT
+                    (SELECT COUNT(*)
+                     FROM risk_platform.current_operational_health_summary),
+                    (SELECT health_status
+                     FROM risk_platform.current_operational_health_summary),
+                    (SELECT current_exception_count
+                     FROM risk_platform.current_operational_health_summary),
+                    (SELECT COUNT(*)
+                     FROM risk_platform.current_operational_exception_summary),
+                    (SELECT COUNT(*)
+                     FROM risk_platform.recent_operational_readiness_decisions),
+                    (SELECT COUNT(*)
+                     FROM risk_platform.rolling_operational_objective_attainment),
+                    (SELECT COUNT(*)
+                     FROM risk_platform.operational_evidence_drillthrough)
+                """
+            )
+            review_counts = cursor.fetchone()
+            if review_counts != (1, "blocked", 3, 3, 2, 8, 10):
+                raise AssertionError(
+                    "operational review serving views are incompatible: "
+                    f"{review_counts!r}"
+                )
+
+    review_consistency = run_consistency_checks(
+        dsn=dsn,
+        check_paths=(Path("sql/operational_review_consistency_checks.sql"),),
+    )
+    review_failures = [
+        result for result in review_consistency if result.status != "pass"
+    ]
+    if review_failures:
+        names = ", ".join(result.check_name for result in review_failures)
+        raise AssertionError("operational review reconciliation failed: " + names)
+
     return {
         "first_decision_id": first_decision["decision_id"],
         "second_decision_id": second_decision["decision_id"],
@@ -205,4 +244,7 @@ def run_contract_check(
         "replay_verified": True,
         "conflict_verified": True,
         "consistency_checks": len(consistency),
+        "operational_review_health_status": "blocked",
+        "operational_review_exception_rows": 3,
+        "operational_review_consistency_checks": len(review_consistency),
     }

--- a/tests/unit/test_docker_compose_contract.py
+++ b/tests/unit/test_docker_compose_contract.py
@@ -40,6 +40,7 @@ def test_local_database_seed_mounts_are_read_only_and_ordered() -> None:
         "./sql/operational_service_levels_schema.sql:/docker-entrypoint-initdb.d/13_operational_service_levels_schema.sql:ro",
         "./sql/operational_service_level_objectives_schema.sql:/docker-entrypoint-initdb.d/14_operational_service_level_objectives_schema.sql:ro",
         "./sql/operational_readiness_decisions_schema.sql:/docker-entrypoint-initdb.d/15_operational_readiness_decisions_schema.sql:ro",
+        "./sql/operational_review_schema.sql:/docker-entrypoint-initdb.d/16_operational_review_schema.sql:ro",
     ]
     assert services["mongo"]["volumes"] == [
         "./mongo/init:/docker-entrypoint-initdb.d:ro"

--- a/tests/unit/test_operational_review_architecture_contract.py
+++ b/tests/unit/test_operational_review_architecture_contract.py
@@ -1,0 +1,18 @@
+from pathlib import Path
+
+
+def test_operational_review_documentation_does_not_claim_a_deployed_dashboard() -> None:
+    documentation = Path("docs/operational-review-queries.md").read_text(
+        encoding="utf-8"
+    )
+
+    for required in (
+        "current_operational_health_summary",
+        "current_operational_exception_summary",
+        "recent_operational_readiness_decisions",
+        "rolling_operational_objective_attainment",
+        "operational_evidence_drillthrough",
+        "Missing evidence remains explicit",
+        "No dashboard is deployed",
+    ):
+        assert required in documentation

--- a/tests/unit/test_operational_review_sql_contract.py
+++ b/tests/unit/test_operational_review_sql_contract.py
@@ -1,0 +1,42 @@
+from pathlib import Path
+
+
+def test_operational_review_schema_exposes_dashboard_ready_grains() -> None:
+    sql = Path("sql/operational_review_schema.sql").read_text(encoding="utf-8")
+
+    for view in (
+        "current_operational_health_summary",
+        "current_operational_exception_summary",
+        "recent_operational_readiness_decisions",
+        "rolling_operational_objective_attainment",
+        "operational_evidence_drillthrough",
+    ):
+        assert f"risk_platform.{view}" in sql
+    assert "readiness_missing" in sql
+    assert "service_level_missing" in sql
+    assert "objective_missing" in sql
+    assert "decision_recency_rank" in sql
+    assert "attainment_gap" in sql
+    assert "parent_evidence_ids" in sql
+
+
+def test_operational_review_consistency_contract_covers_all_views() -> None:
+    sql = Path("sql/operational_review_consistency_checks.sql").read_text(
+        encoding="utf-8"
+    )
+
+    for check_name in (
+        "operational_review_health_rows_match_contracts",
+        "operational_review_health_grain_unique",
+        "operational_review_health_status_reconciles",
+        "operational_review_exception_rows_match_sources",
+        "operational_review_exception_identity_unique",
+        "operational_review_recent_decisions_match_history",
+        "operational_review_recent_decision_rank_matches_latest",
+        "operational_review_objective_trend_rows_match_history",
+        "operational_review_objective_trend_arithmetic_reconciles",
+        "operational_review_drillthrough_rows_match_evidence",
+        "operational_review_drillthrough_identity_unique",
+        "operational_review_drillthrough_parents_exist",
+    ):
+        assert check_name in sql


### PR DESCRIPTION
## Outcome

Turn retained operational SLI, rolling SLO and readiness evidence into compact dashboard-ready PostgreSQL grains without deploying or claiming a dashboard:

```text
append-only SLI reports
  + append-only rolling SLO reports
  + append-only readiness decisions
  -> current health summary
  -> current exception summary
  -> recent readiness decisions
  -> rolling objective attainment
  -> evidence drill-through
```

Primary arc42 block: `warehouse`, with read-only interfaces to the three append-only operational evidence contracts.

## Serving views

Add:

- `risk_platform.current_operational_health_summary` — one row per exact operating contract and expected market session, with missing evidence explicit and deterministic status precedence;
- `current_operational_exception_summary` — one common grain for SLI metrics, SLO objectives and readiness blocking reasons;
- `recent_operational_readiness_decisions` — full readiness history with correction-aware recency rank;
- `rolling_operational_objective_attainment` — objective observations, missing sessions, attainment ratios, gaps and status ranks; and
- `operational_evidence_drillthrough` — one retained evidence row with document digest and parent report IDs.

The health precedence is:

```text
blocked > critical > missed > readiness_missing > service_level_missing
> objective_missing > warning > insufficient > ok
```

Missing evidence remains visible rather than disappearing through inner joins.

## Dashboard-ready contract

`docs/operational-review-queries.md` defines card, exception-table, timeline, trend and drill-through grains. Consumers must preserve policy, schedule, mandate and objective fingerprints. The document explicitly states that no dashboard is deployed.

## Reconciliation and real PostgreSQL evidence

`sql/operational_review_consistency_checks.sql` verifies health row counts and grains, status precedence, exception counts and identities, readiness recency ranking, objective trend arithmetic, drill-through counts, evidence uniqueness and parent references.

The live PostgreSQL fixture exercised one blocked health row, three current exceptions, two readiness decisions, eight rolling objective rows and ten retained drill-through rows, then passed all 12 review reconciliation checks.

## Validation

GitHub Actions run `32713383826` (`ci` run 294) passed on exact head `5275e3ffed1a5585996f0ab7167b9b6fdc016272`:

- Security guardrails: passed.
- Python readiness: passed.
  - locked dependencies resolved;
  - Ruff passed;
  - mypy passed across 96 source files;
  - 723 tests passed in both quality and readiness runs;
  - `pip check` passed;
  - the standard readiness replay passed.
- PostgreSQL contract: passed against PostgreSQL 16.
  - all schema layers initialized, including operational review layer 16;
  - source-to-serving, model-approval, operational SLI, rolling SLO and readiness contracts passed;
  - operational review row counts, status precedence, parent identities and reconciliation passed.
- Infrastructure validation: passed.
  - Kubernetes overlays rendered;
  - Terraform format/init/validate passed without apply.

No unresolved review threads or requested changes are present.

## Scope

The branch is directly based on the PR #99 merge, is zero commits behind and changes eight files with 1,021 additions as one query-and-review layer. Connector file writes produced eight working commits; the PR is intended for squash merge.

No dashboard, alert delivery, schedule execution, override, checkpoint mutation, cloud activation, deployment or `terraform apply` is included.

## Acceptance boundary

Validated and ready for squash merge as the read-only operational review surface.