### PR TITLE
Add readiness-aware local schedule planning

### DIFF
--- a/docs/readiness-aware-schedule-planning.md
+++ b/docs/readiness-aware-schedule-planning.md
@@ -1,0 +1,110 @@
+# Readiness-Aware Local Schedule Planning
+
+## Outcome
+
+This plan-only layer combines the existing bounded local schedule plan with the
+exact retained operational readiness decision:
+
+```text
+current schedule, calendar and effective mandate
+  + exact current readiness decision
+  + bounded local session plan
+  -> would_run, would_block or no_work
+  -> deterministic JSON evidence
+  -> no command execution or checkpoint mutation
+```
+
+The existing `run_local_portfolio_schedule` remains the source of session and
+command planning. It is invoked only with execution disabled. The readiness-aware
+wrapper rejects any planner result that reports command execution, provider
+access, delivery or cloud-schedule activity.
+
+## Operator Command
+
+```bash
+.venv/bin/python -m src.orchestration.plan_readiness_aware_local_schedule \
+  --schedule-id us-tech-local \
+  --gate-id us-tech-local \
+  --as-of-date 2026-04-01 \
+  --summary-json .demo/readiness-aware-schedule-plan.json
+```
+
+The command exposes no `--execute` option.
+
+Exit codes are:
+
+- `0` — `would_run` or `no_work`;
+- `2` — `would_block` using valid current or missing-decision evidence; and
+- `1` — invalid configuration, retained evidence, local state or PostgreSQL
+  access.
+
+## Exact Current Contract
+
+Before reading readiness evidence, the wrapper resolves the current:
+
+- readiness gate and fingerprint;
+- operational service-level policy and fingerprint;
+- local schedule and fingerprint;
+- market calendar and latest expected session; and
+- effective portfolio mandate and fingerprint.
+
+The operational policy must belong to the selected schedule. The readiness query
+uses the exact gate, policy, schedule, calendar, portfolio, risk-limit policy,
+mandate and expected-session identities. The selected row is joined back to the
+append-only decision history so its complete `decision_json` can be validated and
+its canonical SHA-256 can be rechecked.
+
+A missing exact decision is represented explicitly as:
+
+```text
+status = missing
+decision = block
+reasons = [decision_missing]
+```
+
+It is not treated as an error because it is valid plan evidence, but it produces
+`would_block` whenever work is selected.
+
+## Schedule Effect
+
+The result is derived as follows:
+
+```text
+no sessions selected                       -> no_work
+sessions selected + current allow decision -> would_run
+sessions selected + block/missing decision -> would_block
+```
+
+The wrapper still includes the underlying command plans for human inspection.
+No command is run.
+
+## Deterministic Identity
+
+`readiness-aware-schedule-plan-v1` binds:
+
+- as-of date and latest expected session;
+- schedule, calendar, gate, operational-policy and mandate fingerprints;
+- selected sessions and exact command plans;
+- checkpoint-before evidence;
+- readiness decision ID, decision and reasons; and
+- resulting schedule effect.
+
+The random `run_id` produced by the underlying local schedule planner is removed
+before identity calculation. Repeating the same state produces the same plan ID.
+
+## Side-Effect Boundary
+
+Every result records:
+
+```text
+execution.requested = false
+execution.performed = false
+checkpoint_updated = false
+provider_request_performed = false
+notification_delivery_performed = false
+cloud_schedule_activated = false
+```
+
+This increment does not grant execution authority. Overrides and enforcement are
+separate dependency layers so the local schedule cannot accidentally begin using
+a newly introduced gate before human-authority semantics have been reviewed.

--- a/src/orchestration/plan_readiness_aware_local_schedule.py
+++ b/src/orchestration/plan_readiness_aware_local_schedule.py
@@ -1,0 +1,434 @@
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import sys
+from collections.abc import Callable, Mapping, Sequence
+from datetime import date
+from pathlib import Path
+from typing import Any
+
+from src.analytics.market_calendar import MarketCalendar, load_market_calendar
+from src.analytics.operational_service_levels import (
+    OperationalServiceLevelPolicy,
+    load_operational_service_level_policy,
+)
+from src.analytics.portfolio_mandates import (
+    PortfolioMandate,
+    load_portfolio_mandate,
+)
+from src.common.exceptions import StorageError, ValidationError
+from src.orchestration.run_local_portfolio_schedule import (
+    LocalPortfolioSchedule,
+    load_local_portfolio_schedule,
+    run_local_portfolio_schedule,
+)
+from src.warehouse.operational_readiness_decision_reader import (
+    read_current_operational_readiness_decision,
+)
+from src.warehouse.operational_readiness_gate import (
+    OperationalReadinessGatePolicy,
+    load_operational_readiness_gate_policy,
+)
+from src.warehouse.postgres_loader import DEFAULT_POSTGRES_DSN
+
+MODEL_VERSION = "readiness-aware-schedule-plan-v1"
+
+ScheduleLoader = Callable[[Path, str], LocalPortfolioSchedule]
+GateLoader = Callable[[Path, str], OperationalReadinessGatePolicy]
+OperationalPolicyLoader = Callable[[Path, str], OperationalServiceLevelPolicy]
+CalendarLoader = Callable[[Path, str], MarketCalendar]
+MandateLoader = Callable[[Path, str, date], PortfolioMandate]
+ReadinessReader = Callable[..., dict[str, Any] | None]
+SchedulePlanner = Callable[..., Mapping[str, Any]]
+
+
+def _calendar_date(value: str) -> date:
+    try:
+        parsed = date.fromisoformat(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(
+            "must be a calendar date in YYYY-MM-DD format"
+        ) from exc
+    if value != parsed.isoformat():
+        raise argparse.ArgumentTypeError(
+            "must be a calendar date in YYYY-MM-DD format"
+        )
+    return parsed
+
+
+def _default_schedule_planner(**kwargs: Any) -> Mapping[str, Any]:
+    return run_local_portfolio_schedule(
+        **kwargs,
+        execute=False,
+        command_runner=lambda *_: (_ for _ in ()).throw(
+            AssertionError("plan-only readiness integration executed a command")
+        ),
+    )
+
+
+def _deterministic_schedule_plan(
+    raw: Mapping[str, Any],
+    *,
+    schedule: LocalPortfolioSchedule,
+    calendar: MarketCalendar,
+    as_of_date: date,
+) -> dict[str, Any]:
+    required = {
+        "schedule_id",
+        "schedule_fingerprint",
+        "enabled",
+        "calendar",
+        "selection",
+        "plans",
+        "execution",
+        "provider_request_performed",
+        "external_delivery_performed",
+        "cloud_schedule_activated",
+    }
+    if not required.issubset(raw):
+        raise StorageError("local schedule plan is missing required evidence")
+    if raw.get("schedule_id") != schedule.schedule_id:
+        raise StorageError("local schedule plan belongs to another schedule")
+    if raw.get("schedule_fingerprint") != schedule.fingerprint:
+        raise StorageError("local schedule plan fingerprint changed during planning")
+    if raw.get("enabled") != schedule.enabled:
+        raise StorageError("local schedule enabled state changed during planning")
+    calendar_evidence = raw.get("calendar")
+    if not isinstance(calendar_evidence, Mapping) or calendar_evidence != {
+        "calendar_id": calendar.calendar_id,
+        "calendar_fingerprint": calendar.fingerprint,
+    }:
+        raise StorageError("local schedule calendar evidence changed during planning")
+    selection = raw.get("selection")
+    if not isinstance(selection, Mapping):
+        raise StorageError("local schedule selection evidence is incompatible")
+    if selection.get("as_of_date") != as_of_date.isoformat():
+        raise StorageError("local schedule plan uses another as_of_date")
+    session_dates = selection.get("session_dates")
+    sessions_selected = selection.get("sessions_selected")
+    if (
+        not isinstance(session_dates, list)
+        or any(not isinstance(value, str) for value in session_dates)
+        or type(sessions_selected) is not int
+        or sessions_selected != len(session_dates)
+    ):
+        raise StorageError("local schedule selected sessions are incompatible")
+    plans = raw.get("plans")
+    if not isinstance(plans, list) or len(plans) != sessions_selected:
+        raise StorageError("local schedule command plans are incompatible")
+    execution = raw.get("execution")
+    if not isinstance(execution, Mapping) or execution != {
+        "requested": False,
+        "performed": False,
+        "completed_sessions": [],
+    }:
+        raise StorageError("local schedule plan performed execution")
+    for flag in (
+        "provider_request_performed",
+        "external_delivery_performed",
+        "cloud_schedule_activated",
+    ):
+        if raw.get(flag) is not False:
+            raise StorageError("local schedule plan reported a side effect")
+    return {
+        "schedule_id": schedule.schedule_id,
+        "schedule_fingerprint": schedule.fingerprint,
+        "enabled": schedule.enabled,
+        "calendar": dict(calendar_evidence),
+        "selection": dict(selection),
+        "plans": plans,
+    }
+
+
+def _plan_id(payload: Mapping[str, Any]) -> str:
+    digest = hashlib.sha256(
+        json.dumps(
+            payload,
+            sort_keys=True,
+            separators=(",", ":"),
+            allow_nan=False,
+        ).encode("utf-8")
+    ).hexdigest()[:24]
+    return f"{MODEL_VERSION}-plan-{digest}"
+
+
+def plan_readiness_aware_local_schedule(
+    *,
+    schedule_id: str,
+    gate_id: str,
+    as_of_date: date,
+    schedule_config_path: Path,
+    gate_config_path: Path,
+    operational_policy_config_path: Path,
+    calendar_config_path: Path,
+    portfolio_config_path: Path,
+    risk_limit_config_path: Path,
+    storage_config_path: Path,
+    state_dir: Path,
+    dsn: str,
+    python_executable: str = sys.executable,
+    schedule_loader: ScheduleLoader | None = None,
+    gate_loader: GateLoader | None = None,
+    operational_policy_loader: OperationalPolicyLoader | None = None,
+    calendar_loader: CalendarLoader | None = None,
+    mandate_loader: MandateLoader | None = None,
+    readiness_reader: ReadinessReader | None = None,
+    schedule_planner: SchedulePlanner | None = None,
+) -> dict[str, Any]:
+    selected_schedule_loader = schedule_loader or load_local_portfolio_schedule
+    selected_gate_loader = gate_loader or load_operational_readiness_gate_policy
+    selected_policy_loader = (
+        operational_policy_loader or load_operational_service_level_policy
+    )
+    selected_calendar_loader = calendar_loader or load_market_calendar
+    selected_mandate_loader = mandate_loader or load_portfolio_mandate
+    selected_readiness_reader = (
+        readiness_reader or read_current_operational_readiness_decision
+    )
+    selected_schedule_planner = schedule_planner or _default_schedule_planner
+
+    schedule = selected_schedule_loader(schedule_config_path, schedule_id)
+    gate = selected_gate_loader(gate_config_path, gate_id)
+    policy = selected_policy_loader(
+        operational_policy_config_path,
+        gate.operational_policy_id,
+    )
+    if policy.policy_id != gate.operational_policy_id:
+        raise ValidationError("readiness gate selected another operational policy")
+    if policy.schedule_id != schedule.schedule_id:
+        raise ValidationError(
+            "operational readiness policy belongs to another schedule"
+        )
+
+    calendar = selected_calendar_loader(
+        calendar_config_path,
+        schedule.calendar_id,
+    )
+    calendar.require_covered(as_of_date)
+    latest_expected_session = calendar.latest_expected_session(as_of_date)
+    mandate = selected_mandate_loader(
+        portfolio_config_path,
+        schedule.portfolio_id,
+        latest_expected_session,
+    )
+
+    readiness = selected_readiness_reader(
+        dsn=dsn,
+        gate_id=gate.gate_id,
+        gate_fingerprint=gate.fingerprint,
+        operational_policy_id=policy.policy_id,
+        operational_policy_fingerprint=policy.fingerprint,
+        schedule_id=schedule.schedule_id,
+        schedule_fingerprint=schedule.fingerprint,
+        calendar_id=calendar.calendar_id,
+        portfolio_id=schedule.portfolio_id,
+        risk_limit_policy_id=schedule.policy_id,
+        mandate_fingerprint=mandate.fingerprint,
+        latest_expected_session=latest_expected_session,
+    )
+
+    raw_schedule_plan = selected_schedule_planner(
+        schedule_id=schedule.schedule_id,
+        as_of_date=as_of_date,
+        schedule_config_path=schedule_config_path,
+        calendar_config_path=calendar_config_path,
+        portfolio_config_path=portfolio_config_path,
+        risk_limit_config_path=risk_limit_config_path,
+        storage_config_path=storage_config_path,
+        state_dir=state_dir,
+        dsn=dsn,
+        python_executable=python_executable,
+    )
+    if not isinstance(raw_schedule_plan, Mapping):
+        raise StorageError("local schedule planner returned invalid evidence")
+    schedule_plan = _deterministic_schedule_plan(
+        raw_schedule_plan,
+        schedule=schedule,
+        calendar=calendar,
+        as_of_date=as_of_date,
+    )
+    sessions_selected = schedule_plan["selection"]["sessions_selected"]
+    if sessions_selected == 0:
+        schedule_effect = "no_work"
+    elif readiness is not None and readiness.get("decision") == "allow":
+        schedule_effect = "would_run"
+    else:
+        schedule_effect = "would_block"
+
+    readiness_evidence = {
+        "status": "missing" if readiness is None else "current",
+        "decision_id": readiness.get("decision_id") if readiness else None,
+        "decision": readiness.get("decision") if readiness else "block",
+        "reasons": readiness.get("reasons") if readiness else ["decision_missing"],
+        "document_sha256": (
+            readiness.get("document_sha256") if readiness else None
+        ),
+        "recorded_at": readiness.get("recorded_at") if readiness else None,
+        "gate_id": gate.gate_id,
+        "gate_fingerprint": gate.fingerprint,
+        "operational_policy_id": policy.policy_id,
+        "operational_policy_fingerprint": policy.fingerprint,
+        "latest_expected_session": latest_expected_session.isoformat(),
+    }
+    identity_payload = {
+        "as_of_date": as_of_date.isoformat(),
+        "calendar_fingerprint": calendar.fingerprint,
+        "gate_fingerprint": gate.fingerprint,
+        "latest_expected_session": latest_expected_session.isoformat(),
+        "mandate_fingerprint": mandate.fingerprint,
+        "model_version": MODEL_VERSION,
+        "operational_policy_fingerprint": policy.fingerprint,
+        "readiness_decision": readiness_evidence["decision"],
+        "readiness_decision_id": readiness_evidence["decision_id"],
+        "readiness_reasons": readiness_evidence["reasons"],
+        "schedule_effect": schedule_effect,
+        "schedule_fingerprint": schedule.fingerprint,
+        "schedule_plan": schedule_plan,
+    }
+    return {
+        "plan_id": _plan_id(identity_payload),
+        "model_version": MODEL_VERSION,
+        "schedule_id": schedule.schedule_id,
+        "schedule_fingerprint": schedule.fingerprint,
+        "portfolio_id": schedule.portfolio_id,
+        "risk_limit_policy_id": schedule.policy_id,
+        "mandate_id": mandate.mandate_id,
+        "mandate_fingerprint": mandate.fingerprint,
+        "as_of_date": as_of_date.isoformat(),
+        "latest_expected_session": latest_expected_session.isoformat(),
+        "readiness": readiness_evidence,
+        "schedule_plan": schedule_plan,
+        "schedule_effect": {
+            "decision": schedule_effect,
+            "sessions_selected": sessions_selected,
+            "session_dates": schedule_plan["selection"]["session_dates"],
+        },
+        "execution": {
+            "requested": False,
+            "performed": False,
+            "completed_sessions": [],
+        },
+        "checkpoint_updated": False,
+        "provider_request_performed": False,
+        "notification_delivery_performed": False,
+        "cloud_schedule_activated": False,
+    }
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Combine a local schedule plan with the exact retained operational "
+            "readiness decision without executing commands."
+        )
+    )
+    parser.add_argument("--schedule-id", required=True)
+    parser.add_argument("--gate-id", required=True)
+    parser.add_argument("--as-of-date", required=True, type=_calendar_date)
+    parser.add_argument(
+        "--schedule-config",
+        type=Path,
+        default=Path("config/local_portfolio_schedules.yaml"),
+    )
+    parser.add_argument(
+        "--gate-config",
+        type=Path,
+        default=Path("config/operational_readiness_gates.yaml"),
+    )
+    parser.add_argument(
+        "--operational-policy-config",
+        type=Path,
+        default=Path("config/operational_service_levels.yaml"),
+    )
+    parser.add_argument(
+        "--calendar-config",
+        type=Path,
+        default=Path("config/market_calendars.yaml"),
+    )
+    parser.add_argument(
+        "--portfolio-config",
+        type=Path,
+        default=Path("config/portfolios.yaml"),
+    )
+    parser.add_argument(
+        "--risk-limit-config",
+        type=Path,
+        default=Path("config/portfolio_risk_limits.yaml"),
+    )
+    parser.add_argument(
+        "--storage-config",
+        type=Path,
+        default=Path("config/storage.yaml"),
+    )
+    parser.add_argument("--state-dir", type=Path, default=Path(".scheduler"))
+    parser.add_argument(
+        "--dsn",
+        default=os.environ.get("WAREHOUSE_POSTGRES_DSN", DEFAULT_POSTGRES_DSN),
+    )
+    parser.add_argument("--summary-json", type=Path)
+    return parser
+
+
+def _write_summary(path: Path, summary: Mapping[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_suffix(path.suffix + ".tmp")
+    try:
+        temporary.write_text(
+            json.dumps(summary, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        temporary.replace(path)
+    except OSError:
+        temporary.unlink(missing_ok=True)
+        raise StorageError("Unable to write readiness-aware schedule plan") from None
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    try:
+        summary = plan_readiness_aware_local_schedule(
+            schedule_id=args.schedule_id,
+            gate_id=args.gate_id,
+            as_of_date=args.as_of_date,
+            schedule_config_path=args.schedule_config,
+            gate_config_path=args.gate_config,
+            operational_policy_config_path=args.operational_policy_config,
+            calendar_config_path=args.calendar_config,
+            portfolio_config_path=args.portfolio_config,
+            risk_limit_config_path=args.risk_limit_config,
+            storage_config_path=args.storage_config,
+            state_dir=args.state_dir,
+            dsn=args.dsn,
+        )
+        if args.summary_json is not None:
+            _write_summary(args.summary_json, summary)
+    except ValidationError:
+        print(
+            "Readiness-aware schedule planning failed: configuration or "
+            "retained evidence was invalid",
+            file=sys.stderr,
+        )
+        return 1
+    except StorageError:
+        print(
+            "Readiness-aware schedule planning failed: local or PostgreSQL "
+            "operation failed",
+            file=sys.stderr,
+        )
+        return 1
+    except Exception:
+        print(
+            "Readiness-aware schedule planning failed: unexpected local failure",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(json.dumps(summary, sort_keys=True))
+    return 2 if summary["schedule_effect"]["decision"] == "would_block" else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/warehouse/operational_readiness_decision_reader.py
+++ b/src/warehouse/operational_readiness_decision_reader.py
@@ -1,0 +1,184 @@
+from __future__ import annotations
+
+import hashlib
+from collections.abc import Callable, Mapping
+from datetime import date, datetime, timezone
+from typing import Any
+
+from src.common.exceptions import StorageError, ValidationError
+from src.warehouse.operational_readiness_decision_recorder import (
+    canonical_operational_readiness_decision_bytes,
+    validate_operational_readiness_decision,
+)
+
+CurrentRowReader = Callable[..., list[Mapping[str, Any]]]
+
+
+def _quote_identifier(value: str) -> str:
+    if not isinstance(value, str) or not value:
+        raise ValidationError("schema_name must be non-empty text")
+    return '"' + value.replace('"', '""') + '"'
+
+
+def _read_current_rows_postgres(
+    *,
+    dsn: str,
+    gate_id: str,
+    gate_fingerprint: str,
+    operational_policy_id: str,
+    operational_policy_fingerprint: str,
+    schedule_id: str,
+    schedule_fingerprint: str,
+    calendar_id: str,
+    portfolio_id: str,
+    risk_limit_policy_id: str,
+    mandate_fingerprint: str,
+    latest_expected_session: date,
+    schema_name: str,
+) -> list[Mapping[str, Any]]:
+    if not isinstance(dsn, str) or not dsn.strip():
+        raise ValidationError("PostgreSQL DSN must be non-empty text")
+    schema = _quote_identifier(schema_name)
+    try:
+        import psycopg
+        from psycopg.rows import dict_row
+    except ImportError as exc:  # pragma: no cover - required in CI.
+        raise RuntimeError("Readiness-aware planning requires psycopg") from exc
+
+    query = f"""
+        SELECT
+            history.decision_json,
+            latest.document_sha256,
+            latest.recorded_at
+        FROM {schema}.latest_operational_readiness_decisions latest
+        JOIN {schema}.operational_readiness_decisions history
+          ON history.decision_id = latest.decision_id
+        WHERE latest.gate_id = %s
+          AND latest.gate_fingerprint = %s
+          AND latest.operational_policy_id = %s
+          AND latest.operational_policy_fingerprint = %s
+          AND latest.schedule_id = %s
+          AND latest.schedule_fingerprint = %s
+          AND latest.calendar_id = %s
+          AND latest.portfolio_id = %s
+          AND latest.risk_limit_policy_id = %s
+          AND latest.mandate_fingerprint = %s
+          AND latest.latest_expected_session = %s
+        ORDER BY latest.evaluated_at DESC, latest.decision_id DESC
+        LIMIT 2
+    """
+    try:
+        with psycopg.connect(dsn, row_factory=dict_row) as connection:
+            with connection.cursor() as cursor:
+                cursor.execute(
+                    query,
+                    (
+                        gate_id,
+                        gate_fingerprint,
+                        operational_policy_id,
+                        operational_policy_fingerprint,
+                        schedule_id,
+                        schedule_fingerprint,
+                        calendar_id,
+                        portfolio_id,
+                        risk_limit_policy_id,
+                        mandate_fingerprint,
+                        latest_expected_session,
+                    ),
+                )
+                return [dict(row) for row in cursor.fetchall()]
+    except Exception:
+        raise StorageError(
+            "Unable to read the current operational readiness decision"
+        ) from None
+
+
+def read_current_operational_readiness_decision(
+    *,
+    dsn: str,
+    gate_id: str,
+    gate_fingerprint: str,
+    operational_policy_id: str,
+    operational_policy_fingerprint: str,
+    schedule_id: str,
+    schedule_fingerprint: str,
+    calendar_id: str,
+    portfolio_id: str,
+    risk_limit_policy_id: str,
+    mandate_fingerprint: str,
+    latest_expected_session: date,
+    schema_name: str = "risk_platform",
+    row_reader: CurrentRowReader | None = None,
+) -> dict[str, Any] | None:
+    selected_reader = row_reader or _read_current_rows_postgres
+    rows = selected_reader(
+        dsn=dsn,
+        gate_id=gate_id,
+        gate_fingerprint=gate_fingerprint,
+        operational_policy_id=operational_policy_id,
+        operational_policy_fingerprint=operational_policy_fingerprint,
+        schedule_id=schedule_id,
+        schedule_fingerprint=schedule_fingerprint,
+        calendar_id=calendar_id,
+        portfolio_id=portfolio_id,
+        risk_limit_policy_id=risk_limit_policy_id,
+        mandate_fingerprint=mandate_fingerprint,
+        latest_expected_session=latest_expected_session,
+        schema_name=schema_name,
+    )
+    if not isinstance(rows, list):
+        raise StorageError("current operational readiness query returned invalid rows")
+    if len(rows) > 1:
+        raise StorageError("current operational readiness decision grain is not unique")
+    if not rows:
+        return None
+
+    row = rows[0]
+    if not isinstance(row, Mapping) or set(row) != {
+        "decision_json",
+        "document_sha256",
+        "recorded_at",
+    }:
+        raise StorageError("current operational readiness row is incompatible")
+    decision_json = row.get("decision_json")
+    if not isinstance(decision_json, Mapping):
+        raise StorageError("current operational readiness document is incompatible")
+    decision = validate_operational_readiness_decision(decision_json)
+    expected_contract = {
+        "gate_id": gate_id,
+        "gate_fingerprint": gate_fingerprint,
+        "operational_policy_id": operational_policy_id,
+        "operational_policy_fingerprint": operational_policy_fingerprint,
+        "schedule_id": schedule_id,
+        "schedule_fingerprint": schedule_fingerprint,
+        "calendar_id": calendar_id,
+        "portfolio_id": portfolio_id,
+        "risk_limit_policy_id": risk_limit_policy_id,
+        "mandate_fingerprint": mandate_fingerprint,
+        "latest_expected_session": latest_expected_session.isoformat(),
+    }
+    for key, expected in expected_contract.items():
+        if decision.get(key) != expected:
+            raise StorageError(
+                f"current operational readiness {key} does not match the plan"
+            )
+
+    document_sha256 = row.get("document_sha256")
+    if not isinstance(document_sha256, str) or len(document_sha256) != 64:
+        raise StorageError("current operational readiness digest is incompatible")
+    canonical_sha256 = hashlib.sha256(
+        canonical_operational_readiness_decision_bytes(decision)
+    ).hexdigest()
+    if document_sha256 != canonical_sha256:
+        raise StorageError("current operational readiness digest does not reconcile")
+    recorded_at = row.get("recorded_at")
+    if not isinstance(recorded_at, datetime):
+        raise StorageError("current operational readiness recorded_at is incompatible")
+    if recorded_at.tzinfo is None or recorded_at.utcoffset() is None:
+        raise StorageError("current operational readiness recorded_at must be aware")
+
+    return {
+        **decision,
+        "document_sha256": document_sha256,
+        "recorded_at": recorded_at.astimezone(timezone.utc).isoformat(),
+    }

--- a/tests/unit/test_operational_readiness_decision_reader.py
+++ b/tests/unit/test_operational_readiness_decision_reader.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+import hashlib
+from datetime import date, datetime, timedelta, timezone
+from typing import Any
+
+import pytest
+
+from src.common.exceptions import StorageError
+from src.warehouse.operational_readiness_decision_reader import (
+    read_current_operational_readiness_decision,
+)
+from src.warehouse.operational_readiness_decision_recorder import (
+    canonical_operational_readiness_decision_bytes,
+)
+from src.warehouse.operational_readiness_gate import (
+    OperationalReadinessGatePolicy,
+    evaluate_operational_readiness,
+)
+
+
+def _decision() -> dict[str, Any]:
+    evaluated_at = datetime(2026, 4, 1, 12, tzinfo=timezone.utc)
+    gate = OperationalReadinessGatePolicy(
+        gate_id="us-tech-local",
+        operational_policy_id="us-tech-local",
+        max_report_age_seconds=3600,
+        allow_warning=False,
+    )
+    return evaluate_operational_readiness(
+        gate_policy=gate,
+        evaluated_at=evaluated_at,
+        latest_expected_session=date(2026, 3, 31),
+        operational_policy_fingerprint="operational-slo-policy-" + "a" * 24,
+        schedule_id="us-tech-local",
+        schedule_fingerprint="local-schedule-example",
+        calendar_id="XNYS",
+        portfolio_id="us-tech-equal",
+        risk_limit_policy_id="us-tech-standard",
+        mandate_fingerprint="portfolio-mandate-example",
+        report={
+            "calculation_id": "operational-service-levels-v1-report-" + "b" * 24,
+            "policy_id": "us-tech-local",
+            "policy_fingerprint": "operational-slo-policy-" + "a" * 24,
+            "schedule_id": "us-tech-local",
+            "schedule_fingerprint": "local-schedule-example",
+            "calendar_id": "XNYS",
+            "portfolio_id": "us-tech-equal",
+            "risk_limit_policy_id": "us-tech-standard",
+            "mandate_fingerprint": "portfolio-mandate-example",
+            "as_of": evaluated_at - timedelta(minutes=5),
+            "latest_expected_session": date(2026, 3, 31),
+            "overall_status": "ok",
+            "document_sha256": "c" * 64,
+        },
+    )
+
+
+def _kwargs() -> dict[str, Any]:
+    return {
+        "dsn": "not-used",
+        "gate_id": "us-tech-local",
+        "gate_fingerprint": "operational-readiness-gate-" + "d" * 24,
+        "operational_policy_id": "us-tech-local",
+        "operational_policy_fingerprint": "operational-slo-policy-" + "a" * 24,
+        "schedule_id": "us-tech-local",
+        "schedule_fingerprint": "local-schedule-example",
+        "calendar_id": "XNYS",
+        "portfolio_id": "us-tech-equal",
+        "risk_limit_policy_id": "us-tech-standard",
+        "mandate_fingerprint": "portfolio-mandate-example",
+        "latest_expected_session": date(2026, 3, 31),
+    }
+
+
+def test_current_readiness_reader_validates_document_and_digest() -> None:
+    decision = _decision()
+    decision["gate_fingerprint"] = _kwargs()["gate_fingerprint"]
+    # Gate fingerprint participates in identity, so rebuild the supplied ID.
+    identity = {
+        "calendar_id": decision["calendar_id"],
+        "decision": decision["decision"],
+        "evaluated_at": decision["evaluated_at"],
+        "gate_fingerprint": decision["gate_fingerprint"],
+        "latest_expected_session": decision["latest_expected_session"],
+        "mandate_fingerprint": decision["mandate_fingerprint"],
+        "operational_policy_fingerprint": decision[
+            "operational_policy_fingerprint"
+        ],
+        "portfolio_id": decision["portfolio_id"],
+        "reasons": decision["reasons"],
+        "report_calculation_id": decision["report_calculation_id"],
+        "report_document_sha256": decision["report_document_sha256"],
+        "risk_limit_policy_id": decision["risk_limit_policy_id"],
+        "schedule_fingerprint": decision["schedule_fingerprint"],
+        "schedule_id": decision["schedule_id"],
+    }
+    import json
+
+    decision["decision_id"] = (
+        "operational-readiness-gate-v1-decision-"
+        + hashlib.sha256(
+            json.dumps(identity, sort_keys=True, separators=(",", ":")).encode()
+        ).hexdigest()[:24]
+    )
+    digest = hashlib.sha256(
+        canonical_operational_readiness_decision_bytes(decision)
+    ).hexdigest()
+
+    result = read_current_operational_readiness_decision(
+        **_kwargs(),
+        row_reader=lambda **_: [
+            {
+                "decision_json": decision,
+                "document_sha256": digest,
+                "recorded_at": datetime(2026, 4, 1, 12, 1, tzinfo=timezone.utc),
+            }
+        ],
+    )
+
+    assert result is not None
+    assert result["decision"] == "allow"
+    assert result["document_sha256"] == digest
+
+
+def test_current_readiness_reader_returns_none_and_rejects_duplicate_grain() -> None:
+    assert (
+        read_current_operational_readiness_decision(
+            **_kwargs(),
+            row_reader=lambda **_: [],
+        )
+        is None
+    )
+
+    with pytest.raises(StorageError, match="not unique"):
+        read_current_operational_readiness_decision(
+            **_kwargs(),
+            row_reader=lambda **_: [{}, {}],
+        )
+
+
+def test_current_readiness_reader_rejects_digest_mismatch() -> None:
+    decision = _decision()
+    with pytest.raises(StorageError, match="does not match the plan"):
+        read_current_operational_readiness_decision(
+            **_kwargs(),
+            row_reader=lambda **_: [
+                {
+                    "decision_json": decision,
+                    "document_sha256": "0" * 64,
+                    "recorded_at": datetime.now(timezone.utc),
+                }
+            ],
+        )

--- a/tests/unit/test_readiness_aware_schedule_plan.py
+++ b/tests/unit/test_readiness_aware_schedule_plan.py
@@ -1,0 +1,327 @@
+from __future__ import annotations
+
+from datetime import date
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from src.analytics.market_calendar import parse_market_calendar
+from src.analytics.operational_service_levels import (
+    parse_operational_service_level_policy,
+)
+from src.analytics.portfolio_mandates import select_portfolio_mandate
+from src.common.exceptions import StorageError, ValidationError
+from src.orchestration.plan_readiness_aware_local_schedule import (
+    plan_readiness_aware_local_schedule,
+)
+from src.orchestration.run_local_portfolio_schedule import (
+    parse_local_portfolio_schedule,
+)
+from src.warehouse.operational_readiness_gate import (
+    OperationalReadinessGatePolicy,
+)
+
+
+def _schedule():
+    return parse_local_portfolio_schedule(
+        {
+            "schedules": {
+                "us-tech-local": {
+                    "enabled": False,
+                    "portfolio_id": "us-tech-equal",
+                    "policy_id": "us-tech-standard",
+                    "calendar_id": "XNYS",
+                    "maximum_catch_up_sessions": 5,
+                    "volatility_window": 20,
+                    "var_window": 60,
+                    "var_confidence": 0.95,
+                    "covariance_window": 20,
+                    "max_snapshots": 5,
+                    "max_evaluations": 100,
+                    "max_notification_events": 100,
+                }
+            }
+        },
+        "us-tech-local",
+    )
+
+
+def _calendar():
+    return parse_market_calendar(
+        {
+            "calendars": {
+                "XNYS": {
+                    "timezone": "America/New_York",
+                    "valid_from": "2026-01-01",
+                    "valid_to": "2027-01-01",
+                    "session_weekdays": [0, 1, 2, 3, 4],
+                    "regular_close_time": "16:00",
+                    "holidays": ["2026-01-01"],
+                    "early_closes": {},
+                }
+            }
+        },
+        "XNYS",
+    )
+
+
+def _mandate():
+    return select_portfolio_mandate(
+        {
+            "portfolios": {
+                "us-tech-equal": {
+                    "mandates": [
+                        {
+                            "mandate_id": "us-tech-2026",
+                            "base_currency": "USD",
+                            "effective_from": "2026-01-01",
+                            "effective_to": "2027-01-01",
+                            "constituents": [
+                                {
+                                    "source": "alpha_vantage",
+                                    "symbol": "AAPL",
+                                    "weight": 0.5,
+                                },
+                                {
+                                    "source": "alpha_vantage",
+                                    "symbol": "MSFT",
+                                    "weight": 0.5,
+                                },
+                            ],
+                        }
+                    ]
+                }
+            }
+        },
+        "us-tech-equal",
+        date(2026, 1, 9),
+    )
+
+
+def _policy(*, schedule_id: str = "us-tech-local"):
+    return parse_operational_service_level_policy(
+        {
+            "policies": {
+                "us-tech-local": {
+                    "schedule_id": schedule_id,
+                    "metrics": {
+                        "schedule_lag_sessions": {
+                            "warning": 1,
+                            "critical": 3,
+                        },
+                        "market_freshness_exception_count": {
+                            "warning": 1,
+                            "critical": 2,
+                        },
+                        "notification_retry_exhausted_count": {
+                            "warning": 1,
+                            "critical": 2,
+                        },
+                        "notification_oldest_dead_letter_age_seconds": {
+                            "warning": 900,
+                            "critical": 3600,
+                        },
+                    },
+                }
+            }
+        },
+        "us-tech-local",
+    )
+
+
+def _gate() -> OperationalReadinessGatePolicy:
+    return OperationalReadinessGatePolicy(
+        gate_id="us-tech-local",
+        operational_policy_id="us-tech-local",
+        max_report_age_seconds=3600,
+        allow_warning=False,
+    )
+
+
+def _raw_schedule_plan(
+    *,
+    sessions: list[str] | None = None,
+    run_id: str = "random-run",
+) -> dict[str, Any]:
+    schedule = _schedule()
+    calendar = _calendar()
+    selected = sessions if sessions is not None else ["2026-01-09"]
+    return {
+        "run_id": run_id,
+        "schedule_id": schedule.schedule_id,
+        "schedule_fingerprint": schedule.fingerprint,
+        "enabled": schedule.enabled,
+        "calendar": {
+            "calendar_id": calendar.calendar_id,
+            "calendar_fingerprint": calendar.fingerprint,
+        },
+        "selection": {
+            "as_of_date": "2026-01-10",
+            "checkpoint_before": None,
+            "sessions_selected": len(selected),
+            "session_dates": selected,
+        },
+        "plans": [
+            {
+                "session_date": session,
+                "mandate_id": _mandate().mandate_id,
+                "mandate_fingerprint": _mandate().fingerprint,
+                "commands": [["python", "-m", "example", session]],
+            }
+            for session in selected
+        ],
+        "execution": {
+            "requested": False,
+            "performed": False,
+            "completed_sessions": [],
+        },
+        "provider_request_performed": False,
+        "external_delivery_performed": False,
+        "cloud_schedule_activated": False,
+    }
+
+
+def _run(
+    *,
+    readiness: dict[str, Any] | None,
+    sessions: list[str] | None = None,
+    run_id: str = "random-run",
+    policy_schedule_id: str = "us-tech-local",
+) -> dict[str, Any]:
+    return plan_readiness_aware_local_schedule(
+        schedule_id="us-tech-local",
+        gate_id="us-tech-local",
+        as_of_date=date(2026, 1, 10),
+        schedule_config_path=Path("schedule.yaml"),
+        gate_config_path=Path("gate.yaml"),
+        operational_policy_config_path=Path("policy.yaml"),
+        calendar_config_path=Path("calendar.yaml"),
+        portfolio_config_path=Path("portfolio.yaml"),
+        risk_limit_config_path=Path("limits.yaml"),
+        storage_config_path=Path("storage.yaml"),
+        state_dir=Path(".scheduler"),
+        dsn="not-used",
+        python_executable="python",
+        schedule_loader=lambda *_: _schedule(),
+        gate_loader=lambda *_: _gate(),
+        operational_policy_loader=lambda *_: _policy(
+            schedule_id=policy_schedule_id
+        ),
+        calendar_loader=lambda *_: _calendar(),
+        mandate_loader=lambda *_: _mandate(),
+        readiness_reader=lambda **_: readiness,
+        schedule_planner=lambda **_: _raw_schedule_plan(
+            sessions=sessions,
+            run_id=run_id,
+        ),
+    )
+
+
+def test_allowed_readiness_produces_deterministic_would_run_plan() -> None:
+    readiness = {
+        "decision_id": "decision-1",
+        "decision": "allow",
+        "reasons": [],
+        "document_sha256": "a" * 64,
+        "recorded_at": "2026-01-10T12:00:00+00:00",
+    }
+    first = _run(readiness=readiness, run_id="random-one")
+    second = _run(readiness=readiness, run_id="random-two")
+
+    assert first["plan_id"] == second["plan_id"]
+    assert first["schedule_effect"]["decision"] == "would_run"
+    assert first["execution"]["performed"] is False
+    assert first["checkpoint_updated"] is False
+    assert "run_id" not in first["schedule_plan"]
+
+
+def test_blocked_or_missing_readiness_produces_would_block() -> None:
+    blocked = _run(
+        readiness={
+            "decision_id": "decision-blocked",
+            "decision": "block",
+            "reasons": ["report_status_critical"],
+            "document_sha256": "b" * 64,
+            "recorded_at": "2026-01-10T12:00:00+00:00",
+        }
+    )
+    missing = _run(readiness=None)
+
+    assert blocked["schedule_effect"]["decision"] == "would_block"
+    assert missing["schedule_effect"]["decision"] == "would_block"
+    assert missing["readiness"]["reasons"] == ["decision_missing"]
+
+
+def test_no_selected_sessions_is_no_work_even_when_readiness_is_missing() -> None:
+    result = _run(readiness=None, sessions=[])
+
+    assert result["schedule_effect"] == {
+        "decision": "no_work",
+        "sessions_selected": 0,
+        "session_dates": [],
+    }
+
+
+def test_policy_schedule_mismatch_fails_before_reads_or_planning() -> None:
+    calls = {"read": 0, "plan": 0}
+
+    with pytest.raises(ValidationError, match="another schedule"):
+        plan_readiness_aware_local_schedule(
+            schedule_id="us-tech-local",
+            gate_id="us-tech-local",
+            as_of_date=date(2026, 1, 10),
+            schedule_config_path=Path("schedule.yaml"),
+            gate_config_path=Path("gate.yaml"),
+            operational_policy_config_path=Path("policy.yaml"),
+            calendar_config_path=Path("calendar.yaml"),
+            portfolio_config_path=Path("portfolio.yaml"),
+            risk_limit_config_path=Path("limits.yaml"),
+            storage_config_path=Path("storage.yaml"),
+            state_dir=Path(".scheduler"),
+            dsn="not-used",
+            schedule_loader=lambda *_: _schedule(),
+            gate_loader=lambda *_: _gate(),
+            operational_policy_loader=lambda *_: _policy(schedule_id="other"),
+            calendar_loader=lambda *_: _calendar(),
+            mandate_loader=lambda *_: _mandate(),
+            readiness_reader=lambda **_: calls.__setitem__(
+                "read", calls["read"] + 1
+            ),
+            schedule_planner=lambda **_: calls.__setitem__(
+                "plan", calls["plan"] + 1
+            ),
+        )
+    assert calls == {"read": 0, "plan": 0}
+
+
+def test_schedule_planner_side_effect_evidence_fails_closed() -> None:
+    raw = _raw_schedule_plan()
+    raw["execution"] = {
+        "requested": True,
+        "performed": True,
+        "completed_sessions": ["2026-01-09"],
+    }
+
+    with pytest.raises(StorageError, match="performed execution"):
+        plan_readiness_aware_local_schedule(
+            schedule_id="us-tech-local",
+            gate_id="us-tech-local",
+            as_of_date=date(2026, 1, 10),
+            schedule_config_path=Path("schedule.yaml"),
+            gate_config_path=Path("gate.yaml"),
+            operational_policy_config_path=Path("policy.yaml"),
+            calendar_config_path=Path("calendar.yaml"),
+            portfolio_config_path=Path("portfolio.yaml"),
+            risk_limit_config_path=Path("limits.yaml"),
+            storage_config_path=Path("storage.yaml"),
+            state_dir=Path(".scheduler"),
+            dsn="not-used",
+            schedule_loader=lambda *_: _schedule(),
+            gate_loader=lambda *_: _gate(),
+            operational_policy_loader=lambda *_: _policy(),
+            calendar_loader=lambda *_: _calendar(),
+            mandate_loader=lambda *_: _mandate(),
+            readiness_reader=lambda **_: None,
+            schedule_planner=lambda **_: raw,
+        )

--- a/tests/unit/test_readiness_aware_schedule_plan_architecture_contract.py
+++ b/tests/unit/test_readiness_aware_schedule_plan_architecture_contract.py
@@ -1,0 +1,17 @@
+from pathlib import Path
+
+
+def test_readiness_aware_schedule_plan_is_documented_as_plan_only() -> None:
+    documentation = Path("docs/readiness-aware-schedule-planning.md").read_text(
+        encoding="utf-8"
+    )
+
+    for required in (
+        "would_run, would_block or no_work",
+        "decision_missing",
+        "readiness-aware-schedule-plan-v1",
+        "The command exposes no `--execute` option",
+        "checkpoint_updated = false",
+        "This increment does not grant execution authority",
+    ):
+        assert required in documentation


### PR DESCRIPTION
## Outcome

Combine the existing bounded local schedule plan with the exact retained operational readiness decision, without enabling execution:

```text
current schedule, calendar and effective mandate
  + exact current readiness decision
  + bounded local session and command plan
  -> would_run, would_block or no_work
  -> deterministic JSON evidence
```

Primary arc42 block: `orchestration`, with read-only interfaces to append-only readiness history and the existing local schedule planner.

## Exact current decision

Add `src.warehouse.operational_readiness_decision_reader`.

The reader filters on the exact gate, operational policy, schedule, calendar, portfolio, risk-limit policy, mandate and latest expected session. It joins the current view back to append-only history, strictly validates `decision_json`, recomputes the canonical SHA-256 and rejects a non-unique serving grain.

A missing exact decision remains valid plan evidence and is represented as `decision_missing`; it does not become a storage error.

## Plan-only wrapper

Add `src.orchestration.plan_readiness_aware_local_schedule`:

```bash
.venv/bin/python -m src.orchestration.plan_readiness_aware_local_schedule \
  --schedule-id us-tech-local \
  --gate-id us-tech-local \
  --as-of-date 2026-04-01 \
  --summary-json .demo/readiness-aware-schedule-plan.json
```

The command exposes no `--execute` option. It invokes the established local schedule runner only with execution disabled, strips its random run ID, validates all no-side-effect evidence and derives a deterministic plan identity.

Schedule effect:

```text
no sessions selected                       -> no_work
sessions selected + current allow decision -> would_run
sessions selected + block/missing decision -> would_block
```

Exit code 2 represents a valid `would_block` plan; invalid configuration or evidence uses exit code 1.

## Validation

GitHub Actions run `32714323359` (`ci` run 296) passed on exact head `1aed4e20e2c4f9389e2b4490d14e017456714c61`:

- Security guardrails: passed.
- Python readiness: passed.
  - locked dependencies resolved;
  - Ruff passed;
  - mypy passed across 98 source files;
  - 732 tests passed in both quality and readiness runs;
  - `pip check` passed;
  - the standard readiness replay passed.
- PostgreSQL contract: passed against PostgreSQL 16, including source-to-serving, model approval, operational SLI/SLO, readiness history and review-query contracts.
- Infrastructure validation: passed with Kubernetes rendering and Terraform format/init/validate without apply.

No unresolved review threads or requested changes are present.

## Safety

Focused tests cover strict decision/digest selection, duplicate current grains, deterministic identities despite random underlying run IDs, allowed/blocked/missing/no-work outcomes, policy/schedule mismatch before reads, and rejection of any planner result that reports execution.

Every summary records zero command execution, zero checkpoint mutation, zero provider request, zero notification delivery and zero cloud schedule activation.

## Scope

The branch is directly based on current `main`, is zero commits behind and adds six files with 1,226 lines. Connector writes produced six working commits; this PR is intended for squash merge as one plan-only integration layer.

No executable scheduler path, database mutation, override, provider request, delivery, checkpoint change, cloud activation, deployment or `terraform apply` is included.

## Acceptance boundary

Validated and ready for squash merge as the plan-only gate consumer.