### PR TITLE
Add append-only operational readiness overrides

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,6 +24,7 @@ services:
       - ./sql/operational_service_level_objectives_schema.sql:/docker-entrypoint-initdb.d/14_operational_service_level_objectives_schema.sql:ro
       - ./sql/operational_readiness_decisions_schema.sql:/docker-entrypoint-initdb.d/15_operational_readiness_decisions_schema.sql:ro
       - ./sql/operational_review_schema.sql:/docker-entrypoint-initdb.d/16_operational_review_schema.sql:ro
+      - ./sql/operational_readiness_overrides_schema.sql:/docker-entrypoint-initdb.d/17_operational_readiness_overrides_schema.sql:ro
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U risk_user -d risk_platform"]
       interval: 5s

--- a/docs/operational-readiness-overrides.md
+++ b/docs/operational-readiness-overrides.md
@@ -1,0 +1,131 @@
+# Operational Readiness Override Evidence
+
+## Outcome
+
+A blocked operational readiness decision can receive narrowly scoped,
+time-bounded and revocable human-authority evidence without changing the original
+block:
+
+```text
+retained block decision
+  -> explicit override request
+  -> exact decision and operating-contract binding
+  -> mandatory expiry of no more than 24 hours
+  -> append-only approval or revocation event
+  -> deterministic current and active override views
+```
+
+An override is evidence of reviewed authority. It is not a new readiness decision
+and does not rewrite `block` to `allow`.
+
+## Approval Command
+
+```bash
+.venv/bin/python -m src.warehouse.operational_readiness_override_registry approve \
+  --decision-id operational-readiness-gate-v1-decision-... \
+  --request-id READINESS-OVERRIDE-2026-001 \
+  --expires-at 2026-04-01T18:00:00Z \
+  --approved-by operator@example.test \
+  --reason "Reviewed for one bounded local operating window."
+```
+
+`approved_at` defaults to the current UTC time and may be supplied explicitly for
+replayable historical evidence. It cannot predate the blocked decision. Expiry is
+mandatory, must be after approval and cannot exceed 24 hours.
+
+An override binds the exact:
+
+- blocked readiness decision and document SHA-256;
+- gate and gate fingerprint;
+- operational policy and fingerprint;
+- schedule and fingerprint;
+- calendar, portfolio and risk-limit policy;
+- mandate fingerprint; and
+- latest expected market session.
+
+An `allow` decision cannot be overridden. PostgreSQL independently validates the
+target status, metadata and timestamp ordering.
+
+## Revocation Command
+
+```bash
+.venv/bin/python -m src.warehouse.operational_readiness_override_registry revoke \
+  --override-id operational-readiness-override-v1-... \
+  --request-id READINESS-OVERRIDE-REVOKE-2026-001 \
+  --revoked-by operator@example.test \
+  --reason "Override withdrawn after operational review."
+```
+
+Revocation is a separate append-only event. It cannot predate approval. A later
+override uses a new request and produces a new retained row.
+
+## Retry And Conflict Semantics
+
+Approval and revocation request IDs are idempotency keys within their event type:
+
+- an identical retry returns the retained event;
+- conflicting reuse of one request ID fails closed; and
+- no UPDATE path is exposed.
+
+PostgreSQL triggers reject direct UPDATE and DELETE against both history tables.
+
+## PostgreSQL Contract
+
+History tables:
+
+```text
+risk_platform.operational_readiness_overrides
+risk_platform.operational_readiness_override_revocations
+```
+
+Serving views:
+
+```text
+risk_platform.operational_readiness_override_history
+risk_platform.current_operational_readiness_override_status
+risk_platform.active_operational_readiness_overrides
+```
+
+The current grain is one latest override per blocked `decision_id`, ranked by:
+
+```text
+approved_at DESC
+override_id DESC
+```
+
+The current status is:
+
+- `pending` before approval time;
+- `revoked` when the latest revocation is effective;
+- `expired` at or after expiry; or
+- `active` otherwise.
+
+The runtime lookup accepts an explicit evaluation timestamp and does not rely on
+wall-clock view status when deciding whether an override is active. This allows
+repeatable enforcement tests and correct boundary behaviour at approval,
+revocation and expiry instants.
+
+## Reconciliation
+
+`sql/operational_readiness_overrides_consistency_checks.sql` verifies:
+
+- every target exists and remains a block decision;
+- all copied contract fields and document SHA-256 match the decision;
+- approvals do not predate decisions;
+- expiry windows are positive and no longer than 24 hours;
+- revocations reference overrides and do not predate approval;
+- event and request identities are unique;
+- current selection and status are correct;
+- active rows match current status; and
+- all four append-only mutation triggers exist.
+
+The live PostgreSQL contract proves exact approval/revocation retries, conflict
+rejection, rejection of an allow target, revocation, replacement override,
+explicit-time active/expired lookup and mutation rejection.
+
+## Boundary
+
+This layer records authority but does not consume it. It does not execute the
+local schedule, update a checkpoint, make a provider request, deliver a
+notification or activate a cloud schedule. Execution enforcement is the next
+separate dependency layer.

--- a/sql/operational_readiness_overrides_consistency_checks.sql
+++ b/sql/operational_readiness_overrides_consistency_checks.sql
@@ -1,0 +1,276 @@
+-- Reconciliation checks for append-only operational readiness override evidence.
+
+WITH counts AS (
+    SELECT
+        (SELECT COUNT(*)
+         FROM risk_platform.operational_readiness_overrides) AS override_rows,
+        (SELECT COUNT(*)
+         FROM risk_platform.operational_readiness_override_revocations)
+            AS revocation_rows,
+        (SELECT COUNT(*)
+         FROM risk_platform.operational_readiness_override_history)
+            AS history_rows,
+        (SELECT COUNT(*)
+         FROM risk_platform.current_operational_readiness_override_status)
+            AS current_rows,
+        (SELECT COUNT(*)
+         FROM risk_platform.active_operational_readiness_overrides)
+            AS active_rows,
+        (SELECT COUNT(*)
+         FROM risk_platform.current_operational_readiness_override_status
+         WHERE override_status = 'active') AS expected_active_rows
+),
+integrity AS (
+    SELECT
+        (
+            SELECT COUNT(*)
+            FROM risk_platform.operational_readiness_overrides override
+            LEFT JOIN risk_platform.operational_readiness_decisions decision
+                ON decision.decision_id = override.decision_id
+            WHERE decision.decision_id IS NULL
+        ) AS orphan_decisions,
+        (
+            SELECT COUNT(*)
+            FROM risk_platform.operational_readiness_overrides override
+            JOIN risk_platform.operational_readiness_decisions decision
+                ON decision.decision_id = override.decision_id
+            WHERE decision.decision <> 'block'
+               OR override.decision_document_sha256 <> decision.document_sha256
+               OR override.gate_id <> decision.gate_id
+               OR override.gate_fingerprint <> decision.gate_fingerprint
+               OR override.operational_policy_id
+                    <> decision.operational_policy_id
+               OR override.operational_policy_fingerprint
+                    <> decision.operational_policy_fingerprint
+               OR override.schedule_id <> decision.schedule_id
+               OR override.schedule_fingerprint <> decision.schedule_fingerprint
+               OR override.calendar_id <> decision.calendar_id
+               OR override.portfolio_id <> decision.portfolio_id
+               OR override.risk_limit_policy_id
+                    <> decision.risk_limit_policy_id
+               OR override.mandate_fingerprint <> decision.mandate_fingerprint
+               OR override.latest_expected_session
+                    <> decision.latest_expected_session
+               OR override.approved_at < decision.evaluated_at
+        ) AS invalid_target_contracts,
+        (
+            SELECT COUNT(*)
+            FROM risk_platform.operational_readiness_overrides override
+            WHERE override.expires_at <= override.approved_at
+               OR override.expires_at - override.approved_at
+                    > INTERVAL '24 hours'
+        ) AS invalid_override_windows,
+        (
+            SELECT COUNT(*)
+            FROM risk_platform.operational_readiness_override_revocations revocation
+            LEFT JOIN risk_platform.operational_readiness_overrides override
+                ON override.override_id = revocation.override_id
+            WHERE override.override_id IS NULL
+               OR revocation.revoked_at < override.approved_at
+        ) AS invalid_revocations,
+        (
+            SELECT COUNT(*)
+            FROM (
+                SELECT override_id
+                FROM risk_platform.operational_readiness_overrides
+                GROUP BY override_id
+                HAVING COUNT(*) > 1
+            ) duplicates
+        ) AS duplicate_override_ids,
+        (
+            SELECT COUNT(*)
+            FROM (
+                SELECT request_id
+                FROM risk_platform.operational_readiness_overrides
+                GROUP BY request_id
+                HAVING COUNT(*) > 1
+            ) duplicates
+        ) AS duplicate_override_requests,
+        (
+            SELECT COUNT(*)
+            FROM (
+                SELECT revocation_id
+                FROM risk_platform.operational_readiness_override_revocations
+                GROUP BY revocation_id
+                HAVING COUNT(*) > 1
+            ) duplicates
+        ) AS duplicate_revocation_ids,
+        (
+            SELECT COUNT(*)
+            FROM (
+                SELECT request_id
+                FROM risk_platform.operational_readiness_override_revocations
+                GROUP BY request_id
+                HAVING COUNT(*) > 1
+            ) duplicates
+        ) AS duplicate_revocation_requests,
+        (
+            SELECT COUNT(*)
+            FROM (
+                SELECT decision_id
+                FROM risk_platform.current_operational_readiness_override_status
+                GROUP BY decision_id
+                HAVING COUNT(*) > 1
+            ) duplicates
+        ) AS duplicate_current_decisions,
+        (
+            SELECT COUNT(*)
+            FROM risk_platform.current_operational_readiness_override_status current
+            WHERE EXISTS (
+                SELECT 1
+                FROM risk_platform.operational_readiness_overrides candidate
+                WHERE candidate.decision_id = current.decision_id
+                  AND (
+                        candidate.approved_at,
+                        candidate.override_id
+                  ) > (
+                        current.approved_at,
+                        current.override_id
+                  )
+            )
+        ) AS stale_current_overrides,
+        (
+            SELECT COUNT(*)
+            FROM risk_platform.current_operational_readiness_override_status current
+            WHERE current.override_status <> CASE
+                WHEN current.approved_at > CURRENT_TIMESTAMP THEN 'pending'
+                WHEN current.revoked_at IS NOT NULL
+                     AND current.revoked_at <= CURRENT_TIMESTAMP THEN 'revoked'
+                WHEN current.expires_at <= CURRENT_TIMESTAMP THEN 'expired'
+                ELSE 'active'
+            END
+        ) AS invalid_current_statuses,
+        (
+            SELECT COUNT(*)
+            FROM pg_trigger trigger
+            JOIN pg_class table_ref ON table_ref.oid = trigger.tgrelid
+            JOIN pg_namespace namespace_ref
+                ON namespace_ref.oid = table_ref.relnamespace
+            WHERE namespace_ref.nspname = 'risk_platform'
+              AND trigger.tgname IN (
+                    'prevent_operational_readiness_override_update',
+                    'prevent_operational_readiness_override_delete',
+                    'prevent_operational_readiness_override_revocation_update',
+                    'prevent_operational_readiness_override_revocation_delete'
+              )
+              AND NOT trigger.tgisinternal
+        ) AS append_only_trigger_count
+)
+SELECT
+    'operational_readiness_override_history_rows_match' AS check_name,
+    (override_rows + revocation_rows)::TEXT AS expected,
+    history_rows::TEXT AS actual,
+    CASE
+        WHEN override_rows + revocation_rows = history_rows THEN 'pass'
+        ELSE 'fail'
+    END AS status
+FROM counts
+
+UNION ALL
+
+SELECT
+    'operational_readiness_override_targets_exist',
+    '0',
+    orphan_decisions::TEXT,
+    CASE WHEN orphan_decisions = 0 THEN 'pass' ELSE 'fail' END
+FROM integrity
+
+UNION ALL
+
+SELECT
+    'operational_readiness_override_targets_blocked_exact_contract',
+    '0',
+    invalid_target_contracts::TEXT,
+    CASE WHEN invalid_target_contracts = 0 THEN 'pass' ELSE 'fail' END
+FROM integrity
+
+UNION ALL
+
+SELECT
+    'operational_readiness_override_windows_bounded',
+    '0',
+    invalid_override_windows::TEXT,
+    CASE WHEN invalid_override_windows = 0 THEN 'pass' ELSE 'fail' END
+FROM integrity
+
+UNION ALL
+
+SELECT
+    'operational_readiness_override_revocations_valid',
+    '0',
+    invalid_revocations::TEXT,
+    CASE WHEN invalid_revocations = 0 THEN 'pass' ELSE 'fail' END
+FROM integrity
+
+UNION ALL
+
+SELECT
+    'operational_readiness_override_identities_unique',
+    '0',
+    (duplicate_override_ids + duplicate_override_requests)::TEXT,
+    CASE
+        WHEN duplicate_override_ids + duplicate_override_requests = 0
+            THEN 'pass'
+        ELSE 'fail'
+    END
+FROM integrity
+
+UNION ALL
+
+SELECT
+    'operational_readiness_override_revocation_identities_unique',
+    '0',
+    (duplicate_revocation_ids + duplicate_revocation_requests)::TEXT,
+    CASE
+        WHEN duplicate_revocation_ids + duplicate_revocation_requests = 0
+            THEN 'pass'
+        ELSE 'fail'
+    END
+FROM integrity
+
+UNION ALL
+
+SELECT
+    'current_operational_readiness_override_grain_unique',
+    '0',
+    duplicate_current_decisions::TEXT,
+    CASE WHEN duplicate_current_decisions = 0 THEN 'pass' ELSE 'fail' END
+FROM integrity
+
+UNION ALL
+
+SELECT
+    'current_operational_readiness_override_selects_latest',
+    '0',
+    stale_current_overrides::TEXT,
+    CASE WHEN stale_current_overrides = 0 THEN 'pass' ELSE 'fail' END
+FROM integrity
+
+UNION ALL
+
+SELECT
+    'current_operational_readiness_override_status_reconciles',
+    '0',
+    invalid_current_statuses::TEXT,
+    CASE WHEN invalid_current_statuses = 0 THEN 'pass' ELSE 'fail' END
+FROM integrity
+
+UNION ALL
+
+SELECT
+    'active_operational_readiness_overrides_match_current_status',
+    expected_active_rows::TEXT,
+    active_rows::TEXT,
+    CASE WHEN expected_active_rows = active_rows THEN 'pass' ELSE 'fail' END
+FROM counts
+
+UNION ALL
+
+SELECT
+    'operational_readiness_override_append_only_triggers_present',
+    '4',
+    append_only_trigger_count::TEXT,
+    CASE WHEN append_only_trigger_count = 4 THEN 'pass' ELSE 'fail' END
+FROM integrity
+
+ORDER BY check_name;

--- a/sql/operational_readiness_overrides_schema.sql
+++ b/sql/operational_readiness_overrides_schema.sql
@@ -1,0 +1,308 @@
+-- Append-only, time-bounded human override evidence for blocked readiness decisions.
+-- Apply after sql/operational_readiness_decisions_schema.sql.
+
+CREATE SCHEMA IF NOT EXISTS risk_platform;
+
+CREATE TABLE IF NOT EXISTS risk_platform.operational_readiness_overrides (
+    override_id TEXT PRIMARY KEY,
+    model_version TEXT NOT NULL CHECK (
+        model_version = 'operational-readiness-override-v1'
+    ),
+    decision_id TEXT NOT NULL REFERENCES
+        risk_platform.operational_readiness_decisions (decision_id),
+    decision_document_sha256 TEXT NOT NULL,
+    gate_id TEXT NOT NULL,
+    gate_fingerprint TEXT NOT NULL,
+    operational_policy_id TEXT NOT NULL,
+    operational_policy_fingerprint TEXT NOT NULL,
+    schedule_id TEXT NOT NULL,
+    schedule_fingerprint TEXT NOT NULL,
+    calendar_id TEXT NOT NULL,
+    portfolio_id TEXT NOT NULL,
+    risk_limit_policy_id TEXT NOT NULL,
+    mandate_fingerprint TEXT NOT NULL,
+    latest_expected_session DATE NOT NULL,
+    request_id TEXT NOT NULL UNIQUE,
+    approved_at TIMESTAMPTZ NOT NULL,
+    expires_at TIMESTAMPTZ NOT NULL,
+    approved_by TEXT NOT NULL,
+    reason TEXT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    CHECK (
+        override_id ~ '^operational-readiness-override-v1-[0-9a-f]{24}$'
+    ),
+    CHECK (decision_document_sha256 ~ '^[0-9a-f]{64}$'),
+    CHECK (gate_id ~ '^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$'),
+    CHECK (gate_fingerprint <> ''),
+    CHECK (
+        operational_policy_id ~ '^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$'
+    ),
+    CHECK (operational_policy_fingerprint <> ''),
+    CHECK (schedule_id ~ '^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$'),
+    CHECK (schedule_fingerprint <> ''),
+    CHECK (calendar_id ~ '^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$'),
+    CHECK (portfolio_id ~ '^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$'),
+    CHECK (
+        risk_limit_policy_id ~ '^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$'
+    ),
+    CHECK (mandate_fingerprint <> ''),
+    CHECK (request_id <> '' AND length(request_id) <= 128),
+    CHECK (expires_at > approved_at),
+    CHECK (expires_at - approved_at <= INTERVAL '24 hours'),
+    CHECK (approved_by <> '' AND length(approved_by) <= 320),
+    CHECK (reason <> '' AND length(reason) <= 2000)
+);
+
+CREATE TABLE IF NOT EXISTS
+    risk_platform.operational_readiness_override_revocations (
+        revocation_id TEXT PRIMARY KEY,
+        model_version TEXT NOT NULL CHECK (
+            model_version = 'operational-readiness-override-revocation-v1'
+        ),
+        override_id TEXT NOT NULL REFERENCES
+            risk_platform.operational_readiness_overrides (override_id),
+        request_id TEXT NOT NULL UNIQUE,
+        revoked_at TIMESTAMPTZ NOT NULL,
+        revoked_by TEXT NOT NULL,
+        reason TEXT NOT NULL,
+        created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+        CHECK (
+            revocation_id
+                ~ '^operational-readiness-override-revocation-v1-[0-9a-f]{24}$'
+        ),
+        CHECK (request_id <> '' AND length(request_id) <= 128),
+        CHECK (revoked_by <> '' AND length(revoked_by) <= 320),
+        CHECK (reason <> '' AND length(reason) <= 2000)
+    );
+
+CREATE INDEX IF NOT EXISTS idx_operational_readiness_overrides_current
+    ON risk_platform.operational_readiness_overrides (
+        decision_id,
+        approved_at DESC,
+        override_id DESC
+    );
+
+CREATE INDEX IF NOT EXISTS idx_operational_readiness_override_revocations
+    ON risk_platform.operational_readiness_override_revocations (
+        override_id,
+        revoked_at DESC,
+        revocation_id DESC
+    );
+
+CREATE OR REPLACE FUNCTION
+    risk_platform.validate_operational_readiness_override_target()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    target risk_platform.operational_readiness_decisions%ROWTYPE;
+BEGIN
+    SELECT * INTO target
+    FROM risk_platform.operational_readiness_decisions
+    WHERE decision_id = NEW.decision_id;
+
+    IF NOT FOUND THEN
+        RAISE EXCEPTION 'readiness override target does not exist'
+            USING ERRCODE = '23503';
+    END IF;
+    IF target.decision <> 'block' THEN
+        RAISE EXCEPTION 'readiness override target must be blocked'
+            USING ERRCODE = '23514';
+    END IF;
+    IF NEW.decision_document_sha256 <> target.document_sha256
+        OR NEW.gate_id <> target.gate_id
+        OR NEW.gate_fingerprint <> target.gate_fingerprint
+        OR NEW.operational_policy_id <> target.operational_policy_id
+        OR NEW.operational_policy_fingerprint
+            <> target.operational_policy_fingerprint
+        OR NEW.schedule_id <> target.schedule_id
+        OR NEW.schedule_fingerprint <> target.schedule_fingerprint
+        OR NEW.calendar_id <> target.calendar_id
+        OR NEW.portfolio_id <> target.portfolio_id
+        OR NEW.risk_limit_policy_id <> target.risk_limit_policy_id
+        OR NEW.mandate_fingerprint <> target.mandate_fingerprint
+        OR NEW.latest_expected_session <> target.latest_expected_session
+    THEN
+        RAISE EXCEPTION 'readiness override metadata does not match target'
+            USING ERRCODE = '23514';
+    END IF;
+    IF NEW.approved_at < target.evaluated_at THEN
+        RAISE EXCEPTION 'readiness override predates target decision'
+            USING ERRCODE = '23514';
+    END IF;
+    RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS validate_operational_readiness_override_target
+    ON risk_platform.operational_readiness_overrides;
+CREATE TRIGGER validate_operational_readiness_override_target
+BEFORE INSERT ON risk_platform.operational_readiness_overrides
+FOR EACH ROW
+EXECUTE FUNCTION risk_platform.validate_operational_readiness_override_target();
+
+CREATE OR REPLACE FUNCTION
+    risk_platform.validate_operational_readiness_override_revocation()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    target_approved_at TIMESTAMPTZ;
+BEGIN
+    SELECT approved_at INTO target_approved_at
+    FROM risk_platform.operational_readiness_overrides
+    WHERE override_id = NEW.override_id;
+
+    IF NOT FOUND THEN
+        RAISE EXCEPTION 'readiness override revocation target does not exist'
+            USING ERRCODE = '23503';
+    END IF;
+    IF NEW.revoked_at < target_approved_at THEN
+        RAISE EXCEPTION 'readiness override revocation predates approval'
+            USING ERRCODE = '23514';
+    END IF;
+    RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS validate_operational_readiness_override_revocation
+    ON risk_platform.operational_readiness_override_revocations;
+CREATE TRIGGER validate_operational_readiness_override_revocation
+BEFORE INSERT ON risk_platform.operational_readiness_override_revocations
+FOR EACH ROW
+EXECUTE FUNCTION
+    risk_platform.validate_operational_readiness_override_revocation();
+
+CREATE OR REPLACE FUNCTION
+    risk_platform.prevent_operational_readiness_override_mutation()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    RAISE EXCEPTION 'operational readiness override evidence is append-only'
+        USING ERRCODE = '55000';
+END;
+$$;
+
+DROP TRIGGER IF EXISTS prevent_operational_readiness_override_update
+    ON risk_platform.operational_readiness_overrides;
+CREATE TRIGGER prevent_operational_readiness_override_update
+BEFORE UPDATE ON risk_platform.operational_readiness_overrides
+FOR EACH ROW
+EXECUTE FUNCTION risk_platform.prevent_operational_readiness_override_mutation();
+
+DROP TRIGGER IF EXISTS prevent_operational_readiness_override_delete
+    ON risk_platform.operational_readiness_overrides;
+CREATE TRIGGER prevent_operational_readiness_override_delete
+BEFORE DELETE ON risk_platform.operational_readiness_overrides
+FOR EACH ROW
+EXECUTE FUNCTION risk_platform.prevent_operational_readiness_override_mutation();
+
+DROP TRIGGER IF EXISTS prevent_operational_readiness_override_revocation_update
+    ON risk_platform.operational_readiness_override_revocations;
+CREATE TRIGGER prevent_operational_readiness_override_revocation_update
+BEFORE UPDATE ON risk_platform.operational_readiness_override_revocations
+FOR EACH ROW
+EXECUTE FUNCTION risk_platform.prevent_operational_readiness_override_mutation();
+
+DROP TRIGGER IF EXISTS prevent_operational_readiness_override_revocation_delete
+    ON risk_platform.operational_readiness_override_revocations;
+CREATE TRIGGER prevent_operational_readiness_override_revocation_delete
+BEFORE DELETE ON risk_platform.operational_readiness_override_revocations
+FOR EACH ROW
+EXECUTE FUNCTION risk_platform.prevent_operational_readiness_override_mutation();
+
+CREATE OR REPLACE VIEW risk_platform.operational_readiness_override_history AS
+SELECT
+    override.override_id AS event_id,
+    override.model_version,
+    'approved'::TEXT AS event_type,
+    override.decision_id,
+    override.override_id,
+    override.request_id,
+    override.approved_at AS event_at,
+    override.approved_by AS actor,
+    override.reason,
+    override.expires_at,
+    override.created_at
+FROM risk_platform.operational_readiness_overrides override
+
+UNION ALL
+
+SELECT
+    revocation.revocation_id,
+    revocation.model_version,
+    'revoked',
+    override.decision_id,
+    revocation.override_id,
+    revocation.request_id,
+    revocation.revoked_at,
+    revocation.revoked_by,
+    revocation.reason,
+    override.expires_at,
+    revocation.created_at
+FROM risk_platform.operational_readiness_override_revocations revocation
+JOIN risk_platform.operational_readiness_overrides override
+    ON override.override_id = revocation.override_id;
+
+CREATE OR REPLACE VIEW
+    risk_platform.current_operational_readiness_override_status AS
+SELECT
+    override.override_id,
+    override.model_version,
+    override.decision_id,
+    override.decision_document_sha256,
+    override.gate_id,
+    override.gate_fingerprint,
+    override.operational_policy_id,
+    override.operational_policy_fingerprint,
+    override.schedule_id,
+    override.schedule_fingerprint,
+    override.calendar_id,
+    override.portfolio_id,
+    override.risk_limit_policy_id,
+    override.mandate_fingerprint,
+    override.latest_expected_session,
+    override.request_id,
+    override.approved_at,
+    override.expires_at,
+    override.approved_by,
+    override.reason,
+    revocation.revocation_id,
+    revocation.request_id AS revocation_request_id,
+    revocation.revoked_at,
+    revocation.revoked_by,
+    CASE
+        WHEN override.approved_at > CURRENT_TIMESTAMP THEN 'pending'
+        WHEN revocation.revoked_at IS NOT NULL
+             AND revocation.revoked_at <= CURRENT_TIMESTAMP THEN 'revoked'
+        WHEN override.expires_at <= CURRENT_TIMESTAMP THEN 'expired'
+        ELSE 'active'
+    END AS override_status,
+    override.created_at
+FROM (
+    SELECT ranked.*
+    FROM (
+        SELECT
+            candidate.*,
+            ROW_NUMBER() OVER (
+                PARTITION BY candidate.decision_id
+                ORDER BY candidate.approved_at DESC, candidate.override_id DESC
+            ) AS override_rank
+        FROM risk_platform.operational_readiness_overrides candidate
+    ) ranked
+    WHERE ranked.override_rank = 1
+) override
+LEFT JOIN LATERAL (
+    SELECT candidate.*
+    FROM risk_platform.operational_readiness_override_revocations candidate
+    WHERE candidate.override_id = override.override_id
+    ORDER BY candidate.revoked_at DESC, candidate.revocation_id DESC
+    LIMIT 1
+) revocation ON TRUE;
+
+CREATE OR REPLACE VIEW
+    risk_platform.active_operational_readiness_overrides AS
+SELECT *
+FROM risk_platform.current_operational_readiness_override_status
+WHERE override_status = 'active';

--- a/src/warehouse/operational_readiness_decision_contract_check.py
+++ b/src/warehouse/operational_readiness_decision_contract_check.py
@@ -13,6 +13,9 @@ from src.warehouse.operational_readiness_gate import (
     OperationalReadinessGatePolicy,
     evaluate_operational_readiness,
 )
+from src.warehouse.operational_readiness_override_contract_check import (
+    run_contract_check as run_override_contract_check,
+)
 from src.warehouse.postgres_consistency import run_consistency_checks
 
 
@@ -235,6 +238,12 @@ def run_contract_check(
         names = ", ".join(result.check_name for result in review_failures)
         raise AssertionError("operational review reconciliation failed: " + names)
 
+    override_result = run_override_contract_check(
+        dsn=dsn,
+        blocked_decision_id=str(second_decision["decision_id"]),
+        allowed_decision_id=str(first_decision["decision_id"]),
+    )
+
     return {
         "first_decision_id": first_decision["decision_id"],
         "second_decision_id": second_decision["decision_id"],
@@ -247,4 +256,5 @@ def run_contract_check(
         "operational_review_health_status": "blocked",
         "operational_review_exception_rows": 3,
         "operational_review_consistency_checks": len(review_consistency),
+        "override_contract": override_result,
     }

--- a/src/warehouse/operational_readiness_override_contract.py
+++ b/src/warehouse/operational_readiness_override_contract.py
@@ -1,0 +1,263 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+from src.common.exceptions import ValidationError
+
+OVERRIDE_MODEL_VERSION = "operational-readiness-override-v1"
+REVOCATION_MODEL_VERSION = "operational-readiness-override-revocation-v1"
+MAX_OVERRIDE_DURATION_SECONDS = 86_400
+MAX_REASON_LENGTH = 2_000
+MAX_ACTOR_LENGTH = 320
+MAX_REQUEST_ID_LENGTH = 128
+DECISION_ID_PATTERN = re.compile(
+    r"^operational-readiness-gate-v1-decision-[0-9a-f]{24}$"
+)
+OVERRIDE_ID_PATTERN = re.compile(
+    r"^operational-readiness-override-v1-[0-9a-f]{24}$"
+)
+SAFE_SEGMENT_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$")
+
+
+@dataclass(frozen=True, slots=True)
+class OperationalReadinessOverride:
+    override_id: str
+    model_version: str
+    decision_id: str
+    decision_document_sha256: str
+    gate_id: str
+    gate_fingerprint: str
+    operational_policy_id: str
+    operational_policy_fingerprint: str
+    schedule_id: str
+    schedule_fingerprint: str
+    calendar_id: str
+    portfolio_id: str
+    risk_limit_policy_id: str
+    mandate_fingerprint: str
+    latest_expected_session: str
+    request_id: str
+    approved_at: datetime
+    expires_at: datetime
+    approved_by: str
+    reason: str
+
+
+@dataclass(frozen=True, slots=True)
+class OperationalReadinessOverrideRevocation:
+    revocation_id: str
+    model_version: str
+    override_id: str
+    request_id: str
+    revoked_at: datetime
+    revoked_by: str
+    reason: str
+
+
+def aware_utc(value: datetime | str, label: str) -> datetime:
+    if isinstance(value, datetime):
+        parsed = value
+    elif isinstance(value, str):
+        try:
+            parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        except ValueError:
+            raise ValidationError(f"{label} must be ISO-8601") from None
+    else:
+        raise ValidationError(f"{label} must be a timezone-aware timestamp")
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise ValidationError(f"{label} must be a timezone-aware timestamp")
+    return parsed.astimezone(timezone.utc)
+
+
+def safe_segment(value: Any, label: str) -> str:
+    if not isinstance(value, str) or not SAFE_SEGMENT_PATTERN.fullmatch(value):
+        raise ValidationError(f"{label} must be one safe text segment")
+    return value
+
+
+def bounded_text(value: Any, label: str, maximum: int) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ValidationError(f"{label} must be non-empty text")
+    parsed = value.strip()
+    if len(parsed) > maximum or any(ord(character) < 32 for character in parsed):
+        raise ValidationError(f"{label} must be bounded printable text")
+    return parsed
+
+
+def request_id(value: Any) -> str:
+    return bounded_text(value, "request_id", MAX_REQUEST_ID_LENGTH)
+
+
+def _bounded_fingerprint(value: Any, label: str) -> str:
+    if not isinstance(value, str) or not value or len(value) > 256:
+        raise ValidationError(f"{label} must be non-empty bounded text")
+    if value != value.strip() or any(ord(character) < 32 for character in value):
+        raise ValidationError(f"{label} must be canonical bounded text")
+    return value
+
+
+def _decision_text(decision: dict[str, Any], key: str) -> str:
+    value = decision.get(key)
+    if key in {
+        "gate_id",
+        "operational_policy_id",
+        "schedule_id",
+        "calendar_id",
+        "portfolio_id",
+        "risk_limit_policy_id",
+    }:
+        return safe_segment(value, key)
+    return _bounded_fingerprint(value, key)
+
+
+def build_operational_readiness_override(
+    *,
+    decision: dict[str, Any],
+    decision_document_sha256: str,
+    request_identifier: str,
+    approved_at: datetime | str,
+    expires_at: datetime | str,
+    approved_by: str,
+    reason: str,
+) -> OperationalReadinessOverride:
+    decision_id = decision.get("decision_id")
+    if not isinstance(decision_id, str) or not DECISION_ID_PATTERN.fullmatch(
+        decision_id
+    ):
+        raise ValidationError("decision_id is incompatible")
+    if decision.get("decision") != "block":
+        raise ValidationError("operational readiness overrides require a block decision")
+    if not isinstance(decision_document_sha256, str) or not re.fullmatch(
+        r"[0-9a-f]{64}", decision_document_sha256
+    ):
+        raise ValidationError("decision_document_sha256 is incompatible")
+
+    decision_evaluated_at = aware_utc(
+        decision.get("evaluated_at"),
+        "decision.evaluated_at",
+    )
+    approval_time = aware_utc(approved_at, "approved_at")
+    expiry_time = aware_utc(expires_at, "expires_at")
+    if approval_time < decision_evaluated_at:
+        raise ValidationError("approved_at must not predate the blocked decision")
+    if expiry_time <= approval_time:
+        raise ValidationError("expires_at must be after approved_at")
+    if expiry_time - approval_time > timedelta(
+        seconds=MAX_OVERRIDE_DURATION_SECONDS
+    ):
+        raise ValidationError(
+            "override duration exceeds the maximum supported duration"
+        )
+
+    canonical_request_id = request_id(request_identifier)
+    canonical_actor = bounded_text(approved_by, "approved_by", MAX_ACTOR_LENGTH)
+    canonical_reason = bounded_text(reason, "reason", MAX_REASON_LENGTH)
+    fields = {
+        "decision_id": decision_id,
+        "decision_document_sha256": decision_document_sha256,
+        "gate_id": _decision_text(decision, "gate_id"),
+        "gate_fingerprint": _decision_text(decision, "gate_fingerprint"),
+        "operational_policy_id": _decision_text(
+            decision,
+            "operational_policy_id",
+        ),
+        "operational_policy_fingerprint": _decision_text(
+            decision,
+            "operational_policy_fingerprint",
+        ),
+        "schedule_id": _decision_text(decision, "schedule_id"),
+        "schedule_fingerprint": _decision_text(
+            decision,
+            "schedule_fingerprint",
+        ),
+        "calendar_id": _decision_text(decision, "calendar_id"),
+        "portfolio_id": _decision_text(decision, "portfolio_id"),
+        "risk_limit_policy_id": _decision_text(
+            decision,
+            "risk_limit_policy_id",
+        ),
+        "mandate_fingerprint": _decision_text(
+            decision,
+            "mandate_fingerprint",
+        ),
+        "latest_expected_session": safe_segment(
+            decision.get("latest_expected_session"),
+            "latest_expected_session",
+        ),
+        "request_id": canonical_request_id,
+        "approved_at": approval_time.isoformat(),
+        "expires_at": expiry_time.isoformat(),
+        "approved_by": canonical_actor,
+        "reason": canonical_reason,
+        "model_version": OVERRIDE_MODEL_VERSION,
+    }
+    digest = hashlib.sha256(
+        json.dumps(fields, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    ).hexdigest()[:24]
+    return OperationalReadinessOverride(
+        override_id=f"{OVERRIDE_MODEL_VERSION}-{digest}",
+        model_version=OVERRIDE_MODEL_VERSION,
+        decision_id=decision_id,
+        decision_document_sha256=decision_document_sha256,
+        gate_id=fields["gate_id"],
+        gate_fingerprint=fields["gate_fingerprint"],
+        operational_policy_id=fields["operational_policy_id"],
+        operational_policy_fingerprint=fields[
+            "operational_policy_fingerprint"
+        ],
+        schedule_id=fields["schedule_id"],
+        schedule_fingerprint=fields["schedule_fingerprint"],
+        calendar_id=fields["calendar_id"],
+        portfolio_id=fields["portfolio_id"],
+        risk_limit_policy_id=fields["risk_limit_policy_id"],
+        mandate_fingerprint=fields["mandate_fingerprint"],
+        latest_expected_session=fields["latest_expected_session"],
+        request_id=canonical_request_id,
+        approved_at=approval_time,
+        expires_at=expiry_time,
+        approved_by=canonical_actor,
+        reason=canonical_reason,
+    )
+
+
+def build_operational_readiness_override_revocation(
+    *,
+    override: OperationalReadinessOverride,
+    request_identifier: str,
+    revoked_at: datetime | str,
+    revoked_by: str,
+    reason: str,
+) -> OperationalReadinessOverrideRevocation:
+    if not OVERRIDE_ID_PATTERN.fullmatch(override.override_id):
+        raise ValidationError("override_id is incompatible")
+    revocation_time = aware_utc(revoked_at, "revoked_at")
+    if revocation_time < override.approved_at:
+        raise ValidationError("revoked_at must not predate the override")
+    canonical_request_id = request_id(request_identifier)
+    canonical_actor = bounded_text(revoked_by, "revoked_by", MAX_ACTOR_LENGTH)
+    canonical_reason = bounded_text(reason, "reason", MAX_REASON_LENGTH)
+    payload = {
+        "model_version": REVOCATION_MODEL_VERSION,
+        "override_id": override.override_id,
+        "request_id": canonical_request_id,
+        "revoked_at": revocation_time.isoformat(),
+        "revoked_by": canonical_actor,
+        "reason": canonical_reason,
+    }
+    digest = hashlib.sha256(
+        json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    ).hexdigest()[:24]
+    return OperationalReadinessOverrideRevocation(
+        revocation_id=f"{REVOCATION_MODEL_VERSION}-{digest}",
+        model_version=REVOCATION_MODEL_VERSION,
+        override_id=override.override_id,
+        request_id=canonical_request_id,
+        revoked_at=revocation_time,
+        revoked_by=canonical_actor,
+        reason=canonical_reason,
+    )

--- a/src/warehouse/operational_readiness_override_contract.py
+++ b/src/warehouse/operational_readiness_override_contract.py
@@ -137,8 +137,13 @@ def build_operational_readiness_override(
     ):
         raise ValidationError("decision_document_sha256 is incompatible")
 
+    raw_decision_evaluated_at = decision.get("evaluated_at")
+    if not isinstance(raw_decision_evaluated_at, (datetime, str)):
+        raise ValidationError(
+            "decision.evaluated_at must be a timezone-aware timestamp"
+        )
     decision_evaluated_at = aware_utc(
-        decision.get("evaluated_at"),
+        raw_decision_evaluated_at,
         "decision.evaluated_at",
     )
     approval_time = aware_utc(approved_at, "approved_at")

--- a/src/warehouse/operational_readiness_override_contract_check.py
+++ b/src/warehouse/operational_readiness_override_contract_check.py
@@ -1,0 +1,218 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+from src.common.exceptions import ValidationError
+from src.warehouse.operational_readiness_override_registry import (
+    approve_operational_readiness_override,
+    read_active_operational_readiness_override,
+    revoke_operational_readiness_override,
+)
+from src.warehouse.postgres_consistency import run_consistency_checks
+
+
+def run_contract_check(
+    *,
+    dsn: str,
+    blocked_decision_id: str,
+    allowed_decision_id: str,
+) -> dict[str, Any]:
+    now = datetime.now(timezone.utc)
+    first_approved_at = now - timedelta(minutes=5)
+    first_expires_at = now + timedelta(minutes=30)
+    first = approve_operational_readiness_override(
+        dsn=dsn,
+        decision_id=blocked_decision_id,
+        request_identifier="READINESS-OVERRIDE-001",
+        approved_at=first_approved_at,
+        expires_at=first_expires_at,
+        approved_by="operator@example.test",
+        reason="Reviewed local execution exception.",
+    )
+    replay = approve_operational_readiness_override(
+        dsn=dsn,
+        decision_id=blocked_decision_id,
+        request_identifier="READINESS-OVERRIDE-001",
+        approved_at=first_approved_at,
+        expires_at=first_expires_at,
+        approved_by="operator@example.test",
+        reason="Reviewed local execution exception.",
+    )
+    if first["created"] is not True or replay["created"] is not False:
+        raise AssertionError("readiness override retry did not converge")
+
+    try:
+        approve_operational_readiness_override(
+            dsn=dsn,
+            decision_id=blocked_decision_id,
+            request_identifier="READINESS-OVERRIDE-001",
+            approved_at=first_approved_at,
+            expires_at=first_expires_at + timedelta(minutes=1),
+            approved_by="operator@example.test",
+            reason="Reviewed local execution exception.",
+        )
+    except ValidationError:
+        pass
+    else:
+        raise AssertionError("conflicting override request was accepted")
+
+    try:
+        approve_operational_readiness_override(
+            dsn=dsn,
+            decision_id=allowed_decision_id,
+            request_identifier="READINESS-OVERRIDE-ALLOW",
+            approved_at=first_approved_at,
+            expires_at=first_expires_at,
+            approved_by="operator@example.test",
+            reason="An allow decision must not accept override evidence.",
+        )
+    except ValidationError:
+        pass
+    else:
+        raise AssertionError("allow decision accepted override evidence")
+
+    revoked_at = now - timedelta(minutes=3)
+    revocation = revoke_operational_readiness_override(
+        dsn=dsn,
+        override_id=str(first["override_id"]),
+        request_identifier="READINESS-OVERRIDE-REVOKE-001",
+        revoked_at=revoked_at,
+        revoked_by="operator@example.test",
+        reason="First override withdrawn after review.",
+    )
+    revocation_replay = revoke_operational_readiness_override(
+        dsn=dsn,
+        override_id=str(first["override_id"]),
+        request_identifier="READINESS-OVERRIDE-REVOKE-001",
+        revoked_at=revoked_at,
+        revoked_by="operator@example.test",
+        reason="First override withdrawn after review.",
+    )
+    if (
+        revocation["created"] is not True
+        or revocation_replay["created"] is not False
+    ):
+        raise AssertionError("readiness override revocation retry did not converge")
+
+    second = approve_operational_readiness_override(
+        dsn=dsn,
+        decision_id=blocked_decision_id,
+        request_identifier="READINESS-OVERRIDE-002",
+        approved_at=now - timedelta(minutes=2),
+        expires_at=now + timedelta(minutes=45),
+        approved_by="operator@example.test",
+        reason="Replacement override approved for one bounded local window.",
+    )
+    active = read_active_operational_readiness_override(
+        dsn=dsn,
+        decision_id=blocked_decision_id,
+        evaluated_at=now,
+    )
+    if active is None or active["override_id"] != second["override_id"]:
+        raise AssertionError("current active readiness override was not selected")
+    if (
+        read_active_operational_readiness_override(
+            dsn=dsn,
+            decision_id=blocked_decision_id,
+            evaluated_at=now + timedelta(hours=1),
+        )
+        is not None
+    ):
+        raise AssertionError("expired readiness override remained active")
+
+    try:
+        import psycopg
+    except ImportError as exc:  # pragma: no cover - dependency is required in CI.
+        raise RuntimeError("Readiness override contract requires psycopg") from exc
+
+    with psycopg.connect(dsn) as connection:
+        with connection.cursor() as cursor:
+            cursor.execute(
+                """
+                SELECT
+                    (SELECT COUNT(*)
+                     FROM risk_platform.operational_readiness_overrides),
+                    (SELECT COUNT(*)
+                     FROM risk_platform.operational_readiness_override_revocations),
+                    (SELECT COUNT(*)
+                     FROM risk_platform.operational_readiness_override_history),
+                    (SELECT COUNT(*)
+                     FROM risk_platform.current_operational_readiness_override_status),
+                    (SELECT COUNT(*)
+                     FROM risk_platform.active_operational_readiness_overrides),
+                    (SELECT override_id
+                     FROM risk_platform.active_operational_readiness_overrides)
+                """
+            )
+            counts = cursor.fetchone()
+            if counts != (2, 1, 3, 1, 1, second["override_id"]):
+                raise AssertionError(
+                    f"readiness override serving views are incompatible: {counts!r}"
+                )
+
+    mutation_statements = (
+        (
+            """
+            UPDATE risk_platform.operational_readiness_overrides
+            SET created_at = created_at
+            WHERE override_id = %s
+            """,
+            first["override_id"],
+        ),
+        (
+            """
+            DELETE FROM risk_platform.operational_readiness_overrides
+            WHERE override_id = %s
+            """,
+            first["override_id"],
+        ),
+        (
+            """
+            UPDATE risk_platform.operational_readiness_override_revocations
+            SET created_at = created_at
+            WHERE revocation_id = %s
+            """,
+            revocation["revocation_id"],
+        ),
+        (
+            """
+            DELETE FROM risk_platform.operational_readiness_override_revocations
+            WHERE revocation_id = %s
+            """,
+            revocation["revocation_id"],
+        ),
+    )
+    for statement, identifier in mutation_statements:
+        with psycopg.connect(dsn) as connection:
+            try:
+                with connection.cursor() as cursor:
+                    cursor.execute(statement, (identifier,))
+            except psycopg.Error:
+                connection.rollback()
+            else:
+                raise AssertionError("readiness override mutation was not blocked")
+
+    consistency = run_consistency_checks(
+        dsn=dsn,
+        check_paths=(
+            Path("sql/operational_readiness_overrides_consistency_checks.sql"),
+        ),
+    )
+    failures = [result for result in consistency if result.status != "pass"]
+    if failures:
+        names = ", ".join(result.check_name for result in failures)
+        raise AssertionError("readiness override reconciliation failed: " + names)
+
+    return {
+        "override_rows": 2,
+        "revocation_rows": 1,
+        "active_override_id": second["override_id"],
+        "retry_verified": True,
+        "conflict_verified": True,
+        "allow_target_rejected": True,
+        "expiry_verified": True,
+        "append_only_verified": True,
+        "consistency_checks": len(consistency),
+    }

--- a/src/warehouse/operational_readiness_override_registry.py
+++ b/src/warehouse/operational_readiness_override_registry.py
@@ -1,0 +1,682 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from collections.abc import Callable, Mapping, Sequence
+from datetime import date, datetime, timezone
+from typing import Any
+
+from src.common.exceptions import StorageError, ValidationError
+from src.warehouse.operational_readiness_decision_recorder import (
+    validate_operational_readiness_decision,
+)
+from src.warehouse.operational_readiness_override_contract import (
+    OperationalReadinessOverride,
+    OperationalReadinessOverrideRevocation,
+    aware_utc,
+    bounded_text,
+    build_operational_readiness_override,
+    build_operational_readiness_override_revocation,
+    request_id,
+)
+from src.warehouse.postgres_loader import DEFAULT_POSTGRES_DSN
+
+CurrentOverrideRowReader = Callable[..., list[Mapping[str, Any]]]
+
+OVERRIDE_COLUMNS = """
+    override_id,
+    model_version,
+    decision_id,
+    decision_document_sha256,
+    gate_id,
+    gate_fingerprint,
+    operational_policy_id,
+    operational_policy_fingerprint,
+    schedule_id,
+    schedule_fingerprint,
+    calendar_id,
+    portfolio_id,
+    risk_limit_policy_id,
+    mandate_fingerprint,
+    latest_expected_session,
+    request_id,
+    approved_at,
+    expires_at,
+    approved_by,
+    reason
+"""
+REVOCATION_COLUMNS = """
+    revocation_id,
+    model_version,
+    override_id,
+    request_id,
+    revoked_at,
+    revoked_by,
+    reason
+"""
+
+
+def _optional_timestamp(value: datetime | str | None, label: str) -> datetime | None:
+    return None if value is None else aware_utc(value, label)
+
+
+def _override_from_row(row: tuple[Any, ...]) -> OperationalReadinessOverride:
+    latest_session = row[14]
+    approved_at = row[16]
+    expires_at = row[17]
+    if not isinstance(latest_session, date) or isinstance(latest_session, datetime):
+        raise StorageError("Stored readiness override session is incompatible")
+    if not isinstance(approved_at, datetime) or not isinstance(expires_at, datetime):
+        raise StorageError("Stored readiness override timestamps are incompatible")
+    return OperationalReadinessOverride(
+        override_id=str(row[0]),
+        model_version=str(row[1]),
+        decision_id=str(row[2]),
+        decision_document_sha256=str(row[3]),
+        gate_id=str(row[4]),
+        gate_fingerprint=str(row[5]),
+        operational_policy_id=str(row[6]),
+        operational_policy_fingerprint=str(row[7]),
+        schedule_id=str(row[8]),
+        schedule_fingerprint=str(row[9]),
+        calendar_id=str(row[10]),
+        portfolio_id=str(row[11]),
+        risk_limit_policy_id=str(row[12]),
+        mandate_fingerprint=str(row[13]),
+        latest_expected_session=latest_session.isoformat(),
+        request_id=str(row[15]),
+        approved_at=approved_at.astimezone(timezone.utc),
+        expires_at=expires_at.astimezone(timezone.utc),
+        approved_by=str(row[18]),
+        reason=str(row[19]),
+    )
+
+
+def _revocation_from_row(
+    row: tuple[Any, ...],
+) -> OperationalReadinessOverrideRevocation:
+    revoked_at = row[4]
+    if not isinstance(revoked_at, datetime):
+        raise StorageError("Stored readiness override revocation is incompatible")
+    return OperationalReadinessOverrideRevocation(
+        revocation_id=str(row[0]),
+        model_version=str(row[1]),
+        override_id=str(row[2]),
+        request_id=str(row[3]),
+        revoked_at=revoked_at.astimezone(timezone.utc),
+        revoked_by=str(row[5]),
+        reason=str(row[6]),
+    )
+
+
+def _override_signature(value: OperationalReadinessOverride) -> tuple[Any, ...]:
+    return (
+        value.model_version,
+        value.decision_id,
+        value.decision_document_sha256,
+        value.gate_id,
+        value.gate_fingerprint,
+        value.operational_policy_id,
+        value.operational_policy_fingerprint,
+        value.schedule_id,
+        value.schedule_fingerprint,
+        value.calendar_id,
+        value.portfolio_id,
+        value.risk_limit_policy_id,
+        value.mandate_fingerprint,
+        value.latest_expected_session,
+        value.request_id,
+        value.approved_at,
+        value.expires_at,
+        value.approved_by,
+        value.reason,
+    )
+
+
+def _revocation_signature(
+    value: OperationalReadinessOverrideRevocation,
+) -> tuple[Any, ...]:
+    return (
+        value.model_version,
+        value.override_id,
+        value.request_id,
+        value.revoked_at,
+        value.revoked_by,
+        value.reason,
+    )
+
+
+def _override_summary(
+    value: OperationalReadinessOverride,
+    *,
+    created: bool,
+) -> dict[str, Any]:
+    return {
+        "override_id": value.override_id,
+        "model_version": value.model_version,
+        "decision_id": value.decision_id,
+        "decision_document_sha256": value.decision_document_sha256,
+        "gate_id": value.gate_id,
+        "schedule_id": value.schedule_id,
+        "schedule_fingerprint": value.schedule_fingerprint,
+        "portfolio_id": value.portfolio_id,
+        "mandate_fingerprint": value.mandate_fingerprint,
+        "latest_expected_session": value.latest_expected_session,
+        "request_id": value.request_id,
+        "approved_at": value.approved_at.isoformat(),
+        "expires_at": value.expires_at.isoformat(),
+        "approved_by": value.approved_by,
+        "created": created,
+    }
+
+
+def _revocation_summary(
+    value: OperationalReadinessOverrideRevocation,
+    *,
+    created: bool,
+) -> dict[str, Any]:
+    return {
+        "revocation_id": value.revocation_id,
+        "model_version": value.model_version,
+        "override_id": value.override_id,
+        "request_id": value.request_id,
+        "revoked_at": value.revoked_at.isoformat(),
+        "revoked_by": value.revoked_by,
+        "created": created,
+    }
+
+
+def approve_operational_readiness_override(
+    *,
+    dsn: str,
+    decision_id: str,
+    request_identifier: str,
+    expires_at: datetime | str,
+    approved_by: str,
+    reason: str,
+    approved_at: datetime | str | None = None,
+) -> dict[str, Any]:
+    canonical_request_id = request_id(request_identifier)
+    canonical_actor = bounded_text(approved_by, "approved_by", 320)
+    canonical_reason = bounded_text(reason, "reason", 2_000)
+    supplied_approved_at = _optional_timestamp(approved_at, "approved_at")
+    canonical_expires_at = aware_utc(expires_at, "expires_at")
+
+    try:
+        import psycopg
+    except ImportError as exc:  # pragma: no cover - dependency is required in CI.
+        raise RuntimeError("Operational readiness override requires psycopg") from exc
+
+    stored: OperationalReadinessOverride | None = None
+    created = False
+    try:
+        with psycopg.connect(dsn) as connection:
+            with connection.cursor() as cursor:
+                cursor.execute(
+                    """
+                    SELECT decision_json, document_sha256
+                    FROM risk_platform.operational_readiness_decisions
+                    WHERE decision_id = %s
+                    """,
+                    (decision_id,),
+                )
+                decision_row = cursor.fetchone()
+                if decision_row is None:
+                    raise ValidationError(
+                        "decision_id does not identify retained readiness evidence"
+                    )
+                decision_json = decision_row[0]
+                if not isinstance(decision_json, Mapping):
+                    raise StorageError("Stored readiness decision is incompatible")
+                decision = validate_operational_readiness_decision(decision_json)
+                document_sha256 = str(decision_row[1])
+
+                cursor.execute(
+                    f"""
+                    SELECT {OVERRIDE_COLUMNS}
+                    FROM risk_platform.operational_readiness_overrides
+                    WHERE request_id = %s
+                    """,
+                    (canonical_request_id,),
+                )
+                existing_row = cursor.fetchone()
+                if existing_row is not None:
+                    stored = _override_from_row(existing_row)
+                    expected = build_operational_readiness_override(
+                        decision=decision,
+                        decision_document_sha256=document_sha256,
+                        request_identifier=canonical_request_id,
+                        approved_at=supplied_approved_at or stored.approved_at,
+                        expires_at=canonical_expires_at,
+                        approved_by=canonical_actor,
+                        reason=canonical_reason,
+                    )
+                    if _override_signature(stored) != _override_signature(expected):
+                        raise ValidationError(
+                            "request_id already exists with different override content"
+                        )
+                    return _override_summary(stored, created=False)
+
+                approval_time = supplied_approved_at or datetime.now(timezone.utc)
+                override = build_operational_readiness_override(
+                    decision=decision,
+                    decision_document_sha256=document_sha256,
+                    request_identifier=canonical_request_id,
+                    approved_at=approval_time,
+                    expires_at=canonical_expires_at,
+                    approved_by=canonical_actor,
+                    reason=canonical_reason,
+                )
+                cursor.execute(
+                    """
+                    INSERT INTO risk_platform.operational_readiness_overrides (
+                        override_id,
+                        model_version,
+                        decision_id,
+                        decision_document_sha256,
+                        gate_id,
+                        gate_fingerprint,
+                        operational_policy_id,
+                        operational_policy_fingerprint,
+                        schedule_id,
+                        schedule_fingerprint,
+                        calendar_id,
+                        portfolio_id,
+                        risk_limit_policy_id,
+                        mandate_fingerprint,
+                        latest_expected_session,
+                        request_id,
+                        approved_at,
+                        expires_at,
+                        approved_by,
+                        reason
+                    ) VALUES (
+                        %s, %s, %s, %s, %s, %s, %s, %s, %s, %s,
+                        %s, %s, %s, %s, %s, %s, %s, %s, %s, %s
+                    )
+                    ON CONFLICT DO NOTHING
+                    RETURNING override_id
+                    """,
+                    (
+                        override.override_id,
+                        override.model_version,
+                        override.decision_id,
+                        override.decision_document_sha256,
+                        override.gate_id,
+                        override.gate_fingerprint,
+                        override.operational_policy_id,
+                        override.operational_policy_fingerprint,
+                        override.schedule_id,
+                        override.schedule_fingerprint,
+                        override.calendar_id,
+                        override.portfolio_id,
+                        override.risk_limit_policy_id,
+                        override.mandate_fingerprint,
+                        date.fromisoformat(override.latest_expected_session),
+                        override.request_id,
+                        override.approved_at,
+                        override.expires_at,
+                        override.approved_by,
+                        override.reason,
+                    ),
+                )
+                created = cursor.fetchone() is not None
+                cursor.execute(
+                    f"""
+                    SELECT {OVERRIDE_COLUMNS}
+                    FROM risk_platform.operational_readiness_overrides
+                    WHERE request_id = %s
+                    """,
+                    (canonical_request_id,),
+                )
+                stored_row = cursor.fetchone()
+                if stored_row is None:
+                    raise StorageError("Readiness override is unavailable after insert")
+                stored = _override_from_row(stored_row)
+                if _override_signature(stored) != _override_signature(override):
+                    raise ValidationError(
+                        "request_id already exists with different override content"
+                    )
+            connection.commit()
+    except (ValidationError, StorageError):
+        raise
+    except Exception:
+        raise StorageError("Readiness override database operation failed") from None
+
+    if stored is None:  # pragma: no cover - guarded above.
+        raise StorageError("Readiness override result is unavailable")
+    return _override_summary(stored, created=created)
+
+
+def revoke_operational_readiness_override(
+    *,
+    dsn: str,
+    override_id: str,
+    request_identifier: str,
+    revoked_by: str,
+    reason: str,
+    revoked_at: datetime | str | None = None,
+) -> dict[str, Any]:
+    canonical_override_id = bounded_text(override_id, "override_id", 256)
+    canonical_request_id = request_id(request_identifier)
+    canonical_actor = bounded_text(revoked_by, "revoked_by", 320)
+    canonical_reason = bounded_text(reason, "reason", 2_000)
+    supplied_revoked_at = _optional_timestamp(revoked_at, "revoked_at")
+
+    try:
+        import psycopg
+    except ImportError as exc:  # pragma: no cover - dependency is required in CI.
+        raise RuntimeError("Operational readiness revocation requires psycopg") from exc
+
+    stored: OperationalReadinessOverrideRevocation | None = None
+    created = False
+    try:
+        with psycopg.connect(dsn) as connection:
+            with connection.cursor() as cursor:
+                cursor.execute(
+                    f"""
+                    SELECT {OVERRIDE_COLUMNS}
+                    FROM risk_platform.operational_readiness_overrides
+                    WHERE override_id = %s
+                    """,
+                    (canonical_override_id,),
+                )
+                override_row = cursor.fetchone()
+                if override_row is None:
+                    raise ValidationError(
+                        "override_id does not identify readiness override evidence"
+                    )
+                override = _override_from_row(override_row)
+
+                cursor.execute(
+                    f"""
+                    SELECT {REVOCATION_COLUMNS}
+                    FROM risk_platform.operational_readiness_override_revocations
+                    WHERE request_id = %s
+                    """,
+                    (canonical_request_id,),
+                )
+                existing_row = cursor.fetchone()
+                if existing_row is not None:
+                    stored = _revocation_from_row(existing_row)
+                    expected = build_operational_readiness_override_revocation(
+                        override=override,
+                        request_identifier=canonical_request_id,
+                        revoked_at=supplied_revoked_at or stored.revoked_at,
+                        revoked_by=canonical_actor,
+                        reason=canonical_reason,
+                    )
+                    if _revocation_signature(stored) != _revocation_signature(expected):
+                        raise ValidationError(
+                            "request_id already exists with different revocation content"
+                        )
+                    return _revocation_summary(stored, created=False)
+
+                revocation_time = supplied_revoked_at or datetime.now(timezone.utc)
+                revocation = build_operational_readiness_override_revocation(
+                    override=override,
+                    request_identifier=canonical_request_id,
+                    revoked_at=revocation_time,
+                    revoked_by=canonical_actor,
+                    reason=canonical_reason,
+                )
+                cursor.execute(
+                    """
+                    INSERT INTO
+                        risk_platform.operational_readiness_override_revocations (
+                            revocation_id,
+                            model_version,
+                            override_id,
+                            request_id,
+                            revoked_at,
+                            revoked_by,
+                            reason
+                        )
+                    VALUES (%s, %s, %s, %s, %s, %s, %s)
+                    ON CONFLICT DO NOTHING
+                    RETURNING revocation_id
+                    """,
+                    (
+                        revocation.revocation_id,
+                        revocation.model_version,
+                        revocation.override_id,
+                        revocation.request_id,
+                        revocation.revoked_at,
+                        revocation.revoked_by,
+                        revocation.reason,
+                    ),
+                )
+                created = cursor.fetchone() is not None
+                cursor.execute(
+                    f"""
+                    SELECT {REVOCATION_COLUMNS}
+                    FROM risk_platform.operational_readiness_override_revocations
+                    WHERE request_id = %s
+                    """,
+                    (canonical_request_id,),
+                )
+                stored_row = cursor.fetchone()
+                if stored_row is None:
+                    raise StorageError(
+                        "Readiness override revocation is unavailable after insert"
+                    )
+                stored = _revocation_from_row(stored_row)
+                if _revocation_signature(stored) != _revocation_signature(revocation):
+                    raise ValidationError(
+                        "request_id already exists with different revocation content"
+                    )
+            connection.commit()
+    except (ValidationError, StorageError):
+        raise
+    except Exception:
+        raise StorageError(
+            "Readiness override revocation database operation failed"
+        ) from None
+
+    if stored is None:  # pragma: no cover - guarded above.
+        raise StorageError("Readiness override revocation result is unavailable")
+    return _revocation_summary(stored, created=created)
+
+
+def _read_current_override_rows_postgres(
+    *,
+    dsn: str,
+    decision_id: str,
+) -> list[Mapping[str, Any]]:
+    try:
+        import psycopg
+        from psycopg.rows import dict_row
+    except ImportError as exc:  # pragma: no cover - dependency is required in CI.
+        raise RuntimeError("Operational readiness override lookup requires psycopg") from exc
+    try:
+        with psycopg.connect(dsn, row_factory=dict_row) as connection:
+            with connection.cursor() as cursor:
+                cursor.execute(
+                    """
+                    SELECT
+                        override_id,
+                        model_version,
+                        decision_id,
+                        decision_document_sha256,
+                        gate_id,
+                        gate_fingerprint,
+                        operational_policy_id,
+                        operational_policy_fingerprint,
+                        schedule_id,
+                        schedule_fingerprint,
+                        calendar_id,
+                        portfolio_id,
+                        risk_limit_policy_id,
+                        mandate_fingerprint,
+                        latest_expected_session,
+                        request_id,
+                        approved_at,
+                        expires_at,
+                        approved_by,
+                        revocation_id,
+                        revoked_at
+                    FROM risk_platform.current_operational_readiness_override_status
+                    WHERE decision_id = %s
+                    LIMIT 2
+                    """,
+                    (decision_id,),
+                )
+                return [dict(row) for row in cursor.fetchall()]
+    except Exception:
+        raise StorageError("Unable to read current readiness override") from None
+
+
+def read_active_operational_readiness_override(
+    *,
+    dsn: str,
+    decision_id: str,
+    evaluated_at: datetime | str,
+    row_reader: CurrentOverrideRowReader | None = None,
+) -> dict[str, Any] | None:
+    evaluation_time = aware_utc(evaluated_at, "evaluated_at")
+    selected_reader = row_reader or _read_current_override_rows_postgres
+    rows = selected_reader(dsn=dsn, decision_id=decision_id)
+    if not isinstance(rows, list):
+        raise StorageError("current readiness override query returned invalid rows")
+    if len(rows) > 1:
+        raise StorageError("current readiness override grain is not unique")
+    if not rows:
+        return None
+    row = rows[0]
+    required = {
+        "override_id",
+        "model_version",
+        "decision_id",
+        "decision_document_sha256",
+        "gate_id",
+        "gate_fingerprint",
+        "operational_policy_id",
+        "operational_policy_fingerprint",
+        "schedule_id",
+        "schedule_fingerprint",
+        "calendar_id",
+        "portfolio_id",
+        "risk_limit_policy_id",
+        "mandate_fingerprint",
+        "latest_expected_session",
+        "request_id",
+        "approved_at",
+        "expires_at",
+        "approved_by",
+        "revocation_id",
+        "revoked_at",
+    }
+    if not isinstance(row, Mapping) or set(row) != required:
+        raise StorageError("current readiness override row is incompatible")
+    if row.get("decision_id") != decision_id:
+        raise StorageError("current readiness override targets another decision")
+    approved_at = row.get("approved_at")
+    expires_at = row.get("expires_at")
+    revoked_at = row.get("revoked_at")
+    if not isinstance(approved_at, datetime) or not isinstance(expires_at, datetime):
+        raise StorageError("current readiness override timestamps are incompatible")
+    approved_at = approved_at.astimezone(timezone.utc)
+    expires_at = expires_at.astimezone(timezone.utc)
+    if revoked_at is not None:
+        if not isinstance(revoked_at, datetime):
+            raise StorageError("current readiness revocation timestamp is incompatible")
+        revoked_at = revoked_at.astimezone(timezone.utc)
+    if evaluation_time < approved_at or evaluation_time >= expires_at:
+        return None
+    if revoked_at is not None and revoked_at <= evaluation_time:
+        return None
+    latest_session = row.get("latest_expected_session")
+    if not isinstance(latest_session, date) or isinstance(latest_session, datetime):
+        raise StorageError("current readiness override session is incompatible")
+    return {
+        "override_id": row["override_id"],
+        "model_version": row["model_version"],
+        "decision_id": row["decision_id"],
+        "decision_document_sha256": row["decision_document_sha256"],
+        "gate_id": row["gate_id"],
+        "gate_fingerprint": row["gate_fingerprint"],
+        "operational_policy_id": row["operational_policy_id"],
+        "operational_policy_fingerprint": row[
+            "operational_policy_fingerprint"
+        ],
+        "schedule_id": row["schedule_id"],
+        "schedule_fingerprint": row["schedule_fingerprint"],
+        "calendar_id": row["calendar_id"],
+        "portfolio_id": row["portfolio_id"],
+        "risk_limit_policy_id": row["risk_limit_policy_id"],
+        "mandate_fingerprint": row["mandate_fingerprint"],
+        "latest_expected_session": latest_session.isoformat(),
+        "request_id": row["request_id"],
+        "approved_at": approved_at.isoformat(),
+        "expires_at": expires_at.isoformat(),
+        "approved_by": row["approved_by"],
+        "revocation_id": row["revocation_id"],
+        "revoked_at": revoked_at.isoformat() if revoked_at is not None else None,
+        "evaluated_at": evaluation_time.isoformat(),
+        "active": True,
+    }
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Append operational readiness override or revocation evidence."
+    )
+    parser.add_argument(
+        "--dsn",
+        default=os.environ.get("WAREHOUSE_POSTGRES_DSN", DEFAULT_POSTGRES_DSN),
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    approve = subparsers.add_parser("approve")
+    approve.add_argument("--decision-id", required=True)
+    approve.add_argument("--request-id", required=True)
+    approve.add_argument("--expires-at", required=True)
+    approve.add_argument("--approved-by", required=True)
+    approve.add_argument("--reason", required=True)
+    approve.add_argument("--approved-at")
+
+    revoke = subparsers.add_parser("revoke")
+    revoke.add_argument("--override-id", required=True)
+    revoke.add_argument("--request-id", required=True)
+    revoke.add_argument("--revoked-by", required=True)
+    revoke.add_argument("--reason", required=True)
+    revoke.add_argument("--revoked-at")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    try:
+        if args.command == "approve":
+            summary = approve_operational_readiness_override(
+                dsn=args.dsn,
+                decision_id=args.decision_id,
+                request_identifier=args.request_id,
+                expires_at=args.expires_at,
+                approved_by=args.approved_by,
+                reason=args.reason,
+                approved_at=args.approved_at,
+            )
+        else:
+            summary = revoke_operational_readiness_override(
+                dsn=args.dsn,
+                override_id=args.override_id,
+                request_identifier=args.request_id,
+                revoked_by=args.revoked_by,
+                reason=args.reason,
+                revoked_at=args.revoked_at,
+            )
+    except ValidationError as exc:
+        print(f"Readiness override evidence rejected: {exc}", file=sys.stderr)
+        return 1
+    except (StorageError, RuntimeError) as exc:
+        print(f"Readiness override evidence failed: {exc}", file=sys.stderr)
+        return 1
+    print(json.dumps(summary, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/test_docker_compose_contract.py
+++ b/tests/unit/test_docker_compose_contract.py
@@ -41,6 +41,7 @@ def test_local_database_seed_mounts_are_read_only_and_ordered() -> None:
         "./sql/operational_service_level_objectives_schema.sql:/docker-entrypoint-initdb.d/14_operational_service_level_objectives_schema.sql:ro",
         "./sql/operational_readiness_decisions_schema.sql:/docker-entrypoint-initdb.d/15_operational_readiness_decisions_schema.sql:ro",
         "./sql/operational_review_schema.sql:/docker-entrypoint-initdb.d/16_operational_review_schema.sql:ro",
+        "./sql/operational_readiness_overrides_schema.sql:/docker-entrypoint-initdb.d/17_operational_readiness_overrides_schema.sql:ro",
     ]
     assert services["mongo"]["volumes"] == [
         "./mongo/init:/docker-entrypoint-initdb.d:ro"

--- a/tests/unit/test_operational_readiness_override_architecture_contract.py
+++ b/tests/unit/test_operational_readiness_override_architecture_contract.py
@@ -1,0 +1,18 @@
+from pathlib import Path
+
+
+def test_readiness_override_documentation_preserves_human_authority_boundary() -> None:
+    documentation = Path("docs/operational-readiness-overrides.md").read_text(
+        encoding="utf-8"
+    )
+
+    for required in (
+        "mandatory expiry of no more than 24 hours",
+        "An `allow` decision cannot be overridden",
+        "operational_readiness_override_history",
+        "current_operational_readiness_override_status",
+        "active_operational_readiness_overrides",
+        "explicit evaluation timestamp",
+        "records authority but does not consume it",
+    ):
+        assert required in documentation

--- a/tests/unit/test_operational_readiness_override_contract.py
+++ b/tests/unit/test_operational_readiness_override_contract.py
@@ -1,0 +1,196 @@
+from __future__ import annotations
+
+from datetime import date, datetime, timedelta, timezone
+from typing import Any
+
+import pytest
+
+from src.common.exceptions import StorageError, ValidationError
+from src.warehouse.operational_readiness_override_contract import (
+    MAX_OVERRIDE_DURATION_SECONDS,
+    build_operational_readiness_override,
+    build_operational_readiness_override_revocation,
+)
+from src.warehouse.operational_readiness_override_registry import (
+    read_active_operational_readiness_override,
+)
+
+
+def _decision(*, result: str = "block") -> dict[str, Any]:
+    return {
+        "decision_id": "operational-readiness-gate-v1-decision-" + "a" * 24,
+        "decision": result,
+        "evaluated_at": "2026-04-01T12:00:00+00:00",
+        "gate_id": "us-tech-local",
+        "gate_fingerprint": "operational-readiness-gate-" + "b" * 24,
+        "operational_policy_id": "us-tech-local",
+        "operational_policy_fingerprint": "operational-slo-policy-" + "c" * 24,
+        "schedule_id": "us-tech-local",
+        "schedule_fingerprint": "local-schedule-example",
+        "calendar_id": "XNYS",
+        "portfolio_id": "us-tech-equal",
+        "risk_limit_policy_id": "us-tech-standard",
+        "mandate_fingerprint": "portfolio-mandate-example",
+        "latest_expected_session": "2026-03-31",
+    }
+
+
+def test_override_identity_is_deterministic_and_time_bounded() -> None:
+    first = build_operational_readiness_override(
+        decision=_decision(),
+        decision_document_sha256="d" * 64,
+        request_identifier="OVERRIDE-001",
+        approved_at="2026-04-01T12:05:00Z",
+        expires_at="2026-04-01T13:05:00Z",
+        approved_by="operator@example.test",
+        reason="Reviewed one bounded local execution exception.",
+    )
+    second = build_operational_readiness_override(
+        decision=_decision(),
+        decision_document_sha256="d" * 64,
+        request_identifier="OVERRIDE-001",
+        approved_at=datetime(2026, 4, 1, 12, 5, tzinfo=timezone.utc),
+        expires_at=datetime(2026, 4, 1, 13, 5, tzinfo=timezone.utc),
+        approved_by="operator@example.test",
+        reason="Reviewed one bounded local execution exception.",
+    )
+
+    assert first == second
+    assert first.override_id.startswith("operational-readiness-override-v1-")
+    assert first.expires_at > first.approved_at
+
+
+def test_override_rejects_allow_predating_and_excess_duration() -> None:
+    common = {
+        "decision_document_sha256": "d" * 64,
+        "request_identifier": "OVERRIDE-001",
+        "approved_by": "operator@example.test",
+        "reason": "Reviewed one bounded local execution exception.",
+    }
+    with pytest.raises(ValidationError, match="block decision"):
+        build_operational_readiness_override(
+            decision=_decision(result="allow"),
+            approved_at="2026-04-01T12:05:00Z",
+            expires_at="2026-04-01T13:05:00Z",
+            **common,
+        )
+    with pytest.raises(ValidationError, match="predate"):
+        build_operational_readiness_override(
+            decision=_decision(),
+            approved_at="2026-04-01T11:59:00Z",
+            expires_at="2026-04-01T12:30:00Z",
+            **common,
+        )
+    with pytest.raises(ValidationError, match="maximum"):
+        build_operational_readiness_override(
+            decision=_decision(),
+            approved_at="2026-04-01T12:05:00Z",
+            expires_at=(
+                datetime(2026, 4, 1, 12, 5, tzinfo=timezone.utc)
+                + timedelta(seconds=MAX_OVERRIDE_DURATION_SECONDS + 1)
+            ),
+            **common,
+        )
+
+
+def test_revocation_identity_is_deterministic_and_cannot_predate_override() -> None:
+    override = build_operational_readiness_override(
+        decision=_decision(),
+        decision_document_sha256="d" * 64,
+        request_identifier="OVERRIDE-001",
+        approved_at="2026-04-01T12:05:00Z",
+        expires_at="2026-04-01T13:05:00Z",
+        approved_by="operator@example.test",
+        reason="Reviewed one bounded local execution exception.",
+    )
+    revocation = build_operational_readiness_override_revocation(
+        override=override,
+        request_identifier="OVERRIDE-REVOKE-001",
+        revoked_at="2026-04-01T12:30:00Z",
+        revoked_by="operator@example.test",
+        reason="Override withdrawn after review.",
+    )
+    assert revocation.revocation_id.startswith(
+        "operational-readiness-override-revocation-v1-"
+    )
+    with pytest.raises(ValidationError, match="predate"):
+        build_operational_readiness_override_revocation(
+            override=override,
+            request_identifier="OVERRIDE-REVOKE-002",
+            revoked_at="2026-04-01T12:00:00Z",
+            revoked_by="operator@example.test",
+            reason="Invalid early revocation.",
+        )
+
+
+def _current_row(
+    *,
+    revoked_at: datetime | None = None,
+) -> dict[str, Any]:
+    return {
+        "override_id": "operational-readiness-override-v1-" + "e" * 24,
+        "model_version": "operational-readiness-override-v1",
+        "decision_id": _decision()["decision_id"],
+        "decision_document_sha256": "d" * 64,
+        "gate_id": "us-tech-local",
+        "gate_fingerprint": "operational-readiness-gate-" + "b" * 24,
+        "operational_policy_id": "us-tech-local",
+        "operational_policy_fingerprint": "operational-slo-policy-" + "c" * 24,
+        "schedule_id": "us-tech-local",
+        "schedule_fingerprint": "local-schedule-example",
+        "calendar_id": "XNYS",
+        "portfolio_id": "us-tech-equal",
+        "risk_limit_policy_id": "us-tech-standard",
+        "mandate_fingerprint": "portfolio-mandate-example",
+        "latest_expected_session": date(2026, 3, 31),
+        "request_id": "OVERRIDE-001",
+        "approved_at": datetime(2026, 4, 1, 12, 5, tzinfo=timezone.utc),
+        "expires_at": datetime(2026, 4, 1, 13, 5, tzinfo=timezone.utc),
+        "approved_by": "operator@example.test",
+        "revocation_id": (
+            "operational-readiness-override-revocation-v1-" + "f" * 24
+            if revoked_at is not None
+            else None
+        ),
+        "revoked_at": revoked_at,
+    }
+
+
+def test_active_override_lookup_uses_explicit_evaluation_time() -> None:
+    decision_id = str(_decision()["decision_id"])
+    active = read_active_operational_readiness_override(
+        dsn="not-used",
+        decision_id=decision_id,
+        evaluated_at="2026-04-01T12:30:00Z",
+        row_reader=lambda **_: [_current_row()],
+    )
+    expired = read_active_operational_readiness_override(
+        dsn="not-used",
+        decision_id=decision_id,
+        evaluated_at="2026-04-01T13:05:00Z",
+        row_reader=lambda **_: [_current_row()],
+    )
+    revoked = read_active_operational_readiness_override(
+        dsn="not-used",
+        decision_id=decision_id,
+        evaluated_at="2026-04-01T12:30:00Z",
+        row_reader=lambda **_: [
+            _current_row(
+                revoked_at=datetime(2026, 4, 1, 12, 20, tzinfo=timezone.utc)
+            )
+        ],
+    )
+
+    assert active is not None and active["active"] is True
+    assert expired is None
+    assert revoked is None
+
+
+def test_active_override_lookup_rejects_duplicate_current_grain() -> None:
+    with pytest.raises(StorageError, match="not unique"):
+        read_active_operational_readiness_override(
+            dsn="not-used",
+            decision_id=str(_decision()["decision_id"]),
+            evaluated_at="2026-04-01T12:30:00Z",
+            row_reader=lambda **_: [{}, {}],
+        )

--- a/tests/unit/test_operational_readiness_override_sql_contract.py
+++ b/tests/unit/test_operational_readiness_override_sql_contract.py
@@ -1,0 +1,48 @@
+from pathlib import Path
+
+
+def test_readiness_override_schema_is_append_only_and_time_bounded() -> None:
+    sql = Path("sql/operational_readiness_overrides_schema.sql").read_text(
+        encoding="utf-8"
+    )
+
+    assert "risk_platform.operational_readiness_overrides" in sql
+    assert "risk_platform.operational_readiness_override_revocations" in sql
+    assert "INTERVAL '24 hours'" in sql
+    assert "readiness override target must be blocked" in sql
+    assert "readiness override metadata does not match target" in sql
+    for view in (
+        "operational_readiness_override_history",
+        "current_operational_readiness_override_status",
+        "active_operational_readiness_overrides",
+    ):
+        assert f"risk_platform.{view}" in sql
+    for trigger in (
+        "prevent_operational_readiness_override_update",
+        "prevent_operational_readiness_override_delete",
+        "prevent_operational_readiness_override_revocation_update",
+        "prevent_operational_readiness_override_revocation_delete",
+    ):
+        assert trigger in sql
+
+
+def test_readiness_override_reconciliation_covers_targets_and_current_status() -> None:
+    sql = Path(
+        "sql/operational_readiness_overrides_consistency_checks.sql"
+    ).read_text(encoding="utf-8")
+
+    for check_name in (
+        "operational_readiness_override_history_rows_match",
+        "operational_readiness_override_targets_exist",
+        "operational_readiness_override_targets_blocked_exact_contract",
+        "operational_readiness_override_windows_bounded",
+        "operational_readiness_override_revocations_valid",
+        "operational_readiness_override_identities_unique",
+        "operational_readiness_override_revocation_identities_unique",
+        "current_operational_readiness_override_grain_unique",
+        "current_operational_readiness_override_selects_latest",
+        "current_operational_readiness_override_status_reconciles",
+        "active_operational_readiness_overrides_match_current_status",
+        "operational_readiness_override_append_only_triggers_present",
+    ):
+        assert check_name in sql


### PR DESCRIPTION
## Outcome

Add narrowly scoped, expiring and revocable human-authority evidence for one exact blocked readiness decision without rewriting the original block:

```text
retained block decision
  -> explicit override request
  -> exact operating-contract binding
  -> mandatory <=24-hour expiry
  -> append-only approval or revocation
  -> current and explicit-time active lookup
```

Primary arc42 block: `warehouse`, with a bounded interface to append-only readiness decisions and the later execution-enforcement layer.

## Contracts and registry

Add:

- `src.warehouse.operational_readiness_override_contract`;
- `operational_readiness_override_registry`; and
- `operational_readiness_override_contract_check`.

An override binds the exact blocked decision/document digest, gate, operational policy, schedule, calendar, portfolio, risk-limit policy, mandate and latest expected session. It cannot predate the decision, expiry is mandatory and the duration cannot exceed 24 hours. An allow decision is rejected.

Approval and revocation request IDs are idempotency keys. Exact retries converge; conflicting reuse fails closed. Revocation is a separate event and cannot predate approval.

The active lookup uses an explicit evaluation timestamp so approval, revocation and expiry boundaries are reproducible rather than relying only on wall-clock view status.

## PostgreSQL contract

Add append-only tables:

- `risk_platform.operational_readiness_overrides`;
- `operational_readiness_override_revocations`.

Serving views:

- `operational_readiness_override_history`;
- `current_operational_readiness_override_status`;
- `active_operational_readiness_overrides`.

The current override per blocked decision is selected by `approved_at DESC, override_id DESC`. PostgreSQL triggers independently enforce blocked target status, copied metadata, timestamp ordering and append-only mutation rejection.

## Validation and repair

The first exact-head run passed security, the live PostgreSQL contract and infrastructure validation but mypy found one un-narrowed optional `decision.evaluated_at` value. The contract now explicitly requires a `datetime` or string before calling the timezone parser; no accepted evidence, database rule or validation gate was weakened.

GitHub Actions run `32715735284` (`ci` run 300) passed on repaired exact head `87578a00bf2e0e2180f24b319d16bd2d43f7189a`:

- Security guardrails: passed.
- Python readiness: passed.
  - locked dependencies resolved;
  - Ruff passed;
  - mypy passed across 101 source files;
  - 740 tests passed in both quality and readiness runs;
  - `pip check` passed;
  - the standard readiness replay passed.
- PostgreSQL contract: passed against PostgreSQL 16.
  - approval retry convergence and conflicting request rejection passed;
  - an allow target was rejected;
  - revocation and revocation retry passed;
  - a later replacement override became current and active;
  - explicit-time active and expired lookup passed;
  - four UPDATE/DELETE attempts were rejected;
  - all override reconciliation checks passed.
- Infrastructure validation: passed with Kubernetes rendering and Terraform format/init/validate without apply.

No unresolved review threads or requested changes are present.

## Scope

The branch is directly based on PR #101, is zero commits behind and changes 12 files with 2,157 additions. Connector writes and the focused typing repair produced 13 working commits; this PR is intended for squash merge as one human-authority evidence layer.

No override is consumed by the schedule yet. No command execution, checkpoint mutation, provider request, notification delivery, cloud activation, deployment or `terraform apply` is included.

## Acceptance boundary

Validated and ready for squash merge as the authority prerequisite for execution enforcement.