### PR TITLE
Enforce operational readiness on local schedule execution

### DIFF
--- a/docs/readiness-enforced-local-schedule.md
+++ b/docs/readiness-enforced-local-schedule.md
@@ -1,0 +1,160 @@
+# Readiness-Enforced Local Schedule Execution
+
+## Outcome
+
+The local schedule can now execute only through deterministic authority derived
+from current retained operational evidence:
+
+```text
+readiness-aware schedule plan
+  -> refresh exact current readiness decision
+  -> reject changed, future or stale decision evidence
+  -> current allow OR exact active override
+  -> deterministic execution-authority document
+  -> recalculate and validate the schedule plan
+  -> execute commands under the established local lock
+  -> advance the checkpoint only after a complete authorised session
+```
+
+The original blocked readiness decision is never rewritten. An override changes
+the authority type, not the decision itself.
+
+## Operator Flow
+
+Plan only:
+
+```bash
+.venv/bin/python -m src.orchestration.run_readiness_enforced_local_schedule \
+  --schedule-id us-tech-local \
+  --gate-id us-tech-local \
+  --as-of-date 2026-04-01 \
+  --evaluated-at 2026-04-01T12:00:00Z \
+  --summary-json .demo/readiness-enforced-schedule.json
+```
+
+Explicit local execution:
+
+```bash
+.venv/bin/python -m src.orchestration.run_readiness_enforced_local_schedule \
+  --schedule-id us-tech-local \
+  --gate-id us-tech-local \
+  --as-of-date 2026-04-01 \
+  --evaluated-at 2026-04-01T12:00:00Z \
+  --execute \
+  --summary-json .demo/readiness-enforced-schedule.json
+```
+
+The bundled local schedule remains disabled. It must be enabled through reviewed
+configuration before an authorised execution can proceed.
+
+Exit codes are:
+
+- `0` — plan/no-work result or successful authorised execution;
+- `2` — valid evidence produced a blocked execution decision; and
+- `1` — invalid configuration, evidence, authority, local state or execution.
+
+## Current-Evidence Refresh
+
+The wrapper first builds the plan-only contract introduced by PR #101. For an
+execution request it then reads the exact current readiness decision again using
+the current gate, policy, schedule, calendar, portfolio, risk-limit policy,
+mandate and expected-session contract.
+
+If the decision ID or canonical document SHA-256 changed after planning, execution
+fails and a new plan is required. A missing decision cannot be overridden.
+
+The explicit `evaluated_at` instant must not predate the readiness decision. The
+decision age must remain within the gate's configured
+`max_report_age_seconds`; future and stale decisions block before override lookup.
+
+## Authority Types
+
+### Gate allow
+
+A current `allow` decision creates:
+
+```text
+authority_type = gate_allow
+override_id = null
+```
+
+The decision must have no blocking reasons.
+
+### Active override
+
+A current `block` decision can create:
+
+```text
+authority_type = active_override
+override_id = operational-readiness-override-v1-...
+```
+
+only when the explicit-time override lookup finds a current, unexpired and
+unrevoked override targeting the exact decision and document digest. Gate,
+policy, schedule, calendar, portfolio, mandate and expected-session identities
+must all match. The authority is invalid at or after override expiry.
+
+A blocked decision without active override returns `decision = block` and does
+not call the schedule executor.
+
+## Deterministic Authority Contract
+
+`operational-readiness-execution-authority-v1` binds:
+
+- readiness-aware plan ID;
+- schedule, calendar, portfolio, risk-limit policy and mandate identities;
+- as-of date, latest expected session and exact selected sessions;
+- gate and operational-policy fingerprints;
+- readiness decision ID, canonical document SHA-256, decision and reasons;
+- explicit authorisation timestamp; and
+- override ID and expiry when authority is override-based.
+
+The base scheduler independently validates the authority ID and all current plan
+fields before checking whether the schedule is enabled, acquiring the execution
+lock, running a command or writing state.
+
+Direct `run_local_portfolio_schedule --execute` has no mechanism for supplying an
+authority document and therefore fails before commands. Programmatic execution
+must supply an exact validated authority.
+
+The base scheduler currently requires one effective mandate fingerprint across
+all selected catch-up sessions. A catch-up window that crosses a mandate boundary
+must be split and replanned rather than authorised under one ambiguous mandate.
+
+## Checkpoint And Failure Semantics
+
+The established local schedule behavior remains:
+
+- one repository-local schedule lock;
+- commands run in session order;
+- the checkpoint is written only after every command for that session succeeds;
+- a failed command does not advance the incomplete session; and
+- lock cleanup runs in `finally`.
+
+The enforcement wrapper also rejects an executor result when completed sessions,
+authority evidence or side-effect flags do not match the authorised plan.
+
+## Summary Evidence
+
+The credential-free result includes:
+
+- readiness-aware plan ID;
+- current decision ID, decision and reasons;
+- deterministic authority ID and authority type;
+- override ID and expiry where applicable;
+- authorised and completed session dates;
+- checkpoint before and after;
+- `executed`, `block`, `no_work` or plan-only decision; and
+- explicit provider, notification-delivery and cloud-schedule side-effect flags.
+
+## Boundary
+
+This is a local execution control, not authentication or a cryptographic access
+control system. An operator who can modify and run repository code remains inside
+the trust boundary. The contract supplies deterministic governance evidence and
+prevents accidental or ordinary direct execution paths from bypassing current
+readiness and override semantics.
+
+No live provider request is added to CI, no external notification is delivered,
+no cloud schedule is activated, no infrastructure is deployed and no
+`terraform apply` is run by this increment.

--- a/src/orchestration/operational_readiness_execution_authority.py
+++ b/src/orchestration/operational_readiness_execution_authority.py
@@ -1,0 +1,418 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from collections.abc import Mapping, Sequence
+from datetime import date, datetime, timezone
+from typing import Any
+
+from src.common.exceptions import ValidationError
+
+MODEL_VERSION = "operational-readiness-execution-authority-v1"
+PLAN_MODEL_VERSION = "readiness-aware-schedule-plan-v1"
+AUTHORITY_ID_PATTERN = re.compile(
+    r"^operational-readiness-execution-authority-v1-authority-[0-9a-f]{24}$"
+)
+PLAN_ID_PATTERN = re.compile(
+    r"^readiness-aware-schedule-plan-v1-plan-[0-9a-f]{24}$"
+)
+DECISION_ID_PATTERN = re.compile(
+    r"^operational-readiness-gate-v1-decision-[0-9a-f]{24}$"
+)
+OVERRIDE_ID_PATTERN = re.compile(
+    r"^operational-readiness-override-v1-[0-9a-f]{24}$"
+)
+SHA256_PATTERN = re.compile(r"^[0-9a-f]{64}$")
+SAFE_SEGMENT_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$")
+AUTHORITY_KEYS = frozenset(
+    {
+        "authority_id",
+        "model_version",
+        "authority_type",
+        "authorized_at",
+        "plan_id",
+        "schedule_id",
+        "schedule_fingerprint",
+        "calendar_id",
+        "calendar_fingerprint",
+        "portfolio_id",
+        "risk_limit_policy_id",
+        "mandate_id",
+        "mandate_fingerprint",
+        "as_of_date",
+        "latest_expected_session",
+        "session_dates",
+        "gate_id",
+        "gate_fingerprint",
+        "operational_policy_id",
+        "operational_policy_fingerprint",
+        "readiness_decision_id",
+        "readiness_document_sha256",
+        "readiness_decision",
+        "readiness_reasons",
+        "override_id",
+        "override_expires_at",
+    }
+)
+
+
+def _safe_segment(value: Any, label: str) -> str:
+    if not isinstance(value, str) or not SAFE_SEGMENT_PATTERN.fullmatch(value):
+        raise ValidationError(f"{label} must be one safe text segment")
+    return value
+
+
+def _bounded_text(value: Any, label: str) -> str:
+    if not isinstance(value, str) or not value or len(value) > 256:
+        raise ValidationError(f"{label} must be non-empty bounded text")
+    if value != value.strip() or any(ord(character) < 32 for character in value):
+        raise ValidationError(f"{label} must be canonical bounded text")
+    return value
+
+
+def _aware_utc(value: Any, label: str) -> datetime:
+    if isinstance(value, datetime):
+        parsed = value
+    elif isinstance(value, str):
+        try:
+            parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        except ValueError:
+            raise ValidationError(f"{label} must be ISO-8601") from None
+    else:
+        raise ValidationError(f"{label} must be a timezone-aware timestamp")
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise ValidationError(f"{label} must be a timezone-aware timestamp")
+    return parsed.astimezone(timezone.utc)
+
+
+def _calendar_date(value: Any, label: str) -> date:
+    if isinstance(value, datetime):
+        raise ValidationError(f"{label} must be a calendar date")
+    if isinstance(value, date):
+        return value
+    if not isinstance(value, str):
+        raise ValidationError(f"{label} must use YYYY-MM-DD")
+    try:
+        parsed = date.fromisoformat(value)
+    except ValueError:
+        raise ValidationError(f"{label} must use YYYY-MM-DD") from None
+    if value != parsed.isoformat():
+        raise ValidationError(f"{label} must use YYYY-MM-DD")
+    return parsed
+
+
+def _string_array(value: Any, label: str) -> list[str]:
+    if not isinstance(value, list) or any(not isinstance(item, str) for item in value):
+        raise ValidationError(f"{label} must be an array of text values")
+    if len(value) != len(set(value)):
+        raise ValidationError(f"{label} must not contain duplicates")
+    return list(value)
+
+
+def _session_dates(value: Any) -> list[str]:
+    values = _string_array(value, "session_dates")
+    parsed = [_calendar_date(item, "session_date").isoformat() for item in values]
+    if parsed != sorted(parsed):
+        raise ValidationError("session_dates must use ascending event-date order")
+    if not parsed:
+        raise ValidationError("execution authority requires at least one session")
+    return parsed
+
+
+def _required_mapping(value: Any, label: str) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        raise ValidationError(f"{label} must be a mapping")
+    return value
+
+
+def _canonical_authority_payload(authority: Mapping[str, Any]) -> dict[str, Any]:
+    return {key: authority[key] for key in sorted(AUTHORITY_KEYS - {"authority_id"})}
+
+
+def _authority_id(authority: Mapping[str, Any]) -> str:
+    digest = hashlib.sha256(
+        json.dumps(
+            _canonical_authority_payload(authority),
+            sort_keys=True,
+            separators=(",", ":"),
+            allow_nan=False,
+        ).encode("utf-8")
+    ).hexdigest()[:24]
+    return f"{MODEL_VERSION}-authority-{digest}"
+
+
+def _validate_override_contract(
+    override: Mapping[str, Any],
+    *,
+    authorized_at: datetime,
+    readiness: Mapping[str, Any],
+    plan: Mapping[str, Any],
+) -> tuple[str, str]:
+    override_id = override.get("override_id")
+    if not isinstance(override_id, str) or not OVERRIDE_ID_PATTERN.fullmatch(
+        override_id
+    ):
+        raise ValidationError("active override ID is incompatible")
+    if override.get("active") is not True:
+        raise ValidationError("readiness override is not active")
+    if override.get("decision_id") != readiness.get("decision_id"):
+        raise ValidationError("readiness override targets another decision")
+    if override.get("decision_document_sha256") != readiness.get(
+        "document_sha256"
+    ):
+        raise ValidationError("readiness override targets another decision digest")
+
+    schedule_plan = _required_mapping(plan.get("schedule_plan"), "schedule_plan")
+    calendar = _required_mapping(schedule_plan.get("calendar"), "schedule calendar")
+    expected = {
+        "gate_id": readiness.get("gate_id"),
+        "gate_fingerprint": readiness.get("gate_fingerprint"),
+        "operational_policy_id": readiness.get("operational_policy_id"),
+        "operational_policy_fingerprint": readiness.get(
+            "operational_policy_fingerprint"
+        ),
+        "schedule_id": plan.get("schedule_id"),
+        "schedule_fingerprint": plan.get("schedule_fingerprint"),
+        "calendar_id": calendar.get("calendar_id"),
+        "portfolio_id": plan.get("portfolio_id"),
+        "risk_limit_policy_id": plan.get("risk_limit_policy_id"),
+        "mandate_fingerprint": plan.get("mandate_fingerprint"),
+        "latest_expected_session": plan.get("latest_expected_session"),
+    }
+    for key, value in expected.items():
+        if override.get(key) != value:
+            raise ValidationError(f"readiness override {key} does not match the plan")
+    evaluated_at = _aware_utc(override.get("evaluated_at"), "override.evaluated_at")
+    if evaluated_at != authorized_at:
+        raise ValidationError("readiness override was evaluated at another instant")
+    expires_at = _aware_utc(override.get("expires_at"), "override.expires_at")
+    if expires_at <= authorized_at:
+        raise ValidationError("readiness override is expired")
+    return override_id, expires_at.isoformat()
+
+
+def build_operational_readiness_execution_authority(
+    *,
+    plan: Mapping[str, Any],
+    authorized_at: datetime | str,
+    active_override: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    if plan.get("model_version") != PLAN_MODEL_VERSION:
+        raise ValidationError("readiness-aware plan model version is unsupported")
+    plan_id = plan.get("plan_id")
+    if not isinstance(plan_id, str) or not PLAN_ID_PATTERN.fullmatch(plan_id):
+        raise ValidationError("readiness-aware plan ID is incompatible")
+    authorization_time = _aware_utc(authorized_at, "authorized_at")
+    schedule_effect = _required_mapping(
+        plan.get("schedule_effect"),
+        "schedule_effect",
+    )
+    if schedule_effect.get("decision") not in {"would_run", "would_block"}:
+        raise ValidationError("execution authority requires selected schedule work")
+    session_dates = _session_dates(schedule_effect.get("session_dates"))
+    if schedule_effect.get("sessions_selected") != len(session_dates):
+        raise ValidationError("schedule effect session count is incompatible")
+
+    readiness = _required_mapping(plan.get("readiness"), "readiness")
+    decision_id = readiness.get("decision_id")
+    if not isinstance(decision_id, str) or not DECISION_ID_PATTERN.fullmatch(
+        decision_id
+    ):
+        raise ValidationError("execution requires a retained readiness decision")
+    document_sha256 = readiness.get("document_sha256")
+    if not isinstance(document_sha256, str) or not SHA256_PATTERN.fullmatch(
+        document_sha256
+    ):
+        raise ValidationError("readiness decision digest is incompatible")
+    reasons = _string_array(readiness.get("reasons"), "readiness_reasons")
+    readiness_decision = readiness.get("decision")
+
+    override_id: str | None = None
+    override_expires_at: str | None = None
+    if schedule_effect.get("decision") == "would_run":
+        if readiness.get("status") != "current" or readiness_decision != "allow":
+            raise ValidationError("would_run plan does not contain a current allow decision")
+        if reasons:
+            raise ValidationError("allow decision must not contain blocking reasons")
+        if active_override is not None:
+            raise ValidationError("allow decision must not use override authority")
+        authority_type = "gate_allow"
+    else:
+        if readiness.get("status") != "current" or readiness_decision != "block":
+            raise ValidationError("missing readiness decisions cannot be overridden")
+        if not reasons:
+            raise ValidationError("blocked readiness decision must contain reasons")
+        if active_override is None:
+            raise ValidationError("blocked readiness decision requires an active override")
+        authority_type = "active_override"
+        override_id, override_expires_at = _validate_override_contract(
+            active_override,
+            authorized_at=authorization_time,
+            readiness=readiness,
+            plan=plan,
+        )
+
+    schedule_plan = _required_mapping(plan.get("schedule_plan"), "schedule_plan")
+    calendar = _required_mapping(schedule_plan.get("calendar"), "schedule calendar")
+    authority: dict[str, Any] = {
+        "authority_id": "",
+        "model_version": MODEL_VERSION,
+        "authority_type": authority_type,
+        "authorized_at": authorization_time.isoformat(),
+        "plan_id": plan_id,
+        "schedule_id": _safe_segment(plan.get("schedule_id"), "schedule_id"),
+        "schedule_fingerprint": _bounded_text(
+            plan.get("schedule_fingerprint"),
+            "schedule_fingerprint",
+        ),
+        "calendar_id": _safe_segment(calendar.get("calendar_id"), "calendar_id"),
+        "calendar_fingerprint": _bounded_text(
+            calendar.get("calendar_fingerprint"),
+            "calendar_fingerprint",
+        ),
+        "portfolio_id": _safe_segment(plan.get("portfolio_id"), "portfolio_id"),
+        "risk_limit_policy_id": _safe_segment(
+            plan.get("risk_limit_policy_id"),
+            "risk_limit_policy_id",
+        ),
+        "mandate_id": _safe_segment(plan.get("mandate_id"), "mandate_id"),
+        "mandate_fingerprint": _bounded_text(
+            plan.get("mandate_fingerprint"),
+            "mandate_fingerprint",
+        ),
+        "as_of_date": _calendar_date(plan.get("as_of_date"), "as_of_date").isoformat(),
+        "latest_expected_session": _calendar_date(
+            plan.get("latest_expected_session"),
+            "latest_expected_session",
+        ).isoformat(),
+        "session_dates": session_dates,
+        "gate_id": _safe_segment(readiness.get("gate_id"), "gate_id"),
+        "gate_fingerprint": _bounded_text(
+            readiness.get("gate_fingerprint"),
+            "gate_fingerprint",
+        ),
+        "operational_policy_id": _safe_segment(
+            readiness.get("operational_policy_id"),
+            "operational_policy_id",
+        ),
+        "operational_policy_fingerprint": _bounded_text(
+            readiness.get("operational_policy_fingerprint"),
+            "operational_policy_fingerprint",
+        ),
+        "readiness_decision_id": decision_id,
+        "readiness_document_sha256": document_sha256,
+        "readiness_decision": readiness_decision,
+        "readiness_reasons": reasons,
+        "override_id": override_id,
+        "override_expires_at": override_expires_at,
+    }
+    authority["authority_id"] = _authority_id(authority)
+    return authority
+
+
+def validate_operational_readiness_execution_authority(
+    authority: Mapping[str, Any] | None,
+    *,
+    schedule_id: str,
+    schedule_fingerprint: str,
+    calendar_id: str,
+    calendar_fingerprint: str,
+    portfolio_id: str,
+    risk_limit_policy_id: str,
+    as_of_date: date,
+    latest_expected_session: date,
+    session_dates: Sequence[date],
+    mandate_fingerprints: Sequence[str],
+) -> dict[str, Any]:
+    if not isinstance(authority, Mapping) or set(authority) != AUTHORITY_KEYS:
+        raise ValidationError(
+            "local schedule execution requires exact operational readiness authority"
+        )
+    if authority.get("model_version") != MODEL_VERSION:
+        raise ValidationError("execution authority model version is unsupported")
+    authority_id = authority.get("authority_id")
+    if not isinstance(authority_id, str) or not AUTHORITY_ID_PATTERN.fullmatch(
+        authority_id
+    ):
+        raise ValidationError("execution authority ID is incompatible")
+    plan_id = authority.get("plan_id")
+    if not isinstance(plan_id, str) or not PLAN_ID_PATTERN.fullmatch(plan_id):
+        raise ValidationError("execution authority plan ID is incompatible")
+    _aware_utc(authority.get("authorized_at"), "authorized_at")
+
+    expected_sessions = [value.isoformat() for value in session_dates]
+    if authority.get("session_dates") != expected_sessions:
+        raise ValidationError("execution authority sessions do not match current plan")
+    if authority.get("schedule_id") != schedule_id:
+        raise ValidationError("execution authority belongs to another schedule")
+    if authority.get("schedule_fingerprint") != schedule_fingerprint:
+        raise ValidationError("execution authority schedule fingerprint is stale")
+    if authority.get("calendar_id") != calendar_id:
+        raise ValidationError("execution authority belongs to another calendar")
+    if authority.get("calendar_fingerprint") != calendar_fingerprint:
+        raise ValidationError("execution authority calendar fingerprint is stale")
+    if authority.get("portfolio_id") != portfolio_id:
+        raise ValidationError("execution authority belongs to another portfolio")
+    if authority.get("risk_limit_policy_id") != risk_limit_policy_id:
+        raise ValidationError("execution authority uses another risk-limit policy")
+    if authority.get("as_of_date") != as_of_date.isoformat():
+        raise ValidationError("execution authority uses another as_of_date")
+    if authority.get("latest_expected_session") != latest_expected_session.isoformat():
+        raise ValidationError("execution authority expected session is stale")
+
+    expected_mandates = list(mandate_fingerprints)
+    if not expected_mandates or len(set(expected_mandates)) != 1:
+        raise ValidationError(
+            "readiness authority currently requires one mandate across selected sessions"
+        )
+    if authority.get("mandate_fingerprint") != expected_mandates[0]:
+        raise ValidationError("execution authority mandate fingerprint is stale")
+    _safe_segment(authority.get("mandate_id"), "mandate_id")
+    _safe_segment(authority.get("gate_id"), "gate_id")
+    _bounded_text(authority.get("gate_fingerprint"), "gate_fingerprint")
+    _safe_segment(authority.get("operational_policy_id"), "operational_policy_id")
+    _bounded_text(
+        authority.get("operational_policy_fingerprint"),
+        "operational_policy_fingerprint",
+    )
+    decision_id = authority.get("readiness_decision_id")
+    if not isinstance(decision_id, str) or not DECISION_ID_PATTERN.fullmatch(
+        decision_id
+    ):
+        raise ValidationError("execution authority readiness decision is incompatible")
+    digest = authority.get("readiness_document_sha256")
+    if not isinstance(digest, str) or not SHA256_PATTERN.fullmatch(digest):
+        raise ValidationError("execution authority readiness digest is incompatible")
+    reasons = _string_array(authority.get("readiness_reasons"), "readiness_reasons")
+
+    authority_type = authority.get("authority_type")
+    if authority_type == "gate_allow":
+        if authority.get("readiness_decision") != "allow" or reasons:
+            raise ValidationError("gate allow authority has invalid readiness evidence")
+        if authority.get("override_id") is not None or authority.get(
+            "override_expires_at"
+        ) is not None:
+            raise ValidationError("gate allow authority must not contain override evidence")
+    elif authority_type == "active_override":
+        if authority.get("readiness_decision") != "block" or not reasons:
+            raise ValidationError("override authority has invalid readiness evidence")
+        override_id = authority.get("override_id")
+        if not isinstance(override_id, str) or not OVERRIDE_ID_PATTERN.fullmatch(
+            override_id
+        ):
+            raise ValidationError("override authority ID is incompatible")
+        expires_at = _aware_utc(
+            authority.get("override_expires_at"),
+            "override_expires_at",
+        )
+        authorized_at = _aware_utc(authority.get("authorized_at"), "authorized_at")
+        if expires_at <= authorized_at:
+            raise ValidationError("override authority is expired")
+    else:
+        raise ValidationError("execution authority type is unsupported")
+
+    canonical = dict(authority)
+    if canonical["authority_id"] != _authority_id(canonical):
+        raise ValidationError("execution authority ID does not match its evidence")
+    return canonical

--- a/src/orchestration/run_local_portfolio_schedule.py
+++ b/src/orchestration/run_local_portfolio_schedule.py
@@ -22,6 +22,9 @@ from ..common.config import load_yaml
 from ..common.exceptions import OverlapError, StorageError, ValidationError
 from ..warehouse.postgres_loader import DEFAULT_POSTGRES_DSN
 from .locks import acquire_partition_locks, release_partition_locks
+from .operational_readiness_execution_authority import (
+    validate_operational_readiness_execution_authority,
+)
 
 MODEL_VERSION = "local-portfolio-schedule-v1"
 MAX_CATCH_UP_SESSIONS = 31
@@ -527,6 +530,7 @@ def run_local_portfolio_schedule(
     state_dir: Path,
     dsn: str,
     execute: bool = False,
+    execution_authority: Mapping[str, Any] | None = None,
     python_executable: str = sys.executable,
     command_runner: CommandRunner | None = None,
     mandate_loader: MandateLoader | None = None,
@@ -598,6 +602,7 @@ def run_local_portfolio_schedule(
             "session_dates": [value.isoformat() for value in sessions],
         },
         "plans": plans,
+        "execution_authority": None,
         "execution": {
             "requested": execute,
             "performed": False,
@@ -609,6 +614,26 @@ def run_local_portfolio_schedule(
     }
     if not execute or not sessions:
         return summary
+
+    latest_expected_session = calendar.latest_expected_session(as_of_date)
+    validated_authority = validate_operational_readiness_execution_authority(
+        execution_authority,
+        schedule_id=schedule.schedule_id,
+        schedule_fingerprint=schedule.fingerprint,
+        calendar_id=calendar.calendar_id,
+        calendar_fingerprint=calendar.fingerprint,
+        portfolio_id=schedule.portfolio_id,
+        risk_limit_policy_id=schedule.policy_id,
+        as_of_date=as_of_date,
+        latest_expected_session=latest_expected_session,
+        session_dates=sessions,
+        mandate_fingerprints=[
+            str(plan["mandate_fingerprint"])
+            for plan in plans
+        ],
+    )
+    summary["execution_authority"] = validated_authority
+
     if not schedule.enabled:
         raise ValidationError(
             "local schedule is disabled; enable it in reviewed configuration "
@@ -674,7 +699,8 @@ def _calendar_date(value: str) -> date:
 def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         description=(
-            "Plan or explicitly execute a bounded local portfolio schedule."
+            "Plan a bounded local portfolio schedule. Direct execution requires "
+            "readiness-enforced authority from the dedicated wrapper."
         )
     )
     parser.add_argument("--schedule-id", required=True)
@@ -751,7 +777,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     except ValidationError:
         print(
             "Local portfolio schedule failed: configuration, checkpoint, "
-            "calendar, or options were invalid",
+            "calendar, options, or execution authority were invalid",
             file=sys.stderr,
         )
         return 1

--- a/src/orchestration/run_readiness_enforced_local_schedule.py
+++ b/src/orchestration/run_readiness_enforced_local_schedule.py
@@ -1,0 +1,553 @@
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import sys
+from collections.abc import Callable, Mapping, Sequence
+from datetime import date, datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from src.common.exceptions import OverlapError, StorageError, ValidationError
+from src.orchestration.operational_readiness_execution_authority import (
+    build_operational_readiness_execution_authority,
+)
+from src.orchestration.plan_readiness_aware_local_schedule import (
+    plan_readiness_aware_local_schedule,
+)
+from src.orchestration.run_local_portfolio_schedule import (
+    CommandRunner,
+    run_local_portfolio_schedule,
+)
+from src.warehouse.operational_readiness_decision_reader import (
+    read_current_operational_readiness_decision,
+)
+from src.warehouse.operational_readiness_override_registry import (
+    read_active_operational_readiness_override,
+)
+from src.warehouse.postgres_loader import DEFAULT_POSTGRES_DSN
+
+MODEL_VERSION = "readiness-enforced-local-schedule-v1"
+
+PlanBuilder = Callable[..., Mapping[str, Any]]
+CurrentDecisionReader = Callable[..., dict[str, Any] | None]
+OverrideReader = Callable[..., dict[str, Any] | None]
+ScheduleExecutor = Callable[..., Mapping[str, Any]]
+
+
+def _calendar_date(value: str) -> date:
+    try:
+        parsed = date.fromisoformat(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(
+            "must be a calendar date in YYYY-MM-DD format"
+        ) from exc
+    if value != parsed.isoformat():
+        raise argparse.ArgumentTypeError(
+            "must be a calendar date in YYYY-MM-DD format"
+        )
+    return parsed
+
+
+def _aware_utc(value: str | datetime, label: str) -> datetime:
+    if isinstance(value, datetime):
+        parsed = value
+    else:
+        try:
+            parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        except ValueError:
+            raise ValidationError(f"{label} must be ISO-8601") from None
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise ValidationError(f"{label} must be timezone-aware")
+    return parsed.astimezone(timezone.utc)
+
+
+def _mapping(value: Any, label: str) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        raise StorageError(f"{label} is incompatible")
+    return value
+
+
+def _current_decision_contract(plan: Mapping[str, Any]) -> dict[str, Any]:
+    readiness = _mapping(plan.get("readiness"), "readiness plan evidence")
+    schedule_plan = _mapping(plan.get("schedule_plan"), "schedule plan evidence")
+    calendar = _mapping(schedule_plan.get("calendar"), "schedule calendar evidence")
+    required = {
+        "gate_id": readiness.get("gate_id"),
+        "gate_fingerprint": readiness.get("gate_fingerprint"),
+        "operational_policy_id": readiness.get("operational_policy_id"),
+        "operational_policy_fingerprint": readiness.get(
+            "operational_policy_fingerprint"
+        ),
+        "schedule_id": plan.get("schedule_id"),
+        "schedule_fingerprint": plan.get("schedule_fingerprint"),
+        "calendar_id": calendar.get("calendar_id"),
+        "portfolio_id": plan.get("portfolio_id"),
+        "risk_limit_policy_id": plan.get("risk_limit_policy_id"),
+        "mandate_fingerprint": plan.get("mandate_fingerprint"),
+        "latest_expected_session": plan.get("latest_expected_session"),
+    }
+    if any(not isinstance(value, str) or not value for value in required.values()):
+        raise StorageError("readiness plan current-contract evidence is incomplete")
+    return required
+
+
+def _refresh_current_decision(
+    *,
+    dsn: str,
+    plan: Mapping[str, Any],
+    reader: CurrentDecisionReader,
+) -> dict[str, Any] | None:
+    contract = _current_decision_contract(plan)
+    current = reader(
+        dsn=dsn,
+        gate_id=contract["gate_id"],
+        gate_fingerprint=contract["gate_fingerprint"],
+        operational_policy_id=contract["operational_policy_id"],
+        operational_policy_fingerprint=contract[
+            "operational_policy_fingerprint"
+        ],
+        schedule_id=contract["schedule_id"],
+        schedule_fingerprint=contract["schedule_fingerprint"],
+        calendar_id=contract["calendar_id"],
+        portfolio_id=contract["portfolio_id"],
+        risk_limit_policy_id=contract["risk_limit_policy_id"],
+        mandate_fingerprint=contract["mandate_fingerprint"],
+        latest_expected_session=date.fromisoformat(
+            contract["latest_expected_session"]
+        ),
+    )
+    if current is None:
+        return None
+    planned = _mapping(plan.get("readiness"), "planned readiness evidence")
+    if (
+        current.get("decision_id") != planned.get("decision_id")
+        or current.get("document_sha256") != planned.get("document_sha256")
+    ):
+        raise ValidationError(
+            "current readiness decision changed after planning; generate a new plan"
+        )
+    return current
+
+
+def _decision_is_fresh(
+    decision: Mapping[str, Any],
+    authorized_at: datetime,
+) -> tuple[bool, str | None]:
+    raw_evaluated_at = decision.get("evaluated_at")
+    if not isinstance(raw_evaluated_at, (str, datetime)):
+        raise StorageError("current readiness decision timestamp is incompatible")
+    evaluated_at = _aware_utc(raw_evaluated_at, "decision.evaluated_at")
+    max_age = decision.get("max_report_age_seconds")
+    if type(max_age) is not int or max_age < 1:
+        raise StorageError("current readiness decision age limit is incompatible")
+    age_seconds = (authorized_at - evaluated_at).total_seconds()
+    if age_seconds < 0:
+        return False, "decision_timestamp_future"
+    if age_seconds > max_age:
+        return False, "decision_age_exceeds_limit"
+    return True, None
+
+
+def _enriched_plan(
+    plan: Mapping[str, Any],
+    current_decision: Mapping[str, Any],
+) -> dict[str, Any]:
+    enriched = dict(plan)
+    enriched["readiness"] = {
+        **dict(current_decision),
+        "status": "current",
+        "document_sha256": current_decision["document_sha256"],
+        "recorded_at": current_decision["recorded_at"],
+    }
+    return enriched
+
+
+def _control_id(payload: Mapping[str, Any]) -> str:
+    digest = hashlib.sha256(
+        json.dumps(
+            payload,
+            sort_keys=True,
+            separators=(",", ":"),
+            allow_nan=False,
+        ).encode("utf-8")
+    ).hexdigest()[:24]
+    return f"{MODEL_VERSION}-control-{digest}"
+
+
+def _base_summary(
+    *,
+    plan: Mapping[str, Any],
+    execute: bool,
+    evaluated_at: datetime,
+) -> dict[str, Any]:
+    return {
+        "control_id": "",
+        "model_version": MODEL_VERSION,
+        "evaluated_at": evaluated_at.isoformat(),
+        "execution_requested": execute,
+        "plan_id": plan.get("plan_id"),
+        "schedule_id": plan.get("schedule_id"),
+        "schedule_fingerprint": plan.get("schedule_fingerprint"),
+        "portfolio_id": plan.get("portfolio_id"),
+        "risk_limit_policy_id": plan.get("risk_limit_policy_id"),
+        "mandate_id": plan.get("mandate_id"),
+        "mandate_fingerprint": plan.get("mandate_fingerprint"),
+        "as_of_date": plan.get("as_of_date"),
+        "latest_expected_session": plan.get("latest_expected_session"),
+        "readiness": plan.get("readiness"),
+        "schedule_effect": plan.get("schedule_effect"),
+        "execution_authority": None,
+        "execution": {
+            "requested": execute,
+            "performed": False,
+            "completed_sessions": [],
+        },
+        "checkpoint_before": _mapping(
+            _mapping(plan.get("schedule_plan"), "schedule plan").get("selection"),
+            "schedule selection",
+        ).get("checkpoint_before"),
+        "checkpoint_after": None,
+        "decision": "plan_only" if not execute else "pending",
+        "block_reasons": [],
+        "provider_request_performed": False,
+        "notification_delivery_performed": False,
+        "cloud_schedule_activated": False,
+    }
+
+
+def run_readiness_enforced_local_schedule(
+    *,
+    schedule_id: str,
+    gate_id: str,
+    as_of_date: date,
+    evaluated_at: datetime | str,
+    schedule_config_path: Path,
+    gate_config_path: Path,
+    operational_policy_config_path: Path,
+    calendar_config_path: Path,
+    portfolio_config_path: Path,
+    risk_limit_config_path: Path,
+    storage_config_path: Path,
+    state_dir: Path,
+    dsn: str,
+    execute: bool = False,
+    python_executable: str = sys.executable,
+    command_runner: CommandRunner | None = None,
+    plan_builder: PlanBuilder | None = None,
+    current_decision_reader: CurrentDecisionReader | None = None,
+    override_reader: OverrideReader | None = None,
+    schedule_executor: ScheduleExecutor | None = None,
+) -> dict[str, Any]:
+    authorization_time = _aware_utc(evaluated_at, "evaluated_at")
+    selected_plan_builder = plan_builder or plan_readiness_aware_local_schedule
+    selected_decision_reader = (
+        current_decision_reader or read_current_operational_readiness_decision
+    )
+    selected_override_reader = (
+        override_reader or read_active_operational_readiness_override
+    )
+    selected_schedule_executor = schedule_executor or run_local_portfolio_schedule
+
+    plan = selected_plan_builder(
+        schedule_id=schedule_id,
+        gate_id=gate_id,
+        as_of_date=as_of_date,
+        schedule_config_path=schedule_config_path,
+        gate_config_path=gate_config_path,
+        operational_policy_config_path=operational_policy_config_path,
+        calendar_config_path=calendar_config_path,
+        portfolio_config_path=portfolio_config_path,
+        risk_limit_config_path=risk_limit_config_path,
+        storage_config_path=storage_config_path,
+        state_dir=state_dir,
+        dsn=dsn,
+        python_executable=python_executable,
+    )
+    if not isinstance(plan, Mapping):
+        raise StorageError("readiness-aware planner returned invalid evidence")
+    summary = _base_summary(
+        plan=plan,
+        execute=execute,
+        evaluated_at=authorization_time,
+    )
+    effect = _mapping(plan.get("schedule_effect"), "schedule_effect").get(
+        "decision"
+    )
+    if effect not in {"would_run", "would_block", "no_work"}:
+        raise StorageError("readiness-aware plan effect is incompatible")
+
+    if not execute:
+        summary["decision"] = effect
+        identity = {
+            "evaluated_at": summary["evaluated_at"],
+            "execution_requested": False,
+            "model_version": MODEL_VERSION,
+            "plan_id": summary["plan_id"],
+            "schedule_effect": effect,
+        }
+        summary["control_id"] = _control_id(identity)
+        return summary
+    if effect == "no_work":
+        summary["decision"] = "no_work"
+        identity = {
+            "evaluated_at": summary["evaluated_at"],
+            "execution_requested": True,
+            "model_version": MODEL_VERSION,
+            "plan_id": summary["plan_id"],
+            "schedule_effect": "no_work",
+        }
+        summary["control_id"] = _control_id(identity)
+        return summary
+
+    current_decision = _refresh_current_decision(
+        dsn=dsn,
+        plan=plan,
+        reader=selected_decision_reader,
+    )
+    if current_decision is None:
+        summary["decision"] = "block"
+        summary["block_reasons"] = ["decision_missing"]
+        summary["control_id"] = _control_id(
+            {
+                "evaluated_at": summary["evaluated_at"],
+                "model_version": MODEL_VERSION,
+                "plan_id": summary["plan_id"],
+                "reasons": summary["block_reasons"],
+            }
+        )
+        return summary
+    fresh, freshness_reason = _decision_is_fresh(
+        current_decision,
+        authorization_time,
+    )
+    if not fresh:
+        summary["decision"] = "block"
+        summary["block_reasons"] = [str(freshness_reason)]
+        summary["readiness"] = current_decision
+        summary["control_id"] = _control_id(
+            {
+                "decision_id": current_decision["decision_id"],
+                "evaluated_at": summary["evaluated_at"],
+                "model_version": MODEL_VERSION,
+                "plan_id": summary["plan_id"],
+                "reasons": summary["block_reasons"],
+            }
+        )
+        return summary
+
+    active_override: dict[str, Any] | None = None
+    if current_decision.get("decision") == "block":
+        active_override = selected_override_reader(
+            dsn=dsn,
+            decision_id=str(current_decision["decision_id"]),
+            evaluated_at=authorization_time,
+        )
+        if active_override is None:
+            summary["decision"] = "block"
+            summary["block_reasons"] = [
+                *list(current_decision.get("reasons", [])),
+                "override_missing_or_inactive",
+            ]
+            summary["readiness"] = current_decision
+            summary["control_id"] = _control_id(
+                {
+                    "decision_id": current_decision["decision_id"],
+                    "evaluated_at": summary["evaluated_at"],
+                    "model_version": MODEL_VERSION,
+                    "plan_id": summary["plan_id"],
+                    "reasons": summary["block_reasons"],
+                }
+            )
+            return summary
+    elif current_decision.get("decision") != "allow":
+        raise StorageError("current readiness decision value is incompatible")
+
+    authority_plan = _enriched_plan(plan, current_decision)
+    authority = build_operational_readiness_execution_authority(
+        plan=authority_plan,
+        authorized_at=authorization_time,
+        active_override=active_override,
+    )
+    execution_result = selected_schedule_executor(
+        schedule_id=schedule_id,
+        as_of_date=as_of_date,
+        schedule_config_path=schedule_config_path,
+        calendar_config_path=calendar_config_path,
+        portfolio_config_path=portfolio_config_path,
+        risk_limit_config_path=risk_limit_config_path,
+        storage_config_path=storage_config_path,
+        state_dir=state_dir,
+        dsn=dsn,
+        execute=True,
+        execution_authority=authority,
+        python_executable=python_executable,
+        command_runner=command_runner,
+    )
+    if not isinstance(execution_result, Mapping):
+        raise StorageError("local schedule executor returned invalid evidence")
+    execution = _mapping(execution_result.get("execution"), "schedule execution")
+    expected_sessions = _mapping(plan.get("schedule_effect"), "schedule effect").get(
+        "session_dates"
+    )
+    if (
+        execution.get("performed") is not True
+        or execution.get("completed_sessions") != expected_sessions
+        or execution_result.get("execution_authority") != authority
+    ):
+        raise StorageError(
+            "local schedule plan changed or execution evidence is incomplete"
+        )
+
+    summary["decision"] = "executed"
+    summary["readiness"] = current_decision
+    summary["execution_authority"] = authority
+    summary["execution"] = dict(execution)
+    summary["checkpoint_after"] = execution.get("checkpoint_after")
+    summary["provider_request_performed"] = execution_result.get(
+        "provider_request_performed"
+    )
+    summary["notification_delivery_performed"] = execution_result.get(
+        "external_delivery_performed"
+    )
+    summary["cloud_schedule_activated"] = execution_result.get(
+        "cloud_schedule_activated"
+    )
+    if any(
+        summary[key] is not False
+        for key in (
+            "provider_request_performed",
+            "notification_delivery_performed",
+            "cloud_schedule_activated",
+        )
+    ):
+        raise StorageError("local schedule execution reported an unauthorized side effect")
+    summary["control_id"] = _control_id(
+        {
+            "authority_id": authority["authority_id"],
+            "completed_sessions": execution["completed_sessions"],
+            "evaluated_at": summary["evaluated_at"],
+            "model_version": MODEL_VERSION,
+            "plan_id": summary["plan_id"],
+        }
+    )
+    return summary
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Plan or explicitly execute the local portfolio schedule through "
+            "current operational readiness and override evidence."
+        )
+    )
+    parser.add_argument("--schedule-id", required=True)
+    parser.add_argument("--gate-id", required=True)
+    parser.add_argument("--as-of-date", required=True, type=_calendar_date)
+    parser.add_argument("--evaluated-at", required=True)
+    parser.add_argument(
+        "--schedule-config",
+        type=Path,
+        default=Path("config/local_portfolio_schedules.yaml"),
+    )
+    parser.add_argument(
+        "--gate-config",
+        type=Path,
+        default=Path("config/operational_readiness_gates.yaml"),
+    )
+    parser.add_argument(
+        "--operational-policy-config",
+        type=Path,
+        default=Path("config/operational_service_levels.yaml"),
+    )
+    parser.add_argument(
+        "--calendar-config",
+        type=Path,
+        default=Path("config/market_calendars.yaml"),
+    )
+    parser.add_argument(
+        "--portfolio-config",
+        type=Path,
+        default=Path("config/portfolios.yaml"),
+    )
+    parser.add_argument(
+        "--risk-limit-config",
+        type=Path,
+        default=Path("config/portfolio_risk_limits.yaml"),
+    )
+    parser.add_argument(
+        "--storage-config",
+        type=Path,
+        default=Path("config/storage.yaml"),
+    )
+    parser.add_argument("--state-dir", type=Path, default=Path(".scheduler"))
+    parser.add_argument(
+        "--dsn",
+        default=os.environ.get("WAREHOUSE_POSTGRES_DSN", DEFAULT_POSTGRES_DSN),
+    )
+    parser.add_argument("--execute", action="store_true")
+    parser.add_argument("--summary-json", type=Path)
+    return parser
+
+
+def _write_summary(path: Path, summary: Mapping[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_suffix(path.suffix + ".tmp")
+    try:
+        temporary.write_text(
+            json.dumps(summary, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        temporary.replace(path)
+    except OSError:
+        temporary.unlink(missing_ok=True)
+        raise StorageError("unable to write readiness-enforced schedule summary") from None
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    try:
+        summary = run_readiness_enforced_local_schedule(
+            schedule_id=args.schedule_id,
+            gate_id=args.gate_id,
+            as_of_date=args.as_of_date,
+            evaluated_at=args.evaluated_at,
+            schedule_config_path=args.schedule_config,
+            gate_config_path=args.gate_config,
+            operational_policy_config_path=args.operational_policy_config,
+            calendar_config_path=args.calendar_config,
+            portfolio_config_path=args.portfolio_config,
+            risk_limit_config_path=args.risk_limit_config,
+            storage_config_path=args.storage_config,
+            state_dir=args.state_dir,
+            dsn=args.dsn,
+            execute=args.execute,
+        )
+        if args.summary_json is not None:
+            _write_summary(args.summary_json, summary)
+    except ValidationError as exc:
+        print(f"Readiness-enforced local schedule rejected: {exc}", file=sys.stderr)
+        return 1
+    except OverlapError:
+        print(
+            "Readiness-enforced local schedule failed: another schedule run owns the lock",
+            file=sys.stderr,
+        )
+        return 1
+    except StorageError as exc:
+        print(f"Readiness-enforced local schedule failed: {exc}", file=sys.stderr)
+        return 1
+    except Exception:
+        print(
+            "Readiness-enforced local schedule failed: unexpected local failure",
+            file=sys.stderr,
+        )
+        return 1
+    print(json.dumps(summary, sort_keys=True))
+    return 2 if summary["decision"] == "block" else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/test_local_portfolio_schedule.py
+++ b/tests/unit/test_local_portfolio_schedule.py
@@ -11,6 +11,9 @@ import yaml
 from src.analytics.market_calendar import parse_market_calendar
 from src.analytics.portfolio_mandates import select_portfolio_mandate
 from src.common.exceptions import StorageError, ValidationError
+from src.orchestration.operational_readiness_execution_authority import (
+    build_operational_readiness_execution_authority,
+)
 from src.orchestration.run_local_portfolio_schedule import (
     MODEL_VERSION,
     build_session_commands,
@@ -112,6 +115,55 @@ def _write_schedule(tmp_path: Path, *, enabled: bool, maximum: int = 5) -> Path:
     return path
 
 
+def _execution_authority(*, enabled: bool) -> dict[str, Any]:
+    schedule = _schedule(enabled=enabled)
+    calendar = _calendar()
+    mandate = _mandate()
+    return build_operational_readiness_execution_authority(
+        plan={
+            "plan_id": "readiness-aware-schedule-plan-v1-plan-" + "a" * 24,
+            "model_version": "readiness-aware-schedule-plan-v1",
+            "schedule_id": schedule.schedule_id,
+            "schedule_fingerprint": schedule.fingerprint,
+            "portfolio_id": schedule.portfolio_id,
+            "risk_limit_policy_id": schedule.policy_id,
+            "mandate_id": mandate.mandate_id,
+            "mandate_fingerprint": mandate.fingerprint,
+            "as_of_date": "2026-01-10",
+            "latest_expected_session": "2026-01-09",
+            "readiness": {
+                "status": "current",
+                "decision_id": (
+                    "operational-readiness-gate-v1-decision-" + "b" * 24
+                ),
+                "decision": "allow",
+                "reasons": [],
+                "document_sha256": "c" * 64,
+                "gate_id": "us-tech-local",
+                "gate_fingerprint": (
+                    "operational-readiness-gate-" + "d" * 24
+                ),
+                "operational_policy_id": "us-tech-local",
+                "operational_policy_fingerprint": (
+                    "operational-slo-policy-" + "e" * 24
+                ),
+            },
+            "schedule_plan": {
+                "calendar": {
+                    "calendar_id": calendar.calendar_id,
+                    "calendar_fingerprint": calendar.fingerprint,
+                }
+            },
+            "schedule_effect": {
+                "decision": "would_run",
+                "sessions_selected": 1,
+                "session_dates": ["2026-01-09"],
+            },
+        },
+        authorized_at="2026-01-10T12:00:00Z",
+    )
+
+
 def test_initial_plan_uses_latest_expected_session_on_weekend() -> None:
     sessions = plan_schedule_sessions(
         schedule=_schedule(),
@@ -198,17 +250,18 @@ def test_dry_run_does_not_execute_or_create_state(tmp_path: Path) -> None:
 
     assert calls == []
     assert summary["execution"]["performed"] is False
+    assert summary["execution_authority"] is None
     assert summary["selection"]["session_dates"] == ["2026-01-09"]
     assert not (tmp_path / "state" / "us-tech-local.json").exists()
 
 
-def test_disabled_schedule_refuses_execution_before_commands(tmp_path: Path) -> None:
+def test_direct_execution_without_authority_fails_before_commands(tmp_path: Path) -> None:
     calls: list[tuple[str, ...]] = []
-    with pytest.raises(ValidationError, match="disabled"):
+    with pytest.raises(ValidationError, match="requires exact"):
         run_local_portfolio_schedule(
             schedule_id="us-tech-local",
             as_of_date=date(2026, 1, 10),
-            schedule_config_path=_write_schedule(tmp_path, enabled=False),
+            schedule_config_path=_write_schedule(tmp_path, enabled=True),
             calendar_config_path=Path("calendar.yaml"),
             portfolio_config_path=Path("portfolios.yaml"),
             risk_limit_config_path=Path("limits.yaml"),
@@ -222,9 +275,37 @@ def test_disabled_schedule_refuses_execution_before_commands(tmp_path: Path) -> 
             calendar_loader=lambda *_: _calendar(),
         )
     assert calls == []
+    assert not (tmp_path / "state" / "us-tech-local.json").exists()
 
 
-def test_successful_execution_checkpoints_after_complete_session(tmp_path: Path) -> None:
+def test_disabled_schedule_refuses_authorized_execution_before_commands(
+    tmp_path: Path,
+) -> None:
+    calls: list[tuple[str, ...]] = []
+    with pytest.raises(ValidationError, match="disabled"):
+        run_local_portfolio_schedule(
+            schedule_id="us-tech-local",
+            as_of_date=date(2026, 1, 10),
+            schedule_config_path=_write_schedule(tmp_path, enabled=False),
+            calendar_config_path=Path("calendar.yaml"),
+            portfolio_config_path=Path("portfolios.yaml"),
+            risk_limit_config_path=Path("limits.yaml"),
+            storage_config_path=Path("storage.yaml"),
+            state_dir=tmp_path / "state",
+            dsn="dsn",
+            execute=True,
+            execution_authority=_execution_authority(enabled=False),
+            python_executable="python",
+            command_runner=lambda command, _: calls.append(command),
+            mandate_loader=lambda *_: _mandate(),
+            calendar_loader=lambda *_: _calendar(),
+        )
+    assert calls == []
+
+
+def test_successful_authorized_execution_checkpoints_after_complete_session(
+    tmp_path: Path,
+) -> None:
     calls: list[tuple[str, ...]] = []
     environments: list[dict[str, str]] = []
 
@@ -232,6 +313,7 @@ def test_successful_execution_checkpoints_after_complete_session(tmp_path: Path)
         calls.append(command)
         environments.append(dict(environment))
 
+    authority = _execution_authority(enabled=True)
     summary = run_local_portfolio_schedule(
         schedule_id="us-tech-local",
         as_of_date=date(2026, 1, 10),
@@ -243,6 +325,7 @@ def test_successful_execution_checkpoints_after_complete_session(tmp_path: Path)
         state_dir=tmp_path / "state",
         dsn="postgresql://secret-value",
         execute=True,
+        execution_authority=authority,
         python_executable="python",
         command_runner=runner,
         mandate_loader=lambda *_: _mandate(),
@@ -256,6 +339,7 @@ def test_successful_execution_checkpoints_after_complete_session(tmp_path: Path)
     )
     assert state["last_successful_session"] == "2026-01-09"
     assert summary["execution"]["completed_sessions"] == ["2026-01-09"]
+    assert summary["execution_authority"] == authority
     assert len(calls) == 9
     assert all(
         environment["WAREHOUSE_POSTGRES_DSN"] == "postgresql://secret-value"
@@ -264,7 +348,9 @@ def test_successful_execution_checkpoints_after_complete_session(tmp_path: Path)
     assert "postgresql://secret-value" not in json.dumps(summary)
 
 
-def test_failed_command_does_not_advance_checkpoint(tmp_path: Path) -> None:
+def test_failed_authorized_command_does_not_advance_checkpoint(
+    tmp_path: Path,
+) -> None:
     calls = 0
 
     def fail_after_first(command: tuple[str, ...], environment: Any) -> None:
@@ -285,6 +371,7 @@ def test_failed_command_does_not_advance_checkpoint(tmp_path: Path) -> None:
             state_dir=tmp_path / "state",
             dsn="dsn",
             execute=True,
+            execution_authority=_execution_authority(enabled=True),
             python_executable="python",
             command_runner=fail_after_first,
             mandate_loader=lambda *_: _mandate(),

--- a/tests/unit/test_operational_readiness_execution_authority.py
+++ b/tests/unit/test_operational_readiness_execution_authority.py
@@ -1,0 +1,201 @@
+from __future__ import annotations
+
+from datetime import date, datetime, timezone
+from typing import Any
+
+import pytest
+
+from src.common.exceptions import ValidationError
+from src.orchestration.operational_readiness_execution_authority import (
+    build_operational_readiness_execution_authority,
+    validate_operational_readiness_execution_authority,
+)
+
+
+def _plan(*, effect: str = "would_run", decision: str = "allow") -> dict[str, Any]:
+    reasons = [] if decision == "allow" else ["report_status_critical"]
+    return {
+        "plan_id": "readiness-aware-schedule-plan-v1-plan-" + "a" * 24,
+        "model_version": "readiness-aware-schedule-plan-v1",
+        "schedule_id": "us-tech-local",
+        "schedule_fingerprint": "local-schedule-example",
+        "portfolio_id": "us-tech-equal",
+        "risk_limit_policy_id": "us-tech-standard",
+        "mandate_id": "us-tech-2026",
+        "mandate_fingerprint": "portfolio-mandate-example",
+        "as_of_date": "2026-01-10",
+        "latest_expected_session": "2026-01-09",
+        "readiness": {
+            "status": "current",
+            "decision_id": "operational-readiness-gate-v1-decision-" + "b" * 24,
+            "decision": decision,
+            "reasons": reasons,
+            "document_sha256": "c" * 64,
+            "gate_id": "us-tech-local",
+            "gate_fingerprint": "operational-readiness-gate-" + "d" * 24,
+            "operational_policy_id": "us-tech-local",
+            "operational_policy_fingerprint": "operational-slo-policy-" + "e" * 24,
+        },
+        "schedule_plan": {
+            "calendar": {
+                "calendar_id": "XNYS",
+                "calendar_fingerprint": "market-calendar-example",
+            },
+        },
+        "schedule_effect": {
+            "decision": effect,
+            "sessions_selected": 1,
+            "session_dates": ["2026-01-09"],
+        },
+    }
+
+
+def _override() -> dict[str, Any]:
+    return {
+        "override_id": "operational-readiness-override-v1-" + "f" * 24,
+        "active": True,
+        "decision_id": "operational-readiness-gate-v1-decision-" + "b" * 24,
+        "decision_document_sha256": "c" * 64,
+        "gate_id": "us-tech-local",
+        "gate_fingerprint": "operational-readiness-gate-" + "d" * 24,
+        "operational_policy_id": "us-tech-local",
+        "operational_policy_fingerprint": "operational-slo-policy-" + "e" * 24,
+        "schedule_id": "us-tech-local",
+        "schedule_fingerprint": "local-schedule-example",
+        "calendar_id": "XNYS",
+        "portfolio_id": "us-tech-equal",
+        "risk_limit_policy_id": "us-tech-standard",
+        "mandate_fingerprint": "portfolio-mandate-example",
+        "latest_expected_session": "2026-01-09",
+        "evaluated_at": "2026-01-10T12:00:00+00:00",
+        "expires_at": "2026-01-10T13:00:00+00:00",
+    }
+
+
+def _validate(authority: dict[str, Any]) -> dict[str, Any]:
+    return validate_operational_readiness_execution_authority(
+        authority,
+        schedule_id="us-tech-local",
+        schedule_fingerprint="local-schedule-example",
+        calendar_id="XNYS",
+        calendar_fingerprint="market-calendar-example",
+        portfolio_id="us-tech-equal",
+        risk_limit_policy_id="us-tech-standard",
+        as_of_date=date(2026, 1, 10),
+        latest_expected_session=date(2026, 1, 9),
+        session_dates=(date(2026, 1, 9),),
+        mandate_fingerprints=("portfolio-mandate-example",),
+    )
+
+
+def test_gate_allow_authority_is_deterministic_and_validates() -> None:
+    first = build_operational_readiness_execution_authority(
+        plan=_plan(),
+        authorized_at="2026-01-10T12:00:00Z",
+    )
+    second = build_operational_readiness_execution_authority(
+        plan=_plan(),
+        authorized_at=datetime(2026, 1, 10, 12, tzinfo=timezone.utc),
+    )
+
+    assert first == second
+    assert first["authority_type"] == "gate_allow"
+    assert first["override_id"] is None
+    assert _validate(first) == first
+
+
+def test_blocked_decision_requires_exact_active_override() -> None:
+    plan = _plan(effect="would_block", decision="block")
+    with pytest.raises(ValidationError, match="active override"):
+        build_operational_readiness_execution_authority(
+            plan=plan,
+            authorized_at="2026-01-10T12:00:00Z",
+        )
+
+    authority = build_operational_readiness_execution_authority(
+        plan=plan,
+        authorized_at="2026-01-10T12:00:00Z",
+        active_override=_override(),
+    )
+    assert authority["authority_type"] == "active_override"
+    assert authority["override_id"] == _override()["override_id"]
+    assert _validate(authority) == authority
+
+    wrong = _override()
+    wrong["mandate_fingerprint"] = "other-mandate"
+    with pytest.raises(ValidationError, match="mandate_fingerprint"):
+        build_operational_readiness_execution_authority(
+            plan=plan,
+            authorized_at="2026-01-10T12:00:00Z",
+            active_override=wrong,
+        )
+
+
+def test_missing_decision_and_expired_override_cannot_authorize() -> None:
+    missing = _plan(effect="would_block", decision="block")
+    missing["readiness"]["status"] = "missing"
+    missing["readiness"]["decision_id"] = None
+    missing["readiness"]["document_sha256"] = None
+    with pytest.raises(ValidationError, match="retained readiness decision"):
+        build_operational_readiness_execution_authority(
+            plan=missing,
+            authorized_at="2026-01-10T12:00:00Z",
+            active_override=_override(),
+        )
+
+    expired = _override()
+    expired["expires_at"] = "2026-01-10T12:00:00Z"
+    with pytest.raises(ValidationError, match="expired"):
+        build_operational_readiness_execution_authority(
+            plan=_plan(effect="would_block", decision="block"),
+            authorized_at="2026-01-10T12:00:00Z",
+            active_override=expired,
+        )
+
+
+def test_base_validation_rejects_stale_sessions_and_tampered_identity() -> None:
+    authority = build_operational_readiness_execution_authority(
+        plan=_plan(),
+        authorized_at="2026-01-10T12:00:00Z",
+    )
+    with pytest.raises(ValidationError, match="sessions"):
+        validate_operational_readiness_execution_authority(
+            authority,
+            schedule_id="us-tech-local",
+            schedule_fingerprint="local-schedule-example",
+            calendar_id="XNYS",
+            calendar_fingerprint="market-calendar-example",
+            portfolio_id="us-tech-equal",
+            risk_limit_policy_id="us-tech-standard",
+            as_of_date=date(2026, 1, 10),
+            latest_expected_session=date(2026, 1, 9),
+            session_dates=(date(2026, 1, 8),),
+            mandate_fingerprints=("portfolio-mandate-example",),
+        )
+
+    authority["authority_id"] = (
+        "operational-readiness-execution-authority-v1-authority-" + "0" * 24
+    )
+    with pytest.raises(ValidationError, match="does not match"):
+        _validate(authority)
+
+
+def test_base_validation_rejects_multiple_mandates_in_one_authority() -> None:
+    authority = build_operational_readiness_execution_authority(
+        plan=_plan(),
+        authorized_at="2026-01-10T12:00:00Z",
+    )
+    with pytest.raises(ValidationError, match="one mandate"):
+        validate_operational_readiness_execution_authority(
+            authority,
+            schedule_id="us-tech-local",
+            schedule_fingerprint="local-schedule-example",
+            calendar_id="XNYS",
+            calendar_fingerprint="market-calendar-example",
+            portfolio_id="us-tech-equal",
+            risk_limit_policy_id="us-tech-standard",
+            as_of_date=date(2026, 1, 10),
+            latest_expected_session=date(2026, 1, 9),
+            session_dates=(date(2026, 1, 8), date(2026, 1, 9)),
+            mandate_fingerprints=("mandate-a", "mandate-b"),
+        )

--- a/tests/unit/test_operational_readiness_execution_authority.py
+++ b/tests/unit/test_operational_readiness_execution_authority.py
@@ -181,8 +181,14 @@ def test_base_validation_rejects_stale_sessions_and_tampered_identity() -> None:
 
 
 def test_base_validation_rejects_multiple_mandates_in_one_authority() -> None:
+    plan = _plan()
+    plan["schedule_effect"] = {
+        "decision": "would_run",
+        "sessions_selected": 2,
+        "session_dates": ["2026-01-08", "2026-01-09"],
+    }
     authority = build_operational_readiness_execution_authority(
-        plan=_plan(),
+        plan=plan,
         authorized_at="2026-01-10T12:00:00Z",
     )
     with pytest.raises(ValidationError, match="one mandate"):

--- a/tests/unit/test_readiness_enforced_local_schedule_architecture_contract.py
+++ b/tests/unit/test_readiness_enforced_local_schedule_architecture_contract.py
@@ -1,0 +1,18 @@
+from pathlib import Path
+
+
+def test_readiness_enforced_schedule_documentation_preserves_control_boundary() -> None:
+    documentation = Path(
+        "docs/readiness-enforced-local-schedule.md"
+    ).read_text(encoding="utf-8")
+
+    for required in (
+        "operational-readiness-execution-authority-v1",
+        "authority_type = gate_allow",
+        "authority_type = active_override",
+        "A missing decision cannot be overridden",
+        "fails before commands",
+        "checkpoint is written only after every command",
+        "No live provider request is added to CI",
+    ):
+        assert required in documentation

--- a/tests/unit/test_run_readiness_enforced_local_schedule.py
+++ b/tests/unit/test_run_readiness_enforced_local_schedule.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import datetime, timedelta, timezone
+from datetime import date, datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
 

--- a/tests/unit/test_run_readiness_enforced_local_schedule.py
+++ b/tests/unit/test_run_readiness_enforced_local_schedule.py
@@ -1,0 +1,334 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from src.common.exceptions import StorageError, ValidationError
+from src.orchestration.run_readiness_enforced_local_schedule import (
+    run_readiness_enforced_local_schedule,
+)
+
+AUTHORIZATION_TIME = datetime(2026, 1, 10, 12, tzinfo=timezone.utc)
+DECISION_ID = "operational-readiness-gate-v1-decision-" + "a" * 24
+DOCUMENT_SHA256 = "b" * 64
+
+
+def _plan(
+    *,
+    effect: str = "would_run",
+    decision: str = "allow",
+    decision_id: str | None = DECISION_ID,
+) -> dict[str, Any]:
+    reasons = [] if decision == "allow" else ["report_status_critical"]
+    status = "current" if decision_id is not None else "missing"
+    return {
+        "plan_id": "readiness-aware-schedule-plan-v1-plan-" + "c" * 24,
+        "model_version": "readiness-aware-schedule-plan-v1",
+        "schedule_id": "us-tech-local",
+        "schedule_fingerprint": "local-schedule-example",
+        "portfolio_id": "us-tech-equal",
+        "risk_limit_policy_id": "us-tech-standard",
+        "mandate_id": "us-tech-2026",
+        "mandate_fingerprint": "portfolio-mandate-example",
+        "as_of_date": "2026-01-10",
+        "latest_expected_session": "2026-01-09",
+        "readiness": {
+            "status": status,
+            "decision_id": decision_id,
+            "decision": decision if decision_id is not None else "block",
+            "reasons": reasons if decision_id is not None else ["decision_missing"],
+            "document_sha256": DOCUMENT_SHA256 if decision_id is not None else None,
+            "recorded_at": "2026-01-10T11:56:00+00:00",
+            "gate_id": "us-tech-local",
+            "gate_fingerprint": "operational-readiness-gate-" + "d" * 24,
+            "operational_policy_id": "us-tech-local",
+            "operational_policy_fingerprint": "operational-slo-policy-" + "e" * 24,
+            "latest_expected_session": "2026-01-09",
+        },
+        "schedule_plan": {
+            "schedule_id": "us-tech-local",
+            "schedule_fingerprint": "local-schedule-example",
+            "enabled": True,
+            "calendar": {
+                "calendar_id": "XNYS",
+                "calendar_fingerprint": "market-calendar-example",
+            },
+            "selection": {
+                "as_of_date": "2026-01-10",
+                "checkpoint_before": None,
+                "sessions_selected": 0 if effect == "no_work" else 1,
+                "session_dates": [] if effect == "no_work" else ["2026-01-09"],
+            },
+            "plans": [],
+        },
+        "schedule_effect": {
+            "decision": effect,
+            "sessions_selected": 0 if effect == "no_work" else 1,
+            "session_dates": [] if effect == "no_work" else ["2026-01-09"],
+        },
+    }
+
+
+def _current_decision(
+    *,
+    decision: str = "allow",
+    evaluated_at: datetime | None = None,
+    decision_id: str = DECISION_ID,
+) -> dict[str, Any]:
+    reasons = [] if decision == "allow" else ["report_status_critical"]
+    return {
+        "decision_id": decision_id,
+        "model_version": "operational-readiness-gate-v1",
+        "gate_id": "us-tech-local",
+        "gate_fingerprint": "operational-readiness-gate-" + "d" * 24,
+        "operational_policy_id": "us-tech-local",
+        "operational_policy_fingerprint": "operational-slo-policy-" + "e" * 24,
+        "schedule_id": "us-tech-local",
+        "schedule_fingerprint": "local-schedule-example",
+        "calendar_id": "XNYS",
+        "portfolio_id": "us-tech-equal",
+        "risk_limit_policy_id": "us-tech-standard",
+        "mandate_fingerprint": "portfolio-mandate-example",
+        "evaluated_at": (
+            evaluated_at
+            or AUTHORIZATION_TIME - timedelta(minutes=5)
+        ).isoformat(),
+        "latest_expected_session": "2026-01-09",
+        "max_report_age_seconds": 3600,
+        "allow_warning": False,
+        "report_calculation_id": "operational-service-levels-v1-report-" + "f" * 24,
+        "report_document_sha256": "1" * 64,
+        "report_as_of": (AUTHORIZATION_TIME - timedelta(minutes=10)).isoformat(),
+        "report_latest_expected_session": "2026-01-09",
+        "report_status": "ok" if decision == "allow" else "critical",
+        "report_age_seconds": 300.0,
+        "report_future_seconds": 0.0,
+        "decision": decision,
+        "reasons": reasons,
+        "schedule_executed": False,
+        "provider_request_performed": False,
+        "notification_delivery_performed": False,
+        "cloud_schedule_activated": False,
+        "document_sha256": DOCUMENT_SHA256,
+        "recorded_at": "2026-01-10T11:56:00+00:00",
+    }
+
+
+def _override() -> dict[str, Any]:
+    return {
+        "override_id": "operational-readiness-override-v1-" + "2" * 24,
+        "model_version": "operational-readiness-override-v1",
+        "decision_id": DECISION_ID,
+        "decision_document_sha256": DOCUMENT_SHA256,
+        "gate_id": "us-tech-local",
+        "gate_fingerprint": "operational-readiness-gate-" + "d" * 24,
+        "operational_policy_id": "us-tech-local",
+        "operational_policy_fingerprint": "operational-slo-policy-" + "e" * 24,
+        "schedule_id": "us-tech-local",
+        "schedule_fingerprint": "local-schedule-example",
+        "calendar_id": "XNYS",
+        "portfolio_id": "us-tech-equal",
+        "risk_limit_policy_id": "us-tech-standard",
+        "mandate_fingerprint": "portfolio-mandate-example",
+        "latest_expected_session": "2026-01-09",
+        "request_id": "OVERRIDE-001",
+        "approved_at": "2026-01-10T11:55:00+00:00",
+        "expires_at": "2026-01-10T13:00:00+00:00",
+        "approved_by": "operator@example.test",
+        "revocation_id": None,
+        "revoked_at": None,
+        "evaluated_at": AUTHORIZATION_TIME.isoformat(),
+        "active": True,
+    }
+
+
+def _execution_result(authority: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "run_id": "schedule-run",
+        "execution_authority": authority,
+        "execution": {
+            "requested": True,
+            "performed": True,
+            "completed_sessions": ["2026-01-09"],
+            "checkpoint_after": "2026-01-09",
+        },
+        "provider_request_performed": False,
+        "external_delivery_performed": False,
+        "cloud_schedule_activated": False,
+    }
+
+
+def _run(
+    *,
+    plan: dict[str, Any],
+    current: dict[str, Any] | None,
+    override: dict[str, Any] | None = None,
+    execute: bool = True,
+    counters: dict[str, int] | None = None,
+    executor_result_factory: Any = _execution_result,
+) -> dict[str, Any]:
+    calls = counters if counters is not None else {
+        "current": 0,
+        "override": 0,
+        "executor": 0,
+    }
+
+    def current_reader(**_: Any) -> dict[str, Any] | None:
+        calls["current"] += 1
+        return current
+
+    def override_reader(**_: Any) -> dict[str, Any] | None:
+        calls["override"] += 1
+        return override
+
+    def executor(**kwargs: Any) -> dict[str, Any]:
+        calls["executor"] += 1
+        return executor_result_factory(kwargs["execution_authority"])
+
+    return run_readiness_enforced_local_schedule(
+        schedule_id="us-tech-local",
+        gate_id="us-tech-local",
+        as_of_date=date(2026, 1, 10),
+        evaluated_at=AUTHORIZATION_TIME,
+        schedule_config_path=Path("schedule.yaml"),
+        gate_config_path=Path("gate.yaml"),
+        operational_policy_config_path=Path("policy.yaml"),
+        calendar_config_path=Path("calendar.yaml"),
+        portfolio_config_path=Path("portfolio.yaml"),
+        risk_limit_config_path=Path("limits.yaml"),
+        storage_config_path=Path("storage.yaml"),
+        state_dir=Path(".scheduler"),
+        dsn="not-used",
+        execute=execute,
+        python_executable="python",
+        plan_builder=lambda **_: plan,
+        current_decision_reader=current_reader,
+        override_reader=override_reader,
+        schedule_executor=executor,
+    )
+
+
+def test_plan_only_and_no_work_do_not_read_authority_or_execute() -> None:
+    plan_calls = {"current": 0, "override": 0, "executor": 0}
+    plan_result = _run(
+        plan=_plan(),
+        current=_current_decision(),
+        execute=False,
+        counters=plan_calls,
+    )
+    no_work_calls = {"current": 0, "override": 0, "executor": 0}
+    no_work = _run(
+        plan=_plan(effect="no_work"),
+        current=None,
+        counters=no_work_calls,
+    )
+
+    assert plan_result["decision"] == "would_run"
+    assert no_work["decision"] == "no_work"
+    assert plan_calls == {"current": 0, "override": 0, "executor": 0}
+    assert no_work_calls == {"current": 0, "override": 0, "executor": 0}
+
+
+def test_current_allow_executes_with_gate_authority() -> None:
+    calls = {"current": 0, "override": 0, "executor": 0}
+    result = _run(
+        plan=_plan(),
+        current=_current_decision(),
+        counters=calls,
+    )
+
+    assert result["decision"] == "executed"
+    assert result["execution_authority"]["authority_type"] == "gate_allow"
+    assert result["checkpoint_after"] == "2026-01-09"
+    assert calls == {"current": 1, "override": 0, "executor": 1}
+
+
+def test_block_without_active_override_never_calls_executor() -> None:
+    calls = {"current": 0, "override": 0, "executor": 0}
+    result = _run(
+        plan=_plan(effect="would_block", decision="block"),
+        current=_current_decision(decision="block"),
+        override=None,
+        counters=calls,
+    )
+
+    assert result["decision"] == "block"
+    assert result["block_reasons"] == [
+        "report_status_critical",
+        "override_missing_or_inactive",
+    ]
+    assert calls == {"current": 1, "override": 1, "executor": 0}
+
+
+def test_block_with_exact_active_override_executes() -> None:
+    calls = {"current": 0, "override": 0, "executor": 0}
+    result = _run(
+        plan=_plan(effect="would_block", decision="block"),
+        current=_current_decision(decision="block"),
+        override=_override(),
+        counters=calls,
+    )
+
+    authority = result["execution_authority"]
+    assert result["decision"] == "executed"
+    assert authority["authority_type"] == "active_override"
+    assert authority["override_id"] == _override()["override_id"]
+    assert calls == {"current": 1, "override": 1, "executor": 1}
+
+
+def test_missing_or_stale_decision_blocks_without_override_lookup() -> None:
+    missing_calls = {"current": 0, "override": 0, "executor": 0}
+    missing = _run(
+        plan=_plan(effect="would_block", decision="block", decision_id=None),
+        current=None,
+        counters=missing_calls,
+    )
+    stale_calls = {"current": 0, "override": 0, "executor": 0}
+    stale = _run(
+        plan=_plan(),
+        current=_current_decision(
+            evaluated_at=AUTHORIZATION_TIME - timedelta(hours=2)
+        ),
+        counters=stale_calls,
+    )
+
+    assert missing["block_reasons"] == ["decision_missing"]
+    assert stale["block_reasons"] == ["decision_age_exceeds_limit"]
+    assert missing_calls == {"current": 1, "override": 0, "executor": 0}
+    assert stale_calls == {"current": 1, "override": 0, "executor": 0}
+
+
+def test_changed_decision_and_wrong_override_contract_fail_closed() -> None:
+    with pytest.raises(ValidationError, match="changed after planning"):
+        _run(
+            plan=_plan(),
+            current=_current_decision(
+                decision_id="operational-readiness-gate-v1-decision-" + "9" * 24
+            ),
+        )
+
+    wrong_override = _override()
+    wrong_override["schedule_fingerprint"] = "other-schedule"
+    with pytest.raises(ValidationError, match="schedule_fingerprint"):
+        _run(
+            plan=_plan(effect="would_block", decision="block"),
+            current=_current_decision(decision="block"),
+            override=wrong_override,
+        )
+
+
+def test_incomplete_execution_evidence_fails_closed() -> None:
+    def incomplete(authority: dict[str, Any]) -> dict[str, Any]:
+        result = _execution_result(authority)
+        result["execution"]["completed_sessions"] = []
+        return result
+
+    with pytest.raises(StorageError, match="execution evidence"):
+        _run(
+            plan=_plan(),
+            current=_current_decision(),
+            executor_result_factory=incomplete,
+        )


### PR DESCRIPTION
## Outcome

Complete the controlled local execution loop:

```text
readiness-aware schedule plan
  -> refresh the exact current readiness decision
  -> reject changed, future or stale evidence
  -> current allow OR exact active override
  -> deterministic execution authority
  -> recalculate and validate the local schedule plan
  -> execute under the established lock
  -> checkpoint only after complete authorised sessions
```

Primary arc42 block: `orchestration`, with bounded interfaces to retained readiness decisions, active override evidence and the established local scheduler.

## Deterministic authority

Add `operational-readiness-execution-authority-v1`. Authority binds the plan ID, exact schedule/calendar/portfolio/policy/mandate contract, selected sessions, current readiness decision ID and document digest, decision/reasons, explicit authorisation instant, and override ID/expiry where applicable.

Authority types are:

- `gate_allow` — current allow decision, no override;
- `active_override` — current block decision plus exact current unexpired/unrevoked override.

Missing decisions cannot be overridden. A catch-up window crossing mandate fingerprints is rejected and must be split.

## Base scheduler enforcement

`run_local_portfolio_schedule` now accepts an internal `execution_authority` contract. When `execute=True` and work is selected, it validates authority against the newly calculated schedule, latest expected session, selected dates and mandate fingerprint before:

- checking the enabled flag;
- acquiring a lock;
- running any command; or
- writing checkpoint state.

The direct CLI has no authority input. `run_local_portfolio_schedule --execute` therefore fails before commands; plan-only use remains unchanged.

## Readiness-enforced wrapper

Add:

```bash
.venv/bin/python -m src.orchestration.run_readiness_enforced_local_schedule \
  --schedule-id us-tech-local \
  --gate-id us-tech-local \
  --as-of-date 2026-04-01 \
  --evaluated-at 2026-04-01T12:00:00Z \
  --execute \
  --summary-json .demo/readiness-enforced-schedule.json
```

The wrapper refreshes the exact current decision immediately before authorisation and fails if the decision ID/digest changed after planning. The decision must not be future-dated and must remain within its configured age limit.

A current block without active override returns exit code 2 and never calls the scheduler. A current allow or exact active override produces authority and invokes the base scheduler. Executor evidence must return the exact authority and all authorised sessions.

## Validation and repair

The first exact-head run passed security, PostgreSQL and infrastructure checks but found one missing `date` import in a new focused test. The second run reached the tests and exposed a fixture-order issue: the multi-mandate test supplied two sessions to a one-session authority, so session mismatch occurred before the intended mandate-boundary assertion. The fixture now authorises the same two sessions and then proves mixed mandate fingerprints fail. No production rule or validation gate was weakened.

GitHub Actions run `32717729509` (`ci` run 303) passed on final exact head `3dcca011c4ea66d5c0432ba485e244a897928eaf`:

- Security guardrails: passed.
- Python readiness: passed.
  - locked dependencies resolved;
  - Ruff passed;
  - mypy passed across 103 source files;
  - 754 tests passed in both quality and readiness runs;
  - `pip check` passed;
  - the standard readiness replay passed.
- PostgreSQL contract: passed against PostgreSQL 16, including source-to-serving, model approval, operational SLI/SLO, readiness history, review queries and override lifecycle evidence.
- Infrastructure validation: passed with Kubernetes rendering and Terraform format/init/validate without apply.

No unresolved review threads or requested changes are present.

## Tests and safety

Focused tests cover deterministic gate/override authority, tamper and stale-plan rejection, direct execution without authority, disabled schedules after authority, successful checkpointing, failed-command checkpoint safety, plan-only/no-work behavior, missing/stale/changed decisions, inactive/wrong overrides and incomplete executor evidence.

No real commands, provider requests or notification deliveries run in CI; command and executor boundaries are injected.

## Scope

The branch is directly based on PR #102, is zero commits behind and changes eight files with 1,808 additions and five deletions. Connector writes and the two focused test repairs produced ten working commits; this PR is intended for squash merge as one enforcement layer.

No cloud scheduling, external delivery, authentication service, position mutation, infrastructure deployment or `terraform apply` is included.

## Acceptance boundary

Validated and ready for squash merge as the completion of the local operational-readiness enforcement milestone.