### PR TITLE
Persist append-only local schedule run history

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,6 +25,7 @@ services:
       - ./sql/operational_readiness_decisions_schema.sql:/docker-entrypoint-initdb.d/15_operational_readiness_decisions_schema.sql:ro
       - ./sql/operational_review_schema.sql:/docker-entrypoint-initdb.d/16_operational_review_schema.sql:ro
       - ./sql/operational_readiness_overrides_schema.sql:/docker-entrypoint-initdb.d/17_operational_readiness_overrides_schema.sql:ro
+      - ./sql/local_schedule_runs_schema.sql:/docker-entrypoint-initdb.d/18_local_schedule_runs_schema.sql:ro
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U risk_user -d risk_platform"]
       interval: 5s

--- a/docs/local-schedule-run-history.md
+++ b/docs/local-schedule-run-history.md
@@ -38,9 +38,9 @@ terminal evidence.
 - ordered bounded stage outcomes for each started session; and
 - one stable failure code and failed session/stage identity where applicable.
 
-The execution-authority ID is the idempotency request key. Re-recording the exact
-same canonical document converges. Reusing that request identity with different
-evidence fails closed.
+The execution-authority ID is the idempotency request key. Exact retries converge
+when the canonical document is unchanged. Reusing that request identity with
+different evidence fails closed.
 
 ## Session And Stage Semantics
 

--- a/docs/local-schedule-run-history.md
+++ b/docs/local-schedule-run-history.md
@@ -38,7 +38,7 @@ terminal evidence.
 - ordered bounded stage outcomes for each started session; and
 - one stable failure code and failed session/stage identity where applicable.
 
-The execution-authority ID is the idempotency request key. Exact retries converge
+The execution-authority ID is the idempotency request key; exact retries converge
 when the canonical document is unchanged. Reusing that request identity with
 different evidence fails closed.
 

--- a/docs/local-schedule-run-history.md
+++ b/docs/local-schedule-run-history.md
@@ -1,0 +1,155 @@
+# Append-Only Local Schedule Run History
+
+## Outcome
+
+The readiness-enforced local scheduler now retains one immutable terminal document
+for every authorised execution attempt:
+
+```text
+readiness-aware plan
+  + exact current readiness decision
+  + gate_allow or active_override authority
+  + selected local sessions
+  -> bounded stage execution
+  -> completed or failed terminal run document
+  -> append-only PostgreSQL evidence
+  -> current failure, incomplete-session and recent-run views
+```
+
+Primary arc42 block: `warehouse`, with a bounded instrumentation interface from
+`orchestration`. The base scheduler remains responsible for locking, command order
+and checkpoint mutation. The warehouse layer validates and retains the resulting
+terminal evidence.
+
+## Terminal Run Contract
+
+`local-schedule-run-v1` binds:
+
+- a deterministic run ID and request ID;
+- the readiness-aware plan ID;
+- execution-authority ID and `gate_allow` or `active_override` type;
+- exact readiness-decision ID and canonical document SHA-256;
+- exact override ID when override authority was used;
+- schedule, calendar, portfolio, risk-limit policy and mandate identities;
+- as-of date and latest expected market session;
+- checkpoint before and after the attempt;
+- selected, started and completed session counts;
+- ordered terminal session outcomes;
+- ordered bounded stage outcomes for each started session; and
+- one stable failure code and failed session/stage identity where applicable.
+
+The execution-authority ID is the idempotency request key. Re-recording the exact
+same canonical document converges. Reusing that request identity with different
+evidence fails closed.
+
+## Session And Stage Semantics
+
+Sessions use one terminal prefix:
+
+```text
+completed* [failed]? selected*
+```
+
+A completed session contains only completed stages and ends with the successful
+`checkpoint` stage. Its `checkpoint_after` is the session date.
+
+A failed session has exactly one failed final attempted stage. Later selected
+sessions remain explicit and unstarted. A failure before the first session retains
+all sessions as selected and records a run-level failure code without inventing a
+failed session.
+
+Stage names identify the bounded operation only, for example:
+
+```text
+run_daily_risk:AAPL
+run_market_freshness:AAPL
+run_governed_portfolio_cycle
+make:portfolio-risk-limits-warehouse-load
+checkpoint
+```
+
+**No command arguments**, environment variables, PostgreSQL DSNs, API keys or
+other credentials are retained in the history document.
+
+## Scheduler Integration
+
+`run_local_portfolio_schedule` validates the current execution authority before
+creating a run identity. Plan-only and no-work calls remain unrecorded because no
+execution attempt starts.
+
+For an authorised attempt the scheduler:
+
+1. creates a deterministic run ID from the plan and authority identity;
+2. records bounded stage start/finish evidence while retaining the existing lock;
+3. advances the checkpoint only after every command for a session succeeds;
+4. records a completed terminal document after all selected sessions finish; or
+5. records a failed terminal document before re-raising the original execution
+   failure.
+
+A history-recording failure also fails the operation. Successful execution is not
+reported without durable terminal evidence.
+
+## PostgreSQL Contract
+
+The schema adds:
+
+```text
+risk_platform.local_schedule_runs
+risk_platform.local_schedule_run_session_history
+risk_platform.local_schedule_run_stage_history
+risk_platform.recent_local_schedule_runs
+risk_platform.current_local_schedule_run_status
+risk_platform.current_local_schedule_run_failures
+risk_platform.incomplete_local_schedule_sessions
+```
+
+The base table stores the complete canonical JSONB document plus extracted query
+columns and its SHA-256. PostgreSQL independently validates the referenced
+readiness decision and, for override authority, the exact approved, unexpired and
+unrevoked override at run start.
+
+`recent_local_schedule_runs` ranks attempts by schedule and start time.
+`current_local_schedule_run_status` exposes one latest attempt per schedule.
+`current_local_schedule_run_failures` exposes the latest failed schedules.
+`incomplete_local_schedule_sessions` exposes failed and never-started selected
+sessions for operational follow-up.
+
+UPDATE and DELETE are rejected by append-only triggers.
+
+## Operator Recording Path
+
+Scheduler instrumentation records terminal evidence automatically. A reviewed
+canonical document can also be replayed explicitly:
+
+```bash
+.venv/bin/python -m src.warehouse.local_schedule_run_recorder \
+  --run .demo/local-schedule-run.json
+```
+
+The recorder accepts one regular JSON file no larger than 1 MB and rejects
+symbolic links, unknown fields, malformed identities, non-canonical session/stage
+ordering and inconsistent checkpoint arithmetic before PostgreSQL mutation.
+
+## Validation
+
+The PostgreSQL 16 contract exercises:
+
+- one completed `gate_allow` run and exact retry convergence;
+- conflicting request reuse rejection;
+- one later failed `active_override` run;
+- completed, failed and selected session expansion;
+- completed and failed stage expansion;
+- current failure and incomplete-session views;
+- readiness and override reference reconciliation; and
+- UPDATE and DELETE rejection.
+
+## Boundary
+
+This increment persists local execution evidence. It does not add provider access,
+external alerting, authentication, cryptographic authorization, position mutation,
+managed scheduling or infrastructure deployment. CI performs no live provider
+request, no external notification delivery, no cloud schedule activation and no
+`terraform apply`.
+
+The next dependency-safe roadmap slice is **P4b — bounded dead-letter retry
+planning**, which remains report-only and delivery-free.

--- a/sql/local_schedule_runs_consistency_checks.sql
+++ b/sql/local_schedule_runs_consistency_checks.sql
@@ -1,0 +1,321 @@
+-- Reconciliation checks for append-only readiness-authorised local schedule runs.
+
+WITH counts AS (
+    SELECT
+        (SELECT COUNT(*) FROM risk_platform.local_schedule_runs) AS run_rows,
+        (SELECT COALESCE(SUM(selected_session_count), 0)
+         FROM risk_platform.local_schedule_runs) AS expected_session_rows,
+        (SELECT COUNT(*)
+         FROM risk_platform.local_schedule_run_session_history) AS session_rows,
+        (SELECT COALESCE(SUM(jsonb_array_length(session.value -> 'stages')), 0)
+         FROM risk_platform.local_schedule_runs run
+         CROSS JOIN LATERAL jsonb_array_elements(run.run_json -> 'sessions')
+            AS session(value)) AS expected_stage_rows,
+        (SELECT COUNT(*)
+         FROM risk_platform.local_schedule_run_stage_history) AS stage_rows,
+        (SELECT COUNT(*)
+         FROM risk_platform.current_local_schedule_run_status) AS current_rows,
+        (SELECT COUNT(DISTINCT schedule_id)
+         FROM risk_platform.local_schedule_runs) AS expected_current_rows,
+        (SELECT COUNT(*)
+         FROM risk_platform.current_local_schedule_run_failures)
+            AS current_failure_rows,
+        (SELECT COUNT(*)
+         FROM risk_platform.current_local_schedule_run_status
+         WHERE run_status = 'failed') AS expected_current_failure_rows,
+        (SELECT COUNT(*)
+         FROM risk_platform.incomplete_local_schedule_sessions)
+            AS incomplete_session_rows,
+        (SELECT COUNT(*)
+         FROM risk_platform.local_schedule_run_session_history
+         WHERE session_status IN ('selected', 'failed'))
+            AS expected_incomplete_session_rows
+),
+integrity AS (
+    SELECT
+        (
+            SELECT COUNT(*)
+            FROM risk_platform.local_schedule_runs run
+            LEFT JOIN risk_platform.operational_readiness_decisions decision
+                ON decision.decision_id = run.readiness_decision_id
+            WHERE decision.decision_id IS NULL
+        ) AS orphan_decisions,
+        (
+            SELECT COUNT(*)
+            FROM risk_platform.local_schedule_runs run
+            JOIN risk_platform.operational_readiness_decisions decision
+                ON decision.decision_id = run.readiness_decision_id
+            WHERE run.readiness_document_sha256 <> decision.document_sha256
+               OR run.schedule_id <> decision.schedule_id
+               OR run.schedule_fingerprint <> decision.schedule_fingerprint
+               OR run.calendar_id <> decision.calendar_id
+               OR run.portfolio_id <> decision.portfolio_id
+               OR run.risk_limit_policy_id <> decision.risk_limit_policy_id
+               OR run.mandate_fingerprint <> decision.mandate_fingerprint
+               OR run.latest_expected_session <> decision.latest_expected_session
+               OR (run.authority_type = 'gate_allow'
+                   AND (decision.decision <> 'allow' OR run.override_id IS NOT NULL))
+               OR (run.authority_type = 'active_override'
+                   AND (decision.decision <> 'block' OR run.override_id IS NULL))
+        ) AS invalid_decision_contracts,
+        (
+            SELECT COUNT(*)
+            FROM risk_platform.local_schedule_runs run
+            LEFT JOIN risk_platform.operational_readiness_overrides override
+                ON override.override_id = run.override_id
+            WHERE run.authority_type = 'active_override'
+              AND (
+                    override.override_id IS NULL
+                    OR override.decision_id <> run.readiness_decision_id
+                    OR override.decision_document_sha256
+                        <> run.readiness_document_sha256
+                    OR override.schedule_id <> run.schedule_id
+                    OR override.schedule_fingerprint <> run.schedule_fingerprint
+                    OR override.calendar_id <> run.calendar_id
+                    OR override.portfolio_id <> run.portfolio_id
+                    OR override.risk_limit_policy_id <> run.risk_limit_policy_id
+                    OR override.mandate_fingerprint <> run.mandate_fingerprint
+                    OR override.latest_expected_session
+                        <> run.latest_expected_session
+                    OR NOT (
+                        override.approved_at <= run.started_at
+                        AND run.started_at < override.expires_at
+                    )
+                    OR EXISTS (
+                        SELECT 1
+                        FROM risk_platform.operational_readiness_override_revocations
+                            revocation
+                        WHERE revocation.override_id = run.override_id
+                          AND revocation.revoked_at <= run.started_at
+                    )
+              )
+        ) AS invalid_override_contracts,
+        (
+            SELECT COUNT(*)
+            FROM risk_platform.local_schedule_runs run
+            WHERE run.selected_session_count
+                    <> jsonb_array_length(run.run_json -> 'sessions')
+               OR run.started_session_count <> (
+                    SELECT COUNT(*)
+                    FROM jsonb_array_elements(run.run_json -> 'sessions') session
+                    WHERE session ->> 'status' IN ('completed', 'failed')
+               )
+               OR run.completed_session_count <> (
+                    SELECT COUNT(*)
+                    FROM jsonb_array_elements(run.run_json -> 'sessions') session
+                    WHERE session ->> 'status' = 'completed'
+               )
+        ) AS invalid_run_counts,
+        (
+            SELECT COUNT(*)
+            FROM risk_platform.local_schedule_run_session_history session
+            WHERE (session.session_status = 'completed'
+                   AND session.checkpoint_after <> session.session_date)
+               OR (session.session_status <> 'completed'
+                   AND session.checkpoint_after IS NOT NULL)
+               OR (session.session_status = 'selected'
+                   AND (session.started_at IS NOT NULL
+                        OR session.finished_at IS NOT NULL
+                        OR session.attempted_stage_count <> 0))
+               OR (session.session_status IN ('completed', 'failed')
+                   AND (session.started_at IS NULL
+                        OR session.finished_at IS NULL
+                        OR session.attempted_stage_count = 0))
+        ) AS invalid_session_outcomes,
+        (
+            SELECT COUNT(*)
+            FROM risk_platform.local_schedule_run_stage_history stage
+            WHERE stage.stage_index < 0
+               OR stage.stage_status NOT IN ('completed', 'failed')
+               OR stage.finished_at < stage.started_at
+               OR (stage.stage_status = 'completed' AND stage.failure_code IS NOT NULL)
+               OR (stage.stage_status = 'failed' AND stage.failure_code IS NULL)
+        ) AS invalid_stage_outcomes,
+        (
+            SELECT COUNT(*)
+            FROM (
+                SELECT run_id FROM risk_platform.local_schedule_runs
+                GROUP BY run_id HAVING COUNT(*) > 1
+            ) duplicate_ids
+        ) AS duplicate_run_ids,
+        (
+            SELECT COUNT(*)
+            FROM (
+                SELECT request_id FROM risk_platform.local_schedule_runs
+                GROUP BY request_id HAVING COUNT(*) > 1
+            ) duplicate_requests
+        ) AS duplicate_requests,
+        (
+            SELECT COUNT(*)
+            FROM (
+                SELECT schedule_id
+                FROM risk_platform.current_local_schedule_run_status
+                GROUP BY schedule_id
+                HAVING COUNT(*) > 1
+            ) duplicate_current_schedules
+        ) AS duplicate_current_schedules,
+        (
+            SELECT COUNT(*)
+            FROM risk_platform.current_local_schedule_run_status current
+            WHERE EXISTS (
+                SELECT 1
+                FROM risk_platform.local_schedule_runs candidate
+                WHERE candidate.schedule_id = current.schedule_id
+                  AND (candidate.started_at, candidate.run_id)
+                        > (current.started_at, current.run_id)
+            )
+        ) AS stale_current_runs,
+        (
+            SELECT COUNT(*)
+            FROM pg_trigger trigger
+            JOIN pg_class table_ref ON table_ref.oid = trigger.tgrelid
+            JOIN pg_namespace namespace_ref
+                ON namespace_ref.oid = table_ref.relnamespace
+            WHERE namespace_ref.nspname = 'risk_platform'
+              AND trigger.tgname IN (
+                    'prevent_local_schedule_run_update',
+                    'prevent_local_schedule_run_delete'
+              )
+              AND NOT trigger.tgisinternal
+        ) AS append_only_trigger_count
+)
+SELECT
+    'local_schedule_run_sessions_expand_exactly' AS check_name,
+    expected_session_rows::TEXT AS expected,
+    session_rows::TEXT AS actual,
+    CASE WHEN expected_session_rows = session_rows THEN 'pass' ELSE 'fail' END
+FROM counts
+
+UNION ALL
+
+SELECT
+    'local_schedule_run_stages_expand_exactly',
+    expected_stage_rows::TEXT,
+    stage_rows::TEXT,
+    CASE WHEN expected_stage_rows = stage_rows THEN 'pass' ELSE 'fail' END
+FROM counts
+
+UNION ALL
+
+SELECT
+    'local_schedule_run_readiness_targets_exist',
+    '0',
+    orphan_decisions::TEXT,
+    CASE WHEN orphan_decisions = 0 THEN 'pass' ELSE 'fail' END
+FROM integrity
+
+UNION ALL
+
+SELECT
+    'local_schedule_run_readiness_contracts_match',
+    '0',
+    invalid_decision_contracts::TEXT,
+    CASE WHEN invalid_decision_contracts = 0 THEN 'pass' ELSE 'fail' END
+FROM integrity
+
+UNION ALL
+
+SELECT
+    'local_schedule_run_override_contracts_match',
+    '0',
+    invalid_override_contracts::TEXT,
+    CASE WHEN invalid_override_contracts = 0 THEN 'pass' ELSE 'fail' END
+FROM integrity
+
+UNION ALL
+
+SELECT
+    'local_schedule_run_counts_reconcile',
+    '0',
+    invalid_run_counts::TEXT,
+    CASE WHEN invalid_run_counts = 0 THEN 'pass' ELSE 'fail' END
+FROM integrity
+
+UNION ALL
+
+SELECT
+    'local_schedule_run_session_outcomes_reconcile',
+    '0',
+    invalid_session_outcomes::TEXT,
+    CASE WHEN invalid_session_outcomes = 0 THEN 'pass' ELSE 'fail' END
+FROM integrity
+
+UNION ALL
+
+SELECT
+    'local_schedule_run_stage_outcomes_reconcile',
+    '0',
+    invalid_stage_outcomes::TEXT,
+    CASE WHEN invalid_stage_outcomes = 0 THEN 'pass' ELSE 'fail' END
+FROM integrity
+
+UNION ALL
+
+SELECT
+    'local_schedule_run_identities_unique',
+    '0',
+    (duplicate_run_ids + duplicate_requests)::TEXT,
+    CASE WHEN duplicate_run_ids + duplicate_requests = 0 THEN 'pass' ELSE 'fail' END
+FROM integrity
+
+UNION ALL
+
+SELECT
+    'current_local_schedule_run_grain_unique',
+    '0',
+    duplicate_current_schedules::TEXT,
+    CASE WHEN duplicate_current_schedules = 0 THEN 'pass' ELSE 'fail' END
+FROM integrity
+
+UNION ALL
+
+SELECT
+    'current_local_schedule_run_selects_latest',
+    '0',
+    stale_current_runs::TEXT,
+    CASE WHEN stale_current_runs = 0 THEN 'pass' ELSE 'fail' END
+FROM integrity
+
+UNION ALL
+
+SELECT
+    'current_local_schedule_run_row_count_matches_schedules',
+    expected_current_rows::TEXT,
+    current_rows::TEXT,
+    CASE WHEN expected_current_rows = current_rows THEN 'pass' ELSE 'fail' END
+FROM counts
+
+UNION ALL
+
+SELECT
+    'current_local_schedule_failures_match_current_status',
+    expected_current_failure_rows::TEXT,
+    current_failure_rows::TEXT,
+    CASE
+        WHEN expected_current_failure_rows = current_failure_rows THEN 'pass'
+        ELSE 'fail'
+    END
+FROM counts
+
+UNION ALL
+
+SELECT
+    'incomplete_local_schedule_sessions_match_terminal_status',
+    expected_incomplete_session_rows::TEXT,
+    incomplete_session_rows::TEXT,
+    CASE
+        WHEN expected_incomplete_session_rows = incomplete_session_rows THEN 'pass'
+        ELSE 'fail'
+    END
+FROM counts
+
+UNION ALL
+
+SELECT
+    'local_schedule_run_append_only_triggers_present',
+    '2',
+    append_only_trigger_count::TEXT,
+    CASE WHEN append_only_trigger_count = 2 THEN 'pass' ELSE 'fail' END
+FROM integrity
+
+ORDER BY check_name;

--- a/sql/local_schedule_runs_consistency_checks.sql
+++ b/sql/local_schedule_runs_consistency_checks.sql
@@ -184,6 +184,7 @@ SELECT
     expected_session_rows::TEXT AS expected,
     session_rows::TEXT AS actual,
     CASE WHEN expected_session_rows = session_rows THEN 'pass' ELSE 'fail' END
+        AS status
 FROM counts
 
 UNION ALL

--- a/sql/local_schedule_runs_schema.sql
+++ b/sql/local_schedule_runs_schema.sql
@@ -1,0 +1,372 @@
+-- Append-only terminal evidence for readiness-authorised local schedule attempts.
+-- Apply after sql/operational_readiness_overrides_schema.sql.
+
+CREATE SCHEMA IF NOT EXISTS risk_platform;
+
+CREATE TABLE IF NOT EXISTS risk_platform.local_schedule_runs (
+    run_id TEXT PRIMARY KEY,
+    model_version TEXT NOT NULL CHECK (model_version = 'local-schedule-run-v1'),
+    request_id TEXT NOT NULL UNIQUE,
+    plan_id TEXT NOT NULL,
+    authority_id TEXT NOT NULL,
+    authority_type TEXT NOT NULL CHECK (
+        authority_type IN ('gate_allow', 'active_override')
+    ),
+    schedule_id TEXT NOT NULL,
+    schedule_fingerprint TEXT NOT NULL,
+    calendar_id TEXT NOT NULL,
+    calendar_fingerprint TEXT NOT NULL,
+    portfolio_id TEXT NOT NULL,
+    risk_limit_policy_id TEXT NOT NULL,
+    mandate_id TEXT NOT NULL,
+    mandate_fingerprint TEXT NOT NULL,
+    as_of_date DATE NOT NULL,
+    latest_expected_session DATE NOT NULL,
+    readiness_decision_id TEXT NOT NULL REFERENCES
+        risk_platform.operational_readiness_decisions (decision_id),
+    readiness_document_sha256 TEXT NOT NULL,
+    override_id TEXT NULL REFERENCES
+        risk_platform.operational_readiness_overrides (override_id),
+    authorized_at TIMESTAMPTZ NOT NULL,
+    started_at TIMESTAMPTZ NOT NULL,
+    finished_at TIMESTAMPTZ NOT NULL,
+    run_status TEXT NOT NULL CHECK (run_status IN ('completed', 'failed')),
+    checkpoint_before DATE NULL,
+    checkpoint_after DATE NULL,
+    selected_session_count INTEGER NOT NULL,
+    started_session_count INTEGER NOT NULL,
+    completed_session_count INTEGER NOT NULL,
+    failed_session DATE NULL,
+    failed_stage_index INTEGER NULL,
+    failed_stage_name TEXT NULL,
+    failure_code TEXT NULL,
+    run_json JSONB NOT NULL,
+    document_sha256 TEXT NOT NULL,
+    recorded_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    CHECK (run_id ~ '^local-schedule-run-v1-run-[0-9a-f]{24}$'),
+    CHECK (
+        plan_id
+            ~ '^readiness-aware-schedule-plan-v1-plan-[0-9a-f]{24}$'
+    ),
+    CHECK (
+        authority_id
+            ~ '^operational-readiness-execution-authority-v1-authority-[0-9a-f]{24}$'
+    ),
+    CHECK (
+        readiness_decision_id
+            ~ '^operational-readiness-gate-v1-decision-[0-9a-f]{24}$'
+    ),
+    CHECK (
+        override_id IS NULL
+        OR override_id ~ '^operational-readiness-override-v1-[0-9a-f]{24}$'
+    ),
+    CHECK (readiness_document_sha256 ~ '^[0-9a-f]{64}$'),
+    CHECK (document_sha256 ~ '^[0-9a-f]{64}$'),
+    CHECK (request_id <> '' AND length(request_id) <= 128),
+    CHECK (request_id = authority_id),
+    CHECK (schedule_id ~ '^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$'),
+    CHECK (schedule_fingerprint <> ''),
+    CHECK (calendar_id ~ '^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$'),
+    CHECK (calendar_fingerprint <> ''),
+    CHECK (portfolio_id ~ '^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$'),
+    CHECK (
+        risk_limit_policy_id ~ '^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$'
+    ),
+    CHECK (mandate_id ~ '^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$'),
+    CHECK (mandate_fingerprint <> ''),
+    CHECK (latest_expected_session <= as_of_date),
+    CHECK (authorized_at <= started_at AND started_at <= finished_at),
+    CHECK (
+        selected_session_count BETWEEN 1 AND 31
+        AND started_session_count BETWEEN 0 AND selected_session_count
+        AND completed_session_count BETWEEN 0 AND started_session_count
+    ),
+    CHECK (failed_stage_index IS NULL OR failed_stage_index >= 0),
+    CHECK (
+        (authority_type = 'gate_allow' AND override_id IS NULL)
+        OR (authority_type = 'active_override' AND override_id IS NOT NULL)
+    ),
+    CHECK (
+        (run_status = 'completed'
+         AND completed_session_count = selected_session_count
+         AND failed_session IS NULL
+         AND failed_stage_index IS NULL
+         AND failed_stage_name IS NULL
+         AND failure_code IS NULL)
+        OR
+        (run_status = 'failed'
+         AND failure_code IS NOT NULL)
+    ),
+    CHECK (jsonb_typeof(run_json) = 'object'),
+    CHECK (jsonb_typeof(run_json -> 'sessions') = 'array'),
+    CHECK (jsonb_array_length(run_json -> 'sessions') = selected_session_count),
+    CHECK (run_json ->> 'run_id' = run_id),
+    CHECK (run_json ->> 'model_version' = model_version),
+    CHECK (run_json ->> 'request_id' = request_id),
+    CHECK (run_json ->> 'plan_id' = plan_id),
+    CHECK (run_json ->> 'authority_id' = authority_id),
+    CHECK (run_json ->> 'authority_type' = authority_type),
+    CHECK ((run_json ->> 'override_id') IS NOT DISTINCT FROM override_id),
+    CHECK (run_json ->> 'schedule_id' = schedule_id),
+    CHECK (run_json ->> 'schedule_fingerprint' = schedule_fingerprint),
+    CHECK (run_json ->> 'calendar_id' = calendar_id),
+    CHECK (run_json ->> 'calendar_fingerprint' = calendar_fingerprint),
+    CHECK (run_json ->> 'portfolio_id' = portfolio_id),
+    CHECK (run_json ->> 'risk_limit_policy_id' = risk_limit_policy_id),
+    CHECK (run_json ->> 'mandate_id' = mandate_id),
+    CHECK (run_json ->> 'mandate_fingerprint' = mandate_fingerprint),
+    CHECK ((run_json ->> 'as_of_date')::DATE = as_of_date),
+    CHECK (
+        (run_json ->> 'latest_expected_session')::DATE
+            = latest_expected_session
+    ),
+    CHECK (run_json ->> 'readiness_decision_id' = readiness_decision_id),
+    CHECK (
+        run_json ->> 'readiness_document_sha256'
+            = readiness_document_sha256
+    ),
+    CHECK ((run_json ->> 'authorized_at')::TIMESTAMPTZ = authorized_at),
+    CHECK ((run_json ->> 'started_at')::TIMESTAMPTZ = started_at),
+    CHECK ((run_json ->> 'finished_at')::TIMESTAMPTZ = finished_at),
+    CHECK (run_json ->> 'run_status' = run_status),
+    CHECK (
+        (run_json ->> 'checkpoint_before')::DATE
+            IS NOT DISTINCT FROM checkpoint_before
+    ),
+    CHECK (
+        (run_json ->> 'checkpoint_after')::DATE
+            IS NOT DISTINCT FROM checkpoint_after
+    ),
+    CHECK (
+        (run_json ->> 'failed_session')::DATE
+            IS NOT DISTINCT FROM failed_session
+    ),
+    CHECK (
+        (run_json ->> 'failed_stage_index')::INTEGER
+            IS NOT DISTINCT FROM failed_stage_index
+    ),
+    CHECK (
+        (run_json ->> 'failed_stage_name')
+            IS NOT DISTINCT FROM failed_stage_name
+    ),
+    CHECK (
+        (run_json ->> 'failure_code') IS NOT DISTINCT FROM failure_code
+    ),
+    CHECK (
+        (run_json ->> 'selected_session_count')::INTEGER
+            = selected_session_count
+    ),
+    CHECK (
+        (run_json ->> 'started_session_count')::INTEGER
+            = started_session_count
+    ),
+    CHECK (
+        (run_json ->> 'completed_session_count')::INTEGER
+            = completed_session_count
+    ),
+    CHECK ((run_json ->> 'provider_request_performed')::BOOLEAN = FALSE),
+    CHECK ((run_json ->> 'notification_delivery_performed')::BOOLEAN = FALSE),
+    CHECK ((run_json ->> 'cloud_schedule_activated')::BOOLEAN = FALSE)
+);
+
+CREATE INDEX IF NOT EXISTS idx_local_schedule_runs_recent
+    ON risk_platform.local_schedule_runs (
+        schedule_id,
+        started_at DESC,
+        run_id DESC
+    );
+
+CREATE INDEX IF NOT EXISTS idx_local_schedule_runs_status
+    ON risk_platform.local_schedule_runs (
+        run_status,
+        finished_at DESC
+    );
+
+CREATE INDEX IF NOT EXISTS idx_local_schedule_runs_decision
+    ON risk_platform.local_schedule_runs (
+        readiness_decision_id,
+        started_at DESC
+    );
+
+CREATE OR REPLACE FUNCTION risk_platform.validate_local_schedule_run_authority()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    decision_row risk_platform.operational_readiness_decisions%ROWTYPE;
+    override_row risk_platform.operational_readiness_overrides%ROWTYPE;
+BEGIN
+    SELECT * INTO decision_row
+    FROM risk_platform.operational_readiness_decisions
+    WHERE decision_id = NEW.readiness_decision_id;
+
+    IF NOT FOUND THEN
+        RAISE EXCEPTION 'local schedule run readiness decision does not exist'
+            USING ERRCODE = '23503';
+    END IF;
+    IF NEW.readiness_document_sha256 <> decision_row.document_sha256
+        OR NEW.schedule_id <> decision_row.schedule_id
+        OR NEW.schedule_fingerprint <> decision_row.schedule_fingerprint
+        OR NEW.calendar_id <> decision_row.calendar_id
+        OR NEW.portfolio_id <> decision_row.portfolio_id
+        OR NEW.risk_limit_policy_id <> decision_row.risk_limit_policy_id
+        OR NEW.mandate_fingerprint <> decision_row.mandate_fingerprint
+        OR NEW.latest_expected_session <> decision_row.latest_expected_session
+    THEN
+        RAISE EXCEPTION 'local schedule run metadata does not match readiness decision'
+            USING ERRCODE = '23514';
+    END IF;
+
+    IF NEW.authority_type = 'gate_allow' THEN
+        IF decision_row.decision <> 'allow' OR NEW.override_id IS NOT NULL THEN
+            RAISE EXCEPTION 'gate_allow run requires an allow decision without override'
+                USING ERRCODE = '23514';
+        END IF;
+    ELSE
+        IF decision_row.decision <> 'block' OR NEW.override_id IS NULL THEN
+            RAISE EXCEPTION 'active_override run requires a blocked decision and override'
+                USING ERRCODE = '23514';
+        END IF;
+        SELECT * INTO override_row
+        FROM risk_platform.operational_readiness_overrides
+        WHERE override_id = NEW.override_id;
+        IF NOT FOUND THEN
+            RAISE EXCEPTION 'local schedule run override does not exist'
+                USING ERRCODE = '23503';
+        END IF;
+        IF override_row.decision_id <> NEW.readiness_decision_id
+            OR override_row.decision_document_sha256
+                <> NEW.readiness_document_sha256
+            OR override_row.schedule_id <> NEW.schedule_id
+            OR override_row.schedule_fingerprint <> NEW.schedule_fingerprint
+            OR override_row.calendar_id <> NEW.calendar_id
+            OR override_row.portfolio_id <> NEW.portfolio_id
+            OR override_row.risk_limit_policy_id <> NEW.risk_limit_policy_id
+            OR override_row.mandate_fingerprint <> NEW.mandate_fingerprint
+            OR override_row.latest_expected_session
+                <> NEW.latest_expected_session
+        THEN
+            RAISE EXCEPTION 'local schedule run override metadata does not match'
+                USING ERRCODE = '23514';
+        END IF;
+        IF NOT (
+            override_row.approved_at <= NEW.started_at
+            AND NEW.started_at < override_row.expires_at
+        ) THEN
+            RAISE EXCEPTION 'local schedule run started outside override window'
+                USING ERRCODE = '23514';
+        END IF;
+        IF EXISTS (
+            SELECT 1
+            FROM risk_platform.operational_readiness_override_revocations revocation
+            WHERE revocation.override_id = NEW.override_id
+              AND revocation.revoked_at <= NEW.started_at
+        ) THEN
+            RAISE EXCEPTION 'local schedule run used a revoked override'
+                USING ERRCODE = '23514';
+        END IF;
+    END IF;
+    RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS validate_local_schedule_run_authority
+    ON risk_platform.local_schedule_runs;
+CREATE TRIGGER validate_local_schedule_run_authority
+BEFORE INSERT ON risk_platform.local_schedule_runs
+FOR EACH ROW
+EXECUTE FUNCTION risk_platform.validate_local_schedule_run_authority();
+
+CREATE OR REPLACE FUNCTION risk_platform.prevent_local_schedule_run_mutation()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    RAISE EXCEPTION 'local schedule run evidence is append-only'
+        USING ERRCODE = '55000';
+END;
+$$;
+
+DROP TRIGGER IF EXISTS prevent_local_schedule_run_update
+    ON risk_platform.local_schedule_runs;
+CREATE TRIGGER prevent_local_schedule_run_update
+BEFORE UPDATE ON risk_platform.local_schedule_runs
+FOR EACH ROW
+EXECUTE FUNCTION risk_platform.prevent_local_schedule_run_mutation();
+
+DROP TRIGGER IF EXISTS prevent_local_schedule_run_delete
+    ON risk_platform.local_schedule_runs;
+CREATE TRIGGER prevent_local_schedule_run_delete
+BEFORE DELETE ON risk_platform.local_schedule_runs
+FOR EACH ROW
+EXECUTE FUNCTION risk_platform.prevent_local_schedule_run_mutation();
+
+CREATE OR REPLACE VIEW risk_platform.local_schedule_run_session_history AS
+SELECT
+    run.run_id,
+    run.request_id,
+    run.plan_id,
+    run.authority_id,
+    run.authority_type,
+    run.schedule_id,
+    run.run_status,
+    session.ordinality::INTEGER - 1 AS session_index,
+    (session.value ->> 'session_date')::DATE AS session_date,
+    session.value ->> 'mandate_id' AS mandate_id,
+    session.value ->> 'mandate_fingerprint' AS mandate_fingerprint,
+    session.value ->> 'status' AS session_status,
+    (session.value ->> 'started_at')::TIMESTAMPTZ AS started_at,
+    (session.value ->> 'finished_at')::TIMESTAMPTZ AS finished_at,
+    (session.value ->> 'checkpoint_after')::DATE AS checkpoint_after,
+    (session.value ->> 'failed_stage_index')::INTEGER AS failed_stage_index,
+    session.value ->> 'failed_stage_name' AS failed_stage_name,
+    session.value ->> 'failure_code' AS failure_code,
+    jsonb_array_length(session.value -> 'stages') AS attempted_stage_count,
+    run.recorded_at
+FROM risk_platform.local_schedule_runs run
+CROSS JOIN LATERAL jsonb_array_elements(run.run_json -> 'sessions')
+    WITH ORDINALITY AS session(value, ordinality);
+
+CREATE OR REPLACE VIEW risk_platform.local_schedule_run_stage_history AS
+SELECT
+    run.run_id,
+    run.request_id,
+    run.schedule_id,
+    session.ordinality::INTEGER - 1 AS session_index,
+    (session.value ->> 'session_date')::DATE AS session_date,
+    stage.ordinality::INTEGER - 1 AS stage_index,
+    stage.value ->> 'stage_name' AS stage_name,
+    stage.value ->> 'status' AS stage_status,
+    (stage.value ->> 'started_at')::TIMESTAMPTZ AS started_at,
+    (stage.value ->> 'finished_at')::TIMESTAMPTZ AS finished_at,
+    stage.value ->> 'failure_code' AS failure_code,
+    run.recorded_at
+FROM risk_platform.local_schedule_runs run
+CROSS JOIN LATERAL jsonb_array_elements(run.run_json -> 'sessions')
+    WITH ORDINALITY AS session(value, ordinality)
+CROSS JOIN LATERAL jsonb_array_elements(session.value -> 'stages')
+    WITH ORDINALITY AS stage(value, ordinality);
+
+CREATE OR REPLACE VIEW risk_platform.recent_local_schedule_runs AS
+SELECT
+    run.*,
+    ROW_NUMBER() OVER (
+        PARTITION BY run.schedule_id
+        ORDER BY run.started_at DESC, run.run_id DESC
+    ) AS schedule_recency_rank
+FROM risk_platform.local_schedule_runs run;
+
+CREATE OR REPLACE VIEW risk_platform.current_local_schedule_run_status AS
+SELECT *
+FROM risk_platform.recent_local_schedule_runs
+WHERE schedule_recency_rank = 1;
+
+CREATE OR REPLACE VIEW risk_platform.current_local_schedule_run_failures AS
+SELECT *
+FROM risk_platform.current_local_schedule_run_status
+WHERE run_status = 'failed';
+
+CREATE OR REPLACE VIEW risk_platform.incomplete_local_schedule_sessions AS
+SELECT *
+FROM risk_platform.local_schedule_run_session_history
+WHERE session_status IN ('selected', 'failed');

--- a/src/orchestration/run_local_portfolio_schedule.py
+++ b/src/orchestration/run_local_portfolio_schedule.py
@@ -20,6 +20,10 @@ from ..analytics.portfolio_mandates import (
 )
 from ..common.config import load_yaml
 from ..common.exceptions import OverlapError, StorageError, ValidationError
+from ..warehouse.local_schedule_run_recorder import (
+    build_local_schedule_run_id,
+    record_local_schedule_run,
+)
 from ..warehouse.postgres_loader import DEFAULT_POSTGRES_DSN
 from .locks import acquire_partition_locks, release_partition_locks
 from .operational_readiness_execution_authority import (
@@ -34,6 +38,8 @@ Command = tuple[str, ...]
 CommandRunner = Callable[[Command, Mapping[str, str]], None]
 MandateLoader = Callable[[Path, str, date], PortfolioMandate]
 CalendarLoader = Callable[[Path, str], MarketCalendar]
+RunHistoryRecorder = Callable[..., Mapping[str, Any]]
+Clock = Callable[[], datetime]
 
 
 @dataclass(frozen=True, slots=True)
@@ -122,9 +128,7 @@ def parse_local_portfolio_schedule(
         )
     candidate = schedules.get(schedule_id)
     if not isinstance(candidate, Mapping):
-        raise ValidationError(
-            f"local schedule '{schedule_id}' is not configured"
-        )
+        raise ValidationError(f"local schedule '{schedule_id}' is not configured")
     enabled = candidate.get("enabled")
     if type(enabled) is not bool:
         raise ValidationError("schedule enabled must be boolean")
@@ -139,15 +143,9 @@ def parse_local_portfolio_schedule(
     return LocalPortfolioSchedule(
         schedule_id=schedule_id,
         enabled=enabled,
-        portfolio_id=_required_text(
-            candidate.get("portfolio_id"),
-            "portfolio_id",
-        ),
+        portfolio_id=_required_text(candidate.get("portfolio_id"), "portfolio_id"),
         policy_id=_required_text(candidate.get("policy_id"), "policy_id"),
-        calendar_id=_required_text(
-            candidate.get("calendar_id"),
-            "calendar_id",
-        ),
+        calendar_id=_required_text(candidate.get("calendar_id"), "calendar_id"),
         maximum_catch_up_sessions=_bounded_integer(
             candidate.get("maximum_catch_up_sessions"),
             "maximum_catch_up_sessions",
@@ -194,16 +192,11 @@ def parse_local_portfolio_schedule(
     )
 
 
-def load_local_portfolio_schedule(
-    path: Path,
-    schedule_id: str,
-) -> LocalPortfolioSchedule:
+def load_local_portfolio_schedule(path: Path, schedule_id: str) -> LocalPortfolioSchedule:
     try:
         payload = load_yaml(path)
     except Exception:
-        raise ValidationError(
-            "local schedule configuration could not be loaded"
-        ) from None
+        raise ValidationError("local schedule configuration could not be loaded") from None
     if not isinstance(payload, Mapping):
         raise ValidationError("local schedule configuration must be a mapping")
     return parse_local_portfolio_schedule(payload, schedule_id)
@@ -251,19 +244,13 @@ def _checkpoint_date(
         )
     raw = state.get("last_successful_session")
     if not isinstance(raw, str):
-        raise ValidationError(
-            "local schedule state is missing last_successful_session"
-        )
+        raise ValidationError("local schedule state is missing last_successful_session")
     try:
         parsed = date.fromisoformat(raw)
     except ValueError:
-        raise ValidationError(
-            "local schedule checkpoint must use YYYY-MM-DD"
-        ) from None
+        raise ValidationError("local schedule checkpoint must use YYYY-MM-DD") from None
     if raw != parsed.isoformat():
-        raise ValidationError(
-            "local schedule checkpoint must use YYYY-MM-DD"
-        )
+        raise ValidationError("local schedule checkpoint must use YYYY-MM-DD")
     return parsed
 
 
@@ -286,10 +273,7 @@ def plan_schedule_sessions(
         )
     if checkpoint == latest_expected:
         return ()
-    candidates = calendar.sessions_between(
-        checkpoint + timedelta(days=1),
-        latest_expected,
-    )
+    candidates = calendar.sessions_between(checkpoint + timedelta(days=1), latest_expected)
     if len(candidates) > schedule.maximum_catch_up_sessions:
         raise ValidationError(
             "local schedule catch-up exceeds maximum_catch_up_sessions; "
@@ -472,18 +456,11 @@ def build_session_commands(
     return tuple(commands)
 
 
-def _default_command_runner(
-    command: Command,
-    environment: Mapping[str, str],
-) -> None:
+def _default_command_runner(command: Command, environment: Mapping[str, str]) -> None:
     merged_environment = dict(os.environ)
     merged_environment.update(environment)
     try:
-        subprocess.run(
-            list(command),
-            check=True,
-            env=merged_environment,
-        )
+        subprocess.run(list(command), check=True, env=merged_environment)
     except (OSError, subprocess.CalledProcessError):
         raise StorageError(
             "local portfolio schedule command failed; checkpoint was not advanced"
@@ -518,6 +495,103 @@ def _write_state(
         raise StorageError("unable to update local schedule checkpoint") from None
 
 
+def _clock_value(clock: Clock) -> datetime:
+    value = clock()
+    if value.tzinfo is None or value.utcoffset() is None:
+        raise StorageError("local schedule execution clock must be timezone-aware")
+    return value.astimezone(timezone.utc)
+
+
+def _command_stage_name(command: Sequence[str]) -> str:
+    if len(command) >= 3 and command[1] == "-m":
+        name = command[2].rsplit(".", 1)[-1]
+        if "--symbol" in command:
+            index = command.index("--symbol")
+            if index + 1 < len(command):
+                name = f"{name}:{command[index + 1]}"
+        return name
+    if len(command) >= 2 and command[0] == "make":
+        return f"make:{command[1]}"
+    return command[0] if command else "unknown-stage"
+
+
+def _selected_session_outcomes(plans: Sequence[Mapping[str, Any]]) -> list[dict[str, Any]]:
+    return [
+        {
+            "session_date": str(plan["session_date"]),
+            "mandate_id": str(plan["mandate_id"]),
+            "mandate_fingerprint": str(plan["mandate_fingerprint"]),
+            "status": "selected",
+            "started_at": None,
+            "finished_at": None,
+            "checkpoint_after": None,
+            "failed_stage_index": None,
+            "failed_stage_name": None,
+            "failure_code": None,
+            "stages": [],
+        }
+        for plan in plans
+    ]
+
+
+def _terminal_run_document(
+    *,
+    run_id: str,
+    authority: Mapping[str, Any],
+    started_at: datetime,
+    finished_at: datetime,
+    run_status: str,
+    checkpoint_before: date | None,
+    checkpoint_after: date | None,
+    session_outcomes: Sequence[Mapping[str, Any]],
+    failed_session: str | None,
+    failed_stage_index: int | None,
+    failed_stage_name: str | None,
+    failure_code: str | None,
+) -> dict[str, Any]:
+    statuses = [str(session["status"]) for session in session_outcomes]
+    return {
+        "run_id": run_id,
+        "model_version": "local-schedule-run-v1",
+        "request_id": str(authority["authority_id"]),
+        "plan_id": str(authority["plan_id"]),
+        "authority_id": str(authority["authority_id"]),
+        "authority_type": str(authority["authority_type"]),
+        "schedule_id": str(authority["schedule_id"]),
+        "schedule_fingerprint": str(authority["schedule_fingerprint"]),
+        "calendar_id": str(authority["calendar_id"]),
+        "calendar_fingerprint": str(authority["calendar_fingerprint"]),
+        "portfolio_id": str(authority["portfolio_id"]),
+        "risk_limit_policy_id": str(authority["risk_limit_policy_id"]),
+        "mandate_id": str(authority["mandate_id"]),
+        "mandate_fingerprint": str(authority["mandate_fingerprint"]),
+        "as_of_date": str(authority["as_of_date"]),
+        "latest_expected_session": str(authority["latest_expected_session"]),
+        "readiness_decision_id": str(authority["readiness_decision_id"]),
+        "readiness_document_sha256": str(authority["readiness_document_sha256"]),
+        "override_id": authority.get("override_id"),
+        "authorized_at": str(authority["authorized_at"]),
+        "started_at": started_at.isoformat(),
+        "finished_at": finished_at.isoformat(),
+        "run_status": run_status,
+        "checkpoint_before": checkpoint_before.isoformat() if checkpoint_before else None,
+        "checkpoint_after": checkpoint_after.isoformat() if checkpoint_after else None,
+        "selected_session_count": len(session_outcomes),
+        "started_session_count": sum(
+            status in {"completed", "failed"} for status in statuses
+        ),
+        "completed_session_count": statuses.count("completed"),
+        "failed_session": failed_session,
+        "failed_stage_index": failed_stage_index,
+        "failed_stage_name": failed_stage_name,
+        "failure_code": failure_code,
+        "sessions": [dict(session) for session in session_outcomes],
+        "provider_request_performed": False,
+        "notification_delivery_performed": False,
+        "cloud_schedule_activated": False,
+    }
+
+
 def run_local_portfolio_schedule(
     *,
     schedule_id: str,
@@ -535,16 +609,12 @@ def run_local_portfolio_schedule(
     command_runner: CommandRunner | None = None,
     mandate_loader: MandateLoader | None = None,
     calendar_loader: CalendarLoader | None = None,
+    run_history_recorder: RunHistoryRecorder | None = None,
+    clock: Clock | None = None,
 ) -> dict[str, Any]:
-    schedule = load_local_portfolio_schedule(
-        schedule_config_path,
-        schedule_id,
-    )
+    schedule = load_local_portfolio_schedule(schedule_config_path, schedule_id)
     selected_calendar_loader = calendar_loader or load_market_calendar
-    calendar = selected_calendar_loader(
-        calendar_config_path,
-        schedule.calendar_id,
-    )
+    calendar = selected_calendar_loader(calendar_config_path, schedule.calendar_id)
     state_path = _state_path(state_dir, schedule.schedule_id)
     state = _read_state(state_path)
     checkpoint_before = _checkpoint_date(state, schedule=schedule)
@@ -593,11 +663,7 @@ def run_local_portfolio_schedule(
         },
         "selection": {
             "as_of_date": as_of_date.isoformat(),
-            "checkpoint_before": (
-                checkpoint_before.isoformat()
-                if checkpoint_before is not None
-                else None
-            ),
+            "checkpoint_before": checkpoint_before.isoformat() if checkpoint_before else None,
             "sessions_selected": len(sessions),
             "session_dates": [value.isoformat() for value in sessions],
         },
@@ -608,6 +674,7 @@ def run_local_portfolio_schedule(
             "performed": False,
             "completed_sessions": [],
         },
+        "run_history": None,
         "provider_request_performed": False,
         "external_delivery_performed": False,
         "cloud_schedule_activated": False,
@@ -627,10 +694,7 @@ def run_local_portfolio_schedule(
         as_of_date=as_of_date,
         latest_expected_session=latest_expected_session,
         session_dates=sessions,
-        mandate_fingerprints=[
-            str(plan["mandate_fingerprint"])
-            for plan in plans
-        ],
+        mandate_fingerprints=[str(plan["mandate_fingerprint"]) for plan in plans],
     )
     summary["execution_authority"] = validated_authority
 
@@ -642,42 +706,199 @@ def run_local_portfolio_schedule(
     if not isinstance(dsn, str) or not dsn.strip():
         raise ValidationError("PostgreSQL DSN must be non-empty text")
 
+    run_id = build_local_schedule_run_id(
+        request_identifier=str(validated_authority["authority_id"]),
+        plan_id=str(validated_authority["plan_id"]),
+        authority_id=str(validated_authority["authority_id"]),
+    )
+    summary["run_id"] = run_id
     selected_runner = command_runner or _default_command_runner
+    selected_recorder = run_history_recorder or record_local_schedule_run
+    selected_clock = clock or (lambda: datetime.now(timezone.utc))
     environment = {
         "LOCAL_POSTGRES_DSN": dsn,
         "WAREHOUSE_POSTGRES_DSN": dsn,
     }
     lock_paths: list[Path] = []
     completed: list[str] = []
-    try:
-        lock_paths = acquire_partition_locks(
-            state_dir,
-            [f"local-schedule/{schedule.schedule_id}"],
-            summary["run_id"],
-            stale_after_seconds=21_600,
-        )
-        if len(lock_paths) != 1:
-            raise StorageError(
-                "local schedule did not acquire exactly one lock"
-            )
-        for session_date, plan in zip(sessions, plans, strict=True):
-            for raw_command in plan["commands"]:
-                selected_runner(tuple(raw_command), environment)
-            _write_state(
-                state_path,
-                schedule=schedule,
-                session_date=session_date,
-            )
-            completed.append(session_date.isoformat())
-    finally:
-        if lock_paths:
-            release_partition_locks(lock_paths)
+    session_outcomes = _selected_session_outcomes(plans)
+    run_started_at = _clock_value(selected_clock)
+    failure_code: str | None = None
+    failed_session: str | None = None
+    failed_stage_index: int | None = None
+    failed_stage_name: str | None = None
 
+    try:
+        try:
+            lock_paths = acquire_partition_locks(
+                state_dir,
+                [f"local-schedule/{schedule.schedule_id}"],
+                run_id,
+                stale_after_seconds=21_600,
+            )
+            if len(lock_paths) != 1:
+                raise StorageError("local schedule did not acquire exactly one lock")
+            for session_date, plan, outcome in zip(
+                sessions,
+                plans,
+                session_outcomes,
+                strict=True,
+            ):
+                session_started_at = _clock_value(selected_clock)
+                outcome["started_at"] = session_started_at.isoformat()
+                for stage_index, raw_command in enumerate(plan["commands"]):
+                    command = tuple(str(value) for value in raw_command)
+                    stage_name = _command_stage_name(command)
+                    stage_started_at = _clock_value(selected_clock)
+                    try:
+                        selected_runner(command, environment)
+                    except Exception:
+                        stage_finished_at = _clock_value(selected_clock)
+                        failure_code = "command_failed"
+                        failed_session = session_date.isoformat()
+                        failed_stage_index = stage_index
+                        failed_stage_name = stage_name
+                        outcome["status"] = "failed"
+                        outcome["finished_at"] = stage_finished_at.isoformat()
+                        outcome["failed_stage_index"] = stage_index
+                        outcome["failed_stage_name"] = stage_name
+                        outcome["failure_code"] = failure_code
+                        outcome["stages"].append(
+                            {
+                                "stage_index": stage_index,
+                                "stage_name": stage_name,
+                                "status": "failed",
+                                "started_at": stage_started_at.isoformat(),
+                                "finished_at": stage_finished_at.isoformat(),
+                                "failure_code": failure_code,
+                            }
+                        )
+                        raise
+                    stage_finished_at = _clock_value(selected_clock)
+                    outcome["stages"].append(
+                        {
+                            "stage_index": stage_index,
+                            "stage_name": stage_name,
+                            "status": "completed",
+                            "started_at": stage_started_at.isoformat(),
+                            "finished_at": stage_finished_at.isoformat(),
+                            "failure_code": None,
+                        }
+                    )
+
+                checkpoint_index = len(plan["commands"])
+                checkpoint_started_at = _clock_value(selected_clock)
+                try:
+                    _write_state(
+                        state_path,
+                        schedule=schedule,
+                        session_date=session_date,
+                    )
+                except Exception:
+                    checkpoint_finished_at = _clock_value(selected_clock)
+                    failure_code = "checkpoint_failed"
+                    failed_session = session_date.isoformat()
+                    failed_stage_index = checkpoint_index
+                    failed_stage_name = "checkpoint"
+                    outcome["status"] = "failed"
+                    outcome["finished_at"] = checkpoint_finished_at.isoformat()
+                    outcome["failed_stage_index"] = checkpoint_index
+                    outcome["failed_stage_name"] = "checkpoint"
+                    outcome["failure_code"] = failure_code
+                    outcome["stages"].append(
+                        {
+                            "stage_index": checkpoint_index,
+                            "stage_name": "checkpoint",
+                            "status": "failed",
+                            "started_at": checkpoint_started_at.isoformat(),
+                            "finished_at": checkpoint_finished_at.isoformat(),
+                            "failure_code": failure_code,
+                        }
+                    )
+                    raise
+                checkpoint_finished_at = _clock_value(selected_clock)
+                outcome["stages"].append(
+                    {
+                        "stage_index": checkpoint_index,
+                        "stage_name": "checkpoint",
+                        "status": "completed",
+                        "started_at": checkpoint_started_at.isoformat(),
+                        "finished_at": checkpoint_finished_at.isoformat(),
+                        "failure_code": None,
+                    }
+                )
+                outcome["status"] = "completed"
+                outcome["finished_at"] = checkpoint_finished_at.isoformat()
+                outcome["checkpoint_after"] = session_date.isoformat()
+                completed.append(session_date.isoformat())
+        finally:
+            if lock_paths:
+                release_partition_locks(lock_paths)
+    except Exception as exc:
+        if failure_code is None:
+            failure_code = (
+                "lock_overlap"
+                if isinstance(exc, OverlapError)
+                else "execution_stage_failed"
+            )
+        run_finished_at = _clock_value(selected_clock)
+        checkpoint_after = date.fromisoformat(completed[-1]) if completed else checkpoint_before
+        run_document = _terminal_run_document(
+            run_id=run_id,
+            authority=validated_authority,
+            started_at=run_started_at,
+            finished_at=run_finished_at,
+            run_status="failed",
+            checkpoint_before=checkpoint_before,
+            checkpoint_after=checkpoint_after,
+            session_outcomes=session_outcomes,
+            failed_session=failed_session,
+            failed_stage_index=failed_stage_index,
+            failed_stage_name=failed_stage_name,
+            failure_code=failure_code,
+        )
+        history = selected_recorder(dsn=dsn, run=run_document)
+        summary["run_history"] = dict(history)
+        summary["execution"] = {
+            "requested": True,
+            "performed": any(
+                outcome["status"] in {"completed", "failed"}
+                for outcome in session_outcomes
+            ),
+            "completed_sessions": completed,
+            "checkpoint_after": checkpoint_after.isoformat() if checkpoint_after else None,
+            "failure_code": failure_code,
+            "failed_session": failed_session,
+            "failed_stage_index": failed_stage_index,
+            "failed_stage_name": failed_stage_name,
+            "session_outcomes": session_outcomes,
+        }
+        raise
+
+    run_finished_at = _clock_value(selected_clock)
+    checkpoint_after = date.fromisoformat(completed[-1])
+    run_document = _terminal_run_document(
+        run_id=run_id,
+        authority=validated_authority,
+        started_at=run_started_at,
+        finished_at=run_finished_at,
+        run_status="completed",
+        checkpoint_before=checkpoint_before,
+        checkpoint_after=checkpoint_after,
+        session_outcomes=session_outcomes,
+        failed_session=None,
+        failed_stage_index=None,
+        failed_stage_name=None,
+        failure_code=None,
+    )
+    history = selected_recorder(dsn=dsn, run=run_document)
+    summary["run_history"] = dict(history)
     summary["execution"] = {
         "requested": True,
         "performed": True,
         "completed_sessions": completed,
         "checkpoint_after": completed[-1],
+        "session_outcomes": session_outcomes,
     }
     return summary
 
@@ -690,9 +911,7 @@ def _calendar_date(value: str) -> date:
             "must be a calendar date in YYYY-MM-DD format"
         ) from exc
     if value != parsed.isoformat():
-        raise argparse.ArgumentTypeError(
-            "must be a calendar date in YYYY-MM-DD format"
-        )
+        raise argparse.ArgumentTypeError("must be a calendar date in YYYY-MM-DD format")
     return parsed
 
 
@@ -733,10 +952,7 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--state-dir", type=Path, default=Path(".scheduler"))
     parser.add_argument(
         "--dsn",
-        default=os.environ.get(
-            "WAREHOUSE_POSTGRES_DSN",
-            DEFAULT_POSTGRES_DSN,
-        ),
+        default=os.environ.get("WAREHOUSE_POSTGRES_DSN", DEFAULT_POSTGRES_DSN),
     )
     parser.add_argument("--execute", action="store_true")
     parser.add_argument("--summary-json", type=Path)
@@ -795,10 +1011,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         )
         return 1
     except Exception:
-        print(
-            "Local portfolio schedule failed: unexpected local failure",
-            file=sys.stderr,
-        )
+        print("Local portfolio schedule failed: unexpected local failure", file=sys.stderr)
         return 1
 
     print(json.dumps(summary, sort_keys=True))

--- a/src/warehouse/local_schedule_run_contract.py
+++ b/src/warehouse/local_schedule_run_contract.py
@@ -1,0 +1,629 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from collections.abc import Mapping
+from datetime import date, datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from src.common.exceptions import StorageError, ValidationError
+
+MODEL_VERSION = "local-schedule-run-v1"
+MAX_RUN_BYTES = 1_000_000
+MAX_SESSIONS = 31
+MAX_STAGES_PER_SESSION = 128
+MAX_REQUEST_ID_LENGTH = 128
+MAX_TEXT_LENGTH = 256
+
+RUN_ID_PATTERN = re.compile(r"^local-schedule-run-v1-run-[0-9a-f]{24}$")
+PLAN_ID_PATTERN = re.compile(
+    r"^readiness-aware-schedule-plan-v1-plan-[0-9a-f]{24}$"
+)
+AUTHORITY_ID_PATTERN = re.compile(
+    r"^operational-readiness-execution-authority-v1-authority-[0-9a-f]{24}$"
+)
+DECISION_ID_PATTERN = re.compile(
+    r"^operational-readiness-gate-v1-decision-[0-9a-f]{24}$"
+)
+OVERRIDE_ID_PATTERN = re.compile(
+    r"^operational-readiness-override-v1-[0-9a-f]{24}$"
+)
+SHA256_PATTERN = re.compile(r"^[0-9a-f]{64}$")
+SAFE_SEGMENT_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$")
+
+RUN_KEYS = frozenset(
+    {
+        "run_id",
+        "model_version",
+        "request_id",
+        "plan_id",
+        "authority_id",
+        "authority_type",
+        "schedule_id",
+        "schedule_fingerprint",
+        "calendar_id",
+        "calendar_fingerprint",
+        "portfolio_id",
+        "risk_limit_policy_id",
+        "mandate_id",
+        "mandate_fingerprint",
+        "as_of_date",
+        "latest_expected_session",
+        "readiness_decision_id",
+        "readiness_document_sha256",
+        "override_id",
+        "authorized_at",
+        "started_at",
+        "finished_at",
+        "run_status",
+        "checkpoint_before",
+        "checkpoint_after",
+        "selected_session_count",
+        "started_session_count",
+        "completed_session_count",
+        "failed_session",
+        "failed_stage_index",
+        "failed_stage_name",
+        "failure_code",
+        "sessions",
+        "provider_request_performed",
+        "notification_delivery_performed",
+        "cloud_schedule_activated",
+    }
+)
+SESSION_KEYS = frozenset(
+    {
+        "session_date",
+        "mandate_id",
+        "mandate_fingerprint",
+        "status",
+        "started_at",
+        "finished_at",
+        "checkpoint_after",
+        "failed_stage_index",
+        "failed_stage_name",
+        "failure_code",
+        "stages",
+    }
+)
+STAGE_KEYS = frozenset(
+    {
+        "stage_index",
+        "stage_name",
+        "status",
+        "started_at",
+        "finished_at",
+        "failure_code",
+    }
+)
+
+
+def _safe_segment(value: Any, label: str) -> str:
+    if not isinstance(value, str) or not SAFE_SEGMENT_PATTERN.fullmatch(value):
+        raise ValidationError(f"{label} must be one safe text segment")
+    return value
+
+
+def _bounded_text(value: Any, label: str, maximum: int = MAX_TEXT_LENGTH) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ValidationError(f"{label} must be non-empty text")
+    parsed = value.strip()
+    if len(parsed) > maximum or any(ord(character) < 32 for character in parsed):
+        raise ValidationError(f"{label} must be bounded printable text")
+    return parsed
+
+
+def _pattern(value: Any, label: str, pattern: re.Pattern[str]) -> str:
+    if not isinstance(value, str) or not pattern.fullmatch(value):
+        raise ValidationError(f"{label} is incompatible")
+    return value
+
+
+def _aware_utc(value: Any, label: str) -> datetime:
+    if isinstance(value, datetime):
+        parsed = value
+    elif isinstance(value, str):
+        try:
+            parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        except ValueError:
+            raise ValidationError(f"{label} must be ISO-8601") from None
+    else:
+        raise ValidationError(f"{label} must be timezone-aware")
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise ValidationError(f"{label} must be timezone-aware")
+    return parsed.astimezone(timezone.utc)
+
+
+def _optional_timestamp(value: Any, label: str) -> datetime | None:
+    return None if value is None else _aware_utc(value, label)
+
+
+def _calendar_date(value: Any, label: str) -> date:
+    if isinstance(value, datetime):
+        raise ValidationError(f"{label} must be a calendar date")
+    if isinstance(value, date):
+        return value
+    if not isinstance(value, str):
+        raise ValidationError(f"{label} must use YYYY-MM-DD")
+    try:
+        parsed = date.fromisoformat(value)
+    except ValueError:
+        raise ValidationError(f"{label} must use YYYY-MM-DD") from None
+    if value != parsed.isoformat():
+        raise ValidationError(f"{label} must use YYYY-MM-DD")
+    return parsed
+
+
+def _optional_date(value: Any, label: str) -> date | None:
+    return None if value is None else _calendar_date(value, label)
+
+
+def _optional_integer(value: Any, label: str) -> int | None:
+    if value is None:
+        return None
+    if type(value) is not int or value < 0:
+        raise ValidationError(f"{label} must be a non-negative integer")
+    return value
+
+
+def _optional_text(value: Any, label: str) -> str | None:
+    return None if value is None else _bounded_text(value, label)
+
+
+def _request_id(value: Any) -> str:
+    return _bounded_text(value, "request_id", MAX_REQUEST_ID_LENGTH)
+
+
+def build_local_schedule_run_id(
+    *,
+    request_identifier: str,
+    plan_id: str,
+    authority_id: str,
+) -> str:
+    request = _request_id(request_identifier)
+    canonical_plan_id = _pattern(plan_id, "plan_id", PLAN_ID_PATTERN)
+    canonical_authority_id = _pattern(
+        authority_id,
+        "authority_id",
+        AUTHORITY_ID_PATTERN,
+    )
+    digest = hashlib.sha256(
+        json.dumps(
+            {
+                "authority_id": canonical_authority_id,
+                "model_version": MODEL_VERSION,
+                "plan_id": canonical_plan_id,
+                "request_id": request,
+            },
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+    ).hexdigest()[:24]
+    return f"{MODEL_VERSION}-run-{digest}"
+
+
+def _validate_stage(
+    payload: Any,
+    *,
+    expected_index: int,
+    session_started_at: datetime,
+    session_finished_at: datetime,
+    previous_finished_at: datetime | None,
+) -> tuple[dict[str, Any], datetime]:
+    if not isinstance(payload, Mapping) or set(payload) != STAGE_KEYS:
+        raise ValidationError("local schedule stage has an invalid shape")
+    stage_index = payload.get("stage_index")
+    if stage_index != expected_index:
+        raise ValidationError("stage_index must use contiguous zero-based order")
+    status = payload.get("status")
+    if status not in {"completed", "failed"}:
+        raise ValidationError("stage status must be completed or failed")
+    started_at = _aware_utc(payload.get("started_at"), "stage.started_at")
+    finished_at = _aware_utc(payload.get("finished_at"), "stage.finished_at")
+    if not session_started_at <= started_at <= finished_at <= session_finished_at:
+        raise ValidationError("stage timestamps fall outside the session interval")
+    if previous_finished_at is not None and started_at < previous_finished_at:
+        raise ValidationError("stage timestamps must use non-overlapping order")
+    failure_code = _optional_text(payload.get("failure_code"), "stage.failure_code")
+    if (status == "failed") != (failure_code is not None):
+        raise ValidationError("failed stage evidence must include one failure_code")
+    return (
+        {
+            "stage_index": expected_index,
+            "stage_name": _bounded_text(payload.get("stage_name"), "stage_name"),
+            "status": status,
+            "started_at": started_at.isoformat(),
+            "finished_at": finished_at.isoformat(),
+            "failure_code": failure_code,
+        },
+        finished_at,
+    )
+
+
+def _validate_session(payload: Any, *, expected_date: date) -> dict[str, Any]:
+    if not isinstance(payload, Mapping) or set(payload) != SESSION_KEYS:
+        raise ValidationError("local schedule session has an invalid shape")
+    session_date = _calendar_date(payload.get("session_date"), "session_date")
+    if session_date != expected_date:
+        raise ValidationError("session evidence does not match selected session order")
+    status = payload.get("status")
+    if status not in {"selected", "completed", "failed"}:
+        raise ValidationError("session status is incompatible")
+    started_at = _optional_timestamp(payload.get("started_at"), "session.started_at")
+    finished_at = _optional_timestamp(payload.get("finished_at"), "session.finished_at")
+    checkpoint_after = _optional_date(
+        payload.get("checkpoint_after"),
+        "session.checkpoint_after",
+    )
+    failed_stage_index = _optional_integer(
+        payload.get("failed_stage_index"),
+        "session.failed_stage_index",
+    )
+    failed_stage_name = _optional_text(
+        payload.get("failed_stage_name"),
+        "session.failed_stage_name",
+    )
+    failure_code = _optional_text(payload.get("failure_code"), "session.failure_code")
+    stages = payload.get("stages")
+    if not isinstance(stages, list) or len(stages) > MAX_STAGES_PER_SESSION:
+        raise ValidationError("session stages must be a bounded array")
+
+    if status == "selected":
+        if any(
+            value is not None
+            for value in (
+                started_at,
+                finished_at,
+                checkpoint_after,
+                failed_stage_index,
+                failed_stage_name,
+                failure_code,
+            )
+        ) or stages:
+            raise ValidationError("unstarted selected session contains outcome evidence")
+        validated_stages: list[dict[str, Any]] = []
+    else:
+        if started_at is None or finished_at is None or finished_at < started_at:
+            raise ValidationError("started session requires an ordered time interval")
+        if not stages:
+            raise ValidationError("started session requires stage outcomes")
+        validated_stages = []
+        previous_finished_at: datetime | None = None
+        for index, stage in enumerate(stages):
+            validated, previous_finished_at = _validate_stage(
+                stage,
+                expected_index=index,
+                session_started_at=started_at,
+                session_finished_at=finished_at,
+                previous_finished_at=previous_finished_at,
+            )
+            validated_stages.append(validated)
+
+        failed_stages = [
+            stage for stage in validated_stages if stage["status"] == "failed"
+        ]
+        if status == "completed":
+            if failed_stages or checkpoint_after != session_date:
+                raise ValidationError(
+                    "completed session stages and checkpoint do not reconcile"
+                )
+            if any(
+                value is not None
+                for value in (failed_stage_index, failed_stage_name, failure_code)
+            ):
+                raise ValidationError("completed session contains failure evidence")
+        else:
+            if checkpoint_after is not None or len(failed_stages) != 1:
+                raise ValidationError("failed session evidence is incompatible")
+            failed_stage = failed_stages[0]
+            if failed_stage is not validated_stages[-1]:
+                raise ValidationError("failed stage must be the final attempted stage")
+            if (
+                failed_stage_index != failed_stage["stage_index"]
+                or failed_stage_name != failed_stage["stage_name"]
+                or failure_code != failed_stage["failure_code"]
+            ):
+                raise ValidationError("session failure fields do not match failed stage")
+
+    return {
+        "session_date": session_date.isoformat(),
+        "mandate_id": _safe_segment(payload.get("mandate_id"), "session.mandate_id"),
+        "mandate_fingerprint": _bounded_text(
+            payload.get("mandate_fingerprint"),
+            "session.mandate_fingerprint",
+        ),
+        "status": status,
+        "started_at": started_at.isoformat() if started_at is not None else None,
+        "finished_at": finished_at.isoformat() if finished_at is not None else None,
+        "checkpoint_after": (
+            checkpoint_after.isoformat() if checkpoint_after is not None else None
+        ),
+        "failed_stage_index": failed_stage_index,
+        "failed_stage_name": failed_stage_name,
+        "failure_code": failure_code,
+        "stages": validated_stages,
+    }
+
+
+def validate_local_schedule_run(payload: Mapping[str, Any]) -> dict[str, Any]:
+    if not isinstance(payload, Mapping) or set(payload) != RUN_KEYS:
+        raise ValidationError("local schedule run has an invalid shape")
+    if payload.get("model_version") != MODEL_VERSION:
+        raise ValidationError("local schedule run model version is unsupported")
+
+    request = _request_id(payload.get("request_id"))
+    plan_id = _pattern(payload.get("plan_id"), "plan_id", PLAN_ID_PATTERN)
+    authority_id = _pattern(
+        payload.get("authority_id"),
+        "authority_id",
+        AUTHORITY_ID_PATTERN,
+    )
+    if request != authority_id:
+        raise ValidationError("request_id must equal the execution authority ID")
+    run_id = _pattern(payload.get("run_id"), "run_id", RUN_ID_PATTERN)
+    expected_run_id = build_local_schedule_run_id(
+        request_identifier=request,
+        plan_id=plan_id,
+        authority_id=authority_id,
+    )
+    if run_id != expected_run_id:
+        raise ValidationError("run_id does not match request, plan and authority")
+
+    authority_type = payload.get("authority_type")
+    if authority_type not in {"gate_allow", "active_override"}:
+        raise ValidationError("authority_type is incompatible")
+    override_id = payload.get("override_id")
+    if authority_type == "gate_allow":
+        if override_id is not None:
+            raise ValidationError("gate_allow run must not include an override_id")
+        canonical_override_id: str | None = None
+    else:
+        canonical_override_id = _pattern(
+            override_id,
+            "override_id",
+            OVERRIDE_ID_PATTERN,
+        )
+
+    authorized_at = _aware_utc(payload.get("authorized_at"), "authorized_at")
+    started_at = _aware_utc(payload.get("started_at"), "started_at")
+    finished_at = _aware_utc(payload.get("finished_at"), "finished_at")
+    if not authorized_at <= started_at <= finished_at:
+        raise ValidationError("run timestamps do not follow authorization order")
+
+    as_of_date = _calendar_date(payload.get("as_of_date"), "as_of_date")
+    latest_expected_session = _calendar_date(
+        payload.get("latest_expected_session"),
+        "latest_expected_session",
+    )
+    if latest_expected_session > as_of_date:
+        raise ValidationError("latest_expected_session is after as_of_date")
+
+    sessions = payload.get("sessions")
+    if not isinstance(sessions, list) or not 1 <= len(sessions) <= MAX_SESSIONS:
+        raise ValidationError("sessions must be a non-empty bounded array")
+    raw_session_dates = [
+        _calendar_date(
+            session.get("session_date") if isinstance(session, Mapping) else None,
+            "session_date",
+        )
+        for session in sessions
+    ]
+    if raw_session_dates != sorted(raw_session_dates) or len(raw_session_dates) != len(
+        set(raw_session_dates)
+    ):
+        raise ValidationError("sessions must use unique ascending dates")
+    if raw_session_dates[-1] != latest_expected_session:
+        raise ValidationError("selected sessions must end at latest_expected_session")
+
+    validated_sessions = [
+        _validate_session(session, expected_date=session_date)
+        for session, session_date in zip(sessions, raw_session_dates, strict=True)
+    ]
+    statuses = [session["status"] for session in validated_sessions]
+    completed_count = statuses.count("completed")
+    failed_count = statuses.count("failed")
+    started_count = completed_count + failed_count
+    completed_prefix = ["completed"] * completed_count
+    if failed_count == 0:
+        expected_statuses = completed_prefix + ["selected"] * (
+            len(statuses) - completed_count
+        )
+    else:
+        expected_statuses = (
+            completed_prefix
+            + ["failed"]
+            + ["selected"] * (len(statuses) - completed_count - 1)
+        )
+    if statuses != expected_statuses or failed_count > 1:
+        raise ValidationError("session statuses do not form a terminal execution prefix")
+
+    selected_count = payload.get("selected_session_count")
+    supplied_started_count = payload.get("started_session_count")
+    supplied_completed_count = payload.get("completed_session_count")
+    if (
+        selected_count != len(validated_sessions)
+        or supplied_started_count != started_count
+        or supplied_completed_count != completed_count
+    ):
+        raise ValidationError("run session counts do not reconcile")
+
+    checkpoint_before = _optional_date(
+        payload.get("checkpoint_before"),
+        "checkpoint_before",
+    )
+    checkpoint_after = _optional_date(
+        payload.get("checkpoint_after"),
+        "checkpoint_after",
+    )
+    expected_checkpoint_after = (
+        raw_session_dates[completed_count - 1]
+        if completed_count
+        else checkpoint_before
+    )
+    if checkpoint_after != expected_checkpoint_after:
+        raise ValidationError("checkpoint_after does not match completed session prefix")
+
+    run_status = payload.get("run_status")
+    failed_session = _optional_date(payload.get("failed_session"), "failed_session")
+    failed_stage_index = _optional_integer(
+        payload.get("failed_stage_index"),
+        "failed_stage_index",
+    )
+    failed_stage_name = _optional_text(
+        payload.get("failed_stage_name"),
+        "failed_stage_name",
+    )
+    failure_code = _optional_text(payload.get("failure_code"), "failure_code")
+    if run_status == "completed":
+        if completed_count != len(validated_sessions) or failed_count:
+            raise ValidationError("completed run does not contain all completed sessions")
+        if any(
+            value is not None
+            for value in (
+                failed_session,
+                failed_stage_index,
+                failed_stage_name,
+                failure_code,
+            )
+        ):
+            raise ValidationError("completed run contains failure evidence")
+    elif run_status == "failed":
+        if failure_code is None:
+            raise ValidationError("failed run requires a failure_code")
+        failed_sessions = [
+            session for session in validated_sessions if session["status"] == "failed"
+        ]
+        if failed_sessions:
+            failed = failed_sessions[0]
+            if (
+                failed_session != date.fromisoformat(failed["session_date"])
+                or failed_stage_index != failed["failed_stage_index"]
+                or failed_stage_name != failed["failed_stage_name"]
+                or failure_code != failed["failure_code"]
+            ):
+                raise ValidationError("run failure fields do not match failed session")
+        elif any(
+            value is not None
+            for value in (failed_session, failed_stage_index, failed_stage_name)
+        ):
+            raise ValidationError("pre-session failure contains session failure fields")
+    else:
+        raise ValidationError("run_status must be completed or failed")
+
+    session_start_values = [
+        _aware_utc(session["started_at"], "session.started_at")
+        for session in validated_sessions
+        if session["started_at"] is not None
+    ]
+    session_finish_values = [
+        _aware_utc(session["finished_at"], "session.finished_at")
+        for session in validated_sessions
+        if session["finished_at"] is not None
+    ]
+    if session_start_values and started_at > min(session_start_values):
+        raise ValidationError("run started_at is after the first session start")
+    if session_finish_values and finished_at < max(session_finish_values):
+        raise ValidationError("run finished_at is before a session finish")
+
+    for flag in (
+        "provider_request_performed",
+        "notification_delivery_performed",
+        "cloud_schedule_activated",
+    ):
+        if payload.get(flag) is not False:
+            raise ValidationError(f"{flag} must remain false")
+
+    return {
+        "run_id": run_id,
+        "model_version": MODEL_VERSION,
+        "request_id": request,
+        "plan_id": plan_id,
+        "authority_id": authority_id,
+        "authority_type": authority_type,
+        "schedule_id": _safe_segment(payload.get("schedule_id"), "schedule_id"),
+        "schedule_fingerprint": _bounded_text(
+            payload.get("schedule_fingerprint"),
+            "schedule_fingerprint",
+        ),
+        "calendar_id": _safe_segment(payload.get("calendar_id"), "calendar_id"),
+        "calendar_fingerprint": _bounded_text(
+            payload.get("calendar_fingerprint"),
+            "calendar_fingerprint",
+        ),
+        "portfolio_id": _safe_segment(payload.get("portfolio_id"), "portfolio_id"),
+        "risk_limit_policy_id": _safe_segment(
+            payload.get("risk_limit_policy_id"),
+            "risk_limit_policy_id",
+        ),
+        "mandate_id": _safe_segment(payload.get("mandate_id"), "mandate_id"),
+        "mandate_fingerprint": _bounded_text(
+            payload.get("mandate_fingerprint"),
+            "mandate_fingerprint",
+        ),
+        "as_of_date": as_of_date.isoformat(),
+        "latest_expected_session": latest_expected_session.isoformat(),
+        "readiness_decision_id": _pattern(
+            payload.get("readiness_decision_id"),
+            "readiness_decision_id",
+            DECISION_ID_PATTERN,
+        ),
+        "readiness_document_sha256": _pattern(
+            payload.get("readiness_document_sha256"),
+            "readiness_document_sha256",
+            SHA256_PATTERN,
+        ),
+        "override_id": canonical_override_id,
+        "authorized_at": authorized_at.isoformat(),
+        "started_at": started_at.isoformat(),
+        "finished_at": finished_at.isoformat(),
+        "run_status": run_status,
+        "checkpoint_before": (
+            checkpoint_before.isoformat() if checkpoint_before is not None else None
+        ),
+        "checkpoint_after": (
+            checkpoint_after.isoformat() if checkpoint_after is not None else None
+        ),
+        "selected_session_count": len(validated_sessions),
+        "started_session_count": started_count,
+        "completed_session_count": completed_count,
+        "failed_session": failed_session.isoformat() if failed_session else None,
+        "failed_stage_index": failed_stage_index,
+        "failed_stage_name": failed_stage_name,
+        "failure_code": failure_code,
+        "sessions": validated_sessions,
+        "provider_request_performed": False,
+        "notification_delivery_performed": False,
+        "cloud_schedule_activated": False,
+    }
+
+
+def canonical_local_schedule_run_bytes(run: Mapping[str, Any]) -> bytes:
+    try:
+        return json.dumps(
+            run,
+            sort_keys=True,
+            separators=(",", ":"),
+            allow_nan=False,
+        ).encode("utf-8")
+    except (TypeError, ValueError):
+        raise ValidationError("local schedule run is not canonical JSON") from None
+
+
+def read_local_schedule_run(path: Path) -> dict[str, Any]:
+    if path.is_symlink():
+        raise StorageError("local schedule run must not be a symbolic link")
+    if not path.is_file():
+        raise StorageError("local schedule run must be a regular file")
+    try:
+        if path.stat().st_size > MAX_RUN_BYTES:
+            raise StorageError("local schedule run exceeds the byte limit")
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except StorageError:
+        raise
+    except (OSError, ValueError):
+        raise StorageError("local schedule run could not be read") from None
+    if not isinstance(payload, Mapping):
+        raise ValidationError("local schedule run must be a JSON object")
+    return validate_local_schedule_run(payload)

--- a/src/warehouse/local_schedule_run_contract_check.py
+++ b/src/warehouse/local_schedule_run_contract_check.py
@@ -1,0 +1,426 @@
+from __future__ import annotations
+
+from datetime import date, datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+from src.common.exceptions import ValidationError
+from src.warehouse.local_schedule_run_recorder import (
+    build_local_schedule_run_id,
+    record_local_schedule_run,
+)
+from src.warehouse.postgres_consistency import run_consistency_checks
+
+
+def _stage(
+    index: int,
+    name: str,
+    *,
+    started_at: datetime,
+    finished_at: datetime,
+    status: str = "completed",
+    failure_code: str | None = None,
+) -> dict[str, Any]:
+    return {
+        "stage_index": index,
+        "stage_name": name,
+        "status": status,
+        "started_at": started_at.isoformat(),
+        "finished_at": finished_at.isoformat(),
+        "failure_code": failure_code,
+    }
+
+
+def _session(
+    session_date: date,
+    *,
+    mandate_id: str,
+    mandate_fingerprint: str,
+    status: str,
+    started_at: datetime | None = None,
+    finished_at: datetime | None = None,
+    stages: list[dict[str, Any]] | None = None,
+    failed_stage_index: int | None = None,
+    failed_stage_name: str | None = None,
+    failure_code: str | None = None,
+) -> dict[str, Any]:
+    return {
+        "session_date": session_date.isoformat(),
+        "mandate_id": mandate_id,
+        "mandate_fingerprint": mandate_fingerprint,
+        "status": status,
+        "started_at": started_at.isoformat() if started_at else None,
+        "finished_at": finished_at.isoformat() if finished_at else None,
+        "checkpoint_after": session_date.isoformat() if status == "completed" else None,
+        "failed_stage_index": failed_stage_index,
+        "failed_stage_name": failed_stage_name,
+        "failure_code": failure_code,
+        "stages": stages or [],
+    }
+
+
+def _run_document(
+    *,
+    request_id: str,
+    plan_id: str,
+    authority_id: str,
+    authority_type: str,
+    decision: dict[str, Any],
+    override_id: str | None,
+    authorized_at: datetime,
+    started_at: datetime,
+    finished_at: datetime,
+    status: str,
+    checkpoint_before: date | None,
+    checkpoint_after: date | None,
+    sessions: list[dict[str, Any]],
+    failure_code: str | None = None,
+    failed_session: date | None = None,
+    failed_stage_index: int | None = None,
+    failed_stage_name: str | None = None,
+) -> dict[str, Any]:
+    started_count = sum(
+        1 for session in sessions if session["status"] in {"completed", "failed"}
+    )
+    completed_count = sum(
+        1 for session in sessions if session["status"] == "completed"
+    )
+    return {
+        "run_id": build_local_schedule_run_id(
+            request_identifier=request_id,
+            plan_id=plan_id,
+            authority_id=authority_id,
+        ),
+        "model_version": "local-schedule-run-v1",
+        "request_id": request_id,
+        "plan_id": plan_id,
+        "authority_id": authority_id,
+        "authority_type": authority_type,
+        "schedule_id": decision["schedule_id"],
+        "schedule_fingerprint": decision["schedule_fingerprint"],
+        "calendar_id": decision["calendar_id"],
+        "calendar_fingerprint": "market-calendar-contract-example",
+        "portfolio_id": decision["portfolio_id"],
+        "risk_limit_policy_id": decision["risk_limit_policy_id"],
+        "mandate_id": "us-tech-2026",
+        "mandate_fingerprint": decision["mandate_fingerprint"],
+        "as_of_date": decision["latest_expected_session"],
+        "latest_expected_session": decision["latest_expected_session"],
+        "readiness_decision_id": decision["decision_id"],
+        "readiness_document_sha256": decision["document_sha256"],
+        "override_id": override_id,
+        "authorized_at": authorized_at.isoformat(),
+        "started_at": started_at.isoformat(),
+        "finished_at": finished_at.isoformat(),
+        "run_status": status,
+        "checkpoint_before": checkpoint_before.isoformat() if checkpoint_before else None,
+        "checkpoint_after": checkpoint_after.isoformat() if checkpoint_after else None,
+        "selected_session_count": len(sessions),
+        "started_session_count": started_count,
+        "completed_session_count": completed_count,
+        "failed_session": failed_session.isoformat() if failed_session else None,
+        "failed_stage_index": failed_stage_index,
+        "failed_stage_name": failed_stage_name,
+        "failure_code": failure_code,
+        "sessions": sessions,
+        "provider_request_performed": False,
+        "notification_delivery_performed": False,
+        "cloud_schedule_activated": False,
+    }
+
+
+def run_contract_check(
+    *,
+    dsn: str,
+    allowed_decision_id: str,
+    blocked_decision_id: str,
+    active_override_id: str,
+) -> dict[str, Any]:
+    try:
+        import psycopg
+    except ImportError as exc:  # pragma: no cover - dependency is required in CI.
+        raise RuntimeError("Local schedule run contract requires psycopg") from exc
+
+    with psycopg.connect(dsn) as connection:
+        with connection.cursor() as cursor:
+            cursor.execute(
+                """
+                SELECT
+                    decision_id,
+                    document_sha256,
+                    schedule_id,
+                    schedule_fingerprint,
+                    calendar_id,
+                    portfolio_id,
+                    risk_limit_policy_id,
+                    mandate_fingerprint,
+                    latest_expected_session,
+                    evaluated_at,
+                    decision
+                FROM risk_platform.operational_readiness_decisions
+                WHERE decision_id IN (%s, %s)
+                ORDER BY decision_id
+                """,
+                (allowed_decision_id, blocked_decision_id),
+            )
+            rows = cursor.fetchall()
+            decisions = {
+                str(row[0]): {
+                    "decision_id": str(row[0]),
+                    "document_sha256": str(row[1]),
+                    "schedule_id": str(row[2]),
+                    "schedule_fingerprint": str(row[3]),
+                    "calendar_id": str(row[4]),
+                    "portfolio_id": str(row[5]),
+                    "risk_limit_policy_id": str(row[6]),
+                    "mandate_fingerprint": str(row[7]),
+                    "latest_expected_session": row[8].isoformat(),
+                    "evaluated_at": row[9],
+                    "decision": str(row[10]),
+                }
+                for row in rows
+            }
+            cursor.execute(
+                """
+                SELECT approved_at, expires_at
+                FROM risk_platform.operational_readiness_overrides
+                WHERE override_id = %s
+                """,
+                (active_override_id,),
+            )
+            override_window = cursor.fetchone()
+    if set(decisions) != {allowed_decision_id, blocked_decision_id}:
+        raise AssertionError("local run contract readiness fixtures are missing")
+    if override_window is None:
+        raise AssertionError("local run contract active override fixture is missing")
+
+    allowed = decisions[allowed_decision_id]
+    blocked = decisions[blocked_decision_id]
+    if allowed["decision"] != "allow" or blocked["decision"] != "block":
+        raise AssertionError("local run contract readiness fixture decisions are wrong")
+
+    now = datetime.now(timezone.utc)
+    completed_started = max(
+        allowed["evaluated_at"] + timedelta(seconds=1),
+        now - timedelta(minutes=10),
+    )
+    completed_finished = completed_started + timedelta(seconds=4)
+    completed_session_date = date.fromisoformat(allowed["latest_expected_session"])
+    completed_sessions = [
+        _session(
+            completed_session_date,
+            mandate_id="us-tech-2026",
+            mandate_fingerprint=allowed["mandate_fingerprint"],
+            status="completed",
+            started_at=completed_started,
+            finished_at=completed_finished,
+            stages=[
+                _stage(
+                    0,
+                    "governed-cycle",
+                    started_at=completed_started,
+                    finished_at=completed_started + timedelta(seconds=2),
+                ),
+                _stage(
+                    1,
+                    "checkpoint",
+                    started_at=completed_started + timedelta(seconds=2),
+                    finished_at=completed_finished,
+                ),
+            ],
+        )
+    ]
+    completed_authority_id = (
+        "operational-readiness-execution-authority-v1-authority-" + "2" * 24
+    )
+    completed = _run_document(
+        request_id=completed_authority_id,
+        plan_id="readiness-aware-schedule-plan-v1-plan-" + "1" * 24,
+        authority_id=completed_authority_id,
+        authority_type="gate_allow",
+        decision=allowed,
+        override_id=None,
+        authorized_at=completed_started - timedelta(seconds=1),
+        started_at=completed_started,
+        finished_at=completed_finished,
+        status="completed",
+        checkpoint_before=completed_session_date - timedelta(days=1),
+        checkpoint_after=completed_session_date,
+        sessions=completed_sessions,
+    )
+    first = record_local_schedule_run(dsn=dsn, run=completed)
+    replay = record_local_schedule_run(dsn=dsn, run=completed)
+    if first["created"] is not True or replay["created"] is not False:
+        raise AssertionError("local schedule run retry did not converge")
+
+    conflicting = dict(completed)
+    conflicting["calendar_fingerprint"] = "market-calendar-conflict"
+    try:
+        record_local_schedule_run(dsn=dsn, run=conflicting)
+    except ValidationError:
+        pass
+    else:
+        raise AssertionError("conflicting local schedule run request was accepted")
+
+    override_approved_at, override_expires_at = override_window
+    failed_started = max(now, override_approved_at + timedelta(seconds=1))
+    if failed_started >= override_expires_at:
+        raise AssertionError("active override expired before local run contract check")
+    failed_finished = failed_started + timedelta(seconds=6)
+    if failed_finished >= override_expires_at:
+        failed_finished = override_expires_at - timedelta(milliseconds=1)
+    latest = date.fromisoformat(blocked["latest_expected_session"])
+    first_selected = latest - timedelta(days=4)
+    failed_selected = latest - timedelta(days=1)
+    failed_sessions = [
+        _session(
+            first_selected,
+            mandate_id="us-tech-2026",
+            mandate_fingerprint=blocked["mandate_fingerprint"],
+            status="completed",
+            started_at=failed_started,
+            finished_at=failed_started + timedelta(seconds=2),
+            stages=[
+                _stage(
+                    0,
+                    "governed-cycle",
+                    started_at=failed_started,
+                    finished_at=failed_started + timedelta(seconds=1),
+                ),
+                _stage(
+                    1,
+                    "checkpoint",
+                    started_at=failed_started + timedelta(seconds=1),
+                    finished_at=failed_started + timedelta(seconds=2),
+                ),
+            ],
+        ),
+        _session(
+            failed_selected,
+            mandate_id="us-tech-2026",
+            mandate_fingerprint=blocked["mandate_fingerprint"],
+            status="failed",
+            started_at=failed_started + timedelta(seconds=2),
+            finished_at=failed_finished,
+            failed_stage_index=1,
+            failed_stage_name="warehouse-load",
+            failure_code="command_failed",
+            stages=[
+                _stage(
+                    0,
+                    "governed-cycle",
+                    started_at=failed_started + timedelta(seconds=2),
+                    finished_at=failed_started + timedelta(seconds=3),
+                ),
+                _stage(
+                    1,
+                    "warehouse-load",
+                    started_at=failed_started + timedelta(seconds=3),
+                    finished_at=failed_finished,
+                    status="failed",
+                    failure_code="command_failed",
+                ),
+            ],
+        ),
+        _session(
+            latest,
+            mandate_id="us-tech-2026",
+            mandate_fingerprint=blocked["mandate_fingerprint"],
+            status="selected",
+        ),
+    ]
+    failed_authority_id = (
+        "operational-readiness-execution-authority-v1-authority-" + "4" * 24
+    )
+    failed = _run_document(
+        request_id=failed_authority_id,
+        plan_id="readiness-aware-schedule-plan-v1-plan-" + "3" * 24,
+        authority_id=failed_authority_id,
+        authority_type="active_override",
+        decision=blocked,
+        override_id=active_override_id,
+        authorized_at=failed_started,
+        started_at=failed_started,
+        finished_at=failed_finished,
+        status="failed",
+        checkpoint_before=first_selected - timedelta(days=1),
+        checkpoint_after=first_selected,
+        sessions=failed_sessions,
+        failure_code="command_failed",
+        failed_session=failed_selected,
+        failed_stage_index=1,
+        failed_stage_name="warehouse-load",
+    )
+    second = record_local_schedule_run(dsn=dsn, run=failed)
+    if second["created"] is not True:
+        raise AssertionError("failed local schedule run was not appended")
+
+    with psycopg.connect(dsn) as connection:
+        with connection.cursor() as cursor:
+            cursor.execute(
+                """
+                SELECT
+                    (SELECT COUNT(*) FROM risk_platform.local_schedule_runs),
+                    (SELECT COUNT(*)
+                     FROM risk_platform.local_schedule_run_session_history),
+                    (SELECT COUNT(*)
+                     FROM risk_platform.local_schedule_run_stage_history),
+                    (SELECT COUNT(*)
+                     FROM risk_platform.recent_local_schedule_runs),
+                    (SELECT run_status
+                     FROM risk_platform.current_local_schedule_run_status),
+                    (SELECT COUNT(*)
+                     FROM risk_platform.current_local_schedule_run_failures),
+                    (SELECT COUNT(*)
+                     FROM risk_platform.incomplete_local_schedule_sessions)
+                """
+            )
+            counts = cursor.fetchone()
+            if counts != (2, 4, 6, 2, "failed", 1, 2):
+                raise AssertionError(
+                    f"local schedule run serving views are incompatible: {counts!r}"
+                )
+
+    for statement in (
+        """
+        UPDATE risk_platform.local_schedule_runs
+        SET recorded_at = recorded_at
+        WHERE run_id = %s
+        """,
+        """
+        DELETE FROM risk_platform.local_schedule_runs
+        WHERE run_id = %s
+        """,
+    ):
+        with psycopg.connect(dsn) as connection:
+            try:
+                with connection.cursor() as cursor:
+                    cursor.execute(statement, (completed["run_id"],))
+            except psycopg.Error:
+                connection.rollback()
+            else:
+                raise AssertionError("local schedule run mutation was not blocked")
+
+    consistency = run_consistency_checks(
+        dsn=dsn,
+        check_paths=(Path("sql/local_schedule_runs_consistency_checks.sql"),),
+    )
+    failures = [result for result in consistency if result.status != "pass"]
+    if failures:
+        names = ", ".join(result.check_name for result in failures)
+        raise AssertionError("local schedule run reconciliation failed: " + names)
+
+    return {
+        "run_rows": 2,
+        "session_rows": 4,
+        "stage_rows": 6,
+        "current_status": "failed",
+        "current_failure_rows": 1,
+        "incomplete_session_rows": 2,
+        "replay_verified": True,
+        "conflict_verified": True,
+        "append_only_verified": True,
+        "consistency_checks": len(consistency),
+        "completed_run_id": first["run_id"],
+        "failed_run_id": second["run_id"],
+    }

--- a/src/warehouse/local_schedule_run_recorder.py
+++ b/src/warehouse/local_schedule_run_recorder.py
@@ -1,0 +1,218 @@
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import sys
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+from src.common.exceptions import StorageError, ValidationError
+from src.warehouse.local_schedule_run_contract import (
+    build_local_schedule_run_id as build_local_schedule_run_id,
+    canonical_local_schedule_run_bytes,
+    read_local_schedule_run,
+    validate_local_schedule_run,
+)
+from src.warehouse.postgres_loader import DEFAULT_POSTGRES_DSN
+
+
+def _summary(run: Mapping[str, Any], *, created: bool, digest: str) -> dict[str, Any]:
+    return {
+        "run_id": run["run_id"],
+        "request_id": run["request_id"],
+        "plan_id": run["plan_id"],
+        "authority_id": run["authority_id"],
+        "authority_type": run["authority_type"],
+        "run_status": run["run_status"],
+        "selected_session_count": run["selected_session_count"],
+        "started_session_count": run["started_session_count"],
+        "completed_session_count": run["completed_session_count"],
+        "checkpoint_after": run["checkpoint_after"],
+        "document_sha256": digest,
+        "created": created,
+    }
+
+
+def record_local_schedule_run(
+    *,
+    dsn: str,
+    run: Mapping[str, Any],
+) -> dict[str, Any]:
+    validated = validate_local_schedule_run(run)
+    canonical = canonical_local_schedule_run_bytes(validated)
+    digest = hashlib.sha256(canonical).hexdigest()
+    try:
+        import psycopg
+        from psycopg.types.json import Jsonb
+    except ImportError as exc:  # pragma: no cover - dependency is required in CI.
+        raise RuntimeError("Local schedule run recording requires psycopg") from exc
+
+    created = False
+    stored: dict[str, Any] | None = None
+    try:
+        with psycopg.connect(dsn) as connection:
+            with connection.cursor() as cursor:
+                cursor.execute(
+                    """
+                    SELECT run_json, document_sha256
+                    FROM risk_platform.local_schedule_runs
+                    WHERE request_id = %s
+                    """,
+                    (validated["request_id"],),
+                )
+                existing = cursor.fetchone()
+                if existing is not None:
+                    existing_json, existing_digest = existing
+                    if existing_digest != digest or existing_json != validated:
+                        raise ValidationError(
+                            "request_id already exists with different run evidence"
+                        )
+                    return _summary(validated, created=False, digest=digest)
+
+                cursor.execute(
+                    """
+                    INSERT INTO risk_platform.local_schedule_runs (
+                        run_id,
+                        model_version,
+                        request_id,
+                        plan_id,
+                        authority_id,
+                        authority_type,
+                        schedule_id,
+                        schedule_fingerprint,
+                        calendar_id,
+                        calendar_fingerprint,
+                        portfolio_id,
+                        risk_limit_policy_id,
+                        mandate_id,
+                        mandate_fingerprint,
+                        as_of_date,
+                        latest_expected_session,
+                        readiness_decision_id,
+                        readiness_document_sha256,
+                        override_id,
+                        authorized_at,
+                        started_at,
+                        finished_at,
+                        run_status,
+                        checkpoint_before,
+                        checkpoint_after,
+                        selected_session_count,
+                        started_session_count,
+                        completed_session_count,
+                        failed_session,
+                        failed_stage_index,
+                        failed_stage_name,
+                        failure_code,
+                        run_json,
+                        document_sha256
+                    )
+                    VALUES (
+                        %s, %s, %s, %s, %s, %s, %s, %s, %s, %s,
+                        %s, %s, %s, %s, %s, %s, %s, %s, %s, %s,
+                        %s, %s, %s, %s, %s, %s, %s, %s, %s, %s,
+                        %s, %s, %s, %s
+                    )
+                    ON CONFLICT DO NOTHING
+                    RETURNING run_id
+                    """,
+                    (
+                        validated["run_id"],
+                        validated["model_version"],
+                        validated["request_id"],
+                        validated["plan_id"],
+                        validated["authority_id"],
+                        validated["authority_type"],
+                        validated["schedule_id"],
+                        validated["schedule_fingerprint"],
+                        validated["calendar_id"],
+                        validated["calendar_fingerprint"],
+                        validated["portfolio_id"],
+                        validated["risk_limit_policy_id"],
+                        validated["mandate_id"],
+                        validated["mandate_fingerprint"],
+                        validated["as_of_date"],
+                        validated["latest_expected_session"],
+                        validated["readiness_decision_id"],
+                        validated["readiness_document_sha256"],
+                        validated["override_id"],
+                        validated["authorized_at"],
+                        validated["started_at"],
+                        validated["finished_at"],
+                        validated["run_status"],
+                        validated["checkpoint_before"],
+                        validated["checkpoint_after"],
+                        validated["selected_session_count"],
+                        validated["started_session_count"],
+                        validated["completed_session_count"],
+                        validated["failed_session"],
+                        validated["failed_stage_index"],
+                        validated["failed_stage_name"],
+                        validated["failure_code"],
+                        Jsonb(validated),
+                        digest,
+                    ),
+                )
+                created = cursor.fetchone() is not None
+                cursor.execute(
+                    """
+                    SELECT run_json, document_sha256
+                    FROM risk_platform.local_schedule_runs
+                    WHERE run_id = %s
+                    """,
+                    (validated["run_id"],),
+                )
+                row = cursor.fetchone()
+                if row is None:
+                    raise StorageError("local schedule run could not be read after insert")
+                stored_json, stored_digest = row
+                if stored_digest != digest or stored_json != validated:
+                    raise ValidationError(
+                        "run_id already exists with different run evidence"
+                    )
+                stored = dict(stored_json)
+            connection.commit()
+    except (ValidationError, StorageError):
+        raise
+    except Exception:
+        raise StorageError("local schedule run database operation failed") from None
+
+    if stored is None:  # pragma: no cover - guarded by transaction above.
+        raise StorageError("local schedule run result is unavailable")
+    return _summary(stored, created=created, digest=digest)
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Append one terminal local schedule run document to PostgreSQL."
+    )
+    parser.add_argument("--run", required=True, type=Path)
+    parser.add_argument(
+        "--dsn",
+        default=os.environ.get("WAREHOUSE_POSTGRES_DSN", DEFAULT_POSTGRES_DSN),
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    try:
+        result = record_local_schedule_run(
+            dsn=args.dsn,
+            run=read_local_schedule_run(args.run),
+        )
+    except ValidationError as exc:
+        print(f"Local schedule run rejected: {exc}", file=sys.stderr)
+        return 1
+    except (StorageError, RuntimeError) as exc:
+        print(f"Local schedule run recording failed: {exc}", file=sys.stderr)
+        return 1
+    print(json.dumps(result, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/warehouse/operational_readiness_override_contract_check.py
+++ b/src/warehouse/operational_readiness_override_contract_check.py
@@ -5,6 +5,9 @@ from pathlib import Path
 from typing import Any
 
 from src.common.exceptions import ValidationError
+from src.warehouse.local_schedule_run_contract_check import (
+    run_contract_check as run_local_schedule_run_contract_check,
+)
 from src.warehouse.operational_readiness_override_registry import (
     approve_operational_readiness_override,
     read_active_operational_readiness_override,
@@ -205,6 +208,13 @@ def run_contract_check(
         names = ", ".join(result.check_name for result in failures)
         raise AssertionError("readiness override reconciliation failed: " + names)
 
+    local_run_result = run_local_schedule_run_contract_check(
+        dsn=dsn,
+        allowed_decision_id=allowed_decision_id,
+        blocked_decision_id=blocked_decision_id,
+        active_override_id=str(second["override_id"]),
+    )
+
     return {
         "override_rows": 2,
         "revocation_rows": 1,
@@ -215,4 +225,5 @@ def run_contract_check(
         "expiry_verified": True,
         "append_only_verified": True,
         "consistency_checks": len(consistency),
+        "local_schedule_run_contract": local_run_result,
     }

--- a/tests/unit/test_docker_compose_contract.py
+++ b/tests/unit/test_docker_compose_contract.py
@@ -42,6 +42,7 @@ def test_local_database_seed_mounts_are_read_only_and_ordered() -> None:
         "./sql/operational_readiness_decisions_schema.sql:/docker-entrypoint-initdb.d/15_operational_readiness_decisions_schema.sql:ro",
         "./sql/operational_review_schema.sql:/docker-entrypoint-initdb.d/16_operational_review_schema.sql:ro",
         "./sql/operational_readiness_overrides_schema.sql:/docker-entrypoint-initdb.d/17_operational_readiness_overrides_schema.sql:ro",
+        "./sql/local_schedule_runs_schema.sql:/docker-entrypoint-initdb.d/18_local_schedule_runs_schema.sql:ro",
     ]
     assert services["mongo"]["volumes"] == [
         "./mongo/init:/docker-entrypoint-initdb.d:ro"

--- a/tests/unit/test_local_portfolio_schedule.py
+++ b/tests/unit/test_local_portfolio_schedule.py
@@ -21,6 +21,7 @@ from src.orchestration.run_local_portfolio_schedule import (
     plan_schedule_sessions,
     run_local_portfolio_schedule,
 )
+from src.warehouse.local_schedule_run_recorder import validate_local_schedule_run
 
 
 def _schedule_payload(*, enabled: bool = False, maximum: int = 5):
@@ -164,6 +165,26 @@ def _execution_authority(*, enabled: bool) -> dict[str, Any]:
     )
 
 
+def _history_recorder(records: list[dict[str, Any]]):
+    def recorder(*, dsn: str, run: dict[str, Any]) -> dict[str, Any]:
+        assert dsn
+        validated = validate_local_schedule_run(run)
+        records.append(validated)
+        return {
+            "run_id": validated["run_id"],
+            "request_id": validated["request_id"],
+            "run_status": validated["run_status"],
+            "selected_session_count": validated["selected_session_count"],
+            "started_session_count": validated["started_session_count"],
+            "completed_session_count": validated["completed_session_count"],
+            "checkpoint_after": validated["checkpoint_after"],
+            "document_sha256": "f" * 64,
+            "created": True,
+        }
+
+    return recorder
+
+
 def test_initial_plan_uses_latest_expected_session_on_weekend() -> None:
     sessions = plan_schedule_sessions(
         schedule=_schedule(),
@@ -251,6 +272,7 @@ def test_dry_run_does_not_execute_or_create_state(tmp_path: Path) -> None:
     assert calls == []
     assert summary["execution"]["performed"] is False
     assert summary["execution_authority"] is None
+    assert summary["run_history"] is None
     assert summary["selection"]["session_dates"] == ["2026-01-09"]
     assert not (tmp_path / "state" / "us-tech-local.json").exists()
 
@@ -303,11 +325,12 @@ def test_disabled_schedule_refuses_authorized_execution_before_commands(
     assert calls == []
 
 
-def test_successful_authorized_execution_checkpoints_after_complete_session(
+def test_successful_authorized_execution_checkpoints_and_records_terminal_history(
     tmp_path: Path,
 ) -> None:
     calls: list[tuple[str, ...]] = []
     environments: list[dict[str, str]] = []
+    history: list[dict[str, Any]] = []
 
     def runner(command: tuple[str, ...], environment: Any) -> None:
         calls.append(command)
@@ -330,28 +353,35 @@ def test_successful_authorized_execution_checkpoints_after_complete_session(
         command_runner=runner,
         mandate_loader=lambda *_: _mandate(),
         calendar_loader=lambda *_: _calendar(),
+        run_history_recorder=_history_recorder(history),
     )
 
     state = json.loads(
-        (tmp_path / "state" / "us-tech-local.json").read_text(
-            encoding="utf-8"
-        )
+        (tmp_path / "state" / "us-tech-local.json").read_text(encoding="utf-8")
     )
     assert state["last_successful_session"] == "2026-01-09"
     assert summary["execution"]["completed_sessions"] == ["2026-01-09"]
     assert summary["execution_authority"] == authority
+    assert summary["run_history"]["run_status"] == "completed"
+    assert len(history) == 1
+    assert history[0]["request_id"] == authority["authority_id"]
+    assert history[0]["run_status"] == "completed"
+    assert history[0]["sessions"][0]["status"] == "completed"
+    assert history[0]["sessions"][0]["stages"][-1]["stage_name"] == "checkpoint"
     assert len(calls) == 9
     assert all(
         environment["WAREHOUSE_POSTGRES_DSN"] == "postgresql://secret-value"
         for environment in environments
     )
     assert "postgresql://secret-value" not in json.dumps(summary)
+    assert "postgresql://secret-value" not in json.dumps(history)
 
 
-def test_failed_authorized_command_does_not_advance_checkpoint(
+def test_failed_authorized_command_records_failure_without_advancing_checkpoint(
     tmp_path: Path,
 ) -> None:
     calls = 0
+    history: list[dict[str, Any]] = []
 
     def fail_after_first(command: tuple[str, ...], environment: Any) -> None:
         nonlocal calls
@@ -376,5 +406,16 @@ def test_failed_authorized_command_does_not_advance_checkpoint(
             command_runner=fail_after_first,
             mandate_loader=lambda *_: _mandate(),
             calendar_loader=lambda *_: _calendar(),
+            run_history_recorder=_history_recorder(history),
         )
     assert not (tmp_path / "state" / "us-tech-local.json").exists()
+    assert len(history) == 1
+    assert history[0]["run_status"] == "failed"
+    assert history[0]["failure_code"] == "command_failed"
+    assert history[0]["failed_stage_index"] == 1
+    assert history[0]["sessions"][0]["status"] == "failed"
+    assert [stage["status"] for stage in history[0]["sessions"][0]["stages"]] == [
+        "completed",
+        "failed",
+    ]
+    assert history[0]["checkpoint_after"] is None

--- a/tests/unit/test_local_schedule_run_architecture_contract.py
+++ b/tests/unit/test_local_schedule_run_architecture_contract.py
@@ -16,7 +16,7 @@ def test_local_schedule_run_history_documentation_preserves_arc42_boundary() -> 
         "No command arguments",
         "no external notification delivery",
         "no cloud schedule activation",
-        "no `terraform apply`",
+        "`terraform apply`",
         "P4b",
     ):
         assert fragment in document

--- a/tests/unit/test_local_schedule_run_architecture_contract.py
+++ b/tests/unit/test_local_schedule_run_architecture_contract.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def test_local_schedule_run_history_documentation_preserves_arc42_boundary() -> None:
+    document = Path("docs/local-schedule-run-history.md").read_text(encoding="utf-8")
+
+    for fragment in (
+        "# Append-Only Local Schedule Run History",
+        "Primary arc42 block: `warehouse`",
+        "local-schedule-run-v1",
+        "exact retries converge",
+        "current_local_schedule_run_failures",
+        "incomplete_local_schedule_sessions",
+        "No command arguments",
+        "no external notification delivery",
+        "no cloud schedule activation",
+        "no `terraform apply`",
+        "P4b",
+    ):
+        assert fragment in document

--- a/tests/unit/test_local_schedule_run_recorder.py
+++ b/tests/unit/test_local_schedule_run_recorder.py
@@ -1,0 +1,282 @@
+from __future__ import annotations
+
+from copy import deepcopy
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from src.common.exceptions import StorageError, ValidationError
+from src.warehouse.local_schedule_run_recorder import (
+    build_local_schedule_run_id,
+    canonical_local_schedule_run_bytes,
+    read_local_schedule_run,
+    validate_local_schedule_run,
+)
+
+PLAN_ID = "readiness-aware-schedule-plan-v1-plan-" + "a" * 24
+AUTHORITY_ID = (
+    "operational-readiness-execution-authority-v1-authority-" + "b" * 24
+)
+DECISION_ID = "operational-readiness-gate-v1-decision-" + "c" * 24
+OVERRIDE_ID = "operational-readiness-override-v1-" + "d" * 24
+
+
+def _stage(
+    index: int,
+    name: str,
+    status: str,
+    started_at: str,
+    finished_at: str,
+    failure_code: str | None = None,
+) -> dict[str, Any]:
+    return {
+        "stage_index": index,
+        "stage_name": name,
+        "status": status,
+        "started_at": started_at,
+        "finished_at": finished_at,
+        "failure_code": failure_code,
+    }
+
+
+def _completed_run() -> dict[str, Any]:
+    request_id = AUTHORITY_ID
+    return {
+        "run_id": build_local_schedule_run_id(
+            request_identifier=request_id,
+            plan_id=PLAN_ID,
+            authority_id=AUTHORITY_ID,
+        ),
+        "model_version": "local-schedule-run-v1",
+        "request_id": request_id,
+        "plan_id": PLAN_ID,
+        "authority_id": AUTHORITY_ID,
+        "authority_type": "gate_allow",
+        "schedule_id": "us-tech-local",
+        "schedule_fingerprint": "local-schedule-example",
+        "calendar_id": "XNYS",
+        "calendar_fingerprint": "market-calendar-example",
+        "portfolio_id": "us-tech-equal",
+        "risk_limit_policy_id": "us-tech-standard",
+        "mandate_id": "us-tech-2026",
+        "mandate_fingerprint": "portfolio-mandate-example",
+        "as_of_date": "2026-01-10",
+        "latest_expected_session": "2026-01-09",
+        "readiness_decision_id": DECISION_ID,
+        "readiness_document_sha256": "e" * 64,
+        "override_id": None,
+        "authorized_at": "2026-01-10T11:59:00+00:00",
+        "started_at": "2026-01-10T12:00:00+00:00",
+        "finished_at": "2026-01-10T12:00:04+00:00",
+        "run_status": "completed",
+        "checkpoint_before": None,
+        "checkpoint_after": "2026-01-09",
+        "selected_session_count": 1,
+        "started_session_count": 1,
+        "completed_session_count": 1,
+        "failed_session": None,
+        "failed_stage_index": None,
+        "failed_stage_name": None,
+        "failure_code": None,
+        "sessions": [
+            {
+                "session_date": "2026-01-09",
+                "mandate_id": "us-tech-2026",
+                "mandate_fingerprint": "portfolio-mandate-example",
+                "status": "completed",
+                "started_at": "2026-01-10T12:00:01+00:00",
+                "finished_at": "2026-01-10T12:00:03+00:00",
+                "checkpoint_after": "2026-01-09",
+                "failed_stage_index": None,
+                "failed_stage_name": None,
+                "failure_code": None,
+                "stages": [
+                    _stage(
+                        0,
+                        "run_daily_risk:AAPL",
+                        "completed",
+                        "2026-01-10T12:00:01+00:00",
+                        "2026-01-10T12:00:02+00:00",
+                    ),
+                    _stage(
+                        1,
+                        "checkpoint",
+                        "completed",
+                        "2026-01-10T12:00:02+00:00",
+                        "2026-01-10T12:00:03+00:00",
+                    ),
+                ],
+            }
+        ],
+        "provider_request_performed": False,
+        "notification_delivery_performed": False,
+        "cloud_schedule_activated": False,
+    }
+
+
+def _failed_run() -> dict[str, Any]:
+    payload = _completed_run()
+    payload.update(
+        {
+            "authority_type": "active_override",
+            "override_id": OVERRIDE_ID,
+            "started_at": "2026-01-10T12:00:00+00:00",
+            "finished_at": "2026-01-10T12:00:08+00:00",
+            "run_status": "failed",
+            "checkpoint_before": "2026-01-06",
+            "checkpoint_after": "2026-01-07",
+            "selected_session_count": 3,
+            "started_session_count": 2,
+            "completed_session_count": 1,
+            "failed_session": "2026-01-08",
+            "failed_stage_index": 1,
+            "failed_stage_name": "run_market_freshness:AAPL",
+            "failure_code": "command_failed",
+            "sessions": [
+                {
+                    "session_date": "2026-01-07",
+                    "mandate_id": "us-tech-2026",
+                    "mandate_fingerprint": "portfolio-mandate-example",
+                    "status": "completed",
+                    "started_at": "2026-01-10T12:00:01+00:00",
+                    "finished_at": "2026-01-10T12:00:04+00:00",
+                    "checkpoint_after": "2026-01-07",
+                    "failed_stage_index": None,
+                    "failed_stage_name": None,
+                    "failure_code": None,
+                    "stages": [
+                        _stage(
+                            0,
+                            "run_daily_risk:AAPL",
+                            "completed",
+                            "2026-01-10T12:00:01+00:00",
+                            "2026-01-10T12:00:02+00:00",
+                        ),
+                        _stage(
+                            1,
+                            "checkpoint",
+                            "completed",
+                            "2026-01-10T12:00:03+00:00",
+                            "2026-01-10T12:00:04+00:00",
+                        ),
+                    ],
+                },
+                {
+                    "session_date": "2026-01-08",
+                    "mandate_id": "us-tech-2026",
+                    "mandate_fingerprint": "portfolio-mandate-example",
+                    "status": "failed",
+                    "started_at": "2026-01-10T12:00:05+00:00",
+                    "finished_at": "2026-01-10T12:00:07+00:00",
+                    "checkpoint_after": None,
+                    "failed_stage_index": 1,
+                    "failed_stage_name": "run_market_freshness:AAPL",
+                    "failure_code": "command_failed",
+                    "stages": [
+                        _stage(
+                            0,
+                            "run_daily_risk:AAPL",
+                            "completed",
+                            "2026-01-10T12:00:05+00:00",
+                            "2026-01-10T12:00:06+00:00",
+                        ),
+                        _stage(
+                            1,
+                            "run_market_freshness:AAPL",
+                            "failed",
+                            "2026-01-10T12:00:06+00:00",
+                            "2026-01-10T12:00:07+00:00",
+                            "command_failed",
+                        ),
+                    ],
+                },
+                {
+                    "session_date": "2026-01-09",
+                    "mandate_id": "us-tech-2026",
+                    "mandate_fingerprint": "portfolio-mandate-example",
+                    "status": "selected",
+                    "started_at": None,
+                    "finished_at": None,
+                    "checkpoint_after": None,
+                    "failed_stage_index": None,
+                    "failed_stage_name": None,
+                    "failure_code": None,
+                    "stages": [],
+                },
+            ],
+        }
+    )
+    return payload
+
+
+def test_completed_run_is_canonical_and_deterministic() -> None:
+    first = validate_local_schedule_run(_completed_run())
+    second = validate_local_schedule_run(deepcopy(_completed_run()))
+
+    assert first == second
+    assert first["run_status"] == "completed"
+    assert first["checkpoint_after"] == "2026-01-09"
+    assert canonical_local_schedule_run_bytes(first) == canonical_local_schedule_run_bytes(
+        second
+    )
+
+
+def test_failed_run_retains_terminal_prefix_and_incomplete_sessions() -> None:
+    run = validate_local_schedule_run(_failed_run())
+
+    assert [session["status"] for session in run["sessions"]] == [
+        "completed",
+        "failed",
+        "selected",
+    ]
+    assert run["completed_session_count"] == 1
+    assert run["failed_session"] == "2026-01-08"
+    assert run["failed_stage_name"] == "run_market_freshness:AAPL"
+    assert run["checkpoint_after"] == "2026-01-07"
+
+
+def test_tampering_and_conflicting_authority_shape_fail_closed() -> None:
+    wrong_id = _completed_run()
+    wrong_id["run_id"] = "local-schedule-run-v1-run-" + "0" * 24
+    with pytest.raises(ValidationError, match="run_id"):
+        validate_local_schedule_run(wrong_id)
+
+    extra_secret_field = _completed_run()
+    extra_secret_field["dsn"] = "postgresql://secret"
+    with pytest.raises(ValidationError, match="shape"):
+        validate_local_schedule_run(extra_secret_field)
+
+    gate_with_override = _completed_run()
+    gate_with_override["override_id"] = OVERRIDE_ID
+    with pytest.raises(ValidationError, match="gate_allow"):
+        validate_local_schedule_run(gate_with_override)
+
+
+def test_session_stage_and_checkpoint_arithmetic_is_strict() -> None:
+    wrong_stage = _failed_run()
+    wrong_stage["sessions"][1]["stages"][1]["stage_index"] = 2
+    with pytest.raises(ValidationError, match="stage_index"):
+        validate_local_schedule_run(wrong_stage)
+
+    wrong_prefix = _failed_run()
+    wrong_prefix["sessions"][2]["status"] = "completed"
+    with pytest.raises(ValidationError):
+        validate_local_schedule_run(wrong_prefix)
+
+    wrong_checkpoint = _failed_run()
+    wrong_checkpoint["checkpoint_after"] = "2026-01-08"
+    with pytest.raises(ValidationError, match="checkpoint_after"):
+        validate_local_schedule_run(wrong_checkpoint)
+
+
+def test_reader_rejects_symlinks_and_non_objects(tmp_path: Path) -> None:
+    target = tmp_path / "run.json"
+    target.write_text("[]", encoding="utf-8")
+    link = tmp_path / "run-link.json"
+    link.symlink_to(target)
+
+    with pytest.raises(StorageError, match="symbolic"):
+        read_local_schedule_run(link)
+    with pytest.raises(ValidationError, match="JSON object"):
+        read_local_schedule_run(target)

--- a/tests/unit/test_local_schedule_run_sql_contract.py
+++ b/tests/unit/test_local_schedule_run_sql_contract.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def test_local_schedule_run_schema_exposes_append_only_serving_contract() -> None:
+    schema = Path("sql/local_schedule_runs_schema.sql").read_text(encoding="utf-8")
+
+    for fragment in (
+        "CREATE TABLE IF NOT EXISTS risk_platform.local_schedule_runs",
+        "operational_readiness_decisions (decision_id)",
+        "operational_readiness_overrides (override_id)",
+        "validate_local_schedule_run_authority",
+        "prevent_local_schedule_run_update",
+        "prevent_local_schedule_run_delete",
+        "local_schedule_run_session_history",
+        "local_schedule_run_stage_history",
+        "recent_local_schedule_runs",
+        "current_local_schedule_run_status",
+        "current_local_schedule_run_failures",
+        "incomplete_local_schedule_sessions",
+        "jsonb_array_elements(run.run_json -> 'sessions')",
+    ):
+        assert fragment in schema
+
+    assert "authority_type IN ('gate_allow', 'active_override')" in schema
+    assert "run_status IN ('completed', 'failed')" in schema
+    assert "provider_request_performed')::BOOLEAN = FALSE" in schema
+    assert "notification_delivery_performed')::BOOLEAN = FALSE" in schema
+    assert "cloud_schedule_activated')::BOOLEAN = FALSE" in schema
+
+
+def test_local_schedule_run_reconciliation_uses_shared_result_contract() -> None:
+    checks = Path("sql/local_schedule_runs_consistency_checks.sql").read_text(
+        encoding="utf-8"
+    )
+
+    for fragment in (
+        "AS check_name",
+        "AS expected",
+        "AS actual",
+        "AS status",
+        "local_schedule_run_sessions_expand_exactly",
+        "local_schedule_run_stages_expand_exactly",
+        "local_schedule_run_readiness_contracts_match",
+        "local_schedule_run_override_contracts_match",
+        "current_local_schedule_run_selects_latest",
+        "current_local_schedule_failures_match_current_status",
+        "incomplete_local_schedule_sessions_match_terminal_status",
+        "local_schedule_run_append_only_triggers_present",
+    ):
+        assert fragment in checks


### PR DESCRIPTION
## Outcome

Complete **P4a — append-only local schedule run history** by retaining one immutable terminal document for every readiness-authorised local execution attempt:

```text
readiness-aware plan
  + exact readiness decision
  + gate_allow or active_override authority
  + selected sessions
  -> ordered bounded stage outcomes
  -> completed or failed terminal run evidence
  -> append-only PostgreSQL history and operational views
```

Primary arc42 block: `warehouse`, with bounded instrumentation in the established local scheduler.

## Terminal evidence

Add `local-schedule-run-v1`, binding:

- deterministic run/request identity;
- plan and execution-authority ID/type;
- exact readiness-decision ID/document SHA-256 and optional override ID;
- current schedule, calendar, portfolio, risk-limit policy and mandate identities;
- checkpoint before/after;
- selected, started, completed and failed sessions; and
- ordered stage outcomes without command arguments, environment values, DSNs or credentials.

The execution-authority ID is the idempotency request key. Exact canonical retries converge; conflicting reuse fails closed. Session evidence must form one terminal prefix:

```text
completed* [failed]? selected*
```

## Scheduler instrumentation

`run_local_portfolio_schedule` preserves its existing lock, command order and checkpoint semantics. Plan-only and no-work calls remain unrecorded.

For an authorised execution it now:

1. creates a deterministic run ID;
2. records bounded operation names and timestamps;
3. appends a synthetic `checkpoint` stage only after command completion;
4. records completed terminal history after all selected sessions finish; or
5. records failed terminal history before re-raising the original failure.

Successful execution is not reported if durable terminal history cannot be recorded.

## PostgreSQL contract

Add:

- `risk_platform.local_schedule_runs`;
- `local_schedule_run_session_history`;
- `local_schedule_run_stage_history`;
- `recent_local_schedule_runs`;
- `current_local_schedule_run_status`;
- `current_local_schedule_run_failures`; and
- `incomplete_local_schedule_sessions`.

PostgreSQL independently validates the exact referenced readiness decision and, for `active_override`, the matching unexpired and unrevoked override at run start. UPDATE and DELETE are rejected by append-only triggers.

## Live PostgreSQL evidence

The PostgreSQL 16 operational fixture exercises:

- one completed `gate_allow` run and exact replay convergence;
- conflicting request reuse rejection;
- one later failed `active_override` run;
- **2** terminal run rows;
- **4** expanded session rows: completed, failed and never-started;
- **6** expanded stage rows: completed and failed;
- latest status `failed`, **1** current failure and **2** incomplete sessions;
- exact readiness/override reference reconciliation; and
- UPDATE/DELETE rejection.

All local-schedule-run reconciliation checks passed as part of the complete operational PostgreSQL contract.

## Validation and repairs

The first exact-head run exposed two integration defects: the new reconciliation query omitted the shared `status` result alias, and the documentation contract expected a specific retry phrase. The SQL was restored to the shared `check_name / expected / actual / status` shape and the documentation was made explicit.

Two subsequent Python-only failures were brittle documentation checks: one was case-sensitive and one depended on Markdown line wrapping. The test now checks the semantic `terraform apply` boundary rather than a wrapped sentence. No production rule, database constraint, security check or execution gate was weakened.

GitHub Actions run `32754977502` (`ci` run **309**) passed on final exact head `4dc3ff66b50a07723692ea1dd394480ce0ab7b4c`:

- **Security guardrails:** passed.
- **Python readiness:** passed.
  - locked dependencies resolved;
  - Ruff passed;
  - mypy passed across **106 source files**;
  - **762 tests passed** in the quality run;
  - **762 tests passed** again in the readiness run;
  - `pip check` passed;
  - the standard readiness replay passed.
- **PostgreSQL contract:** passed against PostgreSQL 16, including source-to-serving, model approval, operational SLI/SLO, readiness decisions, operational review, overrides and local schedule run history.
- **Infrastructure validation:** passed with Kubernetes rendering and Terraform format/init/validate without apply.

There are no unresolved review threads or requested changes.

## Scope

The branch is directly based on PR #103, is **zero commits behind**, and changes **14 files** with **2,838 additions and 93 deletions**. Connector writes and focused CI repairs produced 18 working commits; this PR is intended for squash merge as one P4a persistence-and-serving layer.

No provider request, external notification delivery, cloud schedule activation, managed deployment, position mutation or `terraform apply` is included.

## Acceptance boundary

Validated and ready for squash merge. The next dependency-safe roadmap goal is **P4b — bounded dead-letter retry planning**, remaining report-only and delivery-free.