### PR TITLE
Add bounded dead-letter retry planning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,12 @@ jobs:
           --check sql/model_approval_consistency_checks.sql
       - run: python -m src.warehouse.operational_service_level_contract_check
       - run: >-
+          python -m src.orchestration.plan_portfolio_risk_notification_retries
+          --planned-at 2026-12-31T23:59:59Z
+          --policy-id us-tech-standard
+          --portfolio-id us-tech-equal
+          --summary-json .demo/notification-retry-plan-contract.json
+      - run: >-
           python -m src.warehouse.postgres_consistency
           --check sql/operational_service_levels_consistency_checks.sql
       - if: failure()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,12 +69,6 @@ jobs:
           --check sql/model_approval_consistency_checks.sql
       - run: python -m src.warehouse.operational_service_level_contract_check
       - run: >-
-          python -m src.orchestration.plan_portfolio_risk_notification_retries
-          --planned-at 2026-12-31T23:59:59Z
-          --policy-id us-tech-standard
-          --portfolio-id us-tech-equal
-          --summary-json .demo/notification-retry-plan-contract.json
-      - run: >-
           python -m src.warehouse.postgres_consistency
           --check sql/operational_service_levels_consistency_checks.sql
       - if: failure()

--- a/config/notification_delivery.yaml
+++ b/config/notification_delivery.yaml
@@ -6,3 +6,18 @@ delivery:
     max_batch_events: 25
     max_attempts_per_event: 3
     initial_backoff_seconds: 1
+  retry_planning:
+    max_candidate_rows: 500
+    max_plan_events: 25
+    max_event_age_seconds: 604800
+    max_backoff_seconds: 3600
+    retryable_http_statuses:
+      - 408
+      - 425
+      - 429
+      - 500
+      - 502
+      - 503
+      - 504
+    retryable_error_codes:
+      - network_error

--- a/docs/portfolio-risk-notification-retry-planning.md
+++ b/docs/portfolio-risk-notification-retry-planning.md
@@ -1,0 +1,139 @@
+# Bounded Dead-Letter Retry Planning
+
+## Outcome
+
+The platform can now build a deterministic, delivery-free retry plan from retained
+notification outbox and delivery-attempt evidence:
+
+```text
+current pending notification events
+  + append-only webhook attempts
+  + current breach acknowledgement evidence
+  + reviewed delivery and retry policy
+  -> bounded as-of candidate read
+  -> deterministic classification
+  -> exact retryable event list
+  -> credential-free JSON plan
+```
+
+Primary arc42 block: `orchestration`, with a read-only interface to the
+`warehouse`. This increment creates planning evidence only. It does not execute a
+retry or change retained notification evidence.
+
+## Reviewed Policy
+
+The committed policy remains in:
+
+```text
+config/notification_delivery.yaml
+```
+
+The existing webhook contract still supplies:
+
+- maximum delivery attempts per event;
+- initial backoff seconds;
+- maximum batch size; and
+- a deterministic delivery configuration fingerprint.
+
+The new `retry_planning` section supplies:
+
+- the maximum candidate rows that one PostgreSQL read may inspect;
+- the maximum retryable events permitted in one plan;
+- the maximum event age;
+- the maximum cumulative retry backoff;
+- sorted retryable HTTP statuses; and
+- sorted retryable bounded error codes.
+
+`max_plan_events` may not exceed the webhook `max_batch_events`. The retry policy
+fingerprint and webhook configuration fingerprint are both bound into the plan ID.
+A reviewed policy change therefore creates a different plan identity.
+
+## As-Of Evidence
+
+`--planned-at` is required. The PostgreSQL reader includes only evidence visible at
+or before that timestamp:
+
+- pending outbox events whose ingest timestamp is not later than the plan time;
+- delivery attempts whose attempt timestamp is not later than the plan time;
+- successful deliveries are excluded;
+- the latest acknowledgement at or before the plan time is selected; and
+- the latest failed attempt is selected by attempt number, timestamp and attempt ID.
+
+Optional policy and portfolio filters are applied inside the bounded PostgreSQL
+query. The query requests at most `max_candidate_rows + 1`; observing the extra
+row fails the plan instead of silently truncating evidence.
+
+## Classification Precedence
+
+Each exact event identity is classified once using this precedence:
+
+1. `invalid` for incompatible event, payload, attempt or acknowledgement evidence;
+2. `acknowledged` when the source risk-limit evaluation has current acknowledgement
+   evidence;
+3. `expired` when the event age exceeds the reviewed retry policy;
+4. `attempts_exhausted` when the delivery attempt limit has been reached;
+5. `invalid` when there is no failed attempt or the latest failure is not retryable;
+6. `not_yet_eligible` while cumulative exponential backoff remains active; or
+7. `retryable` when all exact policy, failure and timing conditions are satisfied.
+
+A retryable HTTP failure must have the matching bounded `http_<status>` error code.
+A retryable transport failure must use one reviewed bounded error code, such as
+`network_error`. Arbitrary exception messages and response bodies are not used.
+
+## Deterministic Identity
+
+For every candidate the plan retains exact event identities and evidence:
+
+- notification event ID;
+- source risk-limit evaluation ID;
+- policy and portfolio identity;
+- event time;
+- SHA-256 of the canonical event envelope and payload;
+- exact latest attempt ID, number, outcome, status/error and timestamp;
+- exact acknowledgement ID, disposition and timestamp when present;
+- event age and next eligible timestamp;
+- classification and bounded reason.
+
+The plan ID binds the ordered event evidence, `planned_at`, filters, channel,
+delivery configuration fingerprint and retry policy fingerprint. Input row order
+does not change the event order or plan identity.
+
+If the number of retryable events exceeds `max_plan_events`, the planner fails
+closed. It does not select an arbitrary subset.
+
+## Operator Command
+
+Build a plan without network activity:
+
+```bash
+.venv/bin/python -m src.orchestration.plan_portfolio_risk_notification_retries \
+  --planned-at 2026-04-01T12:00:00Z \
+  --policy-id us-tech-standard \
+  --portfolio-id us-tech-equal \
+  --summary-json .demo/notification-retry-plan.json
+```
+
+The PostgreSQL DSN comes from `WAREHOUSE_POSTGRES_DSN` or `--dsn`. It is never
+included in the summary.
+
+The summary exposes classification counts, all bounded candidate evidence and the
+ordered `retryable_event_ids` list. It also declares:
+
+```text
+delivery_performed = false
+delivery_attempt_written = false
+dead_letter_mutated = false
+external_request_performed = false
+```
+
+## Boundary
+
+This command has no `--execute` option. It performs no webhook request, no delivery attempt and no dead-letter mutation. It also performs no retry sleep or attempt insert.
+It does not acknowledge or resolve a breach, expose endpoints or credentials,
+schedule itself, deploy infrastructure, activate cloud scheduling or run
+`terraform apply`.
+
+The next dependency-safe roadmap slice is **P4c — explicit manual retry
+execution**. That later increment must consume one exact reviewed plan under an
+explicit execution gate and retain its own attempt evidence; it must not weaken the
+report-only boundary established here.

--- a/src/orchestration/plan_portfolio_risk_notification_retries.py
+++ b/src/orchestration/plan_portfolio_risk_notification_retries.py
@@ -1,0 +1,872 @@
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import sys
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+from src.common.config import load_yaml
+from src.common.exceptions import StorageError, ValidationError
+from src.orchestration.deliver_portfolio_risk_notifications import (
+    CHANNEL,
+    WebhookDeliveryConfig,
+    parse_webhook_delivery_config,
+)
+from src.warehouse.postgres_loader import DEFAULT_POSTGRES_DSN
+
+MODEL_VERSION = "portfolio-risk-dead-letter-retry-plan-v1"
+POLICY_MODEL_VERSION = "portfolio-risk-dead-letter-retry-policy-v1"
+OUTBOX_MODEL_VERSION = "portfolio-risk-notification-outbox-v1"
+MAX_CANDIDATE_ROWS = 10_000
+MAX_PLAN_EVENTS = 100
+MAX_EVENT_AGE_SECONDS = 30 * 24 * 60 * 60
+MAX_RETRY_BACKOFF_SECONDS = 24 * 60 * 60
+CLASSIFICATIONS = (
+    "retryable",
+    "not_yet_eligible",
+    "attempts_exhausted",
+    "expired",
+    "acknowledged",
+    "invalid",
+)
+SAFE_SEGMENT_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,511}$")
+ERROR_CODE_PATTERN = re.compile(r"^[a-z][a-z0-9_]{0,63}$")
+
+CandidateReader = Callable[..., list[dict[str, Any]]]
+
+
+@dataclass(frozen=True, slots=True)
+class RetryPlanningPolicy:
+    max_candidate_rows: int
+    max_plan_events: int
+    max_event_age_seconds: int
+    max_backoff_seconds: int
+    retryable_http_statuses: tuple[int, ...]
+    retryable_error_codes: tuple[str, ...]
+
+    @property
+    def fingerprint(self) -> str:
+        payload = {
+            "channel": CHANNEL,
+            "max_backoff_seconds": self.max_backoff_seconds,
+            "max_candidate_rows": self.max_candidate_rows,
+            "max_event_age_seconds": self.max_event_age_seconds,
+            "max_plan_events": self.max_plan_events,
+            "model_version": POLICY_MODEL_VERSION,
+            "retryable_error_codes": list(self.retryable_error_codes),
+            "retryable_http_statuses": list(self.retryable_http_statuses),
+        }
+        digest = hashlib.sha256(
+            json.dumps(
+                payload,
+                sort_keys=True,
+                separators=(",", ":"),
+                allow_nan=False,
+            ).encode("utf-8")
+        ).hexdigest()[:24]
+        return f"{POLICY_MODEL_VERSION}-policy-{digest}"
+
+
+def _bounded_integer(
+    value: Any,
+    label: str,
+    *,
+    minimum: int,
+    maximum: int,
+) -> int:
+    if type(value) is not int or not minimum <= value <= maximum:
+        raise ValidationError(
+            f"{label} must be an integer between {minimum} and {maximum}"
+        )
+    return value
+
+
+def _safe_segment(value: Any, label: str, *, optional: bool = False) -> str | None:
+    if value is None and optional:
+        return None
+    if not isinstance(value, str) or not SAFE_SEGMENT_PATTERN.fullmatch(value):
+        raise ValidationError(f"{label} must be one safe text segment")
+    return value
+
+
+def _aware_utc(value: Any, label: str) -> datetime:
+    if isinstance(value, datetime):
+        parsed = value
+    elif isinstance(value, str):
+        try:
+            parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        except ValueError:
+            raise ValidationError(f"{label} must be ISO-8601") from None
+    else:
+        raise ValidationError(f"{label} must be timezone-aware")
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise ValidationError(f"{label} must be timezone-aware")
+    return parsed.astimezone(timezone.utc)
+
+
+def _sorted_unique_http_statuses(value: Any) -> tuple[int, ...]:
+    if not isinstance(value, list) or not value:
+        raise ValidationError("retryable_http_statuses must be a non-empty array")
+    statuses: list[int] = []
+    for item in value:
+        if type(item) is not int or not 100 <= item <= 599 or 200 <= item <= 299:
+            raise ValidationError(
+                "retryable_http_statuses must contain non-success HTTP statuses"
+            )
+        statuses.append(item)
+    if len(statuses) != len(set(statuses)) or statuses != sorted(statuses):
+        raise ValidationError(
+            "retryable_http_statuses must be sorted and contain no duplicates"
+        )
+    return tuple(statuses)
+
+
+def _sorted_unique_error_codes(value: Any) -> tuple[str, ...]:
+    if not isinstance(value, list) or not value:
+        raise ValidationError("retryable_error_codes must be a non-empty array")
+    codes: list[str] = []
+    for item in value:
+        if not isinstance(item, str) or not ERROR_CODE_PATTERN.fullmatch(item):
+            raise ValidationError("retryable_error_codes contains an invalid value")
+        codes.append(item)
+    if len(codes) != len(set(codes)) or codes != sorted(codes):
+        raise ValidationError(
+            "retryable_error_codes must be sorted and contain no duplicates"
+        )
+    return tuple(codes)
+
+
+def parse_retry_planning_policy(
+    payload: Mapping[str, Any],
+    delivery_config: WebhookDeliveryConfig,
+) -> RetryPlanningPolicy:
+    if not isinstance(payload, Mapping):
+        raise ValidationError("notification delivery configuration must be a mapping")
+    delivery = payload.get("delivery")
+    if not isinstance(delivery, Mapping):
+        raise ValidationError("notification delivery configuration is missing delivery")
+    planning = delivery.get("retry_planning")
+    if not isinstance(planning, Mapping):
+        raise ValidationError(
+            "notification delivery configuration is missing retry_planning"
+        )
+    policy = RetryPlanningPolicy(
+        max_candidate_rows=_bounded_integer(
+            planning.get("max_candidate_rows"),
+            "max_candidate_rows",
+            minimum=1,
+            maximum=MAX_CANDIDATE_ROWS,
+        ),
+        max_plan_events=_bounded_integer(
+            planning.get("max_plan_events"),
+            "max_plan_events",
+            minimum=1,
+            maximum=MAX_PLAN_EVENTS,
+        ),
+        max_event_age_seconds=_bounded_integer(
+            planning.get("max_event_age_seconds"),
+            "max_event_age_seconds",
+            minimum=1,
+            maximum=MAX_EVENT_AGE_SECONDS,
+        ),
+        max_backoff_seconds=_bounded_integer(
+            planning.get("max_backoff_seconds"),
+            "max_backoff_seconds",
+            minimum=1,
+            maximum=MAX_RETRY_BACKOFF_SECONDS,
+        ),
+        retryable_http_statuses=_sorted_unique_http_statuses(
+            planning.get("retryable_http_statuses")
+        ),
+        retryable_error_codes=_sorted_unique_error_codes(
+            planning.get("retryable_error_codes")
+        ),
+    )
+    if policy.max_plan_events > delivery_config.max_batch_events:
+        raise ValidationError(
+            "max_plan_events must not exceed webhook max_batch_events"
+        )
+    if policy.max_backoff_seconds < delivery_config.initial_backoff_seconds:
+        raise ValidationError(
+            "max_backoff_seconds must not be below initial_backoff_seconds"
+        )
+    return policy
+
+
+def load_retry_planning_contract(
+    path: Path,
+) -> tuple[WebhookDeliveryConfig, RetryPlanningPolicy]:
+    try:
+        payload = load_yaml(path)
+    except Exception:
+        raise ValidationError(
+            "notification delivery configuration could not be loaded"
+        ) from None
+    if not isinstance(payload, Mapping):
+        raise ValidationError("notification delivery configuration must be a mapping")
+    delivery_config = parse_webhook_delivery_config(payload)
+    policy = parse_retry_planning_policy(payload, delivery_config)
+    return delivery_config, policy
+
+
+def read_notification_retry_candidates(
+    *,
+    dsn: str,
+    planned_at: datetime | str,
+    max_candidate_rows: int,
+    policy_id: str | None = None,
+    portfolio_id: str | None = None,
+    schema_name: str = "risk_platform",
+) -> list[dict[str, Any]]:
+    if not isinstance(dsn, str) or not dsn.strip():
+        raise ValidationError("PostgreSQL DSN must be non-empty text")
+    as_of = _aware_utc(planned_at, "planned_at")
+    row_limit = _bounded_integer(
+        max_candidate_rows,
+        "max_candidate_rows",
+        minimum=1,
+        maximum=MAX_CANDIDATE_ROWS,
+    )
+    selected_policy = _safe_segment(policy_id, "policy_id", optional=True)
+    selected_portfolio = _safe_segment(
+        portfolio_id,
+        "portfolio_id",
+        optional=True,
+    )
+    try:
+        import psycopg
+        from psycopg.rows import dict_row
+    except ImportError as exc:
+        raise RuntimeError(
+            "PostgreSQL retry planning requires psycopg. Run `make setup` first."
+        ) from exc
+
+    schema = '"' + schema_name.replace('"', '""') + '"'
+    filter_clauses: list[str] = []
+    filter_parameters: list[Any] = []
+    if selected_policy is not None:
+        filter_clauses.append("AND pending.policy_id = %s")
+        filter_parameters.append(selected_policy)
+    if selected_portfolio is not None:
+        filter_clauses.append("AND pending.portfolio_id = %s")
+        filter_parameters.append(selected_portfolio)
+    filter_sql = "\n          ".join(filter_clauses)
+    statement = f"""
+        SELECT
+            pending.event_id,
+            pending.model_version AS outbox_model_version,
+            pending.event_type,
+            pending.transition_type,
+            pending.delivery_disposition,
+            pending.source_evaluation_calculation_id,
+            pending.policy_id,
+            pending.policy_fingerprint,
+            pending.portfolio_id,
+            pending.definition_fingerprint,
+            pending.metric_name,
+            pending.subject_type,
+            pending.subject_key,
+            pending.current_status,
+            pending.ts_event,
+            pending.ts_ingest,
+            pending.payload_json,
+            COALESCE(attempt_count.attempt_count, 0)::INTEGER AS attempt_count,
+            latest_attempt.attempt_id AS last_attempt_id,
+            latest_attempt.attempt_number AS last_attempt_number,
+            latest_attempt.attempted_at AS last_attempted_at,
+            latest_attempt.outcome AS last_attempt_outcome,
+            latest_attempt.http_status AS last_http_status,
+            latest_attempt.error_code AS last_error_code,
+            latest_ack.acknowledgement_id,
+            latest_ack.acknowledged_at,
+            latest_ack.disposition AS acknowledgement_disposition
+        FROM {schema}.portfolio_risk_notification_pending pending
+        LEFT JOIN LATERAL (
+            SELECT COUNT(*) AS attempt_count
+            FROM {schema}.portfolio_risk_notification_delivery_attempts attempt
+            WHERE attempt.event_id = pending.event_id
+              AND attempt.channel = %s
+              AND attempt.attempted_at <= %s
+        ) attempt_count ON TRUE
+        LEFT JOIN LATERAL (
+            SELECT
+                attempt.attempt_id,
+                attempt.attempt_number,
+                attempt.attempted_at,
+                attempt.outcome,
+                attempt.http_status,
+                attempt.error_code
+            FROM {schema}.portfolio_risk_notification_delivery_attempts attempt
+            WHERE attempt.event_id = pending.event_id
+              AND attempt.channel = %s
+              AND attempt.attempted_at <= %s
+            ORDER BY
+                attempt.attempt_number DESC,
+                attempt.attempted_at DESC,
+                attempt.attempt_id DESC
+            LIMIT 1
+        ) latest_attempt ON TRUE
+        LEFT JOIN LATERAL (
+            SELECT
+                acknowledgement.acknowledgement_id,
+                acknowledgement.acknowledged_at,
+                acknowledgement.disposition
+            FROM {schema}.portfolio_risk_limit_acknowledgements acknowledgement
+            WHERE acknowledgement.evaluation_calculation_id
+                    = pending.source_evaluation_calculation_id
+              AND acknowledgement.acknowledged_at <= %s
+            ORDER BY
+                acknowledgement.acknowledged_at DESC,
+                acknowledgement.acknowledgement_id DESC
+            LIMIT 1
+        ) latest_ack ON TRUE
+        WHERE pending.ts_ingest <= %s
+          {filter_sql}
+          AND NOT EXISTS (
+              SELECT 1
+              FROM {schema}.portfolio_risk_notification_delivery_attempts success
+              WHERE success.event_id = pending.event_id
+                AND success.channel = %s
+                AND success.outcome = 'succeeded'
+                AND success.attempted_at <= %s
+          )
+        ORDER BY pending.ts_event, pending.event_id
+        LIMIT %s
+    """
+    parameters = (
+        CHANNEL,
+        as_of,
+        CHANNEL,
+        as_of,
+        as_of,
+        as_of,
+        *filter_parameters,
+        CHANNEL,
+        as_of,
+        row_limit + 1,
+    )
+    try:
+        with psycopg.connect(dsn, row_factory=dict_row) as connection:
+            with connection.cursor() as cursor:
+                cursor.execute(statement, parameters)
+                records = [dict(row) for row in cursor.fetchall()]
+    except Exception:
+        raise StorageError("Unable to read notification retry evidence") from None
+    if len(records) > row_limit:
+        raise ValidationError(
+            "notification retry evidence exceeds max_candidate_rows; narrow the plan"
+        )
+    return records
+
+
+def _required_candidate_text(
+    candidate: Mapping[str, Any],
+    key: str,
+    *,
+    maximum: int = 512,
+) -> str:
+    value = candidate.get(key)
+    if not isinstance(value, str) or not value or value != value.strip():
+        raise ValidationError(f"candidate {key} must be non-empty canonical text")
+    if len(value) > maximum or any(ord(character) < 32 for character in value):
+        raise ValidationError(f"candidate {key} is invalid")
+    return value
+
+
+def _optional_candidate_text(
+    candidate: Mapping[str, Any],
+    key: str,
+    *,
+    maximum: int = 512,
+) -> str | None:
+    value = candidate.get(key)
+    if value is None:
+        return None
+    if not isinstance(value, str) or not value or value != value.strip():
+        raise ValidationError(f"candidate {key} must be canonical text")
+    if len(value) > maximum or any(ord(character) < 32 for character in value):
+        raise ValidationError(f"candidate {key} is invalid")
+    return value
+
+
+def _canonical_payload(candidate: Mapping[str, Any]) -> tuple[dict[str, Any], str]:
+    payload = candidate.get("payload_json")
+    if isinstance(payload, str):
+        try:
+            payload = json.loads(payload)
+        except ValueError:
+            raise ValidationError("candidate payload_json is invalid") from None
+    if not isinstance(payload, Mapping):
+        raise ValidationError("candidate payload_json must be an object")
+    canonical_payload = dict(payload)
+    try:
+        encoded = json.dumps(
+            canonical_payload,
+            sort_keys=True,
+            separators=(",", ":"),
+            allow_nan=False,
+        ).encode("utf-8")
+    except (TypeError, ValueError):
+        raise ValidationError("candidate payload_json is not canonical JSON") from None
+    return canonical_payload, hashlib.sha256(encoded).hexdigest()
+
+
+def _retry_failure_is_supported(
+    *,
+    http_status: int | None,
+    error_code: str | None,
+    policy: RetryPlanningPolicy,
+) -> bool:
+    if http_status is not None:
+        return (
+            http_status in policy.retryable_http_statuses
+            and error_code == f"http_{http_status}"
+        )
+    return error_code in policy.retryable_error_codes
+
+
+def _retry_delay_seconds(
+    *,
+    attempt_count: int,
+    delivery_config: WebhookDeliveryConfig,
+    policy: RetryPlanningPolicy,
+) -> int:
+    exponent = max(attempt_count - 1, 0)
+    return min(
+        delivery_config.initial_backoff_seconds * (2**exponent),
+        policy.max_backoff_seconds,
+    )
+
+
+def _classify_candidate(
+    candidate: Mapping[str, Any],
+    *,
+    planned_at: datetime,
+    delivery_config: WebhookDeliveryConfig,
+    policy: RetryPlanningPolicy,
+) -> dict[str, Any]:
+    event_id = _required_candidate_text(candidate, "event_id")
+    event_type = _required_candidate_text(candidate, "event_type", maximum=128)
+    transition_type = _required_candidate_text(
+        candidate,
+        "transition_type",
+        maximum=128,
+    )
+    source_evaluation_id = _required_candidate_text(
+        candidate,
+        "source_evaluation_calculation_id",
+    )
+    policy_id = _required_candidate_text(candidate, "policy_id", maximum=128)
+    policy_fingerprint = _required_candidate_text(
+        candidate,
+        "policy_fingerprint",
+    )
+    portfolio_id = _required_candidate_text(
+        candidate,
+        "portfolio_id",
+        maximum=128,
+    )
+    definition_fingerprint = _required_candidate_text(
+        candidate,
+        "definition_fingerprint",
+    )
+    metric_name = _required_candidate_text(candidate, "metric_name", maximum=128)
+    subject_type = _required_candidate_text(candidate, "subject_type", maximum=128)
+    subject_key = _required_candidate_text(candidate, "subject_key")
+    current_status = _required_candidate_text(
+        candidate,
+        "current_status",
+        maximum=128,
+    )
+    ts_event = _aware_utc(candidate.get("ts_event"), "candidate.ts_event")
+    ts_ingest = _aware_utc(candidate.get("ts_ingest"), "candidate.ts_ingest")
+    payload, payload_sha256 = _canonical_payload(candidate)
+    attempt_count = candidate.get("attempt_count")
+    if type(attempt_count) is not int or attempt_count < 0:
+        raise ValidationError("candidate attempt_count must be non-negative")
+    last_attempt_id = _optional_candidate_text(candidate, "last_attempt_id")
+    last_attempt_number = candidate.get("last_attempt_number")
+    last_attempted_at_raw = candidate.get("last_attempted_at")
+    last_attempted_at = (
+        None
+        if last_attempted_at_raw is None
+        else _aware_utc(last_attempted_at_raw, "candidate.last_attempted_at")
+    )
+    last_attempt_outcome = _optional_candidate_text(
+        candidate,
+        "last_attempt_outcome",
+        maximum=32,
+    )
+    last_http_status = candidate.get("last_http_status")
+    if last_http_status is not None and (
+        type(last_http_status) is not int or not 100 <= last_http_status <= 599
+    ):
+        raise ValidationError("candidate last_http_status is invalid")
+    last_error_code = _optional_candidate_text(
+        candidate,
+        "last_error_code",
+        maximum=128,
+    )
+    acknowledgement_id = _optional_candidate_text(
+        candidate,
+        "acknowledgement_id",
+    )
+    acknowledged_at_raw = candidate.get("acknowledged_at")
+    acknowledged_at = (
+        None
+        if acknowledged_at_raw is None
+        else _aware_utc(acknowledged_at_raw, "candidate.acknowledged_at")
+    )
+    acknowledgement_disposition = _optional_candidate_text(
+        candidate,
+        "acknowledgement_disposition",
+        maximum=64,
+    )
+
+    exact_event = {
+        "current_status": current_status,
+        "definition_fingerprint": definition_fingerprint,
+        "event_id": event_id,
+        "event_type": event_type,
+        "metric_name": metric_name,
+        "payload_sha256": payload_sha256,
+        "policy_fingerprint": policy_fingerprint,
+        "policy_id": policy_id,
+        "portfolio_id": portfolio_id,
+        "source_evaluation_calculation_id": source_evaluation_id,
+        "subject_key": subject_key,
+        "subject_type": subject_type,
+        "transition_type": transition_type,
+        "ts_event": ts_event.isoformat(),
+        "ts_ingest": ts_ingest.isoformat(),
+    }
+    event_document_sha256 = hashlib.sha256(
+        json.dumps(
+            exact_event,
+            sort_keys=True,
+            separators=(",", ":"),
+            allow_nan=False,
+        ).encode("utf-8")
+    ).hexdigest()
+    event_age_seconds = (planned_at - ts_event).total_seconds()
+    next_eligible_at: datetime | None = None
+    classification = "invalid"
+    reason = "candidate_contract_invalid"
+
+    structural_reason: str | None = None
+    if candidate.get("outbox_model_version") != OUTBOX_MODEL_VERSION:
+        structural_reason = "outbox_model_version_unsupported"
+    elif candidate.get("delivery_disposition") != "pending":
+        structural_reason = "delivery_disposition_not_pending"
+    elif ts_ingest < ts_event:
+        structural_reason = "event_ingest_precedes_event"
+    elif ts_event > planned_at or ts_ingest > planned_at:
+        structural_reason = "event_timestamp_future"
+    elif payload.get("event_id") not in {None, event_id}:
+        structural_reason = "payload_event_identity_mismatch"
+    elif attempt_count == 0 and any(
+        value is not None
+        for value in (
+            last_attempt_id,
+            last_attempt_number,
+            last_attempted_at,
+            last_attempt_outcome,
+            last_http_status,
+            last_error_code,
+        )
+    ):
+        structural_reason = "attempt_summary_inconsistent"
+    elif attempt_count > 0 and (
+        last_attempt_id is None
+        or type(last_attempt_number) is not int
+        or last_attempt_number != attempt_count
+        or last_attempted_at is None
+        or last_attempt_outcome is None
+    ):
+        structural_reason = "attempt_summary_inconsistent"
+    elif last_attempted_at is not None and (
+        last_attempted_at < ts_event or last_attempted_at > planned_at
+    ):
+        structural_reason = "attempt_timestamp_invalid"
+    elif acknowledgement_id is None and any(
+        value is not None
+        for value in (acknowledged_at, acknowledgement_disposition)
+    ):
+        structural_reason = "acknowledgement_summary_inconsistent"
+    elif acknowledgement_id is not None and (
+        acknowledged_at is None
+        or acknowledgement_disposition
+        not in {"investigating", "accepted", "false_positive"}
+        or acknowledged_at < ts_event
+        or acknowledged_at > planned_at
+    ):
+        structural_reason = "acknowledgement_summary_inconsistent"
+
+    if structural_reason is not None:
+        reason = structural_reason
+    elif acknowledgement_id is not None:
+        classification = "acknowledged"
+        reason = "source_breach_acknowledged"
+    elif event_age_seconds > policy.max_event_age_seconds:
+        classification = "expired"
+        reason = "event_age_exceeds_policy"
+    elif attempt_count >= delivery_config.max_attempts_per_event:
+        classification = "attempts_exhausted"
+        reason = "maximum_attempts_reached"
+    elif attempt_count == 0:
+        reason = "failed_attempt_missing"
+    elif last_attempt_outcome != "failed":
+        reason = "latest_attempt_not_failed"
+    elif not _retry_failure_is_supported(
+        http_status=last_http_status,
+        error_code=last_error_code,
+        policy=policy,
+    ):
+        reason = "last_failure_not_retryable"
+    else:
+        assert last_attempted_at is not None
+        delay_seconds = _retry_delay_seconds(
+            attempt_count=attempt_count,
+            delivery_config=delivery_config,
+            policy=policy,
+        )
+        next_eligible_at = last_attempted_at + timedelta(seconds=delay_seconds)
+        if planned_at < next_eligible_at:
+            classification = "not_yet_eligible"
+            reason = "retry_backoff_active"
+        else:
+            classification = "retryable"
+            reason = "eligible_retryable_failure"
+
+    acknowledgement_evidence: dict[str, Any] | None = None
+    if acknowledgement_id is not None:
+        assert acknowledged_at is not None
+        acknowledgement_evidence = {
+            "acknowledged_at": acknowledged_at.isoformat(),
+            "acknowledgement_id": acknowledgement_id,
+            "disposition": acknowledgement_disposition,
+        }
+    last_attempt_evidence: dict[str, Any] | None = None
+    if last_attempt_id is not None:
+        assert last_attempted_at is not None
+        last_attempt_evidence = {
+            "attempt_id": last_attempt_id,
+            "attempt_number": last_attempt_number,
+            "attempted_at": last_attempted_at.isoformat(),
+            "error_code": last_error_code,
+            "http_status": last_http_status,
+            "outcome": last_attempt_outcome,
+        }
+
+    return {
+        "acknowledgement": acknowledgement_evidence,
+        "attempt_count": attempt_count,
+        "classification": classification,
+        "event_age_seconds": max(0.0, event_age_seconds),
+        "event_document_sha256": event_document_sha256,
+        "event_id": event_id,
+        "last_attempt": last_attempt_evidence,
+        "next_eligible_at": (
+            next_eligible_at.isoformat() if next_eligible_at is not None else None
+        ),
+        "policy_id": policy_id,
+        "portfolio_id": portfolio_id,
+        "reason": reason,
+        "source_evaluation_calculation_id": source_evaluation_id,
+        "ts_event": ts_event.isoformat(),
+    }
+
+
+def _plan_id(payload: Mapping[str, Any]) -> str:
+    digest = hashlib.sha256(
+        json.dumps(
+            payload,
+            sort_keys=True,
+            separators=(",", ":"),
+            allow_nan=False,
+        ).encode("utf-8")
+    ).hexdigest()[:24]
+    return f"{MODEL_VERSION}-plan-{digest}"
+
+
+def plan_portfolio_risk_notification_retries(
+    *,
+    config_path: Path,
+    dsn: str,
+    planned_at: datetime | str,
+    policy_id: str | None = None,
+    portfolio_id: str | None = None,
+    reader: CandidateReader | None = None,
+) -> dict[str, Any]:
+    as_of = _aware_utc(planned_at, "planned_at")
+    selected_policy_id = _safe_segment(policy_id, "policy_id", optional=True)
+    selected_portfolio_id = _safe_segment(
+        portfolio_id,
+        "portfolio_id",
+        optional=True,
+    )
+    delivery_config, policy = load_retry_planning_contract(config_path)
+    selected_reader = reader or read_notification_retry_candidates
+    candidates = selected_reader(
+        dsn=dsn,
+        planned_at=as_of,
+        max_candidate_rows=policy.max_candidate_rows,
+        policy_id=selected_policy_id,
+        portfolio_id=selected_portfolio_id,
+    )
+    if not isinstance(candidates, list):
+        raise StorageError("notification retry reader returned invalid evidence")
+    if len(candidates) > policy.max_candidate_rows:
+        raise ValidationError(
+            "notification retry evidence exceeds max_candidate_rows"
+        )
+
+    events = [
+        _classify_candidate(
+            candidate,
+            planned_at=as_of,
+            delivery_config=delivery_config,
+            policy=policy,
+        )
+        for candidate in candidates
+    ]
+    events.sort(key=lambda event: (event["ts_event"], event["event_id"]))
+    if len({event["event_id"] for event in events}) != len(events):
+        raise ValidationError("notification retry evidence contains duplicate event_id")
+    retryable_event_ids = [
+        event["event_id"]
+        for event in events
+        if event["classification"] == "retryable"
+    ]
+    if len(retryable_event_ids) > policy.max_plan_events:
+        raise ValidationError(
+            "retryable notification count exceeds max_plan_events; narrow the plan"
+        )
+    classification_counts = {
+        classification: sum(
+            event["classification"] == classification for event in events
+        )
+        for classification in CLASSIFICATIONS
+    }
+    identity = {
+        "channel": CHANNEL,
+        "delivery_config_fingerprint": delivery_config.fingerprint,
+        "events": events,
+        "filters": {
+            "policy_id": selected_policy_id,
+            "portfolio_id": selected_portfolio_id,
+        },
+        "model_version": MODEL_VERSION,
+        "planned_at": as_of.isoformat(),
+        "retry_policy_fingerprint": policy.fingerprint,
+    }
+    return {
+        "plan_id": _plan_id(identity),
+        "model_version": MODEL_VERSION,
+        "planned_at": as_of.isoformat(),
+        "channel": CHANNEL,
+        "delivery_config": {
+            "enabled": delivery_config.enabled,
+            "fingerprint": delivery_config.fingerprint,
+            "max_attempts_per_event": delivery_config.max_attempts_per_event,
+        },
+        "retry_policy": {
+            "fingerprint": policy.fingerprint,
+            "max_backoff_seconds": policy.max_backoff_seconds,
+            "max_candidate_rows": policy.max_candidate_rows,
+            "max_event_age_seconds": policy.max_event_age_seconds,
+            "max_plan_events": policy.max_plan_events,
+            "retryable_error_codes": list(policy.retryable_error_codes),
+            "retryable_http_statuses": list(policy.retryable_http_statuses),
+        },
+        "filters": {
+            "policy_id": selected_policy_id,
+            "portfolio_id": selected_portfolio_id,
+        },
+        "selection": {
+            "candidates_examined": len(events),
+            "classification_counts": classification_counts,
+            "retryable_events": len(retryable_event_ids),
+        },
+        "events": events,
+        "retryable_event_ids": retryable_event_ids,
+        "delivery_performed": False,
+        "delivery_attempt_written": False,
+        "dead_letter_mutated": False,
+        "external_request_performed": False,
+    }
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Build a deterministic, delivery-free retry plan from retained "
+            "portfolio risk notification attempt evidence."
+        )
+    )
+    parser.add_argument("--planned-at", required=True)
+    parser.add_argument(
+        "--config",
+        type=Path,
+        default=Path("config/notification_delivery.yaml"),
+    )
+    parser.add_argument(
+        "--dsn",
+        default=os.environ.get("WAREHOUSE_POSTGRES_DSN", DEFAULT_POSTGRES_DSN),
+    )
+    parser.add_argument("--policy-id")
+    parser.add_argument("--portfolio-id")
+    parser.add_argument("--summary-json", type=Path)
+    return parser
+
+
+def _write_summary(path: Path, summary: Mapping[str, Any]) -> None:
+    if path.is_symlink():
+        raise StorageError("notification retry summary must not be a symbolic link")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_suffix(path.suffix + ".tmp")
+    try:
+        temporary.write_text(
+            json.dumps(summary, indent=2, sort_keys=True, allow_nan=False) + "\n",
+            encoding="utf-8",
+        )
+        temporary.replace(path)
+    except (OSError, TypeError, ValueError):
+        temporary.unlink(missing_ok=True)
+        raise StorageError("unable to write notification retry plan summary") from None
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    try:
+        summary = plan_portfolio_risk_notification_retries(
+            config_path=args.config,
+            dsn=args.dsn,
+            planned_at=args.planned_at,
+            policy_id=args.policy_id,
+            portfolio_id=args.portfolio_id,
+        )
+        if args.summary_json is not None:
+            _write_summary(args.summary_json, summary)
+    except ValidationError as exc:
+        print(f"Notification retry plan rejected: {exc}", file=sys.stderr)
+        return 1
+    except StorageError as exc:
+        print(f"Notification retry plan failed: {exc}", file=sys.stderr)
+        return 1
+    except Exception:
+        print("Notification retry plan failed: unexpected local failure", file=sys.stderr)
+        return 1
+    print(json.dumps(summary, sort_keys=True, allow_nan=False))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/test_portfolio_risk_notification_retry_planning.py
+++ b/tests/unit/test_portfolio_risk_notification_retry_planning.py
@@ -1,0 +1,282 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+from src.common.exceptions import ValidationError
+from src.orchestration.plan_portfolio_risk_notification_retries import (
+    CLASSIFICATIONS,
+    _build_parser,
+    parse_retry_planning_policy,
+    plan_portfolio_risk_notification_retries,
+    read_notification_retry_candidates,
+)
+from src.orchestration.deliver_portfolio_risk_notifications import (
+    parse_webhook_delivery_config,
+)
+
+PLANNED_AT = datetime(2026, 1, 10, 12, tzinfo=timezone.utc)
+
+
+def _config_payload(
+    *,
+    max_plan_events: int = 25,
+    statuses: list[int] | None = None,
+) -> dict[str, Any]:
+    return {
+        "delivery": {
+            "webhook": {
+                "enabled": False,
+                "endpoint_env": "RISK_NOTIFICATION_WEBHOOK_URL",
+                "timeout_seconds": 5,
+                "max_batch_events": 25,
+                "max_attempts_per_event": 3,
+                "initial_backoff_seconds": 1,
+            },
+            "retry_planning": {
+                "max_candidate_rows": 500,
+                "max_plan_events": max_plan_events,
+                "max_event_age_seconds": 7 * 24 * 60 * 60,
+                "max_backoff_seconds": 3600,
+                "retryable_http_statuses": statuses
+                or [408, 425, 429, 500, 502, 503, 504],
+                "retryable_error_codes": ["network_error"],
+            },
+        }
+    }
+
+
+def _write_config(
+    tmp_path: Path,
+    *,
+    max_plan_events: int = 25,
+) -> Path:
+    path = tmp_path / "notification-delivery.yaml"
+    path.write_text(
+        yaml.safe_dump(
+            _config_payload(max_plan_events=max_plan_events),
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+    return path
+
+
+def _candidate(
+    event_id: str,
+    *,
+    ts_event: datetime | None = None,
+    attempt_count: int = 1,
+    last_attempted_at: datetime | None = None,
+    http_status: int | None = 503,
+    error_code: str | None = "http_503",
+    acknowledgement: bool = False,
+) -> dict[str, Any]:
+    event_time = ts_event or PLANNED_AT - timedelta(hours=2)
+    last_time = last_attempted_at or PLANNED_AT - timedelta(minutes=10)
+    candidate: dict[str, Any] = {
+        "event_id": event_id,
+        "outbox_model_version": "portfolio-risk-notification-outbox-v1",
+        "event_type": "breach_opened",
+        "transition_type": "opened",
+        "delivery_disposition": "pending",
+        "source_evaluation_calculation_id": f"evaluation-{event_id}",
+        "policy_id": "us-tech-standard",
+        "policy_fingerprint": "policy-fingerprint",
+        "portfolio_id": "us-tech-equal",
+        "definition_fingerprint": "definition-fingerprint",
+        "metric_name": "portfolio_volatility_annualized",
+        "subject_type": "portfolio",
+        "subject_key": "us-tech-equal",
+        "current_status": "critical",
+        "ts_event": event_time,
+        "ts_ingest": event_time + timedelta(seconds=1),
+        "payload_json": {"event_id": event_id, "severity": "critical"},
+        "attempt_count": attempt_count,
+        "last_attempt_id": (
+            f"attempt-{event_id}-{attempt_count}" if attempt_count else None
+        ),
+        "last_attempt_number": attempt_count if attempt_count else None,
+        "last_attempted_at": last_time if attempt_count else None,
+        "last_attempt_outcome": "failed" if attempt_count else None,
+        "last_http_status": http_status if attempt_count else None,
+        "last_error_code": error_code if attempt_count else None,
+        "acknowledgement_id": None,
+        "acknowledged_at": None,
+        "acknowledgement_disposition": None,
+    }
+    if acknowledgement:
+        candidate.update(
+            {
+                "acknowledgement_id": f"ack-{event_id}",
+                "acknowledged_at": PLANNED_AT - timedelta(minutes=5),
+                "acknowledgement_disposition": "investigating",
+            }
+        )
+    return candidate
+
+
+def test_retry_policy_is_bounded_sorted_and_delivery_compatible() -> None:
+    payload = _config_payload()
+    delivery = parse_webhook_delivery_config(payload)
+    first = parse_retry_planning_policy(payload, delivery)
+    second = parse_retry_planning_policy(payload, delivery)
+
+    assert first.fingerprint == second.fingerprint
+    assert first.max_plan_events == delivery.max_batch_events
+
+    with pytest.raises(ValidationError, match="sorted"):
+        invalid = _config_payload(statuses=[503, 500])
+        parse_retry_planning_policy(
+            invalid,
+            parse_webhook_delivery_config(invalid),
+        )
+
+    too_large = _config_payload(max_plan_events=26)
+    with pytest.raises(ValidationError, match="max_batch_events"):
+        parse_retry_planning_policy(
+            too_large,
+            parse_webhook_delivery_config(too_large),
+        )
+
+
+def test_plan_classifies_every_supported_dead_letter_state(
+    tmp_path: Path,
+) -> None:
+    candidates = [
+        _candidate("event-retryable"),
+        _candidate(
+            "event-not-yet-eligible",
+            attempt_count=2,
+            last_attempted_at=PLANNED_AT - timedelta(seconds=1),
+            http_status=None,
+            error_code="network_error",
+        ),
+        _candidate("event-attempts-exhausted", attempt_count=3),
+        _candidate(
+            "event-expired",
+            ts_event=PLANNED_AT - timedelta(days=8),
+        ),
+        _candidate("event-acknowledged", acknowledgement=True),
+        _candidate(
+            "event-invalid",
+            http_status=400,
+            error_code="http_400",
+        ),
+    ]
+    summary = plan_portfolio_risk_notification_retries(
+        config_path=_write_config(tmp_path),
+        dsn="postgresql://secret-value",
+        planned_at=PLANNED_AT,
+        reader=lambda **_: list(reversed(candidates)),
+    )
+
+    assert summary["selection"]["classification_counts"] == {
+        classification: 1 for classification in CLASSIFICATIONS
+    }
+    assert summary["retryable_event_ids"] == ["event-retryable"]
+    by_id = {event["event_id"]: event for event in summary["events"]}
+    assert by_id["event-not-yet-eligible"]["reason"] == "retry_backoff_active"
+    assert by_id["event-attempts-exhausted"]["reason"] == (
+        "maximum_attempts_reached"
+    )
+    assert by_id["event-expired"]["reason"] == "event_age_exceeds_policy"
+    assert by_id["event-acknowledged"]["reason"] == (
+        "source_breach_acknowledged"
+    )
+    assert by_id["event-invalid"]["reason"] == "last_failure_not_retryable"
+    assert summary["delivery_performed"] is False
+    assert summary["delivery_attempt_written"] is False
+    assert summary["dead_letter_mutated"] is False
+    assert summary["external_request_performed"] is False
+
+    rendered = json.dumps(summary, sort_keys=True)
+    assert "postgresql://secret-value" not in rendered
+    assert '"severity"' not in rendered
+
+
+def test_plan_identity_and_event_order_are_input_order_independent(
+    tmp_path: Path,
+) -> None:
+    candidates = [_candidate("event-b"), _candidate("event-a")]
+    kwargs = {
+        "config_path": _write_config(tmp_path),
+        "dsn": "dsn",
+        "planned_at": PLANNED_AT,
+    }
+    first = plan_portfolio_risk_notification_retries(
+        **kwargs,
+        reader=lambda **_: candidates,
+    )
+    second = plan_portfolio_risk_notification_retries(
+        **kwargs,
+        reader=lambda **_: list(reversed(candidates)),
+    )
+
+    assert first["plan_id"] == second["plan_id"]
+    assert [event["event_id"] for event in first["events"]] == [
+        "event-a",
+        "event-b",
+    ]
+
+
+def test_retryable_plan_limit_fails_closed_without_truncation(
+    tmp_path: Path,
+) -> None:
+    with pytest.raises(ValidationError, match="max_plan_events"):
+        plan_portfolio_risk_notification_retries(
+            config_path=_write_config(tmp_path, max_plan_events=1),
+            dsn="dsn",
+            planned_at=PLANNED_AT,
+            reader=lambda **_: [_candidate("event-a"), _candidate("event-b")],
+        )
+
+
+def test_duplicate_event_identity_and_inconsistent_attempts_fail_closed(
+    tmp_path: Path,
+) -> None:
+    duplicate = _candidate("event-duplicate")
+    with pytest.raises(ValidationError, match="duplicate event_id"):
+        plan_portfolio_risk_notification_retries(
+            config_path=_write_config(tmp_path),
+            dsn="dsn",
+            planned_at=PLANNED_AT,
+            reader=lambda **_: [duplicate, dict(duplicate)],
+        )
+
+    inconsistent = _candidate("event-inconsistent", attempt_count=2)
+    inconsistent["last_attempt_number"] = 1
+    result = plan_portfolio_risk_notification_retries(
+        config_path=_write_config(tmp_path),
+        dsn="dsn",
+        planned_at=PLANNED_AT,
+        reader=lambda **_: [inconsistent],
+    )
+    assert result["events"][0]["classification"] == "invalid"
+    assert result["events"][0]["reason"] == "attempt_summary_inconsistent"
+
+
+def test_candidate_reader_rejects_invalid_bounds_before_database_access() -> None:
+    with pytest.raises(ValidationError, match="max_candidate_rows"):
+        read_notification_retry_candidates(
+            dsn="not-used",
+            planned_at=PLANNED_AT,
+            max_candidate_rows=0,
+        )
+
+
+def test_retry_planner_cli_has_no_execution_switch() -> None:
+    parser = _build_parser()
+    with pytest.raises(SystemExit):
+        parser.parse_args(
+            [
+                "--planned-at",
+                PLANNED_AT.isoformat(),
+                "--execute",
+            ]
+        )

--- a/tests/unit/test_portfolio_risk_notification_retry_planning_architecture_contract.py
+++ b/tests/unit/test_portfolio_risk_notification_retry_planning_architecture_contract.py
@@ -1,0 +1,67 @@
+from pathlib import Path
+
+
+def test_dead_letter_retry_planning_is_deterministic_and_delivery_free() -> None:
+    source = Path(
+        "src/orchestration/plan_portfolio_risk_notification_retries.py"
+    ).read_text(encoding="utf-8")
+    docs = Path(
+        "docs/portfolio-risk-notification-retry-planning.md"
+    ).read_text(encoding="utf-8")
+    config = Path("config/notification_delivery.yaml").read_text(
+        encoding="utf-8"
+    )
+
+    for required in (
+        "portfolio-risk-dead-letter-retry-plan-v1",
+        "retryable",
+        "not_yet_eligible",
+        "attempts_exhausted",
+        "expired",
+        "acknowledged",
+        "invalid",
+        "max_candidate_rows",
+        "max_plan_events",
+        "delivery_attempt_written",
+        "dead_letter_mutated",
+        "portfolio_risk_notification_delivery_attempts",
+        "portfolio_risk_limit_acknowledgements",
+    ):
+        assert required in source
+
+    assert "--execute" not in source
+    assert "urllib.request" not in source
+    assert "INSERT INTO" not in source
+    assert "UPDATE risk_platform" not in source
+    assert "DELETE FROM risk_platform" not in source
+
+    for required in (
+        "# Bounded Dead-Letter Retry Planning",
+        "Primary arc42 block: `orchestration`",
+        "classification precedence",
+        "exact event identities",
+        "no webhook request",
+        "no delivery attempt",
+        "no dead-letter mutation",
+        "P4c",
+    ):
+        assert required.casefold() in docs.casefold()
+
+    for required in (
+        "retry_planning:",
+        "max_candidate_rows:",
+        "max_plan_events:",
+        "max_event_age_seconds:",
+        "max_backoff_seconds:",
+        "retryable_http_statuses:",
+        "retryable_error_codes:",
+    ):
+        assert required in config
+
+
+def test_postgres_contract_executes_delivery_free_retry_planning() -> None:
+    workflow = Path(".github/workflows/ci.yml").read_text(encoding="utf-8")
+
+    assert "src.orchestration.plan_portfolio_risk_notification_retries" in workflow
+    assert "--planned-at 2026-12-31T23:59:59Z" in workflow
+    assert "notification-retry-plan-contract.json" in workflow

--- a/tests/unit/test_portfolio_risk_notification_retry_planning_architecture_contract.py
+++ b/tests/unit/test_portfolio_risk_notification_retry_planning_architecture_contract.py
@@ -57,11 +57,3 @@ def test_dead_letter_retry_planning_is_deterministic_and_delivery_free() -> None
         "retryable_error_codes:",
     ):
         assert required in config
-
-
-def test_postgres_contract_executes_delivery_free_retry_planning() -> None:
-    workflow = Path(".github/workflows/ci.yml").read_text(encoding="utf-8")
-
-    assert "src.orchestration.plan_portfolio_risk_notification_retries" in workflow
-    assert "--planned-at 2026-12-31T23:59:59Z" in workflow
-    assert "notification-retry-plan-contract.json" in workflow


### PR DESCRIPTION
## Goal

Complete **P4b — bounded dead-letter retry planning** with one deterministic, delivery-free contract over retained notification evidence:

```text
current pending notification events
  + append-only webhook delivery attempts
  + current breach acknowledgements
  + reviewed delivery/retry policy
  -> bounded as-of PostgreSQL read
  -> deterministic classification
  -> exact retryable event IDs
  -> credential-free JSON plan
```

Primary arc42 block: `orchestration`, with a read-only `warehouse` interface.

## Classification contract

Each exact event identity receives one classification using documented precedence:

- `invalid` for incompatible event, payload, attempt or acknowledgement evidence;
- `acknowledged` when the source risk-limit breach has retained acknowledgement evidence;
- `expired` when event age exceeds the reviewed policy;
- `attempts_exhausted` when the configured attempt limit has been reached;
- `not_yet_eligible` while cumulative exponential backoff remains active; or
- `retryable` when the latest retained failure is reviewed as retryable and every bound is satisfied.

A retryable HTTP failure must carry the matching bounded `http_<status>` error code. Transport retries are restricted to reviewed bounded codes such as `network_error`. Acknowledged events remain visible but are never placed in the retryable event list.

## Reviewed bounds and exact identity

The committed `retry_planning` policy defines:

- `max_candidate_rows`;
- `max_plan_events`;
- `max_event_age_seconds`;
- `max_backoff_seconds`;
- sorted retryable HTTP statuses; and
- sorted retryable error codes.

`max_plan_events` may not exceed the existing webhook `max_batch_events`. Policy and delivery configuration fingerprints are both bound into the plan identity.

The PostgreSQL reader:

- requires an explicit `planned_at` timestamp;
- considers only outbox, attempt and acknowledgement evidence visible at or before that time;
- applies optional policy and portfolio filters inside the query;
- excludes events with a retained successful delivery;
- selects the exact latest attempt and acknowledgement deterministically; and
- requests `max_candidate_rows + 1`, failing closed if the additional row exists.

More retryable events than `max_plan_events` also fails instead of silently truncating the plan.

Each ordered event record binds its event and source-evaluation identity, canonical event/payload SHA-256, latest attempt identity, acknowledgement identity, event age, next eligible time, classification and bounded reason. Input row order does not change event ordering or the plan ID.

## Delivery-free boundary

The planner has no `--execute` option and declares:

```text
delivery_performed = false
delivery_attempt_written = false
dead_letter_mutated = false
external_request_performed = false
```

It performs no webhook request, delivery-attempt insert, retry sleep, acknowledgement, outbox/dead-letter mutation, infrastructure deployment or `terraform apply`. The PostgreSQL DSN, webhook endpoint, payload body, credentials and arbitrary exception messages are not included in summaries.

## Validation and repair evidence

The first exact-head run exposed the repository's intentional exact-workflow security control: adding a planner-specific CI step changed the reviewed workflow bytes. That run nevertheless executed the new planner query successfully against PostgreSQL 16 before the security job rejected the workflow modification. The branch was repaired by restoring `.github/workflows/ci.yml` byte-for-byte and removing the workflow-coupled test. No security rule or workflow contract was weakened.

GitHub Actions run **313** (`32760274163`) passed on final exact head `fa01703313ce0096cb2d2637592c15392b5d8402`:

- **Security guardrails:** passed with the reviewed CI workflow unchanged.
- **Python readiness:** passed.
  - Ruff passed;
  - mypy passed across **107 source files**;
  - **770 tests passed** in the quality run;
  - **770 tests passed again** in the readiness run;
  - `pip check` reported no broken requirements;
  - the standard readiness replay passed.
- **PostgreSQL contract:** passed against PostgreSQL 16 for the complete retained source-to-serving, governance and operational evidence suite.
- **Infrastructure validation:** Kubernetes rendering and Terraform format/init/validate passed without apply.

The superseded initial head also proved the planner's live PostgreSQL read query successfully; the final planner source is unchanged from that execution, while the final exact head preserves the security-pinned workflow.

## Scope and review state

The branch is directly based on current `main`, is **eight commits ahead and zero behind**, and changes exactly **five files** with **1,367 additions and zero deletions**:

- reviewed retry-planning configuration;
- one deterministic orchestration module;
- focused documentation;
- classification/bounds tests; and
- architecture-boundary tests.

There are no unresolved review threads or requested changes. The connector-produced working commits are intended to squash into one coherent P4b increment.

## Acceptance boundary

Validated and ready for squash merge. The next dependency-safe roadmap goal is **P4c — explicit manual retry execution**, which must consume one exact reviewed plan under a separate explicit execution gate and retain its own attempt evidence.