### PR TITLE
Execute exact manual notification retry plans

### DIFF
--- a/config/notification_delivery.yaml
+++ b/config/notification_delivery.yaml
@@ -21,3 +21,7 @@ delivery:
       - 504
     retryable_error_codes:
       - network_error
+  retry_execution:
+    enabled: false
+    max_plan_age_seconds: 3600
+    max_events: 25

--- a/docs/manual-webhook-delivery.md
+++ b/docs/manual-webhook-delivery.md
@@ -2,32 +2,64 @@
 
 ## Outcome
 
-This adapter delivers current pending portfolio risk notifications to one explicitly configured HTTPS webhook while retaining append-only attempt evidence:
+This adapter makes the **first** delivery attempt for current pending portfolio risk
+notifications while retaining append-only evidence:
 
 ```text
 current pending notification outbox
-  -> exclude an already succeeded event
+  -> exclude delivered events and every event with an existing attempt
   -> bounded manual batch
-  -> HTTPS POST with stable Idempotency-Key
-  -> bounded retry and exponential backoff
+  -> one HTTPS POST with stable Idempotency-Key
   -> append-only PostgreSQL delivery attempt
   -> pending or succeeded operational views
 ```
 
-The implementation is `src/orchestration/deliver_portfolio_risk_notifications.py`. The committed configuration is `config/notification_delivery.yaml`.
+The implementation is
+`src/orchestration/deliver_portfolio_risk_notifications.py`. The committed
+configuration is `config/notification_delivery.yaml`.
 
 ## Disabled-by-default activation
 
-The committed webhook configuration has `enabled: false` and contains no endpoint or recipient. Normal invocation is plan-only. External delivery requires both:
+The committed webhook configuration has `enabled: false` and contains no endpoint
+or recipient. Normal invocation is plan-only. External delivery requires both:
 
 1. a reviewed configuration change setting `enabled: true`; and
-2. an explicit `--execute` invocation with `RISK_NOTIFICATION_WEBHOOK_URL` set locally.
+2. an explicit `--execute` invocation with `RISK_NOTIFICATION_WEBHOOK_URL` set
+   locally.
 
-The endpoint must be HTTPS and may not contain embedded credentials or a URL fragment. Only the endpoint host is recorded in evidence. The full URL and environment value are not written to summaries or the database.
+The endpoint must be HTTPS and may not contain embedded credentials or a URL
+fragment. Only the endpoint host is recorded in evidence. The full URL and
+environment value are not written to summaries or the database.
 
-## Idempotency and retries
+## Initial-attempt boundary
 
-Every request uses the notification `event_id` as the `Idempotency-Key`. Retries of the same event therefore carry the same remote deduplication identity.
+The default PostgreSQL reader selects only events with zero retained webhook
+attempts. A custom reader that supplies an event with any prior attempt is rejected
+before the first network request.
+
+The adapter therefore performs exactly one attempt numbered `1` per selected event.
+It has no internal retry loop and performs no retry sleep. A failed initial attempt
+must continue through the governed workflow:
+
+```text
+P4b deterministic retry plan
+  -> exact retained plan review
+  -> P4c explicit manual retry execution
+```
+
+This prevents the older delivery command from bypassing current event,
+acknowledgement, attempt, expiry and backoff revalidation.
+
+The reviewed `max_attempts_per_event` and `initial_backoff_seconds` settings remain
+part of the delivery fingerprint and are consumed by retry planning and exact retry
+execution. They no longer authorize hidden retries inside this first-attempt
+adapter.
+
+## Idempotency
+
+Every request uses the notification `event_id` as the `Idempotency-Key`. The first
+attempt and every later governed retry therefore carry the same remote
+deduplication identity.
 
 Attempt identity binds:
 
@@ -38,9 +70,9 @@ attempt number
 portfolio-risk-webhook-delivery-v1
 ```
 
-Attempts are append-only and numbered from one. A successful attempt prevents the event from being selected again. A failed attempt may be retried until `max_attempts_per_event` is reached. Backoff begins at `initial_backoff_seconds`, doubles after each failure, and is capped at 60 seconds.
-
-There remains an unavoidable failure window in which the remote receiver accepts a request but local attempt persistence fails. The stable `Idempotency-Key` is the control for that ambiguity; receivers must deduplicate it.
+There remains an unavoidable failure window in which the remote receiver accepts a
+request but local attempt persistence fails. The stable `Idempotency-Key` is the
+control for that ambiguity; receivers must deduplicate it.
 
 ## Evidence boundary
 
@@ -54,11 +86,13 @@ Each attempt stores:
 - payload SHA-256; and
 - idempotency key.
 
-Response bodies, endpoint paths, credentials, headers containing secrets, and arbitrary exception messages are never stored.
+Response bodies, endpoint paths, credentials, headers containing secrets and
+arbitrary exception messages are never stored. Invalid transport status values fail
+before an attempt row is written.
 
 ## Operator commands
 
-Plan the current batch without network activity:
+Plan the current **initial-attempt** batch without network activity:
 
 ```bash
 .venv/bin/python -m src.orchestration.deliver_portfolio_risk_notifications \
@@ -75,7 +109,20 @@ export RISK_NOTIFICATION_WEBHOOK_URL='https://alerts.example.com/risk'
   --summary-json .demo/webhook-delivery-run.json
 ```
 
-The PostgreSQL DSN comes from `WAREHOUSE_POSTGRES_DSN` or `--dsn`. It is not included in summaries.
+The PostgreSQL DSN comes from `WAREHOUSE_POSTGRES_DSN` or `--dsn`. It is not
+included in summaries.
+
+For an event that already has a failed attempt, generate and execute an exact retry
+plan instead of invoking this adapter again:
+
+```bash
+.venv/bin/python \
+  -m src.orchestration.plan_portfolio_risk_notification_retries \
+  --planned-at 2026-04-01T12:00:00Z \
+  --summary-json .demo/notification-retry-plan.json
+```
+
+The separate P4c command consumes the exact resulting plan.
 
 ## PostgreSQL serving
 
@@ -93,8 +140,12 @@ risk_platform.portfolio_risk_notification_delivery_pending
 risk_platform.portfolio_risk_notification_delivery_succeeded
 ```
 
-The source outbox remains immutable. Delivery status is derived from attempts rather than written back to notification records.
+The source outbox remains immutable. Delivery status is derived from attempts rather
+than written back to notification records.
 
 ## Boundary
 
-This adapter does not schedule itself, discover recipients, create webhook endpoints, rotate secrets, acknowledge or resolve breaches, mutate analytical evidence, block trading, deploy infrastructure, or run `terraform apply`. CI uses fake transports and performs no network request.
+This adapter does not schedule itself, retry an existing attempt, discover
+recipients, create webhook endpoints, rotate secrets, acknowledge or resolve
+breaches, mutate analytical evidence, block trading, deploy infrastructure, or run
+`terraform apply`. CI uses fake transports and performs no network request.

--- a/docs/portfolio-risk-notification-retry-execution.md
+++ b/docs/portfolio-risk-notification-retry-execution.md
@@ -10,7 +10,7 @@ retained portfolio-risk-dead-letter-retry-plan-v1
   + exact plan confirmation
   + current reviewed delivery and retry policy
   + current event, attempt and acknowledgement evidence
-  -> fail-closed revalidation before the first request
+  -> fail-closed revalidation before the first network request
   -> one bounded HTTPS attempt per planned event
   -> stable notification Idempotency-Key
   -> append-only delivery-attempt evidence
@@ -43,15 +43,19 @@ retry_execution:
   enabled: false
 ```
 
-External retry delivery requires all of the following:
+The reviewed activation sequence is deliberately split:
 
-1. A reviewed configuration change enabling `delivery.webhook.enabled`.
-2. A reviewed configuration change enabling `delivery.retry_execution.enabled`.
-3. A fresh retry plan generated after those settings were enabled.
-4. A locally supplied HTTPS endpoint through `RISK_NOTIFICATION_WEBHOOK_URL`.
-5. An explicit `--execute` flag.
-6. The exact retained `plan_id` repeated through `--confirm-plan-id`.
-7. A bounded operator request ID and explicit execution timestamp.
+1. Enable `delivery.webhook.enabled` through a reviewed local configuration.
+2. Generate a fresh retry plan that binds that enabled delivery fingerprint.
+3. Inspect the complete plan and retain its exact `plan_id`.
+4. Enable `delivery.retry_execution.enabled` through a second reviewed change.
+5. Supply the HTTPS endpoint locally through `RISK_NOTIFICATION_WEBHOOK_URL`.
+6. Invoke the executor with `--execute`, the exact `--confirm-plan-id`, and a
+   bounded operator request ID.
+
+The retry-execution flag is not part of the P4b plan identity, so it may remain
+disabled while the plan is prepared and reviewed. The delivery fingerprint and
+retry-planning fingerprint are part of the identity and must remain exact.
 
 A plan generated while webhook delivery was disabled cannot later be executed merely
 by changing the configuration. A new plan must bind the enabled delivery
@@ -78,12 +82,16 @@ The validator independently checks:
 The retained plan is evidence, not a general instruction file. The executor does not
 accept an arbitrary list of event IDs.
 
-## Revalidation immediately before delivery
+## Clock-bound revalidation immediately before delivery
+
+The executor derives its execution-start timestamp from the local UTC clock. The
+operator cannot supply or backdate that timestamp. Tests inject a deterministic
+clock, but the CLI always uses the actual current clock.
 
 After validating the file and current configuration, the executor performs one
-bounded PostgreSQL read at the declared `executed_at` timestamp. It rebuilds the
-retry plan using the current evidence and compares it with the retained plan before
-the first network request.
+bounded PostgreSQL read as of that execution-start timestamp. It rebuilds the retry
+plan using current evidence and compares it with the retained plan before the first
+network request.
 
 Execution is rejected when any of the following changes:
 
@@ -121,8 +129,10 @@ The execution event limit may not exceed either:
 - the retry plan's `max_plan_events`; or
 - the webhook delivery `max_batch_events`.
 
-The maximum plan age may not exceed the retry policy's event-age limit. Bounds are
-validated before PostgreSQL access and before any external request.
+The maximum plan age may not exceed the retry policy's event-age limit. The age is
+measured from the retained plan timestamp to the actual clock-derived execution
+start. Bounds are validated before PostgreSQL access and before any external
+request.
 
 ## One attempt per event
 
@@ -132,6 +142,10 @@ This command performs exactly one new attempt for each event listed in the retai
 It deliberately has no internal retry loop and performs no retry sleep. A failed
 manual attempt produces new append-only evidence. A later operator action must
 create a new current plan after the configured backoff has elapsed.
+
+The older `deliver_portfolio_risk_notifications` adapter is now restricted to first
+attempts only. It rejects any event with prior delivery evidence before transport,
+so subsequent attempts cannot bypass the exact P4b/P4c path.
 
 Attempt identity continues to bind:
 
@@ -176,8 +190,9 @@ The attempt retains:
 - canonical payload SHA-256.
 
 No response body, endpoint path, credential, DSN or arbitrary exception text is
-retained. An invalid transport response is rejected before an attempt row is
-written.
+retained. Unknown transport exception text is mapped to the bounded
+`network_error` code. An invalid transport response is rejected before an attempt
+row is written.
 
 ## Deterministic execution summary
 
@@ -186,7 +201,7 @@ The execution ID binds:
 ```text
 retained plan ID
 operator request ID
-executed-at timestamp
+clock-derived execution-start timestamp
 endpoint host
 current delivery fingerprint
 current retry-policy fingerprint
@@ -218,8 +233,8 @@ dead_letter_mutated = false
 
 ## Operator workflow
 
-First apply a reviewed local configuration that enables both webhook delivery and
-manual retry execution, then create a fresh plan:
+First apply a reviewed local configuration that enables webhook delivery, then
+create a fresh plan:
 
 ```bash
 export RISK_NOTIFICATION_WEBHOOK_URL='https://alerts.example.com/risk'
@@ -232,7 +247,8 @@ export RISK_NOTIFICATION_WEBHOOK_URL='https://alerts.example.com/risk'
   --summary-json .demo/notification-retry-plan.json
 ```
 
-Inspect the complete plan, record its exact `plan_id`, and execute it explicitly:
+Inspect the complete plan, record its exact `plan_id`, enable the separate
+`retry_execution` gate through review, and execute it explicitly:
 
 ```bash
 .venv/bin/python \
@@ -240,13 +256,13 @@ Inspect the complete plan, record its exact `plan_id`, and execute it explicitly
   --plan .demo/notification-retry-plan.json \
   --confirm-plan-id '<exact-plan-id>' \
   --request-id 'RETRY-2026-001' \
-  --executed-at 2026-04-01T12:05:00Z \
   --execute \
   --summary-json .demo/notification-retry-execution.json
 ```
 
-The PostgreSQL DSN comes from `WAREHOUSE_POSTGRES_DSN` or `--dsn` and is not
-included in the result.
+The execution-start timestamp is derived internally from the local UTC clock. The
+PostgreSQL DSN comes from `WAREHOUSE_POSTGRES_DSN` or `--dsn`; neither is included
+in the result.
 
 ## Validation boundary
 

--- a/docs/portfolio-risk-notification-retry-execution.md
+++ b/docs/portfolio-risk-notification-retry-execution.md
@@ -1,0 +1,268 @@
+# Explicit Manual Notification Retry Execution
+
+## Outcome
+
+This increment consumes one exact retained notification retry plan under a separate,
+disabled-by-default execution gate:
+
+```text
+retained portfolio-risk-dead-letter-retry-plan-v1
+  + exact plan confirmation
+  + current reviewed delivery and retry policy
+  + current event, attempt and acknowledgement evidence
+  -> fail-closed revalidation before the first request
+  -> one bounded HTTPS attempt per planned event
+  -> stable notification Idempotency-Key
+  -> append-only delivery-attempt evidence
+  -> deterministic credential-free execution summary
+```
+
+Primary arc42 block: `orchestration`, using the existing read-only warehouse evidence
+interface and append-only delivery-attempt writer.
+
+The implementation is:
+
+```text
+src/orchestration/execute_portfolio_risk_notification_retries.py
+```
+
+The strict retained-plan validator is:
+
+```text
+src/orchestration/portfolio_risk_notification_retry_plan_contract.py
+```
+
+## Separate activation gates
+
+Committed configuration remains disabled:
+
+```yaml
+webhook:
+  enabled: false
+retry_execution:
+  enabled: false
+```
+
+External retry delivery requires all of the following:
+
+1. A reviewed configuration change enabling `delivery.webhook.enabled`.
+2. A reviewed configuration change enabling `delivery.retry_execution.enabled`.
+3. A fresh retry plan generated after those settings were enabled.
+4. A locally supplied HTTPS endpoint through `RISK_NOTIFICATION_WEBHOOK_URL`.
+5. An explicit `--execute` flag.
+6. The exact retained `plan_id` repeated through `--confirm-plan-id`.
+7. A bounded operator request ID and explicit execution timestamp.
+
+A plan generated while webhook delivery was disabled cannot later be executed merely
+by changing the configuration. A new plan must bind the enabled delivery
+fingerprint.
+
+## Retained plan contract
+
+The executor accepts one regular JSON file no larger than 1 MB. Symbolic links,
+malformed JSON, unknown fields and incomplete evidence fail closed.
+
+The validator independently checks:
+
+- exact top-level, event, attempt and acknowledgement fields;
+- the `portfolio-risk-dead-letter-retry-plan-v1` model and webhook channel;
+- deterministic plan identity;
+- canonical event ordering and unique event IDs;
+- event-age arithmetic at the original planning time;
+- classification and retryable-event reconciliation;
+- attempt-number and acknowledgement consistency;
+- remaining attempt capacity;
+- backoff and expiry semantics; and
+- all original plan side-effect declarations remaining false.
+
+The retained plan is evidence, not a general instruction file. The executor does not
+accept an arbitrary list of event IDs.
+
+## Revalidation immediately before delivery
+
+After validating the file and current configuration, the executor performs one
+bounded PostgreSQL read at the declared `executed_at` timestamp. It rebuilds the
+retry plan using the current evidence and compares it with the retained plan before
+the first network request.
+
+Execution is rejected when any of the following changes:
+
+- delivery configuration fingerprint;
+- retry-planning policy fingerprint;
+- policy or portfolio filter;
+- exact pending event set;
+- event identity or payload SHA-256;
+- source risk-limit evaluation identity;
+- latest delivery-attempt identity, number, timestamp, status or error code;
+- acknowledgement identity or disposition;
+- retry classification or next-eligible timestamp; or
+- ordered retryable event IDs.
+
+Only the naturally increasing `event_age_seconds` value is excluded from the exact
+equality comparison. Expiry, backoff and classification are recalculated and must
+still agree.
+
+A newly delivered, acknowledged, exhausted, expired or otherwise changed event is
+therefore rejected rather than retried from stale evidence.
+
+## Bounded execution policy
+
+The reviewed configuration declares:
+
+```yaml
+retry_execution:
+  enabled: false
+  max_plan_age_seconds: 3600
+  max_events: 25
+```
+
+The execution event limit may not exceed either:
+
+- the retry plan's `max_plan_events`; or
+- the webhook delivery `max_batch_events`.
+
+The maximum plan age may not exceed the retry policy's event-age limit. Bounds are
+validated before PostgreSQL access and before any external request.
+
+## One attempt per event
+
+This command performs exactly one new attempt for each event listed in the retained
+`retryable_event_ids` array.
+
+It deliberately has no internal retry loop and performs no retry sleep. A failed
+manual attempt produces new append-only evidence. A later operator action must
+create a new current plan after the configured backoff has elapsed.
+
+Attempt identity continues to bind:
+
+```text
+notification event ID
+webhook channel
+attempt number
+portfolio-risk-webhook-delivery-v1
+```
+
+The next attempt number is derived from the exact retained attempt count and must
+remain within the configured maximum.
+
+## Idempotency and ambiguous remote success
+
+Every webhook request uses the notification `event_id` as its stable
+`Idempotency-Key`. The full endpoint is never retained; only its host is included in
+evidence.
+
+There remains an unavoidable ambiguity if the receiver accepts a request but local
+attempt persistence fails. The executor reports failure rather than claiming
+success, and the receiver must deduplicate the stable idempotency key. Concurrent
+operators are inside the local trust boundary and must rely on the same remote
+deduplication contract until a later distributed execution-lock increment is added.
+
+## Append-only outcome evidence
+
+Each external request is followed by an insert into the existing table:
+
+```text
+risk_platform.portfolio_risk_notification_delivery_attempts
+```
+
+The attempt retains:
+
+- deterministic attempt ID;
+- event ID and stable idempotency key;
+- attempt number and timestamp;
+- succeeded or failed outcome;
+- HTTP status or bounded transport error code;
+- endpoint host; and
+- canonical payload SHA-256.
+
+No response body, endpoint path, credential, DSN or arbitrary exception text is
+retained. An invalid transport response is rejected before an attempt row is
+written.
+
+## Deterministic execution summary
+
+The execution ID binds:
+
+```text
+retained plan ID
+operator request ID
+executed-at timestamp
+endpoint host
+current delivery fingerprint
+current retry-policy fingerprint
+current execution-policy fingerprint
+ordered expected attempt IDs and numbers
+```
+
+With identical inputs and deterministic test clocks, the execution summary and
+execution ID are identical.
+
+The summary exposes:
+
+- plan and request identity;
+- current configuration fingerprints;
+- revalidation result;
+- bounded event and attempt counts;
+- attempt IDs, timestamps and outcomes;
+- endpoint host only; and
+- explicit no-mutation declarations.
+
+It declares:
+
+```text
+response_bodies_recorded = false
+plan_mutated = false
+acknowledgement_mutated = false
+dead_letter_mutated = false
+```
+
+## Operator workflow
+
+First apply a reviewed local configuration that enables both webhook delivery and
+manual retry execution, then create a fresh plan:
+
+```bash
+export RISK_NOTIFICATION_WEBHOOK_URL='https://alerts.example.com/risk'
+
+.venv/bin/python \
+  -m src.orchestration.plan_portfolio_risk_notification_retries \
+  --planned-at 2026-04-01T12:00:00Z \
+  --policy-id us-tech-standard \
+  --portfolio-id us-tech-equal \
+  --summary-json .demo/notification-retry-plan.json
+```
+
+Inspect the complete plan, record its exact `plan_id`, and execute it explicitly:
+
+```bash
+.venv/bin/python \
+  -m src.orchestration.execute_portfolio_risk_notification_retries \
+  --plan .demo/notification-retry-plan.json \
+  --confirm-plan-id '<exact-plan-id>' \
+  --request-id 'RETRY-2026-001' \
+  --executed-at 2026-04-01T12:05:00Z \
+  --execute \
+  --summary-json .demo/notification-retry-execution.json
+```
+
+The PostgreSQL DSN comes from `WAREHOUSE_POSTGRES_DSN` or `--dsn` and is not
+included in the result.
+
+## Validation boundary
+
+Unit tests use fake readers, transports, clocks and attempt writers. Ordinary CI
+performs no external delivery and the committed configuration remains disabled.
+
+This increment does not:
+
+- schedule retry execution;
+- enable the committed webhook configuration;
+- discover recipients or create endpoints;
+- mutate acknowledgements, risk evidence, outbox events or dead-letter state;
+- deliver provider data or mutate portfolio positions;
+- deploy infrastructure; or
+- run `terraform apply`.
+
+The next dependency-safe roadmap item is **P4d — reviewed external alert delivery
+activation and operational hardening**, kept separate from this local manual
+authority contract.

--- a/src/orchestration/deliver_portfolio_risk_notifications.py
+++ b/src/orchestration/deliver_portfolio_risk_notifications.py
@@ -331,8 +331,7 @@ def write_delivery_attempt(
     placeholders = ", ".join(["%s"] * len(columns))
     statement = (
         f"INSERT INTO {schema}.portfolio_risk_notification_delivery_attempts "
-        f"({quoted}) VALUES ({placeholders}) "
-        "ON CONFLICT (attempt_id) DO NOTHING"
+        f"({quoted}) VALUES ({placeholders})"
     )
     values = tuple(attempt[column] for column in columns)
     try:
@@ -355,7 +354,7 @@ def deliver_portfolio_risk_notifications(
     transport: Transport | None = None,
 ) -> dict[str, Any]:
     config = load_webhook_delivery_config(config_path)
-    selected_environment = environment or os.environ
+    selected_environment = environment if environment is not None else os.environ
     raw_endpoint = selected_environment.get(config.endpoint_env)
     endpoint_host: str | None = None
     endpoint_value: str | None = None

--- a/src/orchestration/deliver_portfolio_risk_notifications.py
+++ b/src/orchestration/deliver_portfolio_risk_notifications.py
@@ -5,7 +5,6 @@ import hashlib
 import json
 import os
 import sys
-import time as time_module
 import urllib.error
 import urllib.request
 from collections.abc import Callable, Mapping, Sequence
@@ -16,9 +15,9 @@ from typing import Any
 from urllib.parse import urlparse
 from uuid import uuid4
 
-from ..common.config import load_yaml
-from ..common.exceptions import StorageError, ValidationError
-from ..warehouse.postgres_loader import DEFAULT_POSTGRES_DSN
+from src.common.config import load_yaml
+from src.common.exceptions import StorageError, ValidationError
+from src.warehouse.postgres_loader import DEFAULT_POSTGRES_DSN
 
 MODEL_VERSION = "portfolio-risk-webhook-delivery-v1"
 CHANNEL = "webhook"
@@ -30,7 +29,6 @@ MAX_BACKOFF_SECONDS = 60
 CandidateReader = Callable[..., list[dict[str, Any]]]
 AttemptWriter = Callable[[Mapping[str, Any]], None]
 Transport = Callable[[str, bytes, Mapping[str, str], float], int]
-Sleeper = Callable[[float], None]
 
 
 class DeliveryTransportError(RuntimeError):
@@ -210,6 +208,7 @@ def read_pending_delivery_candidates(
             pending.current_status,
             pending.ts_event,
             pending.payload_json
+        HAVING COALESCE(MAX(attempt.attempt_number), 0) = 0
         ORDER BY pending.ts_event, pending.event_id
         LIMIT %s
     """
@@ -354,7 +353,6 @@ def deliver_portfolio_risk_notifications(
     reader: CandidateReader | None = None,
     attempt_writer: AttemptWriter | None = None,
     transport: Transport | None = None,
-    sleeper: Sleeper | None = None,
 ) -> dict[str, Any]:
     config = load_webhook_delivery_config(config_path)
     selected_environment = environment or os.environ
@@ -378,6 +376,10 @@ def deliver_portfolio_risk_notifications(
         dsn=dsn,
         max_events=config.max_batch_events,
     )
+    if not isinstance(candidates, list):
+        raise StorageError("notification delivery reader returned invalid evidence")
+    if len(candidates) > config.max_batch_events:
+        raise ValidationError("notification delivery exceeds max_batch_events")
     plan = [
         {
             "attempts_so_far": int(candidate.get("attempts_so_far", 0)),
@@ -399,6 +401,7 @@ def deliver_portfolio_risk_notifications(
         "selection": {
             "candidates_selected": len(candidates),
             "max_batch_events": config.max_batch_events,
+            "initial_attempts_only": True,
         },
         "plan": plan,
         "execution": {
@@ -416,80 +419,70 @@ def deliver_portfolio_risk_notifications(
     if endpoint_value is None or endpoint_host is None:
         raise ValidationError("webhook endpoint was not resolved for execution")
 
+    for candidate in candidates:
+        attempts_so_far = candidate.get("attempts_so_far", 0)
+        if type(attempts_so_far) is not int or attempts_so_far < 0:
+            raise ValidationError("attempts_so_far must be a non-negative integer")
+        if attempts_so_far != 0:
+            raise ValidationError(
+                "events with existing delivery attempts require an exact retry plan"
+            )
+
     selected_transport = transport or _default_transport
-    selected_sleeper = sleeper or time_module.sleep
     selected_writer = attempt_writer or (
         lambda attempt: write_delivery_attempt(attempt, dsn=dsn)
     )
     succeeded = 0
     failed = 0
-    exhausted = 0
     attempts_recorded = 0
 
     for candidate in candidates:
         event_id = _required_text(candidate.get("event_id"), "event_id", 512)
-        attempts_so_far = candidate.get("attempts_so_far", 0)
-        if type(attempts_so_far) is not int or attempts_so_far < 0:
-            raise ValidationError("attempts_so_far must be a non-negative integer")
-        if attempts_so_far >= config.max_attempts_per_event:
-            exhausted += 1
-            continue
         payload = _canonical_payload(candidate)
         payload_sha256 = hashlib.sha256(payload).hexdigest()
-        event_succeeded = False
-        for attempt_number in range(
-            attempts_so_far + 1,
-            config.max_attempts_per_event + 1,
-        ):
-            attempted_at = datetime.now(timezone.utc)
-            outcome = "failed"
-            http_status: int | None = None
-            error_code: str | None = None
-            try:
-                http_status = selected_transport(
-                    endpoint_value,
-                    payload,
-                    {
-                        "Content-Type": "application/json",
-                        "Idempotency-Key": event_id,
-                        "User-Agent": "financial-risk-data-platform/1",
-                    },
-                    float(config.timeout_seconds),
-                )
-                if 200 <= http_status < 300:
-                    outcome = "succeeded"
-                else:
-                    error_code = f"http_{http_status}"
-            except DeliveryTransportError as exc:
-                error_code = str(exc)
-            attempt = {
-                "attempt_id": _attempt_id(event_id, attempt_number),
-                "model_version": MODEL_VERSION,
-                "event_id": event_id,
-                "channel": CHANNEL,
-                "attempt_number": attempt_number,
-                "idempotency_key": event_id,
-                "attempted_at": attempted_at,
-                "outcome": outcome,
-                "http_status": http_status,
-                "error_code": error_code,
-                "endpoint_host": endpoint_host,
-                "payload_sha256": payload_sha256,
-            }
-            selected_writer(attempt)
-            attempts_recorded += 1
-            if outcome == "succeeded":
-                succeeded += 1
-                event_succeeded = True
-                break
-            if attempt_number < config.max_attempts_per_event:
-                delay = min(
-                    config.initial_backoff_seconds
-                    * (2 ** (attempt_number - attempts_so_far - 1)),
-                    MAX_BACKOFF_SECONDS,
-                )
-                selected_sleeper(float(delay))
-        if not event_succeeded:
+        attempted_at = datetime.now(timezone.utc)
+        outcome = "failed"
+        http_status: int | None = None
+        error_code: str | None = None
+        try:
+            response_status = selected_transport(
+                endpoint_value,
+                payload,
+                {
+                    "Content-Type": "application/json",
+                    "Idempotency-Key": event_id,
+                    "User-Agent": "financial-risk-data-platform/1",
+                },
+                float(config.timeout_seconds),
+            )
+            if type(response_status) is not int or not 100 <= response_status <= 599:
+                raise ValidationError("webhook transport returned an invalid HTTP status")
+            http_status = response_status
+            if 200 <= response_status < 300:
+                outcome = "succeeded"
+            else:
+                error_code = f"http_{response_status}"
+        except DeliveryTransportError:
+            error_code = "network_error"
+        attempt = {
+            "attempt_id": _attempt_id(event_id, 1),
+            "model_version": MODEL_VERSION,
+            "event_id": event_id,
+            "channel": CHANNEL,
+            "attempt_number": 1,
+            "idempotency_key": event_id,
+            "attempted_at": attempted_at,
+            "outcome": outcome,
+            "http_status": http_status,
+            "error_code": error_code,
+            "endpoint_host": endpoint_host,
+            "payload_sha256": payload_sha256,
+        }
+        selected_writer(attempt)
+        attempts_recorded += 1
+        if outcome == "succeeded":
+            succeeded += 1
+        else:
             failed += 1
 
     summary["execution"] = {
@@ -497,7 +490,7 @@ def deliver_portfolio_risk_notifications(
         "performed": True,
         "succeeded": succeeded,
         "failed": failed,
-        "exhausted": exhausted,
+        "exhausted": 0,
         "attempts_recorded": attempts_recorded,
     }
     return summary
@@ -506,8 +499,8 @@ def deliver_portfolio_risk_notifications(
 def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         description=(
-            "Plan or manually deliver pending portfolio risk notifications to "
-            "one explicitly configured HTTPS webhook."
+            "Plan or manually make the first delivery attempt for pending "
+            "portfolio risk notifications."
         )
     )
     parser.add_argument(

--- a/src/orchestration/execute_portfolio_risk_notification_retries.py
+++ b/src/orchestration/execute_portfolio_risk_notification_retries.py
@@ -29,7 +29,6 @@ from src.orchestration.plan_portfolio_risk_notification_retries import (
     read_notification_retry_candidates,
 )
 from src.orchestration.portfolio_risk_notification_retry_execution_policy import (
-    ERROR_CODE_PATTERN,
     EXECUTION_MODEL_VERSION,
     aware_utc,
     load_retry_execution_contract,
@@ -66,7 +65,6 @@ def execute_portfolio_risk_notification_retries(
     plan_path: Path,
     confirm_plan_id: str,
     request_id: str,
-    executed_at: datetime | str,
     config_path: Path,
     dsn: str,
     execute: bool = False,
@@ -78,7 +76,8 @@ def execute_portfolio_risk_notification_retries(
 ) -> dict[str, Any]:
     if execute is not True:
         raise ValidationError("explicit --execute is required for manual retry delivery")
-    execution_time = aware_utc(executed_at, "executed_at")
+    selected_clock = clock or (lambda: datetime.now(timezone.utc))
+    execution_time = _clock_utc(selected_clock, "execution_started_at")
     selected_request_id = safe_segment(request_id, "request_id")
     assert selected_request_id is not None
     retained_plan = load_retry_plan(plan_path)
@@ -110,7 +109,7 @@ def execute_portfolio_risk_notification_retries(
     planned_at = aware_utc(retained_plan["planned_at"], "retry plan planned_at")
     plan_age_seconds = (execution_time - planned_at).total_seconds()
     if plan_age_seconds < 0:
-        raise ValidationError("executed_at must not precede retry plan creation")
+        raise ValidationError("execution start must not precede retry plan creation")
     if plan_age_seconds > execution_policy.max_plan_age_seconds:
         raise ValidationError("retry plan exceeds the manual execution age limit")
     retryable_event_ids = cast(list[str], retained_plan["retryable_event_ids"])
@@ -191,7 +190,6 @@ def execute_portfolio_risk_notification_retries(
         lambda attempt: write_delivery_attempt(attempt, dsn=dsn)
     )
     selected_transport = transport or _default_transport
-    selected_clock = clock or (lambda: datetime.now(timezone.utc))
     outcomes: list[dict[str, Any]] = []
     for expected in expected_attempts:
         event_id = cast(str, expected["event_id"])
@@ -202,7 +200,7 @@ def execute_portfolio_risk_notification_retries(
         payload_sha256 = hashlib.sha256(payload).hexdigest()
         attempted_at = _clock_utc(selected_clock, "attempted_at")
         if attempted_at < execution_time:
-            raise ValidationError("attempted_at must not precede executed_at")
+            raise ValidationError("attempted_at must not precede execution start")
         outcome = "failed"
         http_status: int | None = None
         error_code: str | None = None
@@ -228,7 +226,7 @@ def execute_portfolio_risk_notification_retries(
             bounded_code = str(exc)
             error_code = (
                 bounded_code
-                if ERROR_CODE_PATTERN.fullmatch(bounded_code)
+                if bounded_code in retry_policy.retryable_error_codes
                 else "network_error"
             )
         attempt = {
@@ -332,7 +330,6 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--plan", required=True, type=Path)
     parser.add_argument("--confirm-plan-id", required=True)
     parser.add_argument("--request-id", required=True)
-    parser.add_argument("--executed-at", required=True)
     parser.add_argument(
         "--config",
         type=Path,
@@ -354,7 +351,6 @@ def main(argv: Sequence[str] | None = None) -> int:
             plan_path=args.plan,
             confirm_plan_id=args.confirm_plan_id,
             request_id=args.request_id,
-            executed_at=args.executed_at,
             config_path=args.config,
             dsn=args.dsn,
             execute=args.execute,

--- a/src/orchestration/execute_portfolio_risk_notification_retries.py
+++ b/src/orchestration/execute_portfolio_risk_notification_retries.py
@@ -1,0 +1,382 @@
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import sys
+from collections.abc import Callable, Mapping, Sequence
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, cast
+
+from src.common.exceptions import StorageError, ValidationError
+from src.orchestration.deliver_portfolio_risk_notifications import (
+    CHANNEL,
+    MODEL_VERSION as DELIVERY_MODEL_VERSION,
+    AttemptWriter,
+    DeliveryTransportError,
+    Transport,
+    _attempt_id,
+    _canonical_payload,
+    _default_transport,
+    _endpoint,
+    write_delivery_attempt,
+)
+from src.orchestration.plan_portfolio_risk_notification_retries import (
+    CandidateReader,
+    plan_portfolio_risk_notification_retries,
+    read_notification_retry_candidates,
+)
+from src.orchestration.portfolio_risk_notification_retry_execution_policy import (
+    ERROR_CODE_PATTERN,
+    EXECUTION_MODEL_VERSION,
+    aware_utc,
+    load_retry_execution_contract,
+    safe_segment,
+    safe_text,
+)
+from src.orchestration.portfolio_risk_notification_retry_plan_contract import (
+    assert_retry_plan_is_current,
+    load_retry_plan,
+)
+from src.warehouse.postgres_loader import DEFAULT_POSTGRES_DSN
+
+Clock = Callable[[], datetime]
+
+
+def _execution_id(identity: Mapping[str, Any]) -> str:
+    digest = hashlib.sha256(
+        json.dumps(
+            identity,
+            sort_keys=True,
+            separators=(",", ":"),
+            allow_nan=False,
+        ).encode("utf-8")
+    ).hexdigest()[:24]
+    return f"{EXECUTION_MODEL_VERSION}-execution-{digest}"
+
+
+def _clock_utc(clock: Clock, label: str) -> datetime:
+    return aware_utc(clock(), label)
+
+
+def execute_portfolio_risk_notification_retries(
+    *,
+    plan_path: Path,
+    confirm_plan_id: str,
+    request_id: str,
+    executed_at: datetime | str,
+    config_path: Path,
+    dsn: str,
+    execute: bool = False,
+    environment: Mapping[str, str] | None = None,
+    reader: CandidateReader | None = None,
+    attempt_writer: AttemptWriter | None = None,
+    transport: Transport | None = None,
+    clock: Clock | None = None,
+) -> dict[str, Any]:
+    if execute is not True:
+        raise ValidationError("explicit --execute is required for manual retry delivery")
+    execution_time = aware_utc(executed_at, "executed_at")
+    selected_request_id = safe_segment(request_id, "request_id")
+    assert selected_request_id is not None
+    retained_plan = load_retry_plan(plan_path)
+    confirmed = safe_text(confirm_plan_id, "confirm_plan_id")
+    if confirmed != retained_plan["plan_id"]:
+        raise ValidationError("confirm_plan_id does not match the retained retry plan")
+
+    delivery_config, retry_policy, execution_policy = load_retry_execution_contract(
+        config_path
+    )
+    if not execution_policy.enabled:
+        raise ValidationError("manual retry execution is disabled in reviewed configuration")
+    if not delivery_config.enabled:
+        raise ValidationError("webhook delivery is disabled in reviewed configuration")
+    retained_delivery = cast(Mapping[str, Any], retained_plan["delivery_config"])
+    retained_retry_policy = cast(Mapping[str, Any], retained_plan["retry_policy"])
+    if retained_delivery["enabled"] is not True:
+        raise ValidationError("retained retry plan was not generated under enabled delivery")
+    if retained_delivery["fingerprint"] != delivery_config.fingerprint:
+        raise ValidationError("delivery configuration fingerprint changed after planning")
+    if retained_retry_policy["fingerprint"] != retry_policy.fingerprint:
+        raise ValidationError("retry policy fingerprint changed after planning")
+    if (
+        retained_delivery["max_attempts_per_event"]
+        != delivery_config.max_attempts_per_event
+    ):
+        raise ValidationError("delivery attempt limit changed after planning")
+
+    planned_at = aware_utc(retained_plan["planned_at"], "retry plan planned_at")
+    plan_age_seconds = (execution_time - planned_at).total_seconds()
+    if plan_age_seconds < 0:
+        raise ValidationError("executed_at must not precede retry plan creation")
+    if plan_age_seconds > execution_policy.max_plan_age_seconds:
+        raise ValidationError("retry plan exceeds the manual execution age limit")
+    retryable_event_ids = cast(list[str], retained_plan["retryable_event_ids"])
+    if not retryable_event_ids:
+        raise ValidationError("retry plan contains no retryable events")
+    if len(retryable_event_ids) > execution_policy.max_events:
+        raise ValidationError("retry plan exceeds the manual execution event limit")
+
+    selected_environment = environment if environment is not None else os.environ
+    raw_endpoint = selected_environment.get(delivery_config.endpoint_env)
+    if raw_endpoint is None:
+        raise ValidationError(
+            f"webhook endpoint environment variable {delivery_config.endpoint_env} is not set"
+        )
+    endpoint, endpoint_host = _endpoint(raw_endpoint)
+
+    selected_reader = reader or read_notification_retry_candidates
+    filters = cast(Mapping[str, Any], retained_plan["filters"])
+    candidates = selected_reader(
+        dsn=dsn,
+        planned_at=execution_time,
+        max_candidate_rows=retry_policy.max_candidate_rows,
+        policy_id=filters["policy_id"],
+        portfolio_id=filters["portfolio_id"],
+    )
+    if not isinstance(candidates, list):
+        raise StorageError("notification retry reader returned invalid evidence")
+    if len(candidates) > retry_policy.max_candidate_rows:
+        raise ValidationError("notification retry evidence exceeds max_candidate_rows")
+    current_plan = plan_portfolio_risk_notification_retries(
+        config_path=config_path,
+        dsn=dsn,
+        planned_at=execution_time,
+        policy_id=cast(str | None, filters["policy_id"]),
+        portfolio_id=cast(str | None, filters["portfolio_id"]),
+        reader=lambda **_: candidates,
+    )
+    assert_retry_plan_is_current(retained_plan, current_plan)
+
+    candidate_by_id = {
+        cast(str, candidate.get("event_id")): candidate for candidate in candidates
+    }
+    retained_events = cast(list[Mapping[str, Any]], retained_plan["events"])
+    event_by_id = {
+        cast(str, event["event_id"]): event for event in retained_events
+    }
+    expected_attempts: list[dict[str, Any]] = []
+    for event_id in retryable_event_ids:
+        event = event_by_id[event_id]
+        attempt_number = cast(int, event["attempt_count"]) + 1
+        if attempt_number > delivery_config.max_attempts_per_event:
+            raise ValidationError(
+                f"event {event_id} has no remaining delivery attempt capacity"
+            )
+        expected_attempts.append(
+            {
+                "attempt_id": _attempt_id(event_id, attempt_number),
+                "attempt_number": attempt_number,
+                "event_document_sha256": event["event_document_sha256"],
+                "event_id": event_id,
+            }
+        )
+    identity = {
+        "channel": CHANNEL,
+        "delivery_config_fingerprint": delivery_config.fingerprint,
+        "endpoint_host": endpoint_host,
+        "executed_at": execution_time.isoformat(),
+        "expected_attempts": expected_attempts,
+        "model_version": EXECUTION_MODEL_VERSION,
+        "plan_id": retained_plan["plan_id"],
+        "request_id": selected_request_id,
+        "retry_execution_policy_fingerprint": execution_policy.fingerprint,
+        "retry_policy_fingerprint": retry_policy.fingerprint,
+    }
+    execution_id = _execution_id(identity)
+
+    selected_writer = attempt_writer or (
+        lambda attempt: write_delivery_attempt(attempt, dsn=dsn)
+    )
+    selected_transport = transport or _default_transport
+    selected_clock = clock or (lambda: datetime.now(timezone.utc))
+    outcomes: list[dict[str, Any]] = []
+    for expected in expected_attempts:
+        event_id = cast(str, expected["event_id"])
+        candidate = candidate_by_id.get(event_id)
+        if candidate is None:
+            raise ValidationError(f"current candidate evidence is missing {event_id}")
+        payload = _canonical_payload(candidate)
+        payload_sha256 = hashlib.sha256(payload).hexdigest()
+        attempted_at = _clock_utc(selected_clock, "attempted_at")
+        if attempted_at < execution_time:
+            raise ValidationError("attempted_at must not precede executed_at")
+        outcome = "failed"
+        http_status: int | None = None
+        error_code: str | None = None
+        try:
+            response_status = selected_transport(
+                endpoint,
+                payload,
+                {
+                    "Content-Type": "application/json",
+                    "Idempotency-Key": event_id,
+                    "User-Agent": "financial-risk-data-platform/1",
+                },
+                float(delivery_config.timeout_seconds),
+            )
+            if type(response_status) is not int or not 100 <= response_status <= 599:
+                raise ValidationError("webhook transport returned an invalid HTTP status")
+            http_status = response_status
+            if 200 <= response_status <= 299:
+                outcome = "succeeded"
+            else:
+                error_code = f"http_{response_status}"
+        except DeliveryTransportError as exc:
+            bounded_code = str(exc)
+            error_code = (
+                bounded_code
+                if ERROR_CODE_PATTERN.fullmatch(bounded_code)
+                else "network_error"
+            )
+        attempt = {
+            "attempt_id": expected["attempt_id"],
+            "model_version": DELIVERY_MODEL_VERSION,
+            "event_id": event_id,
+            "channel": CHANNEL,
+            "attempt_number": expected["attempt_number"],
+            "idempotency_key": event_id,
+            "attempted_at": attempted_at,
+            "outcome": outcome,
+            "http_status": http_status,
+            "error_code": error_code,
+            "endpoint_host": endpoint_host,
+            "payload_sha256": payload_sha256,
+        }
+        selected_writer(attempt)
+        outcomes.append(
+            {
+                "attempt_id": attempt["attempt_id"],
+                "attempt_number": attempt["attempt_number"],
+                "attempted_at": attempted_at.isoformat(),
+                "error_code": error_code,
+                "event_id": event_id,
+                "http_status": http_status,
+                "outcome": outcome,
+                "payload_sha256": payload_sha256,
+            }
+        )
+
+    succeeded = sum(outcome["outcome"] == "succeeded" for outcome in outcomes)
+    failed = len(outcomes) - succeeded
+    return {
+        "execution_id": execution_id,
+        "model_version": EXECUTION_MODEL_VERSION,
+        "request_id": selected_request_id,
+        "plan_id": retained_plan["plan_id"],
+        "executed_at": execution_time.isoformat(),
+        "channel": CHANNEL,
+        "endpoint": {
+            "host": endpoint_host,
+            "full_url_recorded": False,
+        },
+        "configuration": {
+            "delivery_fingerprint": delivery_config.fingerprint,
+            "retry_execution_policy_fingerprint": execution_policy.fingerprint,
+            "retry_policy_fingerprint": retry_policy.fingerprint,
+        },
+        "revalidation": {
+            "performed": True,
+            "current_plan_id": current_plan["plan_id"],
+            "events_checked": len(cast(list[Any], retained_plan["events"])),
+            "exact_event_evidence_unchanged": True,
+        },
+        "selection": {
+            "planned_retryable_events": len(retryable_event_ids),
+            "executed_events": len(outcomes),
+            "max_events": execution_policy.max_events,
+        },
+        "outcomes": outcomes,
+        "outcome_counts": {
+            "succeeded": succeeded,
+            "failed": failed,
+        },
+        "execution": {
+            "requested": True,
+            "performed": True,
+            "external_requests_performed": len(outcomes),
+            "delivery_attempts_written": len(outcomes),
+        },
+        "response_bodies_recorded": False,
+        "plan_mutated": False,
+        "acknowledgement_mutated": False,
+        "dead_letter_mutated": False,
+    }
+
+
+def _write_summary(path: Path, summary: Mapping[str, Any]) -> None:
+    if path.is_symlink():
+        raise StorageError("manual retry summary must not be a symbolic link")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_suffix(path.suffix + ".tmp")
+    try:
+        temporary.write_text(
+            json.dumps(summary, indent=2, sort_keys=True, allow_nan=False) + "\n",
+            encoding="utf-8",
+        )
+        temporary.replace(path)
+    except (OSError, TypeError, ValueError):
+        temporary.unlink(missing_ok=True)
+        raise StorageError("unable to write manual retry execution summary") from None
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Execute one exact retained notification retry plan under an explicit "
+            "disabled-by-default manual delivery gate."
+        )
+    )
+    parser.add_argument("--plan", required=True, type=Path)
+    parser.add_argument("--confirm-plan-id", required=True)
+    parser.add_argument("--request-id", required=True)
+    parser.add_argument("--executed-at", required=True)
+    parser.add_argument(
+        "--config",
+        type=Path,
+        default=Path("config/notification_delivery.yaml"),
+    )
+    parser.add_argument(
+        "--dsn",
+        default=os.environ.get("WAREHOUSE_POSTGRES_DSN", DEFAULT_POSTGRES_DSN),
+    )
+    parser.add_argument("--execute", action="store_true")
+    parser.add_argument("--summary-json", type=Path)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    try:
+        summary = execute_portfolio_risk_notification_retries(
+            plan_path=args.plan,
+            confirm_plan_id=args.confirm_plan_id,
+            request_id=args.request_id,
+            executed_at=args.executed_at,
+            config_path=args.config,
+            dsn=args.dsn,
+            execute=args.execute,
+        )
+        if args.summary_json is not None:
+            _write_summary(args.summary_json, summary)
+    except ValidationError as exc:
+        print(f"Manual notification retry rejected: {exc}", file=sys.stderr)
+        return 1
+    except StorageError:
+        print(
+            "Manual notification retry failed: PostgreSQL or attempt persistence "
+            "failed; remote receivers must deduplicate by Idempotency-Key",
+            file=sys.stderr,
+        )
+        return 1
+    except Exception:
+        print("Manual notification retry failed: unexpected local failure", file=sys.stderr)
+        return 1
+    print(json.dumps(summary, sort_keys=True, allow_nan=False))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/orchestration/portfolio_risk_notification_retry_execution_policy.py
+++ b/src/orchestration/portfolio_risk_notification_retry_execution_policy.py
@@ -1,0 +1,194 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import re
+from collections.abc import Mapping
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from src.common.config import load_yaml
+from src.common.exceptions import ValidationError
+from src.orchestration.deliver_portfolio_risk_notifications import (
+    CHANNEL,
+    WebhookDeliveryConfig,
+    parse_webhook_delivery_config,
+)
+from src.orchestration.plan_portfolio_risk_notification_retries import (
+    RetryPlanningPolicy,
+    parse_retry_planning_policy,
+)
+
+EXECUTION_MODEL_VERSION = "portfolio-risk-manual-retry-execution-v1"
+POLICY_MODEL_VERSION = "portfolio-risk-manual-retry-execution-policy-v1"
+MAX_PLAN_FILE_BYTES = 1_048_576
+MAX_PLAN_AGE_SECONDS = 24 * 60 * 60
+MAX_EXECUTION_EVENTS = 100
+SAFE_SEGMENT_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,511}$")
+SHA256_PATTERN = re.compile(r"^[0-9a-f]{64}$")
+ERROR_CODE_PATTERN = re.compile(r"^[a-z][a-z0-9_]{0,63}$")
+
+
+@dataclass(frozen=True, slots=True)
+class RetryExecutionPolicy:
+    enabled: bool
+    max_plan_age_seconds: int
+    max_events: int
+
+    @property
+    def fingerprint(self) -> str:
+        payload = {
+            "channel": CHANNEL,
+            "enabled": self.enabled,
+            "max_events": self.max_events,
+            "max_plan_age_seconds": self.max_plan_age_seconds,
+            "model_version": POLICY_MODEL_VERSION,
+        }
+        digest = hashlib.sha256(
+            json.dumps(
+                payload,
+                sort_keys=True,
+                separators=(",", ":"),
+                allow_nan=False,
+            ).encode("utf-8")
+        ).hexdigest()[:24]
+        return f"{POLICY_MODEL_VERSION}-policy-{digest}"
+
+
+def exact_mapping(
+    value: Any,
+    expected: frozenset[str],
+    label: str,
+) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        raise ValidationError(f"{label} must be an object")
+    fields = set(value)
+    if fields != expected:
+        missing = sorted(expected - fields)
+        unknown = sorted(fields - expected)
+        raise ValidationError(
+            f"{label} fields are not exact; missing={missing}, unknown={unknown}"
+        )
+    return value
+
+
+def bounded_integer(
+    value: Any,
+    label: str,
+    *,
+    minimum: int,
+    maximum: int,
+) -> int:
+    if type(value) is not int or not minimum <= value <= maximum:
+        raise ValidationError(
+            f"{label} must be an integer between {minimum} and {maximum}"
+        )
+    return value
+
+
+def safe_text(value: Any, label: str, *, maximum: int = 512) -> str:
+    if not isinstance(value, str) or not value or value != value.strip():
+        raise ValidationError(f"{label} must be non-empty canonical text")
+    if len(value) > maximum or any(ord(character) < 32 for character in value):
+        raise ValidationError(f"{label} is invalid")
+    return value
+
+
+def safe_segment(value: Any, label: str, *, optional: bool = False) -> str | None:
+    if value is None and optional:
+        return None
+    if not isinstance(value, str) or not SAFE_SEGMENT_PATTERN.fullmatch(value):
+        raise ValidationError(f"{label} must be one safe text segment")
+    return value
+
+
+def aware_utc(value: Any, label: str) -> datetime:
+    if isinstance(value, datetime):
+        parsed = value
+    elif isinstance(value, str):
+        try:
+            parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        except ValueError:
+            raise ValidationError(f"{label} must be ISO-8601") from None
+    else:
+        raise ValidationError(f"{label} must be timezone-aware")
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise ValidationError(f"{label} must be timezone-aware")
+    return parsed.astimezone(timezone.utc)
+
+
+def nonnegative_number(value: Any, label: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ValidationError(f"{label} must be a finite non-negative number")
+    parsed = float(value)
+    if not math.isfinite(parsed) or parsed < 0:
+        raise ValidationError(f"{label} must be a finite non-negative number")
+    return parsed
+
+
+def parse_retry_execution_policy(
+    payload: Mapping[str, Any],
+    delivery_config: WebhookDeliveryConfig,
+    retry_policy: RetryPlanningPolicy,
+) -> RetryExecutionPolicy:
+    if not isinstance(payload, Mapping):
+        raise ValidationError("notification delivery configuration must be a mapping")
+    delivery = payload.get("delivery")
+    if not isinstance(delivery, Mapping):
+        raise ValidationError("notification delivery configuration is missing delivery")
+    execution = delivery.get("retry_execution")
+    if not isinstance(execution, Mapping):
+        raise ValidationError(
+            "notification delivery configuration is missing retry_execution"
+        )
+    enabled = execution.get("enabled")
+    if type(enabled) is not bool:
+        raise ValidationError("retry_execution enabled must be boolean")
+    policy = RetryExecutionPolicy(
+        enabled=enabled,
+        max_plan_age_seconds=bounded_integer(
+            execution.get("max_plan_age_seconds"),
+            "max_plan_age_seconds",
+            minimum=1,
+            maximum=MAX_PLAN_AGE_SECONDS,
+        ),
+        max_events=bounded_integer(
+            execution.get("max_events"),
+            "max_events",
+            minimum=1,
+            maximum=MAX_EXECUTION_EVENTS,
+        ),
+    )
+    if policy.max_events > retry_policy.max_plan_events:
+        raise ValidationError("retry execution max_events exceeds retry planning limit")
+    if policy.max_events > delivery_config.max_batch_events:
+        raise ValidationError("retry execution max_events exceeds webhook batch limit")
+    if policy.max_plan_age_seconds > retry_policy.max_event_age_seconds:
+        raise ValidationError(
+            "retry execution max_plan_age_seconds exceeds retry event age policy"
+        )
+    return policy
+
+
+def load_retry_execution_contract(
+    path: Path,
+) -> tuple[WebhookDeliveryConfig, RetryPlanningPolicy, RetryExecutionPolicy]:
+    try:
+        payload = load_yaml(path)
+    except Exception:
+        raise ValidationError(
+            "notification delivery configuration could not be loaded"
+        ) from None
+    if not isinstance(payload, Mapping):
+        raise ValidationError("notification delivery configuration must be a mapping")
+    delivery_config = parse_webhook_delivery_config(payload)
+    retry_policy = parse_retry_planning_policy(payload, delivery_config)
+    execution_policy = parse_retry_execution_policy(
+        payload,
+        delivery_config,
+        retry_policy,
+    )
+    return delivery_config, retry_policy, execution_policy

--- a/src/orchestration/portfolio_risk_notification_retry_plan_contract.py
+++ b/src/orchestration/portfolio_risk_notification_retry_plan_contract.py
@@ -1,0 +1,442 @@
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from datetime import datetime
+from pathlib import Path
+from typing import Any, cast
+
+from src.common.exceptions import ValidationError
+from src.orchestration.deliver_portfolio_risk_notifications import CHANNEL
+from src.orchestration.plan_portfolio_risk_notification_retries import (
+    CLASSIFICATIONS,
+    MODEL_VERSION as RETRY_PLAN_MODEL_VERSION,
+    _plan_id,
+)
+from src.orchestration.portfolio_risk_notification_retry_execution_policy import (
+    ERROR_CODE_PATTERN,
+    MAX_PLAN_FILE_BYTES,
+    SAFE_SEGMENT_PATTERN,
+    SHA256_PATTERN,
+    aware_utc,
+    bounded_integer,
+    exact_mapping,
+    nonnegative_number,
+    safe_segment,
+    safe_text,
+)
+
+PLAN_FIELDS = frozenset(
+    {
+        "plan_id",
+        "model_version",
+        "planned_at",
+        "channel",
+        "delivery_config",
+        "retry_policy",
+        "filters",
+        "selection",
+        "events",
+        "retryable_event_ids",
+        "delivery_performed",
+        "delivery_attempt_written",
+        "dead_letter_mutated",
+        "external_request_performed",
+    }
+)
+PLAN_EVENT_FIELDS = frozenset(
+    {
+        "acknowledgement",
+        "attempt_count",
+        "classification",
+        "event_age_seconds",
+        "event_document_sha256",
+        "event_id",
+        "last_attempt",
+        "next_eligible_at",
+        "policy_id",
+        "portfolio_id",
+        "reason",
+        "source_evaluation_calculation_id",
+        "ts_event",
+    }
+)
+LAST_ATTEMPT_FIELDS = frozenset(
+    {
+        "attempt_id",
+        "attempt_number",
+        "attempted_at",
+        "error_code",
+        "http_status",
+        "outcome",
+    }
+)
+ACKNOWLEDGEMENT_FIELDS = frozenset(
+    {"acknowledged_at", "acknowledgement_id", "disposition"}
+)
+
+
+def _validate_last_attempt(value: Any, attempt_count: int, label: str) -> None:
+    if value is None:
+        if attempt_count != 0:
+            raise ValidationError(f"{label} is required when attempt_count is positive")
+        return
+    mapping = exact_mapping(value, LAST_ATTEMPT_FIELDS, label)
+    if attempt_count == 0:
+        raise ValidationError(f"{label} must be null when attempt_count is zero")
+    safe_text(mapping.get("attempt_id"), f"{label}.attempt_id")
+    attempt_number = bounded_integer(
+        mapping.get("attempt_number"),
+        f"{label}.attempt_number",
+        minimum=1,
+        maximum=10,
+    )
+    if attempt_number != attempt_count:
+        raise ValidationError(f"{label}.attempt_number must equal attempt_count")
+    aware_utc(mapping.get("attempted_at"), f"{label}.attempted_at")
+    if mapping.get("outcome") != "failed":
+        raise ValidationError(f"{label}.outcome must be failed")
+    http_status = mapping.get("http_status")
+    if http_status is not None and (
+        type(http_status) is not int or not 100 <= http_status <= 599
+    ):
+        raise ValidationError(f"{label}.http_status is invalid")
+    error_code = mapping.get("error_code")
+    if error_code is not None and (
+        not isinstance(error_code, str) or not ERROR_CODE_PATTERN.fullmatch(error_code)
+    ):
+        raise ValidationError(f"{label}.error_code is invalid")
+    if error_code is None:
+        raise ValidationError(f"{label}.error_code is required for a failed attempt")
+
+
+def _validate_acknowledgement(value: Any, label: str) -> None:
+    if value is None:
+        return
+    mapping = exact_mapping(value, ACKNOWLEDGEMENT_FIELDS, label)
+    safe_text(mapping.get("acknowledgement_id"), f"{label}.acknowledgement_id")
+    aware_utc(mapping.get("acknowledged_at"), f"{label}.acknowledged_at")
+    if mapping.get("disposition") not in {
+        "investigating",
+        "accepted",
+        "false_positive",
+    }:
+        raise ValidationError(f"{label}.disposition is invalid")
+
+
+def _validate_plan_event(
+    value: Any,
+    *,
+    planned_at: datetime,
+    max_attempts_per_event: int,
+    max_event_age_seconds: int,
+    label: str,
+) -> Mapping[str, Any]:
+    event = exact_mapping(value, PLAN_EVENT_FIELDS, label)
+    event_id = safe_text(event.get("event_id"), f"{label}.event_id")
+    safe_text(event.get("policy_id"), f"{label}.policy_id", maximum=128)
+    safe_text(event.get("portfolio_id"), f"{label}.portfolio_id", maximum=128)
+    safe_text(
+        event.get("source_evaluation_calculation_id"),
+        f"{label}.source_evaluation_calculation_id",
+    )
+    event_sha = event.get("event_document_sha256")
+    if not isinstance(event_sha, str) or not SHA256_PATTERN.fullmatch(event_sha):
+        raise ValidationError(f"{label}.event_document_sha256 is invalid")
+    classification = event.get("classification")
+    if classification not in CLASSIFICATIONS:
+        raise ValidationError(f"{label}.classification is invalid")
+    safe_text(event.get("reason"), f"{label}.reason", maximum=128)
+    ts_event = aware_utc(event.get("ts_event"), f"{label}.ts_event")
+    event_age = nonnegative_number(
+        event.get("event_age_seconds"),
+        f"{label}.event_age_seconds",
+    )
+    expected_age = max(0.0, (planned_at - ts_event).total_seconds())
+    if abs(event_age - expected_age) > 0.000001:
+        raise ValidationError(f"{label}.event_age_seconds does not reconcile")
+    attempt_count = bounded_integer(
+        event.get("attempt_count"),
+        f"{label}.attempt_count",
+        minimum=0,
+        maximum=10,
+    )
+    _validate_last_attempt(event.get("last_attempt"), attempt_count, f"{label}.last_attempt")
+    _validate_acknowledgement(event.get("acknowledgement"), f"{label}.acknowledgement")
+    next_eligible_raw = event.get("next_eligible_at")
+    next_eligible = (
+        None
+        if next_eligible_raw is None
+        else aware_utc(next_eligible_raw, f"{label}.next_eligible_at")
+    )
+    if classification in {"retryable", "not_yet_eligible"}:
+        if next_eligible is None or event.get("last_attempt") is None:
+            raise ValidationError(
+                f"{label} retry eligibility requires a failed attempt and timestamp"
+            )
+        if classification == "retryable" and planned_at < next_eligible:
+            raise ValidationError(f"{label} retryable event is still in backoff")
+        if classification == "not_yet_eligible" and planned_at >= next_eligible:
+            raise ValidationError(f"{label} not_yet_eligible event has completed backoff")
+    elif next_eligible is not None:
+        raise ValidationError(
+            f"{label}.next_eligible_at is only valid for retryable failures"
+        )
+    if classification == "acknowledged" and event.get("acknowledgement") is None:
+        raise ValidationError(f"{label} acknowledged event lacks acknowledgement evidence")
+    if classification == "attempts_exhausted" and attempt_count < max_attempts_per_event:
+        raise ValidationError(f"{label} exhausted event has remaining attempt capacity")
+    if classification == "expired" and event_age <= max_event_age_seconds:
+        raise ValidationError(f"{label} expired event is within the age policy")
+    if classification == "retryable":
+        if event.get("acknowledgement") is not None:
+            raise ValidationError(f"{label} retryable event must be unacknowledged")
+        if attempt_count >= max_attempts_per_event:
+            raise ValidationError(f"{label} retryable event has no attempt capacity")
+    if not SAFE_SEGMENT_PATTERN.fullmatch(event_id):
+        raise ValidationError(f"{label}.event_id must be a safe text segment")
+    return event
+
+
+def validate_retry_plan_document(payload: Any) -> dict[str, Any]:
+    plan = exact_mapping(payload, PLAN_FIELDS, "retry plan")
+    if plan.get("model_version") != RETRY_PLAN_MODEL_VERSION:
+        raise ValidationError("retry plan model_version is unsupported")
+    if plan.get("channel") != CHANNEL:
+        raise ValidationError("retry plan channel is unsupported")
+    planned_at = aware_utc(plan.get("planned_at"), "retry plan planned_at")
+    plan_id = safe_text(plan.get("plan_id"), "retry plan plan_id")
+
+    delivery = exact_mapping(
+        plan.get("delivery_config"),
+        frozenset({"enabled", "fingerprint", "max_attempts_per_event"}),
+        "retry plan delivery_config",
+    )
+    if type(delivery.get("enabled")) is not bool:
+        raise ValidationError("retry plan delivery_config.enabled must be boolean")
+    safe_text(delivery.get("fingerprint"), "retry plan delivery_config.fingerprint")
+    max_attempts = bounded_integer(
+        delivery.get("max_attempts_per_event"),
+        "retry plan delivery_config.max_attempts_per_event",
+        minimum=1,
+        maximum=10,
+    )
+
+    retry_policy = exact_mapping(
+        plan.get("retry_policy"),
+        frozenset(
+            {
+                "fingerprint",
+                "max_backoff_seconds",
+                "max_candidate_rows",
+                "max_event_age_seconds",
+                "max_plan_events",
+                "retryable_error_codes",
+                "retryable_http_statuses",
+            }
+        ),
+        "retry plan retry_policy",
+    )
+    safe_text(retry_policy.get("fingerprint"), "retry plan retry_policy.fingerprint")
+    max_event_age = bounded_integer(
+        retry_policy.get("max_event_age_seconds"),
+        "retry plan retry_policy.max_event_age_seconds",
+        minimum=1,
+        maximum=30 * 24 * 60 * 60,
+    )
+    max_plan_events = bounded_integer(
+        retry_policy.get("max_plan_events"),
+        "retry plan retry_policy.max_plan_events",
+        minimum=1,
+        maximum=100,
+    )
+    bounded_integer(
+        retry_policy.get("max_backoff_seconds"),
+        "retry plan retry_policy.max_backoff_seconds",
+        minimum=1,
+        maximum=24 * 60 * 60,
+    )
+    bounded_integer(
+        retry_policy.get("max_candidate_rows"),
+        "retry plan retry_policy.max_candidate_rows",
+        minimum=1,
+        maximum=10_000,
+    )
+    statuses = retry_policy.get("retryable_http_statuses")
+    if (
+        not isinstance(statuses, list)
+        or not statuses
+        or any(type(status) is not int for status in statuses)
+        or statuses != sorted(set(statuses))
+    ):
+        raise ValidationError(
+            "retry plan retryable_http_statuses must be sorted and unique"
+        )
+    error_codes = retry_policy.get("retryable_error_codes")
+    if (
+        not isinstance(error_codes, list)
+        or not error_codes
+        or any(
+            not isinstance(code, str) or not ERROR_CODE_PATTERN.fullmatch(code)
+            for code in error_codes
+        )
+        or error_codes != sorted(set(error_codes))
+    ):
+        raise ValidationError(
+            "retry plan retryable_error_codes must be sorted and unique"
+        )
+
+    filters = exact_mapping(
+        plan.get("filters"),
+        frozenset({"policy_id", "portfolio_id"}),
+        "retry plan filters",
+    )
+    safe_segment(filters.get("policy_id"), "retry plan policy_id", optional=True)
+    safe_segment(filters.get("portfolio_id"), "retry plan portfolio_id", optional=True)
+
+    events_raw = plan.get("events")
+    if not isinstance(events_raw, list):
+        raise ValidationError("retry plan events must be an array")
+    events = [
+        _validate_plan_event(
+            event,
+            planned_at=planned_at,
+            max_attempts_per_event=max_attempts,
+            max_event_age_seconds=max_event_age,
+            label=f"retry plan events[{index}]",
+        )
+        for index, event in enumerate(events_raw)
+    ]
+    event_ids = [cast(str, event["event_id"]) for event in events]
+    if len(event_ids) != len(set(event_ids)):
+        raise ValidationError("retry plan contains duplicate event_id")
+    expected_order = sorted(
+        events,
+        key=lambda event: (
+            cast(str, event["ts_event"]),
+            cast(str, event["event_id"]),
+        ),
+    )
+    if events != expected_order:
+        raise ValidationError("retry plan events are not in canonical order")
+
+    retryable_ids = plan.get("retryable_event_ids")
+    if not isinstance(retryable_ids, list) or any(
+        not isinstance(event_id, str) for event_id in retryable_ids
+    ):
+        raise ValidationError("retry plan retryable_event_ids must be a text array")
+    expected_retryable_ids = [
+        cast(str, event["event_id"])
+        for event in events
+        if event["classification"] == "retryable"
+    ]
+    if retryable_ids != expected_retryable_ids:
+        raise ValidationError(
+            "retry plan retryable_event_ids do not match event classifications"
+        )
+    if len(retryable_ids) > max_plan_events:
+        raise ValidationError("retry plan exceeds its max_plan_events bound")
+
+    selection = exact_mapping(
+        plan.get("selection"),
+        frozenset(
+            {"candidates_examined", "classification_counts", "retryable_events"}
+        ),
+        "retry plan selection",
+    )
+    if selection.get("candidates_examined") != len(events):
+        raise ValidationError("retry plan candidates_examined does not reconcile")
+    if selection.get("retryable_events") != len(retryable_ids):
+        raise ValidationError("retry plan retryable_events does not reconcile")
+    counts = exact_mapping(
+        selection.get("classification_counts"),
+        frozenset(CLASSIFICATIONS),
+        "retry plan classification_counts",
+    )
+    for classification in CLASSIFICATIONS:
+        expected_count = sum(
+            event["classification"] == classification for event in events
+        )
+        if counts.get(classification) != expected_count:
+            raise ValidationError(
+                f"retry plan classification count for {classification} does not reconcile"
+            )
+
+    for side_effect_field in (
+        "delivery_performed",
+        "delivery_attempt_written",
+        "dead_letter_mutated",
+        "external_request_performed",
+    ):
+        if plan.get(side_effect_field) is not False:
+            raise ValidationError(f"retry plan {side_effect_field} must be false")
+
+    identity = {
+        "channel": plan["channel"],
+        "delivery_config_fingerprint": delivery["fingerprint"],
+        "events": events,
+        "filters": dict(filters),
+        "model_version": plan["model_version"],
+        "planned_at": planned_at.isoformat(),
+        "retry_policy_fingerprint": retry_policy["fingerprint"],
+    }
+    if plan_id != _plan_id(identity):
+        raise ValidationError("retry plan plan_id does not match canonical evidence")
+    return dict(plan)
+
+
+def load_retry_plan(path: Path) -> dict[str, Any]:
+    try:
+        if path.is_symlink():
+            raise ValidationError("retry plan must not be a symbolic link")
+        if not path.exists() or not path.is_file():
+            raise ValidationError("retry plan must be one regular JSON file")
+        if path.stat().st_size > MAX_PLAN_FILE_BYTES:
+            raise ValidationError("retry plan exceeds the 1 MB file bound")
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except ValidationError:
+        raise
+    except (OSError, UnicodeError, json.JSONDecodeError):
+        raise ValidationError("retry plan could not be read as JSON") from None
+    return validate_retry_plan_document(payload)
+
+
+def _event_revalidation_identity(event: Mapping[str, Any]) -> dict[str, Any]:
+    return {
+        key: event[key]
+        for key in sorted(PLAN_EVENT_FIELDS - {"event_age_seconds"})
+    }
+
+
+def assert_retry_plan_is_current(
+    retained_plan: Mapping[str, Any],
+    current_plan: Mapping[str, Any],
+) -> None:
+    current_delivery = cast(Mapping[str, Any], current_plan.get("delivery_config"))
+    retained_delivery = cast(Mapping[str, Any], retained_plan.get("delivery_config"))
+    if current_delivery.get("fingerprint") != retained_delivery.get("fingerprint"):
+        raise ValidationError("delivery configuration changed after retry planning")
+    current_policy = cast(Mapping[str, Any], current_plan.get("retry_policy"))
+    retained_policy = cast(Mapping[str, Any], retained_plan.get("retry_policy"))
+    if current_policy.get("fingerprint") != retained_policy.get("fingerprint"):
+        raise ValidationError("retry policy changed after retry planning")
+    if current_plan.get("filters") != retained_plan.get("filters"):
+        raise ValidationError("retry plan filters changed during revalidation")
+
+    retained_events = cast(list[Mapping[str, Any]], retained_plan.get("events"))
+    current_events = cast(list[Mapping[str, Any]], current_plan.get("events"))
+    retained_ids = [cast(str, event["event_id"]) for event in retained_events]
+    current_ids = [cast(str, event["event_id"]) for event in current_events]
+    if current_ids != retained_ids:
+        raise ValidationError("notification event set changed after retry planning")
+    for retained, current in zip(retained_events, current_events, strict=True):
+        if _event_revalidation_identity(current) != _event_revalidation_identity(
+            retained
+        ):
+            raise ValidationError(
+                f"notification retry evidence changed for event {retained['event_id']}"
+            )
+    if current_plan.get("retryable_event_ids") != retained_plan.get(
+        "retryable_event_ids"
+    ):
+        raise ValidationError("notification retry eligibility changed after planning")

--- a/tests/unit/test_portfolio_risk_notification_retry_execution.py
+++ b/tests/unit/test_portfolio_risk_notification_retry_execution.py
@@ -159,7 +159,6 @@ def _execute(
         "plan_path": plan_path,
         "confirm_plan_id": plan["plan_id"],
         "request_id": "RETRY-2026-001",
-        "executed_at": EXECUTED_AT,
         "config_path": config_path,
         "dsn": "postgresql://secret-value",
         "execute": True,
@@ -239,6 +238,50 @@ def test_disabled_execution_rejects_before_database_or_transport(
         )
     assert reads == []
     assert sends == []
+
+
+def test_execution_uses_clock_time_for_current_evidence_read(tmp_path: Path) -> None:
+    config_path = _write_config(tmp_path)
+    candidates = [_candidate()]
+    plan_path, plan = _write_plan(tmp_path, config_path, candidates)
+    as_of_values: list[datetime] = []
+
+    _execute(
+        plan_path=plan_path,
+        plan=plan,
+        config_path=config_path,
+        candidates=candidates,
+        reader=lambda **kwargs: (
+            as_of_values.append(kwargs["planned_at"]) or candidates
+        ),
+    )
+
+    assert as_of_values == [EXECUTED_AT]
+
+
+def test_plan_can_be_reviewed_before_enabling_separate_execution_gate(
+    tmp_path: Path,
+) -> None:
+    config_path = _write_config(tmp_path, execution_enabled=False)
+    candidates = [_candidate()]
+    plan_path, plan = _write_plan(tmp_path, config_path, candidates)
+
+    config_path.write_text(
+        yaml.safe_dump(
+            _config_payload(execution_enabled=True),
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+    summary = _execute(
+        plan_path=plan_path,
+        plan=plan,
+        config_path=config_path,
+        candidates=candidates,
+    )
+
+    assert summary["execution"]["performed"] is True
+    assert summary["plan_id"] == plan["plan_id"]
 
 
 def test_exact_plan_executes_one_attempt_per_event_with_stable_identity(

--- a/tests/unit/test_portfolio_risk_notification_retry_execution.py
+++ b/tests/unit/test_portfolio_risk_notification_retry_execution.py
@@ -1,0 +1,540 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+from src.common.exceptions import StorageError, ValidationError
+from src.orchestration.deliver_portfolio_risk_notifications import (
+    DeliveryTransportError,
+)
+from src.orchestration.execute_portfolio_risk_notification_retries import (
+    _write_summary,
+    execute_portfolio_risk_notification_retries,
+)
+from src.orchestration.plan_portfolio_risk_notification_retries import (
+    plan_portfolio_risk_notification_retries,
+)
+from src.orchestration.portfolio_risk_notification_retry_execution_policy import (
+    load_retry_execution_contract,
+)
+from src.orchestration.portfolio_risk_notification_retry_plan_contract import (
+    load_retry_plan,
+)
+
+PLANNED_AT = datetime(2026, 1, 10, 12, tzinfo=timezone.utc)
+EXECUTED_AT = PLANNED_AT + timedelta(minutes=1)
+ENDPOINT = "https://alerts.example.test/risk"
+
+
+def _config_payload(
+    *,
+    delivery_enabled: bool = True,
+    execution_enabled: bool = True,
+    max_execution_events: int = 25,
+    max_plan_age_seconds: int = 3600,
+    timeout_seconds: int = 5,
+) -> dict[str, Any]:
+    return {
+        "delivery": {
+            "webhook": {
+                "enabled": delivery_enabled,
+                "endpoint_env": "RISK_NOTIFICATION_WEBHOOK_URL",
+                "timeout_seconds": timeout_seconds,
+                "max_batch_events": 25,
+                "max_attempts_per_event": 3,
+                "initial_backoff_seconds": 1,
+            },
+            "retry_planning": {
+                "max_candidate_rows": 500,
+                "max_plan_events": 25,
+                "max_event_age_seconds": 7 * 24 * 60 * 60,
+                "max_backoff_seconds": 3600,
+                "retryable_http_statuses": [408, 425, 429, 500, 502, 503, 504],
+                "retryable_error_codes": ["network_error"],
+            },
+            "retry_execution": {
+                "enabled": execution_enabled,
+                "max_plan_age_seconds": max_plan_age_seconds,
+                "max_events": max_execution_events,
+            },
+        }
+    }
+
+
+def _write_config(tmp_path: Path, **kwargs: Any) -> Path:
+    path = tmp_path / "notification-delivery.yaml"
+    path.write_text(
+        yaml.safe_dump(_config_payload(**kwargs), sort_keys=False),
+        encoding="utf-8",
+    )
+    return path
+
+
+def _candidate(
+    event_id: str = "event-1",
+    *,
+    attempt_count: int = 1,
+    last_attempted_at: datetime | None = None,
+    acknowledgement: bool = False,
+) -> dict[str, Any]:
+    event_time = PLANNED_AT - timedelta(hours=2)
+    attempt_time = last_attempted_at or PLANNED_AT - timedelta(minutes=10)
+    candidate: dict[str, Any] = {
+        "event_id": event_id,
+        "outbox_model_version": "portfolio-risk-notification-outbox-v1",
+        "event_type": "breach_opened",
+        "transition_type": "opened",
+        "delivery_disposition": "pending",
+        "source_evaluation_calculation_id": f"evaluation-{event_id}",
+        "policy_id": "us-tech-standard",
+        "policy_fingerprint": "policy-fingerprint",
+        "portfolio_id": "us-tech-equal",
+        "definition_fingerprint": "definition-fingerprint",
+        "metric_name": "portfolio_volatility_annualized",
+        "subject_type": "portfolio",
+        "subject_key": "us-tech-equal",
+        "current_status": "critical",
+        "ts_event": event_time,
+        "ts_ingest": event_time + timedelta(seconds=1),
+        "payload_json": {"event_id": event_id, "severity": "critical"},
+        "attempt_count": attempt_count,
+        "last_attempt_id": (
+            f"attempt-{event_id}-{attempt_count}" if attempt_count else None
+        ),
+        "last_attempt_number": attempt_count if attempt_count else None,
+        "last_attempted_at": attempt_time if attempt_count else None,
+        "last_attempt_outcome": "failed" if attempt_count else None,
+        "last_http_status": 503 if attempt_count else None,
+        "last_error_code": "http_503" if attempt_count else None,
+        "acknowledgement_id": None,
+        "acknowledged_at": None,
+        "acknowledgement_disposition": None,
+    }
+    if acknowledgement:
+        candidate.update(
+            {
+                "acknowledgement_id": f"ack-{event_id}",
+                "acknowledged_at": PLANNED_AT - timedelta(minutes=5),
+                "acknowledgement_disposition": "investigating",
+            }
+        )
+    return candidate
+
+
+def _write_plan(
+    tmp_path: Path,
+    config_path: Path,
+    candidates: list[dict[str, Any]],
+) -> tuple[Path, dict[str, Any]]:
+    plan = plan_portfolio_risk_notification_retries(
+        config_path=config_path,
+        dsn="not-used",
+        planned_at=PLANNED_AT,
+        policy_id="us-tech-standard",
+        portfolio_id="us-tech-equal",
+        reader=lambda **_: candidates,
+    )
+    path = tmp_path / "retry-plan.json"
+    path.write_text(
+        json.dumps(plan, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    return path, plan
+
+
+def _execute(
+    *,
+    plan_path: Path,
+    plan: dict[str, Any],
+    config_path: Path,
+    candidates: list[dict[str, Any]],
+    **kwargs: Any,
+) -> dict[str, Any]:
+    parameters: dict[str, Any] = {
+        "plan_path": plan_path,
+        "confirm_plan_id": plan["plan_id"],
+        "request_id": "RETRY-2026-001",
+        "executed_at": EXECUTED_AT,
+        "config_path": config_path,
+        "dsn": "postgresql://secret-value",
+        "execute": True,
+        "environment": {"RISK_NOTIFICATION_WEBHOOK_URL": ENDPOINT},
+        "reader": lambda **_: candidates,
+        "attempt_writer": lambda _: None,
+        "transport": lambda *_: 204,
+        "clock": lambda: EXECUTED_AT,
+    }
+    parameters.update(kwargs)
+    return execute_portfolio_risk_notification_retries(**parameters)
+
+
+def test_retry_execution_policy_is_deterministic_and_bounded(tmp_path: Path) -> None:
+    config_path = _write_config(tmp_path)
+    delivery, retry, execution = load_retry_execution_contract(config_path)
+    _, _, repeated = load_retry_execution_contract(config_path)
+
+    assert execution.enabled is True
+    assert execution.max_events == retry.max_plan_events
+    assert execution.max_events == delivery.max_batch_events
+    assert execution.fingerprint == repeated.fingerprint
+
+    invalid_path = _write_config(tmp_path, max_execution_events=26)
+    with pytest.raises(ValidationError, match="retry planning limit"):
+        load_retry_execution_contract(invalid_path)
+
+
+def test_explicit_gate_and_plan_confirmation_fail_before_reading(
+    tmp_path: Path,
+) -> None:
+    config_path = _write_config(tmp_path)
+    candidates = [_candidate()]
+    plan_path, plan = _write_plan(tmp_path, config_path, candidates)
+    reads: list[bool] = []
+
+    with pytest.raises(ValidationError, match="explicit --execute"):
+        _execute(
+            plan_path=plan_path,
+            plan=plan,
+            config_path=config_path,
+            candidates=candidates,
+            execute=False,
+            reader=lambda **_: reads.append(True) or candidates,
+        )
+    assert reads == []
+
+    with pytest.raises(ValidationError, match="confirm_plan_id"):
+        _execute(
+            plan_path=plan_path,
+            plan=plan,
+            config_path=config_path,
+            candidates=candidates,
+            confirm_plan_id="wrong-plan-id",
+            reader=lambda **_: reads.append(True) or candidates,
+        )
+    assert reads == []
+
+
+def test_disabled_execution_rejects_before_database_or_transport(
+    tmp_path: Path,
+) -> None:
+    config_path = _write_config(tmp_path, execution_enabled=False)
+    candidates = [_candidate()]
+    plan_path, plan = _write_plan(tmp_path, config_path, candidates)
+    reads: list[bool] = []
+    sends: list[bool] = []
+
+    with pytest.raises(ValidationError, match="disabled"):
+        _execute(
+            plan_path=plan_path,
+            plan=plan,
+            config_path=config_path,
+            candidates=candidates,
+            reader=lambda **_: reads.append(True) or candidates,
+            transport=lambda *_: sends.append(True) or 204,
+        )
+    assert reads == []
+    assert sends == []
+
+
+def test_exact_plan_executes_one_attempt_per_event_with_stable_identity(
+    tmp_path: Path,
+) -> None:
+    config_path = _write_config(tmp_path)
+    candidates = [_candidate("event-b"), _candidate("event-a")]
+    plan_path, plan = _write_plan(tmp_path, config_path, candidates)
+    attempts: list[dict[str, Any]] = []
+    calls: list[dict[str, Any]] = []
+
+    def transport(
+        endpoint: str,
+        payload: bytes,
+        headers: Any,
+        timeout: float,
+    ) -> int:
+        calls.append(
+            {
+                "endpoint": endpoint,
+                "payload": json.loads(payload),
+                "headers": dict(headers),
+                "timeout": timeout,
+            }
+        )
+        return 204
+
+    summary = _execute(
+        plan_path=plan_path,
+        plan=plan,
+        config_path=config_path,
+        candidates=candidates,
+        attempt_writer=lambda attempt: attempts.append(dict(attempt)),
+        transport=transport,
+    )
+
+    assert [attempt["event_id"] for attempt in attempts] == ["event-a", "event-b"]
+    assert [attempt["attempt_number"] for attempt in attempts] == [2, 2]
+    assert all(
+        attempt["idempotency_key"] == attempt["event_id"] for attempt in attempts
+    )
+    assert [call["headers"]["Idempotency-Key"] for call in calls] == [
+        "event-a",
+        "event-b",
+    ]
+    assert summary["outcome_counts"] == {"succeeded": 2, "failed": 0}
+    assert summary["execution"] == {
+        "requested": True,
+        "performed": True,
+        "external_requests_performed": 2,
+        "delivery_attempts_written": 2,
+    }
+    assert summary["revalidation"]["exact_event_evidence_unchanged"] is True
+    assert summary["plan_mutated"] is False
+    assert summary["acknowledgement_mutated"] is False
+    assert summary["dead_letter_mutated"] is False
+    assert summary["response_bodies_recorded"] is False
+
+    rendered = json.dumps(summary, sort_keys=True)
+    assert ENDPOINT not in rendered
+    assert "postgresql://secret-value" not in rendered
+    assert '"severity"' not in rendered
+    assert summary["endpoint"] == {
+        "host": "alerts.example.test",
+        "full_url_recorded": False,
+    }
+
+
+def test_execution_identity_is_deterministic_for_exact_inputs(tmp_path: Path) -> None:
+    config_path = _write_config(tmp_path)
+    candidates = [_candidate()]
+    plan_path, plan = _write_plan(tmp_path, config_path, candidates)
+
+    first = _execute(
+        plan_path=plan_path,
+        plan=plan,
+        config_path=config_path,
+        candidates=candidates,
+    )
+    second = _execute(
+        plan_path=plan_path,
+        plan=plan,
+        config_path=config_path,
+        candidates=candidates,
+    )
+
+    assert first["execution_id"] == second["execution_id"]
+    assert first["outcomes"] == second["outcomes"]
+
+
+def test_stale_or_reconfigured_plan_rejects_before_reading(tmp_path: Path) -> None:
+    stale_config = _write_config(tmp_path, max_plan_age_seconds=30)
+    candidates = [_candidate()]
+    stale_path, stale_plan = _write_plan(tmp_path, stale_config, candidates)
+    reads: list[bool] = []
+
+    with pytest.raises(ValidationError, match="age limit"):
+        _execute(
+            plan_path=stale_path,
+            plan=stale_plan,
+            config_path=stale_config,
+            candidates=candidates,
+            reader=lambda **_: reads.append(True) or candidates,
+        )
+    assert reads == []
+
+    config_path = _write_config(tmp_path)
+    plan_path, plan = _write_plan(tmp_path, config_path, candidates)
+    config_path.write_text(
+        yaml.safe_dump(
+            _config_payload(timeout_seconds=6),
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+    with pytest.raises(ValidationError, match="fingerprint changed"):
+        _execute(
+            plan_path=plan_path,
+            plan=plan,
+            config_path=config_path,
+            candidates=candidates,
+            reader=lambda **_: reads.append(True) or candidates,
+        )
+    assert reads == []
+
+
+def test_changed_attempt_acknowledgement_or_event_set_rejects_before_transport(
+    tmp_path: Path,
+) -> None:
+    config_path = _write_config(tmp_path)
+    candidates = [_candidate()]
+    plan_path, plan = _write_plan(tmp_path, config_path, candidates)
+    sends: list[bool] = []
+
+    changed_attempt = [_candidate(attempt_count=2)]
+    with pytest.raises(ValidationError, match="changed"):
+        _execute(
+            plan_path=plan_path,
+            plan=plan,
+            config_path=config_path,
+            candidates=changed_attempt,
+            transport=lambda *_: sends.append(True) or 204,
+        )
+
+    acknowledged = [_candidate(acknowledgement=True)]
+    with pytest.raises(ValidationError, match="changed"):
+        _execute(
+            plan_path=plan_path,
+            plan=plan,
+            config_path=config_path,
+            candidates=acknowledged,
+            transport=lambda *_: sends.append(True) or 204,
+        )
+
+    with pytest.raises(ValidationError, match="event set changed"):
+        _execute(
+            plan_path=plan_path,
+            plan=plan,
+            config_path=config_path,
+            candidates=[],
+            transport=lambda *_: sends.append(True) or 204,
+        )
+    assert sends == []
+
+
+def test_failed_retry_records_one_attempt_without_hidden_retry_loop(
+    tmp_path: Path,
+) -> None:
+    config_path = _write_config(tmp_path)
+    candidates = [_candidate()]
+    plan_path, plan = _write_plan(tmp_path, config_path, candidates)
+    attempts: list[dict[str, Any]] = []
+    calls: list[bool] = []
+
+    summary = _execute(
+        plan_path=plan_path,
+        plan=plan,
+        config_path=config_path,
+        candidates=candidates,
+        attempt_writer=lambda attempt: attempts.append(dict(attempt)),
+        transport=lambda *_: calls.append(True) or 503,
+    )
+
+    assert len(calls) == 1
+    assert len(attempts) == 1
+    assert attempts[0]["outcome"] == "failed"
+    assert attempts[0]["error_code"] == "http_503"
+    assert summary["outcome_counts"] == {"succeeded": 0, "failed": 1}
+
+
+def test_transport_errors_are_bounded_and_invalid_status_fails_before_write(
+    tmp_path: Path,
+) -> None:
+    config_path = _write_config(tmp_path)
+    candidates = [_candidate()]
+    plan_path, plan = _write_plan(tmp_path, config_path, candidates)
+    attempts: list[dict[str, Any]] = []
+
+    def network_failure(*_: Any) -> int:
+        raise DeliveryTransportError("arbitrary exception text must not be retained")
+
+    summary = _execute(
+        plan_path=plan_path,
+        plan=plan,
+        config_path=config_path,
+        candidates=candidates,
+        attempt_writer=lambda attempt: attempts.append(dict(attempt)),
+        transport=network_failure,
+    )
+    assert attempts[0]["error_code"] == "network_error"
+    assert summary["outcomes"][0]["error_code"] == "network_error"
+    assert "arbitrary exception" not in json.dumps(summary)
+
+    attempts.clear()
+    with pytest.raises(ValidationError, match="invalid HTTP status"):
+        _execute(
+            plan_path=plan_path,
+            plan=plan,
+            config_path=config_path,
+            candidates=candidates,
+            attempt_writer=lambda attempt: attempts.append(dict(attempt)),
+            transport=lambda *_: 999,
+        )
+    assert attempts == []
+
+
+def test_attempt_persistence_failure_is_not_reported_as_success(tmp_path: Path) -> None:
+    config_path = _write_config(tmp_path)
+    candidates = [_candidate()]
+    plan_path, plan = _write_plan(tmp_path, config_path, candidates)
+    calls: list[bool] = []
+
+    def writer(_: Any) -> None:
+        raise StorageError("write failed")
+
+    with pytest.raises(StorageError, match="write failed"):
+        _execute(
+            plan_path=plan_path,
+            plan=plan,
+            config_path=config_path,
+            candidates=candidates,
+            attempt_writer=writer,
+            transport=lambda *_: calls.append(True) or 204,
+        )
+    assert calls == [True]
+
+
+def test_execution_event_limit_fails_before_reader_or_transport(tmp_path: Path) -> None:
+    config_path = _write_config(tmp_path, max_execution_events=1)
+    candidates = [_candidate("event-a"), _candidate("event-b")]
+    plan_path, plan = _write_plan(tmp_path, config_path, candidates)
+    reads: list[bool] = []
+    sends: list[bool] = []
+
+    with pytest.raises(ValidationError, match="event limit"):
+        _execute(
+            plan_path=plan_path,
+            plan=plan,
+            config_path=config_path,
+            candidates=candidates,
+            reader=lambda **_: reads.append(True) or candidates,
+            transport=lambda *_: sends.append(True) or 204,
+        )
+    assert reads == []
+    assert sends == []
+
+
+def test_tampered_symlink_and_oversized_plans_fail_closed(tmp_path: Path) -> None:
+    config_path = _write_config(tmp_path)
+    candidates = [_candidate()]
+    plan_path, _ = _write_plan(tmp_path, config_path, candidates)
+
+    document = json.loads(plan_path.read_text(encoding="utf-8"))
+    document["retryable_event_ids"] = []
+    plan_path.write_text(json.dumps(document), encoding="utf-8")
+    with pytest.raises(ValidationError, match="retryable_event_ids"):
+        load_retry_plan(plan_path)
+
+    original = tmp_path / "original.json"
+    original.write_text("{}", encoding="utf-8")
+    link = tmp_path / "plan-link.json"
+    link.symlink_to(original)
+    with pytest.raises(ValidationError, match="symbolic link"):
+        load_retry_plan(link)
+
+    oversized = tmp_path / "oversized.json"
+    oversized.write_text("x" * 1_048_577, encoding="utf-8")
+    with pytest.raises(ValidationError, match="1 MB"):
+        load_retry_plan(oversized)
+
+
+def test_summary_writer_rejects_symbolic_links(tmp_path: Path) -> None:
+    target = tmp_path / "target.json"
+    target.write_text("{}", encoding="utf-8")
+    link = tmp_path / "summary.json"
+    link.symlink_to(target)
+
+    with pytest.raises(StorageError, match="symbolic link"):
+        _write_summary(link, {"safe": True})

--- a/tests/unit/test_portfolio_risk_notification_retry_execution_architecture_contract.py
+++ b/tests/unit/test_portfolio_risk_notification_retry_execution_architecture_contract.py
@@ -30,8 +30,8 @@ def test_manual_retry_execution_is_exact_disabled_and_one_attempt_only() -> None
         "--plan",
         "--confirm-plan-id",
         "--request-id",
-        "--executed-at",
         "--execute",
+        "execution_started_at",
         "assert_retry_plan_is_current",
         "Idempotency-Key",
         "response_bodies_recorded",
@@ -41,12 +41,21 @@ def test_manual_retry_execution_is_exact_disabled_and_one_attempt_only() -> None
     ):
         assert required in source
 
+    assert "--executed-at" not in source
     assert "time_module.sleep" not in source
     assert "Sleeper" not in source
     assert "UPDATE risk_platform" not in source
     assert "DELETE FROM risk_platform" not in source
 
-    assert "portfolio_risk_notification_delivery_attempts" in delivery_source
+    for required in (
+        "portfolio_risk_notification_delivery_attempts",
+        "HAVING COALESCE(MAX(attempt.attempt_number), 0) = 0",
+        "events with existing delivery attempts require an exact retry plan",
+        "initial_attempts_only",
+    ):
+        assert required in delivery_source
+    assert "time_module.sleep" not in delivery_source
+    assert "for attempt_number in range" not in delivery_source
 
     for required in (
         "MAX_PLAN_FILE_BYTES",
@@ -71,6 +80,7 @@ def test_manual_retry_execution_is_exact_disabled_and_one_attempt_only() -> None
         "Primary arc42 block: `orchestration`",
         "disabled-by-default",
         "before the first network request",
+        "operator cannot supply or backdate",
         "one new attempt",
         "no internal retry loop",
         "stable `Idempotency-Key`",

--- a/tests/unit/test_portfolio_risk_notification_retry_execution_architecture_contract.py
+++ b/tests/unit/test_portfolio_risk_notification_retry_execution_architecture_contract.py
@@ -5,6 +5,9 @@ def test_manual_retry_execution_is_exact_disabled_and_one_attempt_only() -> None
     source = Path(
         "src/orchestration/execute_portfolio_risk_notification_retries.py"
     ).read_text(encoding="utf-8")
+    delivery_source = Path(
+        "src/orchestration/deliver_portfolio_risk_notifications.py"
+    ).read_text(encoding="utf-8")
     plan_contract = Path(
         "src/orchestration/portfolio_risk_notification_retry_plan_contract.py"
     ).read_text(encoding="utf-8")
@@ -23,7 +26,6 @@ def test_manual_retry_execution_is_exact_disabled_and_one_attempt_only() -> None
     assert "enabled: false" in retry_execution
 
     for required in (
-        "portfolio-risk-manual-retry-execution-v1",
         "--plan",
         "--confirm-plan-id",
         "--request-id",
@@ -31,7 +33,6 @@ def test_manual_retry_execution_is_exact_disabled_and_one_attempt_only() -> None
         "--execute",
         "assert_retry_plan_is_current",
         "Idempotency-Key",
-        "portfolio_risk_notification_delivery_attempts",
         "response_bodies_recorded",
         "plan_mutated",
         "acknowledgement_mutated",
@@ -44,6 +45,8 @@ def test_manual_retry_execution_is_exact_disabled_and_one_attempt_only() -> None
     assert "UPDATE risk_platform" not in source
     assert "DELETE FROM risk_platform" not in source
 
+    assert "portfolio_risk_notification_delivery_attempts" in delivery_source
+
     for required in (
         "MAX_PLAN_FILE_BYTES",
         "exact_mapping",
@@ -55,6 +58,7 @@ def test_manual_retry_execution_is_exact_disabled_and_one_attempt_only() -> None
         assert required in plan_contract
 
     for required in (
+        "portfolio-risk-manual-retry-execution-v1",
         "retry_execution max_events exceeds retry planning limit",
         "retry execution max_events exceeds webhook batch limit",
         "max_plan_age_seconds",

--- a/tests/unit/test_portfolio_risk_notification_retry_execution_architecture_contract.py
+++ b/tests/unit/test_portfolio_risk_notification_retry_execution_architecture_contract.py
@@ -20,6 +20,7 @@ def test_manual_retry_execution_is_exact_disabled_and_one_attempt_only() -> None
     docs = Path(
         "docs/portfolio-risk-notification-retry-execution.md"
     ).read_text(encoding="utf-8")
+    normalized_docs = " ".join(docs.split()).casefold()
 
     assert "retry_execution:" in config
     retry_execution = config.split("retry_execution:", maxsplit=1)[1]
@@ -79,4 +80,4 @@ def test_manual_retry_execution_is_exact_disabled_and_one_attempt_only() -> None
         "terraform apply",
         "P4d",
     ):
-        assert required.casefold() in docs.casefold()
+        assert required.casefold() in normalized_docs

--- a/tests/unit/test_portfolio_risk_notification_retry_execution_architecture_contract.py
+++ b/tests/unit/test_portfolio_risk_notification_retry_execution_architecture_contract.py
@@ -52,10 +52,12 @@ def test_manual_retry_execution_is_exact_disabled_and_one_attempt_only() -> None
         "HAVING COALESCE(MAX(attempt.attempt_number), 0) = 0",
         "events with existing delivery attempts require an exact retry plan",
         "initial_attempts_only",
+        "environment if environment is not None else os.environ",
     ):
         assert required in delivery_source
     assert "time_module.sleep" not in delivery_source
     assert "for attempt_number in range" not in delivery_source
+    assert "ON CONFLICT (attempt_id) DO NOTHING" not in delivery_source
 
     for required in (
         "MAX_PLAN_FILE_BYTES",

--- a/tests/unit/test_portfolio_risk_notification_retry_execution_architecture_contract.py
+++ b/tests/unit/test_portfolio_risk_notification_retry_execution_architecture_contract.py
@@ -1,0 +1,78 @@
+from pathlib import Path
+
+
+def test_manual_retry_execution_is_exact_disabled_and_one_attempt_only() -> None:
+    source = Path(
+        "src/orchestration/execute_portfolio_risk_notification_retries.py"
+    ).read_text(encoding="utf-8")
+    plan_contract = Path(
+        "src/orchestration/portfolio_risk_notification_retry_plan_contract.py"
+    ).read_text(encoding="utf-8")
+    policy_source = Path(
+        "src/orchestration/portfolio_risk_notification_retry_execution_policy.py"
+    ).read_text(encoding="utf-8")
+    config = Path("config/notification_delivery.yaml").read_text(
+        encoding="utf-8"
+    )
+    docs = Path(
+        "docs/portfolio-risk-notification-retry-execution.md"
+    ).read_text(encoding="utf-8")
+
+    assert "retry_execution:" in config
+    retry_execution = config.split("retry_execution:", maxsplit=1)[1]
+    assert "enabled: false" in retry_execution
+
+    for required in (
+        "portfolio-risk-manual-retry-execution-v1",
+        "--plan",
+        "--confirm-plan-id",
+        "--request-id",
+        "--executed-at",
+        "--execute",
+        "assert_retry_plan_is_current",
+        "Idempotency-Key",
+        "portfolio_risk_notification_delivery_attempts",
+        "response_bodies_recorded",
+        "plan_mutated",
+        "acknowledgement_mutated",
+        "dead_letter_mutated",
+    ):
+        assert required in source
+
+    assert "time_module.sleep" not in source
+    assert "Sleeper" not in source
+    assert "UPDATE risk_platform" not in source
+    assert "DELETE FROM risk_platform" not in source
+
+    for required in (
+        "MAX_PLAN_FILE_BYTES",
+        "exact_mapping",
+        "retryable_event_ids",
+        "event_document_sha256",
+        "_plan_id",
+        "assert_retry_plan_is_current",
+    ):
+        assert required in plan_contract
+
+    for required in (
+        "retry_execution max_events exceeds retry planning limit",
+        "retry execution max_events exceeds webhook batch limit",
+        "max_plan_age_seconds",
+    ):
+        assert required in policy_source
+
+    for required in (
+        "# Explicit Manual Notification Retry Execution",
+        "Primary arc42 block: `orchestration`",
+        "disabled-by-default",
+        "before the first network request",
+        "one new attempt",
+        "no internal retry loop",
+        "stable `Idempotency-Key`",
+        "fake readers, transports, clocks and attempt writers",
+        "performs no external delivery",
+        "does not",
+        "terraform apply",
+        "P4d",
+    ):
+        assert required.casefold() in docs.casefold()

--- a/tests/unit/test_portfolio_risk_notification_retry_execution_architecture_contract.py
+++ b/tests/unit/test_portfolio_risk_notification_retry_execution_architecture_contract.py
@@ -59,9 +59,9 @@ def test_manual_retry_execution_is_exact_disabled_and_one_attempt_only() -> None
 
     for required in (
         "portfolio-risk-manual-retry-execution-v1",
-        "retry_execution max_events exceeds retry planning limit",
-        "retry execution max_events exceeds webhook batch limit",
-        "max_plan_age_seconds",
+        "policy.max_events > retry_policy.max_plan_events",
+        "policy.max_events > delivery_config.max_batch_events",
+        "policy.max_plan_age_seconds > retry_policy.max_event_age_seconds",
     ):
         assert required in policy_source
 

--- a/tests/unit/test_portfolio_risk_webhook_delivery.py
+++ b/tests/unit/test_portfolio_risk_webhook_delivery.py
@@ -70,7 +70,7 @@ def test_delivery_config_is_disabled_and_fingerprinted_deterministically() -> No
     assert first.fingerprint == second.fingerprint
 
 
-def test_plan_only_reads_candidates_without_transport_or_attempt_writes(
+def test_plan_only_reads_initial_candidates_without_transport_or_attempt_writes(
     tmp_path: Path,
 ) -> None:
     transports: list[bytes] = []
@@ -90,6 +90,7 @@ def test_plan_only_reads_candidates_without_transport_or_attempt_writes(
     assert transports == []
     assert attempts == []
     assert summary["execution"]["performed"] is False
+    assert summary["selection"]["initial_attempts_only"] is True
     assert summary["endpoint"] == {"configured": False, "host": None}
     assert "dsn" not in json.dumps(summary)
 
@@ -117,13 +118,11 @@ def test_execute_requires_reviewed_enablement_before_reading_candidates(
     assert reads == 0
 
 
-def test_failed_attempt_retries_then_succeeds_with_same_idempotency_key(
+def test_initial_delivery_failure_records_one_attempt_without_hidden_retry(
     tmp_path: Path,
 ) -> None:
-    statuses = iter([503, 204])
     calls: list[dict[str, Any]] = []
     attempts: list[dict[str, Any]] = []
-    sleeps: list[float] = []
 
     def transport(
         endpoint: str,
@@ -139,7 +138,7 @@ def test_failed_attempt_retries_then_succeeds_with_same_idempotency_key(
                 "timeout": timeout,
             }
         )
-        return next(statuses)
+        return 503
 
     summary = deliver_portfolio_risk_notifications(
         config_path=_write_config(tmp_path, enabled=True),
@@ -151,26 +150,22 @@ def test_failed_attempt_retries_then_succeeds_with_same_idempotency_key(
         reader=lambda **_: [_candidate()],
         attempt_writer=lambda attempt: attempts.append(dict(attempt)),
         transport=transport,
-        sleeper=sleeps.append,
     )
 
-    assert [attempt["outcome"] for attempt in attempts] == [
-        "failed",
-        "succeeded",
-    ]
-    assert [attempt["attempt_number"] for attempt in attempts] == [1, 2]
-    assert all(
-        call["headers"]["Idempotency-Key"] == "event-1" for call in calls
-    )
+    assert len(calls) == 1
+    assert len(attempts) == 1
+    assert attempts[0]["outcome"] == "failed"
+    assert attempts[0]["attempt_number"] == 1
+    assert attempts[0]["error_code"] == "http_503"
+    assert calls[0]["headers"]["Idempotency-Key"] == "event-1"
     assert calls[0]["payload"]["event_id"] == "event-1"
-    assert sleeps == [1.0]
     assert summary["execution"] == {
         "requested": True,
         "performed": True,
-        "succeeded": 1,
-        "failed": 0,
+        "succeeded": 0,
+        "failed": 1,
         "exhausted": 0,
-        "attempts_recorded": 2,
+        "attempts_recorded": 1,
     }
     assert "https://alerts.example.test/risk" not in json.dumps(summary)
     assert summary["endpoint"]["host"] == "alerts.example.test"
@@ -182,7 +177,7 @@ def test_network_failure_is_recorded_without_error_message_or_response_body(
     attempts: list[dict[str, Any]] = []
 
     def transport(*_: Any) -> int:
-        raise DeliveryTransportError("network_error")
+        raise DeliveryTransportError("arbitrary transport text")
 
     summary = deliver_portfolio_risk_notifications(
         config_path=_write_config(tmp_path, enabled=True, attempts=1),
@@ -194,37 +189,59 @@ def test_network_failure_is_recorded_without_error_message_or_response_body(
         reader=lambda **_: [_candidate()],
         attempt_writer=lambda attempt: attempts.append(dict(attempt)),
         transport=transport,
-        sleeper=lambda _: None,
     )
 
     assert attempts[0]["error_code"] == "network_error"
     assert attempts[0]["http_status"] is None
     assert summary["response_bodies_recorded"] is False
     assert summary["execution"]["failed"] == 1
+    assert "arbitrary transport text" not in json.dumps(summary)
 
 
-def test_exhausted_candidate_is_not_sent_again(tmp_path: Path) -> None:
+def test_candidate_with_prior_attempt_requires_exact_retry_plan_before_transport(
+    tmp_path: Path,
+) -> None:
     calls = 0
+    attempts: list[dict[str, Any]] = []
 
     def transport(*_: Any) -> int:
         nonlocal calls
         calls += 1
         return 204
 
-    summary = deliver_portfolio_risk_notifications(
-        config_path=_write_config(tmp_path, enabled=True, attempts=3),
-        dsn="dsn",
-        execute=True,
-        environment={
-            "RISK_NOTIFICATION_WEBHOOK_URL": "https://alerts.example.test/risk"
-        },
-        reader=lambda **_: [_candidate(attempts_so_far=3)],
-        attempt_writer=lambda _: None,
-        transport=transport,
-    )
+    with pytest.raises(ValidationError, match="exact retry plan"):
+        deliver_portfolio_risk_notifications(
+            config_path=_write_config(tmp_path, enabled=True, attempts=3),
+            dsn="dsn",
+            execute=True,
+            environment={
+                "RISK_NOTIFICATION_WEBHOOK_URL": "https://alerts.example.test/risk"
+            },
+            reader=lambda **_: [_candidate(attempts_so_far=1)],
+            attempt_writer=lambda attempt: attempts.append(dict(attempt)),
+            transport=transport,
+        )
 
     assert calls == 0
-    assert summary["execution"]["exhausted"] == 1
+    assert attempts == []
+
+
+def test_invalid_transport_status_fails_before_attempt_write(tmp_path: Path) -> None:
+    attempts: list[dict[str, Any]] = []
+
+    with pytest.raises(ValidationError, match="invalid HTTP status"):
+        deliver_portfolio_risk_notifications(
+            config_path=_write_config(tmp_path, enabled=True),
+            dsn="dsn",
+            execute=True,
+            environment={
+                "RISK_NOTIFICATION_WEBHOOK_URL": "https://alerts.example.test/risk"
+            },
+            reader=lambda **_: [_candidate()],
+            attempt_writer=lambda attempt: attempts.append(dict(attempt)),
+            transport=lambda *_: 999,
+        )
+    assert attempts == []
 
 
 def test_endpoint_must_be_https_without_embedded_credentials(


### PR DESCRIPTION
## Goal

Complete **P4c — explicit manual retry execution** by consuming one exact retained retry plan under a separate, disabled-by-default delivery authority:

```text
retained portfolio-risk-dead-letter-retry-plan-v1
  + exact plan confirmation
  + current delivery/retry fingerprints
  + current event, attempt and acknowledgement evidence
  -> clock-bound fail-closed revalidation before the first request
  -> one bounded HTTPS attempt per planned event
  -> stable notification Idempotency-Key
  -> append-only delivery-attempt evidence
  -> credential-free deterministic execution summary
```

Primary arc42 block: `orchestration`, reusing the existing bounded PostgreSQL evidence reader and append-only delivery-attempt table.

## Separate reviewed gates

Committed configuration remains disabled for both:

```yaml
webhook:
  enabled: false
retry_execution:
  enabled: false
```

The intended two-stage review sequence is:

1. enable webhook delivery locally through review;
2. create and inspect a fresh exact P4b plan under that enabled delivery fingerprint;
3. separately enable manual retry execution through review; and
4. invoke P4c with `--execute`, the exact `--confirm-plan-id`, a bounded request ID, and a locally supplied HTTPS endpoint.

A plan generated while webhook delivery was disabled cannot later be executed. The execution timestamp is derived from the local UTC clock; the CLI exposes no operator-supplied timestamp that could backdate plan age or current-evidence selection.

## Exact retained-plan contract

The executor accepts one regular JSON file no larger than 1 MB and rejects symbolic links, malformed JSON, unknown fields, incomplete evidence, invalid ordering, duplicate event IDs and inconsistent classifications.

It independently recomputes and validates:

- the canonical `portfolio-risk-dead-letter-retry-plan-v1` identity;
- exact event and source-evaluation identities;
- canonical event/payload SHA-256;
- latest delivery-attempt identity, number, timestamp and failure evidence;
- acknowledgement identity and disposition;
- event age, expiry, backoff and attempt capacity;
- classification counts and ordered retryable event IDs; and
- all original no-side-effect declarations.

The executor does not accept an arbitrary event-ID list.

## Current-evidence revalidation

Immediately before the first network request, the executor performs one bounded PostgreSQL read as of its clock-derived execution-start time and rebuilds the current retry plan.

Execution is rejected if any of these changed after planning:

- delivery configuration fingerprint;
- retry-planning policy fingerprint;
- policy or portfolio filter;
- exact pending event set;
- event/payload content identity;
- latest attempt identity or outcome evidence;
- acknowledgement evidence;
- retry classification or next-eligible time; or
- ordered retryable event IDs.

Only naturally increasing event age is excluded from direct equality; expiry and eligibility are recalculated and must still agree.

## One-attempt execution semantics

- Exactly one new attempt is made per retained retryable event.
- There is no hidden retry loop or retry sleep.
- A later attempt requires a new current plan after backoff.
- Event IDs remain the stable remote `Idempotency-Key`.
- Attempt IDs and attempt numbers remain deterministic.
- Invalid transport status values fail before persistence.
- Unknown exception text is reduced to the bounded `network_error` code.
- Duplicate attempt identities now fail closed at PostgreSQL rather than being silently ignored.

The older `deliver_portfolio_risk_notifications` adapter is now restricted to initial attempts only:

- its default query selects only events with zero retained attempts;
- supplied evidence containing a prior attempt is rejected before transport;
- it performs one attempt numbered `1`; and
- it no longer contains an internal retry loop or sleep.

This closes the bypass around the P4b/P4c authority path.

## Evidence and secret boundary

The existing append-only table retains each attempt:

```text
risk_platform.portfolio_risk_notification_delivery_attempts
```

The execution summary contains plan/request/configuration identities, revalidation evidence, bounded attempt outcomes and endpoint host only. It omits response bodies, full endpoint URLs, DSNs, payload bodies, credentials and arbitrary exception messages.

It explicitly declares:

```text
response_bodies_recorded = false
plan_mutated = false
acknowledgement_mutated = false
dead_letter_mutated = false
```

## Validation and repairs

Early CI runs found three brittle architecture-test assertions: the model constant lived in the policy module, one assertion matched prose rather than the actual bound expression, and one depended on Markdown line wrapping. Those tests were corrected to check semantic controls; no runtime, security or database rule was weakened.

Deeper review then identified and repaired two substantive governance gaps before final validation:

1. the operator-supplied execution timestamp could have backdated revalidation, so execution time is now derived from the local UTC clock; and
2. the legacy webhook adapter could retry directly, so it is now first-attempt-only and all subsequent attempts require an exact P4b/P4c plan.

A silent `ON CONFLICT DO NOTHING` attempt insert was also removed so concurrent identity conflicts fail rather than being reported as persisted outcomes.

GitHub Actions run **327** (`32832479693`) passed on exact final head `3a3409769123c659fbc399ea6fe5d32b931b9b06`:

- **Security guardrails:** passed with the exact reviewed workflow unchanged.
- **Python readiness:** passed.
  - Ruff passed;
  - mypy passed across **110 source files**;
  - **787 tests passed** in the quality run;
  - **787 tests passed again** in the readiness run;
  - `pip check` reported no broken requirements;
  - the standard replay/readiness demonstration passed.
- **PostgreSQL contract:** passed against PostgreSQL 16 for the complete source-to-serving, governance and operational evidence suite.
- **Infrastructure validation:** Kubernetes rendering and Terraform format/init/validate passed without apply.

No live webhook request, provider request, cloud schedule activation, deployment, position mutation or `terraform apply` ran in CI.

## Scope and review state

The branch is directly based on current `main`, is **19 working commits ahead and zero behind**, and changes exactly **10 files** with **2,166 additions and 126 deletions**. The connector-produced commits are intended to squash into one coherent P4c authority increment.

There are no submitted reviews, requested changes or unresolved review threads.

## Acceptance boundary

Validated and ready for squash merge. The next dependency-safe roadmap goal is **P4d — reviewed external alert delivery activation and operational hardening**, kept separate from this local manual execution contract.