### PR TITLE
Serialize portfolio risk notification delivery

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -239,6 +239,8 @@ postgres-contract-check:
 	docker compose down -v --remove-orphans
 	docker compose up -d postgres
 	$(MAKE) local-db-wait
+	$(PYTHON) -m src.warehouse.notification_delivery_lock_contract_check \
+		--dsn "$(LOCAL_POSTGRES_DSN)"
 	$(PYTHON) -m src.warehouse.postgres_consistency \
 		--dsn "$(LOCAL_POSTGRES_DSN)" \
 		--check sql/consistency_checks.sql

--- a/docs/manual-webhook-delivery.md
+++ b/docs/manual-webhook-delivery.md
@@ -7,10 +7,12 @@ notifications while retaining append-only evidence:
 
 ```text
 current pending notification outbox
+  -> acquire shared PostgreSQL delivery lock
   -> exclude delivered events and every event with an existing attempt
   -> bounded manual batch
   -> one HTTPS POST with stable Idempotency-Key
   -> append-only PostgreSQL delivery attempt
+  -> release shared delivery lock
   -> pending or succeeded operational views
 ```
 
@@ -30,6 +32,24 @@ or recipient. Normal invocation is plan-only. External delivery requires both:
 The endpoint must be HTTPS and may not contain embedded credentials or a URL
 fragment. Only the endpoint host is recorded in evidence. The full URL and
 environment value are not written to summaries or the database.
+
+## Shared concurrency control
+
+Plan-only invocation performs no external request or mutation and does not acquire a
+lock. Explicit delivery acquires the non-blocking PostgreSQL advisory lock defined
+by:
+
+```text
+portfolio-risk-notification-delivery-lock-v1
+```
+
+The lock is acquired before candidate selection and held through every network
+request and append-only attempt insert. A second local operator or separate checkout
+using the same PostgreSQL database is rejected immediately while the lock is held.
+It performs no candidate read or webhook request.
+
+The summary exposes the lock model, scope and a credential-free key fingerprint.
+The raw advisory key and PostgreSQL DSN are not retained.
 
 ## Initial-attempt boundary
 
@@ -70,9 +90,10 @@ attempt number
 portfolio-risk-webhook-delivery-v1
 ```
 
-There remains an unavoidable failure window in which the remote receiver accepts a
-request but local attempt persistence fails. The stable `Idempotency-Key` is the
-control for that ambiguity; receivers must deduplicate it.
+The shared lock prevents simultaneous local senders. There remains an unavoidable
+failure window in which the remote receiver accepts a request but local attempt
+persistence fails. The stable `Idempotency-Key` is the control for that ambiguity;
+receivers must deduplicate it.
 
 ## Evidence boundary
 
@@ -89,6 +110,9 @@ Each attempt stores:
 Response bodies, endpoint paths, credentials, headers containing secrets and
 arbitrary exception messages are never stored. Invalid transport status values fail
 before an attempt row is written.
+
+The execution summary also declares whether concurrency control was acquired,
+released and held through attempt persistence.
 
 ## Operator commands
 
@@ -122,7 +146,8 @@ plan instead of invoking this adapter again:
   --summary-json .demo/notification-retry-plan.json
 ```
 
-The separate P4c command consumes the exact resulting plan.
+The separate P4c command consumes the exact resulting plan and uses the same shared
+delivery lock before current-evidence revalidation.
 
 ## PostgreSQL serving
 

--- a/docs/portfolio-risk-notification-delivery-locking.md
+++ b/docs/portfolio-risk-notification-delivery-locking.md
@@ -143,6 +143,11 @@ Unit tests use fake PostgreSQL sessions and prove:
 - initial delivery acquires before candidate selection; and
 - governed retry acquires before current-evidence revalidation.
 
+The PostgreSQL 16 contention contract opens independent sessions and proves that a
+second session is rejected while the first owns the key, then acquires successfully
+after explicit release. This contract runs inside `make postgres-contract-check`
+before the existing warehouse consistency suite.
+
 Ordinary CI uses fake transports and performs no webhook request. The committed
 webhook and retry-execution settings remain disabled. This increment does not
 activate a destination, schedule delivery, deploy infrastructure or run

--- a/docs/portfolio-risk-notification-delivery-locking.md
+++ b/docs/portfolio-risk-notification-delivery-locking.md
@@ -1,0 +1,152 @@
+# PostgreSQL Notification Delivery Concurrency Control
+
+## Outcome
+
+This increment prevents two local operators or separate repository checkouts from
+executing notification delivery at the same time:
+
+```text
+explicit initial delivery or exact retry execution
+  -> non-blocking PostgreSQL advisory-lock acquisition
+  -> candidate selection or current-evidence revalidation
+  -> bounded HTTPS request
+  -> append-only delivery-attempt insert
+  -> advisory-lock release
+```
+
+Primary arc42 block: `orchestration`, with PostgreSQL used as the shared
+coordination boundary.
+
+The implementation is:
+
+```text
+src/orchestration/portfolio_risk_notification_delivery_lock.py
+```
+
+The lock model is:
+
+```text
+portfolio-risk-notification-delivery-lock-v1
+```
+
+## Why the lock is global
+
+The local delivery path is deliberately low-volume and operator-driven. One global
+lock is simpler and safer than event-by-event locking because it also protects the
+bounded candidate-selection and retry-revalidation windows.
+
+While the lock is held, no other initial-delivery or governed-retry process can
+enter the delivery lane, even when it is running from another checkout on the same
+machine or another machine using the same PostgreSQL database.
+
+This conservative scope trades parallelism for an unambiguous operational control.
+A future high-throughput delivery service may replace it with leased event-level
+work claiming, but that is outside this local manual boundary.
+
+## Acquisition semantics
+
+The control uses a deterministic signed 64-bit key derived from the lock model and
+scope. Summaries expose only a SHA-256-derived key fingerprint, not the raw key or
+PostgreSQL DSN.
+
+Acquisition uses:
+
+```sql
+SELECT pg_try_advisory_lock(...)
+```
+
+It is non-blocking. When another process already owns the lock, execution fails
+closed immediately and performs no candidate read, current-plan revalidation,
+network request or attempt insert.
+
+The same PostgreSQL session remains open for the complete protected operation.
+Session close releases the lock after process failure. Normal completion also calls
+`pg_advisory_unlock` explicitly and treats an unexplained release failure as a
+storage error.
+
+## Initial delivery ordering
+
+`deliver_portfolio_risk_notifications` remains plan-only without a lock when
+`--execute` is absent. Explicit delivery follows this order:
+
+```text
+validate reviewed enablement and HTTPS endpoint
+  -> acquire global delivery lock
+  -> read current zero-attempt candidates
+  -> validate first-attempt-only evidence
+  -> send one request per candidate
+  -> persist each append-only attempt
+  -> release lock
+```
+
+Candidate selection therefore occurs inside the shared lock rather than before it.
+
+## Governed retry ordering
+
+`execute_portfolio_risk_notification_retries` follows this order:
+
+```text
+validate retained plan, confirmation and reviewed configuration
+  -> acquire global delivery lock
+  -> read current event/attempt/acknowledgement evidence
+  -> rebuild and compare the exact current retry plan
+  -> send one request per retained retryable event
+  -> persist each append-only attempt
+  -> release lock
+```
+
+The lock is held through current-evidence revalidation and attempt persistence, so a
+second operator cannot pass the same stale revalidation window concurrently.
+
+The lock model version and key fingerprint are bound into the deterministic retry
+execution identity.
+
+## Evidence
+
+Successful execution summaries include:
+
+```text
+concurrency_control.performed = true
+concurrency_control.acquired = true
+concurrency_control.released = true
+concurrency_control.held_through_attempt_persistence = true
+```
+
+Retry summaries additionally declare:
+
+```text
+concurrency_control.held_through_revalidation = true
+```
+
+Plan-only initial-delivery summaries declare that concurrency control was not
+performed because they make no external request or database mutation.
+
+## Failure boundary
+
+The lock prevents concurrent local senders from entering the delivery lane. It does
+not remove the distributed ambiguity in which a remote receiver accepts a request
+but local attempt persistence fails. The stable notification `Idempotency-Key`
+remains the control for that failure window, and receivers must deduplicate it.
+
+The lock is coordination, not authentication. An operator able to change and run
+repository code remains inside the local trust boundary.
+
+## Validation boundary
+
+Unit tests use fake PostgreSQL sessions and prove:
+
+- deterministic signed advisory-lock identity;
+- acquisition and explicit release on one session;
+- immediate rejection when the lock is held;
+- connection close after body failure;
+- release-failure reporting after a successful body;
+- initial delivery acquires before candidate selection; and
+- governed retry acquires before current-evidence revalidation.
+
+Ordinary CI uses fake transports and performs no webhook request. The committed
+webhook and retry-execution settings remain disabled. This increment does not
+activate a destination, schedule delivery, deploy infrastructure or run
+`terraform apply`.
+
+The next dependency-safe P4d slice is append-only retry-execution history and
+current delivery-failure, ambiguous-outcome and retry-follow-up operational views.

--- a/docs/portfolio-risk-notification-retry-execution.md
+++ b/docs/portfolio-risk-notification-retry-execution.md
@@ -9,6 +9,7 @@ disabled-by-default execution gate:
 retained portfolio-risk-dead-letter-retry-plan-v1
   + exact plan confirmation
   + current reviewed delivery and retry policy
+  + shared PostgreSQL delivery lock
   + current event, attempt and acknowledgement evidence
   -> fail-closed revalidation before the first network request
   -> one bounded HTTPS attempt per planned event
@@ -30,6 +31,12 @@ The strict retained-plan validator is:
 
 ```text
 src/orchestration/portfolio_risk_notification_retry_plan_contract.py
+```
+
+The shared concurrency control is:
+
+```text
+src/orchestration/portfolio_risk_notification_delivery_lock.py
 ```
 
 ## Separate activation gates
@@ -88,10 +95,10 @@ The executor derives its execution-start timestamp from the local UTC clock. The
 operator cannot supply or backdate that timestamp. Tests inject a deterministic
 clock, but the CLI always uses the actual current clock.
 
-After validating the file and current configuration, the executor performs one
-bounded PostgreSQL read as of that execution-start timestamp. It rebuilds the retry
-plan using current evidence and compares it with the retained plan before the first
-network request.
+After validating the file and current configuration, the executor acquires the
+shared notification-delivery lock and performs one bounded PostgreSQL read as of
+that execution-start timestamp. It rebuilds the retry plan using current evidence
+and compares it with the retained plan before the first network request.
 
 Execution is rejected when any of the following changes:
 
@@ -134,6 +141,27 @@ measured from the retained plan timestamp to the actual clock-derived execution
 start. Bounds are validated before PostgreSQL access and before any external
 request.
 
+## Shared concurrency control
+
+All notification delivery uses one non-blocking PostgreSQL advisory lock with model:
+
+```text
+portfolio-risk-notification-delivery-lock-v1
+```
+
+The retry executor acquires it before current-evidence revalidation and holds it
+through every network request and append-only attempt insert. A second operator or
+checkout is rejected immediately while the lock is held and performs no evidence
+read or external request.
+
+The lock model version and a credential-free key fingerprint are bound into the
+retry execution identity and exposed in `concurrency_control`. The raw advisory key
+and PostgreSQL DSN are not retained.
+
+The conservative global scope intentionally serializes all local notification
+attempts. This is appropriate for the bounded manual workflow and avoids a second
+operator passing the same stale revalidation window concurrently.
+
 ## One attempt per event
 
 This command performs exactly one new attempt for each event listed in the retained
@@ -145,7 +173,8 @@ create a new current plan after the configured backoff has elapsed.
 
 The older `deliver_portfolio_risk_notifications` adapter is now restricted to first
 attempts only. It rejects any event with prior delivery evidence before transport,
-so subsequent attempts cannot bypass the exact P4b/P4c path.
+so subsequent attempts cannot bypass the exact P4b/P4c path. That initial path uses
+the same PostgreSQL delivery lock before candidate selection.
 
 Attempt identity continues to bind:
 
@@ -165,11 +194,10 @@ Every webhook request uses the notification `event_id` as its stable
 `Idempotency-Key`. The full endpoint is never retained; only its host is included in
 evidence.
 
-There remains an unavoidable ambiguity if the receiver accepts a request but local
-attempt persistence fails. The executor reports failure rather than claiming
-success, and the receiver must deduplicate the stable idempotency key. Concurrent
-operators are inside the local trust boundary and must rely on the same remote
-deduplication contract until a later distributed execution-lock increment is added.
+The shared lock prevents simultaneous local operators from entering the delivery
+lane. There remains an unavoidable ambiguity if the receiver accepts a request but
+local attempt persistence fails. The executor reports failure rather than claiming
+success, and the receiver must deduplicate the stable idempotency key.
 
 ## Append-only outcome evidence
 
@@ -206,6 +234,7 @@ endpoint host
 current delivery fingerprint
 current retry-policy fingerprint
 current execution-policy fingerprint
+delivery-lock model version and key fingerprint
 ordered expected attempt IDs and numbers
 ```
 
@@ -217,6 +246,7 @@ The summary exposes:
 - plan and request identity;
 - current configuration fingerprints;
 - revalidation result;
+- concurrency-control identity and release evidence;
 - bounded event and attempt counts;
 - attempt IDs, timestamps and outcomes;
 - endpoint host only; and
@@ -266,8 +296,9 @@ in the result.
 
 ## Validation boundary
 
-Unit tests use fake readers, transports, clocks and attempt writers. Ordinary CI
-performs no external delivery and the committed configuration remains disabled.
+Unit tests use fake readers, transports, clocks, attempt writers and delivery locks.
+Ordinary CI performs no external delivery and the committed configuration remains
+disabled.
 
 This increment does not:
 
@@ -279,6 +310,5 @@ This increment does not:
 - deploy infrastructure; or
 - run `terraform apply`.
 
-The next dependency-safe roadmap item is **P4d — reviewed external alert delivery
-activation and operational hardening**, kept separate from this local manual
-authority contract.
+The next dependency-safe P4d slice is append-only retry-execution history and
+current delivery-failure, ambiguous-outcome and retry-follow-up operational views.

--- a/src/orchestration/deliver_portfolio_risk_notifications.py
+++ b/src/orchestration/deliver_portfolio_risk_notifications.py
@@ -16,7 +16,11 @@ from urllib.parse import urlparse
 from uuid import uuid4
 
 from src.common.config import load_yaml
-from src.common.exceptions import StorageError, ValidationError
+from src.common.exceptions import OverlapError, StorageError, ValidationError
+from src.orchestration.portfolio_risk_notification_delivery_lock import (
+    DeliveryLockFactory,
+    acquire_notification_delivery_lock,
+)
 from src.warehouse.postgres_loader import DEFAULT_POSTGRES_DSN
 
 MODEL_VERSION = "portfolio-risk-webhook-delivery-v1"
@@ -343,42 +347,28 @@ def write_delivery_attempt(
         raise StorageError("Unable to persist notification delivery attempt") from None
 
 
-def deliver_portfolio_risk_notifications(
+def _read_and_validate_candidates(
     *,
-    config_path: Path,
+    reader: CandidateReader,
     dsn: str,
-    execute: bool = False,
-    environment: Mapping[str, str] | None = None,
-    reader: CandidateReader | None = None,
-    attempt_writer: AttemptWriter | None = None,
-    transport: Transport | None = None,
-) -> dict[str, Any]:
-    config = load_webhook_delivery_config(config_path)
-    selected_environment = environment if environment is not None else os.environ
-    raw_endpoint = selected_environment.get(config.endpoint_env)
-    endpoint_host: str | None = None
-    endpoint_value: str | None = None
-    if raw_endpoint:
-        endpoint_value, endpoint_host = _endpoint(raw_endpoint)
-    if execute:
-        if not config.enabled:
-            raise ValidationError(
-                "webhook delivery is disabled in reviewed configuration"
-            )
-        if endpoint_value is None or endpoint_host is None:
-            raise ValidationError(
-                f"webhook endpoint environment variable {config.endpoint_env} is not set"
-            )
-
-    selected_reader = reader or read_pending_delivery_candidates
-    candidates = selected_reader(
-        dsn=dsn,
-        max_events=config.max_batch_events,
-    )
+    max_events: int,
+) -> list[dict[str, Any]]:
+    candidates = reader(dsn=dsn, max_events=max_events)
     if not isinstance(candidates, list):
         raise StorageError("notification delivery reader returned invalid evidence")
-    if len(candidates) > config.max_batch_events:
+    if len(candidates) > max_events:
         raise ValidationError("notification delivery exceeds max_batch_events")
+    return candidates
+
+
+def _delivery_summary(
+    *,
+    config: WebhookDeliveryConfig,
+    endpoint_host: str | None,
+    candidates: list[dict[str, Any]],
+    execute: bool,
+    lock_evidence: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
     plan = [
         {
             "attempts_so_far": int(candidate.get("attempts_so_far", 0)),
@@ -389,7 +379,20 @@ def deliver_portfolio_risk_notifications(
         }
         for candidate in candidates
     ]
-    summary: dict[str, Any] = {
+    concurrency_control = {
+        "performed": lock_evidence is not None,
+        "acquired": lock_evidence is not None,
+        "released": False,
+        "held_through_attempt_persistence": lock_evidence is not None,
+        "model_version": (
+            lock_evidence.get("model_version") if lock_evidence is not None else None
+        ),
+        "scope": lock_evidence.get("scope") if lock_evidence is not None else None,
+        "key_fingerprint": (
+            lock_evidence.get("key_fingerprint") if lock_evidence is not None else None
+        ),
+    }
+    return {
         "run_id": str(uuid4()),
         "config_fingerprint": config.fingerprint,
         "channel": CHANNEL,
@@ -411,13 +414,20 @@ def deliver_portfolio_risk_notifications(
             "exhausted": 0,
             "attempts_recorded": 0,
         },
+        "concurrency_control": concurrency_control,
         "response_bodies_recorded": False,
     }
-    if not execute or not candidates:
-        return summary
-    if endpoint_value is None or endpoint_host is None:
-        raise ValidationError("webhook endpoint was not resolved for execution")
 
+
+def _execute_initial_attempts(
+    *,
+    candidates: list[dict[str, Any]],
+    endpoint: str,
+    endpoint_host: str,
+    config: WebhookDeliveryConfig,
+    writer: AttemptWriter,
+    transport: Transport,
+) -> dict[str, int | bool]:
     for candidate in candidates:
         attempts_so_far = candidate.get("attempts_so_far", 0)
         if type(attempts_so_far) is not int or attempts_so_far < 0:
@@ -427,14 +437,9 @@ def deliver_portfolio_risk_notifications(
                 "events with existing delivery attempts require an exact retry plan"
             )
 
-    selected_transport = transport or _default_transport
-    selected_writer = attempt_writer or (
-        lambda attempt: write_delivery_attempt(attempt, dsn=dsn)
-    )
     succeeded = 0
     failed = 0
     attempts_recorded = 0
-
     for candidate in candidates:
         event_id = _required_text(candidate.get("event_id"), "event_id", 512)
         payload = _canonical_payload(candidate)
@@ -444,8 +449,8 @@ def deliver_portfolio_risk_notifications(
         http_status: int | None = None
         error_code: str | None = None
         try:
-            response_status = selected_transport(
-                endpoint_value,
+            response_status = transport(
+                endpoint,
                 payload,
                 {
                     "Content-Type": "application/json",
@@ -477,21 +482,96 @@ def deliver_portfolio_risk_notifications(
             "endpoint_host": endpoint_host,
             "payload_sha256": payload_sha256,
         }
-        selected_writer(attempt)
+        writer(attempt)
         attempts_recorded += 1
         if outcome == "succeeded":
             succeeded += 1
         else:
             failed += 1
 
-    summary["execution"] = {
+    return {
         "requested": True,
-        "performed": True,
+        "performed": bool(candidates),
         "succeeded": succeeded,
         "failed": failed,
         "exhausted": 0,
         "attempts_recorded": attempts_recorded,
     }
+
+
+def deliver_portfolio_risk_notifications(
+    *,
+    config_path: Path,
+    dsn: str,
+    execute: bool = False,
+    environment: Mapping[str, str] | None = None,
+    reader: CandidateReader | None = None,
+    attempt_writer: AttemptWriter | None = None,
+    transport: Transport | None = None,
+    lock_factory: DeliveryLockFactory | None = None,
+) -> dict[str, Any]:
+    config = load_webhook_delivery_config(config_path)
+    selected_environment = environment if environment is not None else os.environ
+    raw_endpoint = selected_environment.get(config.endpoint_env)
+    endpoint_host: str | None = None
+    endpoint_value: str | None = None
+    if raw_endpoint:
+        endpoint_value, endpoint_host = _endpoint(raw_endpoint)
+    if execute:
+        if not config.enabled:
+            raise ValidationError(
+                "webhook delivery is disabled in reviewed configuration"
+            )
+        if endpoint_value is None or endpoint_host is None:
+            raise ValidationError(
+                f"webhook endpoint environment variable {config.endpoint_env} is not set"
+            )
+
+    selected_reader = reader or read_pending_delivery_candidates
+    if not execute:
+        candidates = _read_and_validate_candidates(
+            reader=selected_reader,
+            dsn=dsn,
+            max_events=config.max_batch_events,
+        )
+        return _delivery_summary(
+            config=config,
+            endpoint_host=endpoint_host,
+            candidates=candidates,
+            execute=False,
+        )
+
+    if endpoint_value is None or endpoint_host is None:
+        raise ValidationError("webhook endpoint was not resolved for execution")
+    selected_writer = attempt_writer or (
+        lambda attempt: write_delivery_attempt(attempt, dsn=dsn)
+    )
+    selected_transport = transport or _default_transport
+    selected_lock_factory = lock_factory or acquire_notification_delivery_lock
+
+    with selected_lock_factory(dsn=dsn) as lock_evidence:
+        candidates = _read_and_validate_candidates(
+            reader=selected_reader,
+            dsn=dsn,
+            max_events=config.max_batch_events,
+        )
+        summary = _delivery_summary(
+            config=config,
+            endpoint_host=endpoint_host,
+            candidates=candidates,
+            execute=True,
+            lock_evidence=lock_evidence,
+        )
+        summary["execution"] = _execute_initial_attempts(
+            candidates=candidates,
+            endpoint=endpoint_value,
+            endpoint_host=endpoint_host,
+            config=config,
+            writer=selected_writer,
+            transport=selected_transport,
+        )
+
+    summary["concurrency_control"]["released"] = True
     return summary
 
 
@@ -543,6 +623,13 @@ def main(argv: Sequence[str] | None = None) -> int:
         )
         if args.summary_json is not None:
             _write_summary(args.summary_json, summary)
+    except OverlapError:
+        print(
+            "Webhook delivery rejected: another notification delivery execution "
+            "is already active",
+            file=sys.stderr,
+        )
+        return 1
     except ValidationError:
         print(
             "Webhook delivery failed: configuration, endpoint, candidate, or "
@@ -552,8 +639,8 @@ def main(argv: Sequence[str] | None = None) -> int:
         return 1
     except StorageError:
         print(
-            "Webhook delivery failed: PostgreSQL or attempt persistence failed; "
-            "remote receivers should deduplicate by Idempotency-Key",
+            "Webhook delivery failed: PostgreSQL, lock, or attempt persistence "
+            "failed; remote receivers should deduplicate by Idempotency-Key",
             file=sys.stderr,
         )
         return 1

--- a/src/orchestration/execute_portfolio_risk_notification_retries.py
+++ b/src/orchestration/execute_portfolio_risk_notification_retries.py
@@ -10,7 +10,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, cast
 
-from src.common.exceptions import StorageError, ValidationError
+from src.common.exceptions import OverlapError, StorageError, ValidationError
 from src.orchestration.deliver_portfolio_risk_notifications import (
     CHANNEL,
     MODEL_VERSION as DELIVERY_MODEL_VERSION,
@@ -27,6 +27,10 @@ from src.orchestration.plan_portfolio_risk_notification_retries import (
     CandidateReader,
     plan_portfolio_risk_notification_retries,
     read_notification_retry_candidates,
+)
+from src.orchestration.portfolio_risk_notification_delivery_lock import (
+    DeliveryLockFactory,
+    acquire_notification_delivery_lock,
 )
 from src.orchestration.portfolio_risk_notification_retry_execution_policy import (
     EXECUTION_MODEL_VERSION,
@@ -73,6 +77,7 @@ def execute_portfolio_risk_notification_retries(
     attempt_writer: AttemptWriter | None = None,
     transport: Transport | None = None,
     clock: Clock | None = None,
+    lock_factory: DeliveryLockFactory | None = None,
 ) -> dict[str, Any]:
     if execute is not True:
         raise ValidationError("explicit --execute is required for manual retry delivery")
@@ -127,181 +132,203 @@ def execute_portfolio_risk_notification_retries(
     endpoint, endpoint_host = _endpoint(raw_endpoint)
 
     selected_reader = reader or read_notification_retry_candidates
-    filters = cast(Mapping[str, Any], retained_plan["filters"])
-    candidates = selected_reader(
-        dsn=dsn,
-        planned_at=execution_time,
-        max_candidate_rows=retry_policy.max_candidate_rows,
-        policy_id=filters["policy_id"],
-        portfolio_id=filters["portfolio_id"],
-    )
-    if not isinstance(candidates, list):
-        raise StorageError("notification retry reader returned invalid evidence")
-    if len(candidates) > retry_policy.max_candidate_rows:
-        raise ValidationError("notification retry evidence exceeds max_candidate_rows")
-    current_plan = plan_portfolio_risk_notification_retries(
-        config_path=config_path,
-        dsn=dsn,
-        planned_at=execution_time,
-        policy_id=cast(str | None, filters["policy_id"]),
-        portfolio_id=cast(str | None, filters["portfolio_id"]),
-        reader=lambda **_: candidates,
-    )
-    assert_retry_plan_is_current(retained_plan, current_plan)
-
-    candidate_by_id = {
-        cast(str, candidate.get("event_id")): candidate for candidate in candidates
-    }
-    retained_events = cast(list[Mapping[str, Any]], retained_plan["events"])
-    event_by_id = {
-        cast(str, event["event_id"]): event for event in retained_events
-    }
-    expected_attempts: list[dict[str, Any]] = []
-    for event_id in retryable_event_ids:
-        event = event_by_id[event_id]
-        attempt_number = cast(int, event["attempt_count"]) + 1
-        if attempt_number > delivery_config.max_attempts_per_event:
-            raise ValidationError(
-                f"event {event_id} has no remaining delivery attempt capacity"
-            )
-        expected_attempts.append(
-            {
-                "attempt_id": _attempt_id(event_id, attempt_number),
-                "attempt_number": attempt_number,
-                "event_document_sha256": event["event_document_sha256"],
-                "event_id": event_id,
-            }
-        )
-    identity = {
-        "channel": CHANNEL,
-        "delivery_config_fingerprint": delivery_config.fingerprint,
-        "endpoint_host": endpoint_host,
-        "executed_at": execution_time.isoformat(),
-        "expected_attempts": expected_attempts,
-        "model_version": EXECUTION_MODEL_VERSION,
-        "plan_id": retained_plan["plan_id"],
-        "request_id": selected_request_id,
-        "retry_execution_policy_fingerprint": execution_policy.fingerprint,
-        "retry_policy_fingerprint": retry_policy.fingerprint,
-    }
-    execution_id = _execution_id(identity)
-
     selected_writer = attempt_writer or (
         lambda attempt: write_delivery_attempt(attempt, dsn=dsn)
     )
     selected_transport = transport or _default_transport
-    outcomes: list[dict[str, Any]] = []
-    for expected in expected_attempts:
-        event_id = cast(str, expected["event_id"])
-        candidate = candidate_by_id.get(event_id)
-        if candidate is None:
-            raise ValidationError(f"current candidate evidence is missing {event_id}")
-        payload = _canonical_payload(candidate)
-        payload_sha256 = hashlib.sha256(payload).hexdigest()
-        attempted_at = _clock_utc(selected_clock, "attempted_at")
-        if attempted_at < execution_time:
-            raise ValidationError("attempted_at must not precede execution start")
-        outcome = "failed"
-        http_status: int | None = None
-        error_code: str | None = None
-        try:
-            response_status = selected_transport(
-                endpoint,
-                payload,
-                {
-                    "Content-Type": "application/json",
-                    "Idempotency-Key": event_id,
-                    "User-Agent": "financial-risk-data-platform/1",
-                },
-                float(delivery_config.timeout_seconds),
-            )
-            if type(response_status) is not int or not 100 <= response_status <= 599:
-                raise ValidationError("webhook transport returned an invalid HTTP status")
-            http_status = response_status
-            if 200 <= response_status <= 299:
-                outcome = "succeeded"
-            else:
-                error_code = f"http_{response_status}"
-        except DeliveryTransportError as exc:
-            bounded_code = str(exc)
-            error_code = (
-                bounded_code
-                if bounded_code in retry_policy.retryable_error_codes
-                else "network_error"
-            )
-        attempt = {
-            "attempt_id": expected["attempt_id"],
-            "model_version": DELIVERY_MODEL_VERSION,
-            "event_id": event_id,
-            "channel": CHANNEL,
-            "attempt_number": expected["attempt_number"],
-            "idempotency_key": event_id,
-            "attempted_at": attempted_at,
-            "outcome": outcome,
-            "http_status": http_status,
-            "error_code": error_code,
-            "endpoint_host": endpoint_host,
-            "payload_sha256": payload_sha256,
-        }
-        selected_writer(attempt)
-        outcomes.append(
-            {
-                "attempt_id": attempt["attempt_id"],
-                "attempt_number": attempt["attempt_number"],
-                "attempted_at": attempted_at.isoformat(),
-                "error_code": error_code,
-                "event_id": event_id,
-                "http_status": http_status,
-                "outcome": outcome,
-                "payload_sha256": payload_sha256,
-            }
-        )
+    selected_lock_factory = lock_factory or acquire_notification_delivery_lock
+    filters = cast(Mapping[str, Any], retained_plan["filters"])
 
-    succeeded = sum(outcome["outcome"] == "succeeded" for outcome in outcomes)
-    failed = len(outcomes) - succeeded
-    return {
-        "execution_id": execution_id,
-        "model_version": EXECUTION_MODEL_VERSION,
-        "request_id": selected_request_id,
-        "plan_id": retained_plan["plan_id"],
-        "executed_at": execution_time.isoformat(),
-        "channel": CHANNEL,
-        "endpoint": {
-            "host": endpoint_host,
-            "full_url_recorded": False,
-        },
-        "configuration": {
-            "delivery_fingerprint": delivery_config.fingerprint,
+    with selected_lock_factory(dsn=dsn) as lock_evidence:
+        candidates = selected_reader(
+            dsn=dsn,
+            planned_at=execution_time,
+            max_candidate_rows=retry_policy.max_candidate_rows,
+            policy_id=filters["policy_id"],
+            portfolio_id=filters["portfolio_id"],
+        )
+        if not isinstance(candidates, list):
+            raise StorageError("notification retry reader returned invalid evidence")
+        if len(candidates) > retry_policy.max_candidate_rows:
+            raise ValidationError("notification retry evidence exceeds max_candidate_rows")
+        current_plan = plan_portfolio_risk_notification_retries(
+            config_path=config_path,
+            dsn=dsn,
+            planned_at=execution_time,
+            policy_id=cast(str | None, filters["policy_id"]),
+            portfolio_id=cast(str | None, filters["portfolio_id"]),
+            reader=lambda **_: candidates,
+        )
+        assert_retry_plan_is_current(retained_plan, current_plan)
+
+        candidate_by_id = {
+            cast(str, candidate.get("event_id")): candidate for candidate in candidates
+        }
+        retained_events = cast(list[Mapping[str, Any]], retained_plan["events"])
+        event_by_id = {
+            cast(str, event["event_id"]): event for event in retained_events
+        }
+        expected_attempts: list[dict[str, Any]] = []
+        for event_id in retryable_event_ids:
+            event = event_by_id[event_id]
+            attempt_number = cast(int, event["attempt_count"]) + 1
+            if attempt_number > delivery_config.max_attempts_per_event:
+                raise ValidationError(
+                    f"event {event_id} has no remaining delivery attempt capacity"
+                )
+            expected_attempts.append(
+                {
+                    "attempt_id": _attempt_id(event_id, attempt_number),
+                    "attempt_number": attempt_number,
+                    "event_document_sha256": event["event_document_sha256"],
+                    "event_id": event_id,
+                }
+            )
+        identity = {
+            "channel": CHANNEL,
+            "delivery_config_fingerprint": delivery_config.fingerprint,
+            "delivery_lock_key_fingerprint": lock_evidence["key_fingerprint"],
+            "delivery_lock_model_version": lock_evidence["model_version"],
+            "endpoint_host": endpoint_host,
+            "executed_at": execution_time.isoformat(),
+            "expected_attempts": expected_attempts,
+            "model_version": EXECUTION_MODEL_VERSION,
+            "plan_id": retained_plan["plan_id"],
+            "request_id": selected_request_id,
             "retry_execution_policy_fingerprint": execution_policy.fingerprint,
             "retry_policy_fingerprint": retry_policy.fingerprint,
-        },
-        "revalidation": {
-            "performed": True,
-            "current_plan_id": current_plan["plan_id"],
-            "events_checked": len(cast(list[Any], retained_plan["events"])),
-            "exact_event_evidence_unchanged": True,
-        },
-        "selection": {
-            "planned_retryable_events": len(retryable_event_ids),
-            "executed_events": len(outcomes),
-            "max_events": execution_policy.max_events,
-        },
-        "outcomes": outcomes,
-        "outcome_counts": {
-            "succeeded": succeeded,
-            "failed": failed,
-        },
-        "execution": {
-            "requested": True,
-            "performed": True,
-            "external_requests_performed": len(outcomes),
-            "delivery_attempts_written": len(outcomes),
-        },
-        "response_bodies_recorded": False,
-        "plan_mutated": False,
-        "acknowledgement_mutated": False,
-        "dead_letter_mutated": False,
-    }
+        }
+        execution_id = _execution_id(identity)
+
+        outcomes: list[dict[str, Any]] = []
+        for expected in expected_attempts:
+            event_id = cast(str, expected["event_id"])
+            candidate = candidate_by_id.get(event_id)
+            if candidate is None:
+                raise ValidationError(
+                    f"current candidate evidence is missing {event_id}"
+                )
+            payload = _canonical_payload(candidate)
+            payload_sha256 = hashlib.sha256(payload).hexdigest()
+            attempted_at = _clock_utc(selected_clock, "attempted_at")
+            if attempted_at < execution_time:
+                raise ValidationError("attempted_at must not precede execution start")
+            outcome = "failed"
+            http_status: int | None = None
+            error_code: str | None = None
+            try:
+                response_status = selected_transport(
+                    endpoint,
+                    payload,
+                    {
+                        "Content-Type": "application/json",
+                        "Idempotency-Key": event_id,
+                        "User-Agent": "financial-risk-data-platform/1",
+                    },
+                    float(delivery_config.timeout_seconds),
+                )
+                if type(response_status) is not int or not 100 <= response_status <= 599:
+                    raise ValidationError(
+                        "webhook transport returned an invalid HTTP status"
+                    )
+                http_status = response_status
+                if 200 <= response_status <= 299:
+                    outcome = "succeeded"
+                else:
+                    error_code = f"http_{response_status}"
+            except DeliveryTransportError as exc:
+                bounded_code = str(exc)
+                error_code = (
+                    bounded_code
+                    if bounded_code in retry_policy.retryable_error_codes
+                    else "network_error"
+                )
+            attempt = {
+                "attempt_id": expected["attempt_id"],
+                "model_version": DELIVERY_MODEL_VERSION,
+                "event_id": event_id,
+                "channel": CHANNEL,
+                "attempt_number": expected["attempt_number"],
+                "idempotency_key": event_id,
+                "attempted_at": attempted_at,
+                "outcome": outcome,
+                "http_status": http_status,
+                "error_code": error_code,
+                "endpoint_host": endpoint_host,
+                "payload_sha256": payload_sha256,
+            }
+            selected_writer(attempt)
+            outcomes.append(
+                {
+                    "attempt_id": attempt["attempt_id"],
+                    "attempt_number": attempt["attempt_number"],
+                    "attempted_at": attempted_at.isoformat(),
+                    "error_code": error_code,
+                    "event_id": event_id,
+                    "http_status": http_status,
+                    "outcome": outcome,
+                    "payload_sha256": payload_sha256,
+                }
+            )
+
+        succeeded = sum(outcome["outcome"] == "succeeded" for outcome in outcomes)
+        failed = len(outcomes) - succeeded
+        summary = {
+            "execution_id": execution_id,
+            "model_version": EXECUTION_MODEL_VERSION,
+            "request_id": selected_request_id,
+            "plan_id": retained_plan["plan_id"],
+            "executed_at": execution_time.isoformat(),
+            "channel": CHANNEL,
+            "endpoint": {
+                "host": endpoint_host,
+                "full_url_recorded": False,
+            },
+            "configuration": {
+                "delivery_fingerprint": delivery_config.fingerprint,
+                "retry_execution_policy_fingerprint": execution_policy.fingerprint,
+                "retry_policy_fingerprint": retry_policy.fingerprint,
+            },
+            "revalidation": {
+                "performed": True,
+                "current_plan_id": current_plan["plan_id"],
+                "events_checked": len(cast(list[Any], retained_plan["events"])),
+                "exact_event_evidence_unchanged": True,
+            },
+            "selection": {
+                "planned_retryable_events": len(retryable_event_ids),
+                "executed_events": len(outcomes),
+                "max_events": execution_policy.max_events,
+            },
+            "outcomes": outcomes,
+            "outcome_counts": {
+                "succeeded": succeeded,
+                "failed": failed,
+            },
+            "execution": {
+                "requested": True,
+                "performed": True,
+                "external_requests_performed": len(outcomes),
+                "delivery_attempts_written": len(outcomes),
+            },
+            "concurrency_control": {
+                "performed": True,
+                "acquired": True,
+                "released": False,
+                "held_through_revalidation": True,
+                "held_through_attempt_persistence": True,
+                "model_version": lock_evidence["model_version"],
+                "scope": lock_evidence["scope"],
+                "key_fingerprint": lock_evidence["key_fingerprint"],
+            },
+            "response_bodies_recorded": False,
+            "plan_mutated": False,
+            "acknowledgement_mutated": False,
+            "dead_letter_mutated": False,
+        }
+
+    summary["concurrency_control"]["released"] = True
+    return summary
 
 
 def _write_summary(path: Path, summary: Mapping[str, Any]) -> None:
@@ -357,13 +384,21 @@ def main(argv: Sequence[str] | None = None) -> int:
         )
         if args.summary_json is not None:
             _write_summary(args.summary_json, summary)
+    except OverlapError:
+        print(
+            "Manual notification retry rejected: another notification delivery "
+            "execution is already active",
+            file=sys.stderr,
+        )
+        return 1
     except ValidationError as exc:
         print(f"Manual notification retry rejected: {exc}", file=sys.stderr)
         return 1
     except StorageError:
         print(
-            "Manual notification retry failed: PostgreSQL or attempt persistence "
-            "failed; remote receivers must deduplicate by Idempotency-Key",
+            "Manual notification retry failed: PostgreSQL, lock, or attempt "
+            "persistence failed; remote receivers must deduplicate by "
+            "Idempotency-Key",
             file=sys.stderr,
         )
         return 1

--- a/src/orchestration/portfolio_risk_notification_delivery_lock.py
+++ b/src/orchestration/portfolio_risk_notification_delivery_lock.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+import hashlib
+from collections.abc import Callable, Iterator, Mapping, Sequence
+from contextlib import AbstractContextManager, contextmanager
+from typing import Any
+
+from src.common.exceptions import OverlapError, StorageError, ValidationError
+
+LOCK_MODEL_VERSION = "portfolio-risk-notification-delivery-lock-v1"
+LOCK_SCOPE = "portfolio-risk-notification-delivery"
+
+ConnectionFactory = Callable[[str], Any]
+DeliveryLockFactory = Callable[..., AbstractContextManager[Mapping[str, Any]]]
+
+
+def _signed_advisory_key(value: str) -> int:
+    digest = hashlib.sha256(value.encode("utf-8")).digest()
+    unsigned = int.from_bytes(digest[:8], byteorder="big", signed=False)
+    return unsigned if unsigned < 2**63 else unsigned - 2**64
+
+
+LOCK_KEY = _signed_advisory_key(f"{LOCK_MODEL_VERSION}:{LOCK_SCOPE}")
+LOCK_KEY_FINGERPRINT = hashlib.sha256(str(LOCK_KEY).encode("ascii")).hexdigest()[:24]
+
+
+def _default_connection_factory(dsn: str) -> Any:
+    try:
+        import psycopg
+    except ImportError as exc:
+        raise RuntimeError(
+            "PostgreSQL notification locking requires psycopg. Run `make setup` first."
+        ) from exc
+    return psycopg.connect(dsn, autocommit=True)
+
+
+def _boolean_result(row: Any, label: str) -> bool:
+    if (
+        not isinstance(row, Sequence)
+        or isinstance(row, (str, bytes, bytearray))
+        or len(row) != 1
+        or type(row[0]) is not bool
+    ):
+        raise StorageError(f"PostgreSQL returned invalid {label} evidence")
+    return bool(row[0])
+
+
+def _close_quietly(connection: Any) -> None:
+    try:
+        connection.close()
+    except Exception:
+        pass
+
+
+@contextmanager
+def acquire_notification_delivery_lock(
+    *,
+    dsn: str,
+    connection_factory: ConnectionFactory | None = None,
+) -> Iterator[Mapping[str, Any]]:
+    """Hold one repository-wide delivery lock across evidence reads and writes.
+
+    The lock is session-scoped, non-blocking and shared by initial delivery and
+    governed retry execution. Closing the PostgreSQL connection also releases the
+    lock, including after local process failure.
+    """
+
+    if not isinstance(dsn, str) or not dsn.strip():
+        raise ValidationError("PostgreSQL DSN must be non-empty text")
+    selected_factory = connection_factory or _default_connection_factory
+    try:
+        connection = selected_factory(dsn)
+    except Exception:
+        raise StorageError("Unable to open the notification delivery lock session") from None
+
+    try:
+        with connection.cursor() as cursor:
+            cursor.execute("SELECT pg_try_advisory_lock(%s)", [LOCK_KEY])
+            acquired = _boolean_result(cursor.fetchone(), "delivery lock acquisition")
+    except StorageError:
+        _close_quietly(connection)
+        raise
+    except Exception:
+        _close_quietly(connection)
+        raise StorageError("Unable to acquire the notification delivery lock") from None
+
+    if not acquired:
+        _close_quietly(connection)
+        raise OverlapError(
+            "Another notification delivery execution already holds the global lock"
+        )
+
+    evidence = {
+        "model_version": LOCK_MODEL_VERSION,
+        "scope": LOCK_SCOPE,
+        "key_fingerprint": LOCK_KEY_FINGERPRINT,
+        "acquired": True,
+    }
+    body_failed = False
+    release_failed = False
+    try:
+        yield evidence
+    except BaseException:
+        body_failed = True
+        raise
+    finally:
+        try:
+            with connection.cursor() as cursor:
+                cursor.execute("SELECT pg_advisory_unlock(%s)", [LOCK_KEY])
+                released = _boolean_result(
+                    cursor.fetchone(),
+                    "delivery lock release",
+                )
+                if not released:
+                    release_failed = True
+        except Exception:
+            release_failed = True
+        try:
+            connection.close()
+        except Exception:
+            release_failed = True
+        if release_failed and not body_failed:
+            raise StorageError("Unable to release the notification delivery lock")

--- a/src/warehouse/notification_delivery_lock_contract_check.py
+++ b/src/warehouse/notification_delivery_lock_contract_check.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+from src.common.exceptions import OverlapError, StorageError, ValidationError
+from src.orchestration.portfolio_risk_notification_delivery_lock import (
+    LOCK_KEY_FINGERPRINT,
+    LOCK_MODEL_VERSION,
+    LOCK_SCOPE,
+    acquire_notification_delivery_lock,
+)
+from src.warehouse.postgres_loader import DEFAULT_POSTGRES_DSN
+
+
+def run_contract_check(dsn: str) -> dict[str, Any]:
+    contender_rejected = False
+    with acquire_notification_delivery_lock(dsn=dsn) as first:
+        try:
+            with acquire_notification_delivery_lock(dsn=dsn):
+                raise AssertionError("contending lock unexpectedly entered its body")
+        except OverlapError:
+            contender_rejected = True
+
+    if not contender_rejected:
+        raise AssertionError("contending delivery lock was not rejected")
+
+    with acquire_notification_delivery_lock(dsn=dsn) as second:
+        if dict(second) != dict(first):
+            raise AssertionError("delivery lock identity changed after release")
+
+    summary = {
+        "model_version": LOCK_MODEL_VERSION,
+        "scope": LOCK_SCOPE,
+        "key_fingerprint": LOCK_KEY_FINGERPRINT,
+        "first_lock_acquired": True,
+        "contender_rejected": True,
+        "lock_reacquired_after_release": True,
+        "external_request_performed": False,
+        "delivery_attempt_written": False,
+    }
+    if not _summary_is_secret_safe(summary):
+        raise AssertionError("notification delivery lock summary is not secret-safe")
+    return summary
+
+
+def _summary_is_secret_safe(summary: Mapping[str, Any]) -> bool:
+    rendered = json.dumps(summary, sort_keys=True, allow_nan=False)
+    forbidden = ("postgresql://", "password", "secret", "dsn")
+    return not any(value in rendered.casefold() for value in forbidden)
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Exercise real PostgreSQL contention and release for the global "
+            "portfolio risk notification delivery lock."
+        )
+    )
+    parser.add_argument(
+        "--dsn",
+        default=os.environ.get("WAREHOUSE_POSTGRES_DSN", DEFAULT_POSTGRES_DSN),
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    try:
+        summary = run_contract_check(args.dsn)
+    except (ValidationError, StorageError, AssertionError) as exc:
+        print(f"Notification delivery lock contract failed: {exc}", file=sys.stderr)
+        return 1
+    except Exception:
+        print(
+            "Notification delivery lock contract failed: unexpected local failure",
+            file=sys.stderr,
+        )
+        return 1
+    print(json.dumps(summary, sort_keys=True, allow_nan=False))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/test_portfolio_risk_notification_delivery_lock.py
+++ b/tests/unit/test_portfolio_risk_notification_delivery_lock.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from src.common.exceptions import OverlapError, StorageError, ValidationError
+from src.orchestration.portfolio_risk_notification_delivery_lock import (
+    LOCK_KEY,
+    LOCK_KEY_FINGERPRINT,
+    LOCK_MODEL_VERSION,
+    LOCK_SCOPE,
+    acquire_notification_delivery_lock,
+)
+
+
+class _Cursor:
+    def __init__(self, responses: list[tuple[bool]]) -> None:
+        self.responses = responses
+        self.statements: list[tuple[str, list[int]]] = []
+
+    def __enter__(self) -> _Cursor:
+        return self
+
+    def __exit__(self, *_: Any) -> None:
+        return None
+
+    def execute(self, statement: str, parameters: list[int]) -> None:
+        self.statements.append((statement, parameters))
+
+    def fetchone(self) -> tuple[bool]:
+        return self.responses.pop(0)
+
+
+class _Connection:
+    def __init__(self, responses: list[tuple[bool]]) -> None:
+        self.cursor_instance = _Cursor(responses)
+        self.closed = False
+
+    def cursor(self) -> _Cursor:
+        return self.cursor_instance
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def test_delivery_lock_identity_is_stable_and_postgres_safe() -> None:
+    assert -(2**63) <= LOCK_KEY < 2**63
+    assert len(LOCK_KEY_FINGERPRINT) == 24
+    assert LOCK_MODEL_VERSION == "portfolio-risk-notification-delivery-lock-v1"
+    assert LOCK_SCOPE == "portfolio-risk-notification-delivery"
+
+
+def test_delivery_lock_is_acquired_and_released_on_one_session() -> None:
+    connection = _Connection([(True,), (True,)])
+
+    with acquire_notification_delivery_lock(
+        dsn="postgresql://secret-value",
+        connection_factory=lambda _: connection,
+    ) as evidence:
+        assert connection.closed is False
+        assert evidence == {
+            "model_version": LOCK_MODEL_VERSION,
+            "scope": LOCK_SCOPE,
+            "key_fingerprint": LOCK_KEY_FINGERPRINT,
+            "acquired": True,
+        }
+
+    assert connection.closed is True
+    assert connection.cursor_instance.statements == [
+        ("SELECT pg_try_advisory_lock(%s)", [LOCK_KEY]),
+        ("SELECT pg_advisory_unlock(%s)", [LOCK_KEY]),
+    ]
+
+
+def test_held_delivery_lock_fails_closed_without_waiting() -> None:
+    connection = _Connection([(False,)])
+
+    with pytest.raises(OverlapError, match="already holds"):
+        with acquire_notification_delivery_lock(
+            dsn="postgresql://secret-value",
+            connection_factory=lambda _: connection,
+        ):
+            raise AssertionError("lock body must not run")
+
+    assert connection.closed is True
+    assert connection.cursor_instance.statements == [
+        ("SELECT pg_try_advisory_lock(%s)", [LOCK_KEY])
+    ]
+
+
+def test_release_failure_is_reported_after_successful_body() -> None:
+    connection = _Connection([(True,), (False,)])
+
+    with pytest.raises(StorageError, match="release"):
+        with acquire_notification_delivery_lock(
+            dsn="postgresql://secret-value",
+            connection_factory=lambda _: connection,
+        ):
+            pass
+
+    assert connection.closed is True
+
+
+def test_body_failure_is_preserved_while_connection_close_releases_lock() -> None:
+    connection = _Connection([(True,), (False,)])
+
+    with pytest.raises(RuntimeError, match="body failed"):
+        with acquire_notification_delivery_lock(
+            dsn="postgresql://secret-value",
+            connection_factory=lambda _: connection,
+        ):
+            raise RuntimeError("body failed")
+
+    assert connection.closed is True
+
+
+def test_invalid_dsn_fails_before_connection_creation() -> None:
+    calls: list[str] = []
+
+    with pytest.raises(ValidationError, match="DSN"):
+        with acquire_notification_delivery_lock(
+            dsn="",
+            connection_factory=lambda dsn: calls.append(dsn),
+        ):
+            pass
+
+    assert calls == []

--- a/tests/unit/test_portfolio_risk_notification_delivery_lock_architecture_contract.py
+++ b/tests/unit/test_portfolio_risk_notification_delivery_lock_architecture_contract.py
@@ -5,12 +5,16 @@ def test_notification_delivery_is_serialized_before_evidence_and_network_io() ->
     lock_source = Path(
         "src/orchestration/portfolio_risk_notification_delivery_lock.py"
     ).read_text(encoding="utf-8")
+    contract_source = Path(
+        "src/warehouse/notification_delivery_lock_contract_check.py"
+    ).read_text(encoding="utf-8")
     initial_source = Path(
         "src/orchestration/deliver_portfolio_risk_notifications.py"
     ).read_text(encoding="utf-8")
     retry_source = Path(
         "src/orchestration/execute_portfolio_risk_notification_retries.py"
     ).read_text(encoding="utf-8")
+    makefile = Path("Makefile").read_text(encoding="utf-8")
     docs = Path(
         "docs/portfolio-risk-notification-delivery-locking.md"
     ).read_text(encoding="utf-8")
@@ -58,6 +62,21 @@ def test_notification_delivery_is_serialized_before_evidence_and_network_io() ->
     assert "held_through_revalidation" in retry_source
 
     for required in (
+        "contender_rejected",
+        "lock_reacquired_after_release",
+        "with acquire_notification_delivery_lock(dsn=dsn) as first",
+        "with acquire_notification_delivery_lock(dsn=dsn) as second",
+        "external_request_performed",
+        "delivery_attempt_written",
+    ):
+        assert required in contract_source
+    assert "src.warehouse.notification_delivery_lock_contract_check" in makefile
+    assert makefile.index("notification_delivery_lock_contract_check") < makefile.index(
+        "postgres_consistency",
+        makefile.index("postgres-contract-check:"),
+    )
+
+    for required in (
         "# PostgreSQL Notification Delivery Concurrency Control",
         "Primary arc42 block: `orchestration`",
         "non-blocking",
@@ -65,6 +84,7 @@ def test_notification_delivery_is_serialized_before_evidence_and_network_io() ->
         "before current-evidence revalidation",
         "held through current-evidence revalidation and attempt persistence",
         "stable notification `Idempotency-Key`",
+        "PostgreSQL 16 contention contract",
         "performs no webhook request",
         "terraform apply",
     ):

--- a/tests/unit/test_portfolio_risk_notification_delivery_lock_architecture_contract.py
+++ b/tests/unit/test_portfolio_risk_notification_delivery_lock_architecture_contract.py
@@ -1,0 +1,71 @@
+from pathlib import Path
+
+
+def test_notification_delivery_is_serialized_before_evidence_and_network_io() -> None:
+    lock_source = Path(
+        "src/orchestration/portfolio_risk_notification_delivery_lock.py"
+    ).read_text(encoding="utf-8")
+    initial_source = Path(
+        "src/orchestration/deliver_portfolio_risk_notifications.py"
+    ).read_text(encoding="utf-8")
+    retry_source = Path(
+        "src/orchestration/execute_portfolio_risk_notification_retries.py"
+    ).read_text(encoding="utf-8")
+    docs = Path(
+        "docs/portfolio-risk-notification-delivery-locking.md"
+    ).read_text(encoding="utf-8")
+    normalized_docs = " ".join(docs.split()).casefold()
+
+    for required in (
+        "portfolio-risk-notification-delivery-lock-v1",
+        "pg_try_advisory_lock",
+        "pg_advisory_unlock",
+        "Another notification delivery execution already holds the global lock",
+        "key_fingerprint",
+    ):
+        assert required in lock_source
+    assert "SELECT pg_advisory_lock" not in lock_source
+
+    for source in (initial_source, retry_source):
+        for required in (
+            "DeliveryLockFactory",
+            "acquire_notification_delivery_lock",
+            "with selected_lock_factory(dsn=dsn)",
+            "held_through_attempt_persistence",
+            "concurrency_control",
+        ):
+            assert required in source
+
+    initial_lock = initial_source.index("with selected_lock_factory(dsn=dsn)")
+    initial_read = initial_source.index(
+        "candidates = _read_and_validate_candidates",
+        initial_lock,
+    )
+    initial_send = initial_source.index(
+        "summary[\"execution\"] = _execute_initial_attempts",
+        initial_lock,
+    )
+    assert initial_lock < initial_read < initial_send
+
+    retry_lock = retry_source.index("with selected_lock_factory(dsn=dsn)")
+    retry_read = retry_source.index("candidates = selected_reader", retry_lock)
+    retry_revalidation = retry_source.index(
+        "assert_retry_plan_is_current",
+        retry_read,
+    )
+    retry_send = retry_source.index("response_status = selected_transport", retry_lock)
+    assert retry_lock < retry_read < retry_revalidation < retry_send
+    assert "held_through_revalidation" in retry_source
+
+    for required in (
+        "# PostgreSQL Notification Delivery Concurrency Control",
+        "Primary arc42 block: `orchestration`",
+        "non-blocking",
+        "before candidate selection",
+        "before current-evidence revalidation",
+        "held through current-evidence revalidation and attempt persistence",
+        "stable notification `Idempotency-Key`",
+        "performs no webhook request",
+        "terraform apply",
+    ):
+        assert required.casefold() in normalized_docs

--- a/tests/unit/test_portfolio_risk_notification_retry_execution.py
+++ b/tests/unit/test_portfolio_risk_notification_retry_execution.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import json
+from collections.abc import Iterator, Mapping
+from contextlib import contextmanager
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
@@ -8,7 +10,7 @@ from typing import Any
 import pytest
 import yaml
 
-from src.common.exceptions import StorageError, ValidationError
+from src.common.exceptions import OverlapError, StorageError, ValidationError
 from src.orchestration.deliver_portfolio_risk_notifications import (
     DeliveryTransportError,
 )
@@ -18,6 +20,11 @@ from src.orchestration.execute_portfolio_risk_notification_retries import (
 )
 from src.orchestration.plan_portfolio_risk_notification_retries import (
     plan_portfolio_risk_notification_retries,
+)
+from src.orchestration.portfolio_risk_notification_delivery_lock import (
+    LOCK_KEY_FINGERPRINT,
+    LOCK_MODEL_VERSION,
+    LOCK_SCOPE,
 )
 from src.orchestration.portfolio_risk_notification_retry_execution_policy import (
     load_retry_execution_contract,
@@ -147,6 +154,16 @@ def _write_plan(
     return path, plan
 
 
+@contextmanager
+def _delivery_lock(**_: Any) -> Iterator[Mapping[str, Any]]:
+    yield {
+        "model_version": LOCK_MODEL_VERSION,
+        "scope": LOCK_SCOPE,
+        "key_fingerprint": LOCK_KEY_FINGERPRINT,
+        "acquired": True,
+    }
+
+
 def _execute(
     *,
     plan_path: Path,
@@ -167,6 +184,7 @@ def _execute(
         "attempt_writer": lambda _: None,
         "transport": lambda *_: 204,
         "clock": lambda: EXECUTED_AT,
+        "lock_factory": _delivery_lock,
     }
     parameters.update(kwargs)
     return execute_portfolio_risk_notification_retries(**parameters)
@@ -259,6 +277,33 @@ def test_execution_uses_clock_time_for_current_evidence_read(tmp_path: Path) -> 
     assert as_of_values == [EXECUTED_AT]
 
 
+def test_held_lock_rejects_before_current_evidence_or_transport(tmp_path: Path) -> None:
+    config_path = _write_config(tmp_path)
+    candidates = [_candidate()]
+    plan_path, plan = _write_plan(tmp_path, config_path, candidates)
+    reads: list[bool] = []
+    sends: list[bool] = []
+
+    @contextmanager
+    def held_lock(**_: Any) -> Iterator[Mapping[str, Any]]:
+        raise OverlapError("already holds")
+        yield {}
+
+    with pytest.raises(OverlapError, match="already holds"):
+        _execute(
+            plan_path=plan_path,
+            plan=plan,
+            config_path=config_path,
+            candidates=candidates,
+            reader=lambda **_: reads.append(True) or candidates,
+            transport=lambda *_: sends.append(True) or 204,
+            lock_factory=held_lock,
+        )
+
+    assert reads == []
+    assert sends == []
+
+
 def test_plan_can_be_reviewed_before_enabling_separate_execution_gate(
     tmp_path: Path,
 ) -> None:
@@ -335,6 +380,16 @@ def test_exact_plan_executes_one_attempt_per_event_with_stable_identity(
         "delivery_attempts_written": 2,
     }
     assert summary["revalidation"]["exact_event_evidence_unchanged"] is True
+    assert summary["concurrency_control"] == {
+        "performed": True,
+        "acquired": True,
+        "released": True,
+        "held_through_revalidation": True,
+        "held_through_attempt_persistence": True,
+        "model_version": LOCK_MODEL_VERSION,
+        "scope": LOCK_SCOPE,
+        "key_fingerprint": LOCK_KEY_FINGERPRINT,
+    }
     assert summary["plan_mutated"] is False
     assert summary["acknowledgement_mutated"] is False
     assert summary["dead_letter_mutated"] is False

--- a/tests/unit/test_portfolio_risk_notification_retry_execution_architecture_contract.py
+++ b/tests/unit/test_portfolio_risk_notification_retry_execution_architecture_contract.py
@@ -34,6 +34,8 @@ def test_manual_retry_execution_is_exact_disabled_and_one_attempt_only() -> None
         "execution_started_at",
         "assert_retry_plan_is_current",
         "Idempotency-Key",
+        "acquire_notification_delivery_lock",
+        "held_through_revalidation",
         "response_bodies_recorded",
         "plan_mutated",
         "acknowledgement_mutated",
@@ -53,6 +55,7 @@ def test_manual_retry_execution_is_exact_disabled_and_one_attempt_only() -> None
         "events with existing delivery attempts require an exact retry plan",
         "initial_attempts_only",
         "environment if environment is not None else os.environ",
+        "acquire_notification_delivery_lock",
     ):
         assert required in delivery_source
     assert "time_module.sleep" not in delivery_source
@@ -86,7 +89,7 @@ def test_manual_retry_execution_is_exact_disabled_and_one_attempt_only() -> None
         "one new attempt",
         "no internal retry loop",
         "stable `Idempotency-Key`",
-        "fake readers, transports, clocks and attempt writers",
+        "fake readers, transports, clocks, attempt writers and delivery locks",
         "performs no external delivery",
         "does not",
         "terraform apply",

--- a/tests/unit/test_portfolio_risk_webhook_delivery.py
+++ b/tests/unit/test_portfolio_risk_webhook_delivery.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import json
+from collections.abc import Iterator, Mapping
+from contextlib import contextmanager
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -8,11 +10,16 @@ from typing import Any
 import pytest
 import yaml
 
-from src.common.exceptions import ValidationError
+from src.common.exceptions import OverlapError, ValidationError
 from src.orchestration.deliver_portfolio_risk_notifications import (
     DeliveryTransportError,
     deliver_portfolio_risk_notifications,
     parse_webhook_delivery_config,
+)
+from src.orchestration.portfolio_risk_notification_delivery_lock import (
+    LOCK_KEY_FINGERPRINT,
+    LOCK_MODEL_VERSION,
+    LOCK_SCOPE,
 )
 
 
@@ -62,6 +69,16 @@ def _candidate(*, attempts_so_far: int = 0) -> dict[str, Any]:
     }
 
 
+@contextmanager
+def _delivery_lock(**_: Any) -> Iterator[Mapping[str, Any]]:
+    yield {
+        "model_version": LOCK_MODEL_VERSION,
+        "scope": LOCK_SCOPE,
+        "key_fingerprint": LOCK_KEY_FINGERPRINT,
+        "acquired": True,
+    }
+
+
 def test_delivery_config_is_disabled_and_fingerprinted_deterministically() -> None:
     first = parse_webhook_delivery_config(_config_payload())
     second = parse_webhook_delivery_config(_config_payload())
@@ -70,11 +87,18 @@ def test_delivery_config_is_disabled_and_fingerprinted_deterministically() -> No
     assert first.fingerprint == second.fingerprint
 
 
-def test_plan_only_reads_initial_candidates_without_transport_or_attempt_writes(
+def test_plan_only_reads_initial_candidates_without_transport_attempt_or_lock(
     tmp_path: Path,
 ) -> None:
     transports: list[bytes] = []
     attempts: list[dict[str, Any]] = []
+    locks: list[bool] = []
+
+    @contextmanager
+    def lock(**_: Any) -> Iterator[Mapping[str, Any]]:
+        locks.append(True)
+        yield {}
+
     summary = deliver_portfolio_risk_notifications(
         config_path=_write_config(tmp_path, enabled=False),
         dsn="dsn",
@@ -85,13 +109,16 @@ def test_plan_only_reads_initial_candidates_without_transport_or_attempt_writes(
             transports.append(payload) or 204
         ),
         attempt_writer=lambda attempt: attempts.append(dict(attempt)),
+        lock_factory=lock,
     )
 
     assert transports == []
     assert attempts == []
+    assert locks == []
     assert summary["execution"]["performed"] is False
     assert summary["selection"]["initial_attempts_only"] is True
     assert summary["endpoint"] == {"configured": False, "host": None}
+    assert summary["concurrency_control"]["performed"] is False
     assert "dsn" not in json.dumps(summary)
 
 
@@ -114,8 +141,36 @@ def test_execute_requires_reviewed_enablement_before_reading_candidates(
                 "RISK_NOTIFICATION_WEBHOOK_URL": "https://alerts.example.test/risk"
             },
             reader=reader,
+            lock_factory=_delivery_lock,
         )
     assert reads == 0
+
+
+def test_held_lock_rejects_before_candidate_read_or_transport(tmp_path: Path) -> None:
+    reads: list[bool] = []
+    sends: list[bool] = []
+
+    @contextmanager
+    def held_lock(**_: Any) -> Iterator[Mapping[str, Any]]:
+        raise OverlapError("already holds")
+        yield {}
+
+    with pytest.raises(OverlapError, match="already holds"):
+        deliver_portfolio_risk_notifications(
+            config_path=_write_config(tmp_path, enabled=True),
+            dsn="dsn",
+            execute=True,
+            environment={
+                "RISK_NOTIFICATION_WEBHOOK_URL": "https://alerts.example.test/risk"
+            },
+            reader=lambda **_: reads.append(True) or [_candidate()],
+            attempt_writer=lambda _: None,
+            transport=lambda *_: sends.append(True) or 204,
+            lock_factory=held_lock,
+        )
+
+    assert reads == []
+    assert sends == []
 
 
 def test_initial_delivery_failure_records_one_attempt_without_hidden_retry(
@@ -150,6 +205,7 @@ def test_initial_delivery_failure_records_one_attempt_without_hidden_retry(
         reader=lambda **_: [_candidate()],
         attempt_writer=lambda attempt: attempts.append(dict(attempt)),
         transport=transport,
+        lock_factory=_delivery_lock,
     )
 
     assert len(calls) == 1
@@ -166,6 +222,15 @@ def test_initial_delivery_failure_records_one_attempt_without_hidden_retry(
         "failed": 1,
         "exhausted": 0,
         "attempts_recorded": 1,
+    }
+    assert summary["concurrency_control"] == {
+        "performed": True,
+        "acquired": True,
+        "released": True,
+        "held_through_attempt_persistence": True,
+        "model_version": LOCK_MODEL_VERSION,
+        "scope": LOCK_SCOPE,
+        "key_fingerprint": LOCK_KEY_FINGERPRINT,
     }
     assert "https://alerts.example.test/risk" not in json.dumps(summary)
     assert summary["endpoint"]["host"] == "alerts.example.test"
@@ -189,6 +254,7 @@ def test_network_failure_is_recorded_without_error_message_or_response_body(
         reader=lambda **_: [_candidate()],
         attempt_writer=lambda attempt: attempts.append(dict(attempt)),
         transport=transport,
+        lock_factory=_delivery_lock,
     )
 
     assert attempts[0]["error_code"] == "network_error"
@@ -220,6 +286,7 @@ def test_candidate_with_prior_attempt_requires_exact_retry_plan_before_transport
             reader=lambda **_: [_candidate(attempts_so_far=1)],
             attempt_writer=lambda attempt: attempts.append(dict(attempt)),
             transport=transport,
+            lock_factory=_delivery_lock,
         )
 
     assert calls == 0
@@ -240,6 +307,7 @@ def test_invalid_transport_status_fails_before_attempt_write(tmp_path: Path) -> 
             reader=lambda **_: [_candidate()],
             attempt_writer=lambda attempt: attempts.append(dict(attempt)),
             transport=lambda *_: 999,
+            lock_factory=_delivery_lock,
         )
     assert attempts == []
 
@@ -259,4 +327,5 @@ def test_endpoint_must_be_https_without_embedded_credentials(
                 execute=True,
                 environment={"RISK_NOTIFICATION_WEBHOOK_URL": endpoint},
                 reader=lambda **_: [_candidate()],
+                lock_factory=_delivery_lock,
             )


### PR DESCRIPTION
## Goal

Complete the first bounded **P4d operational-hardening slice** by preventing concurrent local notification senders from entering the delivery lane at the same time:

```text
explicit initial delivery or exact governed retry
  -> non-blocking PostgreSQL advisory lock
  -> candidate selection or exact current-evidence revalidation
  -> bounded HTTPS request
  -> append-only delivery-attempt persistence
  -> lock release
```

Primary arc42 block: `orchestration`, with PostgreSQL as the shared coordination boundary.

## Control model

The new `portfolio-risk-notification-delivery-lock-v1` derives one deterministic signed 64-bit advisory-lock key from the versioned global scope. Evidence exposes only a credential-free SHA-256 key fingerprint.

The global scope is intentionally conservative for this bounded operator-driven workflow. It serializes all notification attempts, not only attempts for the same event, so another operator cannot pass a stale candidate-selection or current-plan revalidation window concurrently.

Acquisition uses non-blocking `pg_try_advisory_lock`. When another session holds the key, execution fails immediately and performs no candidate read, current-plan rebuild, network request or attempt insert. The owning PostgreSQL session stays open for the complete protected operation. Normal completion explicitly calls `pg_advisory_unlock`; session close also releases the lock after local process failure.

## Initial-delivery ordering

`deliver_portfolio_risk_notifications` remains lock-free and side-effect-free in plan mode. Explicit execution now:

1. validates reviewed enablement and the HTTPS endpoint;
2. acquires the shared delivery lock;
3. selects current zero-attempt candidates;
4. validates the first-attempt-only contract;
5. sends one request and persists one append-only attempt per candidate; and
6. releases the lock.

Its execution summary records acquisition, release, lock model/scope/fingerprint and that the lock was held through attempt persistence.

## Governed-retry ordering

`execute_portfolio_risk_notification_retries` acquires the same lock before its bounded PostgreSQL evidence read. It holds the lock through:

- current event/attempt/acknowledgement selection;
- exact retained/current plan comparison;
- every remote request; and
- every append-only attempt insert.

The lock model version and key fingerprint are bound into the deterministic retry execution ID. Retry summaries additionally declare that the lock covered current-evidence revalidation.

## Live PostgreSQL contention evidence

`make postgres-contract-check` now runs a dedicated PostgreSQL 16 contract before the warehouse consistency suite. Using independent sessions it proves:

1. the first session acquires the deterministic key;
2. a second session is rejected while the first owns it;
3. no delivery attempt or external request occurs in the contract; and
4. the second session acquires successfully after release.

The emitted evidence was:

```json
{
  "first_lock_acquired": true,
  "contender_rejected": true,
  "lock_reacquired_after_release": true,
  "external_request_performed": false,
  "delivery_attempt_written": false
}
```

## Boundaries

- Committed webhook and retry-execution settings remain disabled.
- Ordinary CI uses fake transports and performs no webhook request.
- No endpoint secret, full URL, DSN, payload body or response body is retained.
- The stable notification `Idempotency-Key` remains required for the remote-success/local-persistence ambiguity.
- The lock is coordination, not authentication; code-running operators remain inside the local trust boundary.
- No schedule activation, infrastructure deployment, provider request, position mutation or `terraform apply` is included.

## Scope

The branch is directly based on current `main`, is **15 working commits ahead and zero behind**, and changes exactly **13 files** with **1,132 additions and 238 deletions**:

- one PostgreSQL advisory-lock module;
- one live PostgreSQL contention checker;
- both initial and governed delivery paths;
- the existing PostgreSQL contract target;
- focused unit and architecture tests; and
- aligned operator documentation.

No GitHub workflow or deployment definition changed. Connector-produced working commits are intended to squash into one coherent P4d concurrency-control increment.

## Validation

The first exact-head run passed all four jobs. Deeper review then added the real PostgreSQL contention contract, after which GitHub Actions run **333** (`32838059692`) passed on final exact head `c9a35fd60f750464cba7244043edfb1491481f6c`:

- **Security guardrails:** passed with the exact reviewed workflow unchanged.
- **Python readiness:** passed.
  - Ruff passed;
  - mypy passed across **112 source files**;
  - **796 tests passed** in the quality run;
  - **796 tests passed again** in the readiness run;
  - `pip check` reported no broken requirements;
  - the standard replay/readiness demonstration passed.
- **PostgreSQL contract:** passed.
  - live advisory-lock contention/release/reacquisition passed;
  - the existing source-to-serving and governance contracts passed;
  - 63 daily/portfolio/attribution/risk-limit consistency checks passed;
  - model-approval and operational-service-level contracts passed.
- **Infrastructure validation:** Kubernetes rendering and Terraform format/init/validate passed without apply.

No live webhook request, provider request, cloud schedule activation, deployment, position mutation or `terraform apply` ran in CI.

## Review state

There are no submitted reviews, requested changes or unresolved review threads. The exact final head is green and the branch is zero commits behind `main`.

## Acceptance boundary

Validated and ready for squash merge. The next dependency-safe P4d slice is **append-only retry-execution history plus current delivery-failure, ambiguous-outcome and retry-follow-up operational views**.