### PR TITLE
Define notification destination ownership contract

### DIFF
--- a/config/notification_destinations.yaml
+++ b/config/notification_destinations.yaml
@@ -1,0 +1,21 @@
+model_version: portfolio-risk-notification-destination-v1
+destinations:
+  risk-operations-webhook:
+    channel: webhook
+    endpoint_env: RISK_NOTIFICATION_WEBHOOK_URL
+    owner:
+      team: risk-operations
+      contact: risk-operations-oncall
+    purpose: portfolio-risk-breach-lifecycle
+    recipient_scope: risk-operations
+    data_classification: internal
+    allowed_event_types:
+      - breach_escalated
+      - breach_opened
+      - breach_resolved
+    activation:
+      enabled: false
+      change_request_id: null
+      reviewed_by: []
+      reviewed_at: null
+      review_expires_at: null

--- a/docs/portfolio-risk-notification-destination-ownership.md
+++ b/docs/portfolio-risk-notification-destination-ownership.md
@@ -1,0 +1,124 @@
+# Portfolio Risk Notification Destination Ownership
+
+## Outcome
+
+This increment defines a reviewed, secret-free ownership contract for external
+portfolio-risk notification destinations:
+
+```text
+committed destination metadata
+  + accountable owner and contact
+  + bounded recipient scope
+  + explicit lifecycle-event allow-list
+  + change-controlled activation review
+  -> deterministic destination fingerprint
+  -> credential-free activation evidence
+  -> no endpoint resolution or delivery
+```
+
+Primary arc42 block: `governance`, with a read-only orchestration validation
+interface.
+
+The contract is implemented by:
+
+```text
+config/notification_destinations.yaml
+src/orchestration/portfolio_risk_notification_destination_contract.py
+```
+
+## Secret-free endpoint reference
+
+The repository stores only the name of the environment variable that an operator
+would populate locally:
+
+```yaml
+endpoint_env: RISK_NOTIFICATION_WEBHOOK_URL
+```
+
+The contract rejects actual URLs, embedded credentials and other endpoint values in
+committed destination metadata. Validation summaries expose the environment-variable
+name but never its value.
+
+## Ownership and recipient scope
+
+Every destination identifies:
+
+- a stable destination ID;
+- an accountable owner team;
+- an operational contact role;
+- a bounded recipient scope;
+- one declared purpose;
+- the `internal` data classification; and
+- a sorted, explicit lifecycle-event allow-list.
+
+The initial demonstration destination is owned by `risk-operations`, uses the
+`risk-operations-oncall` role contact and is limited to opened, escalated and
+resolved breach events.
+
+## Disabled-by-default activation
+
+Committed activation remains disabled and carries no approval evidence:
+
+```yaml
+activation:
+  enabled: false
+  change_request_id: null
+  reviewed_by: []
+  reviewed_at: null
+  review_expires_at: null
+```
+
+An enabled destination must bind a change-request ID, at least one independent
+reviewer, a timezone-aware review time and a review expiry no more than 366 days
+after review. The destination owner contact cannot act as the sole activation
+reviewer.
+
+At a deterministic evaluation time, activation is classified as:
+
+```text
+disabled
+not_yet_reviewed
+active
+review_expired
+```
+
+An expired review is visible evidence and is not equivalent to an active
+destination.
+
+## Operator validation
+
+```bash
+.venv/bin/python \
+  -m src.orchestration.portfolio_risk_notification_destination_contract \
+  --destination-id risk-operations-webhook \
+  --evaluated-at 2026-04-01T12:00:00Z \
+  --summary-json .demo/notification-destination.json
+```
+
+The validator has no `--execute` option. It does not resolve the endpoint
+environment variable, open a network connection, write a delivery attempt, mutate
+the outbox or acknowledge a breach.
+
+## Activation package
+
+Before a real destination is enabled, a review package should contain:
+
+1. The destination ID and deterministic fingerprint.
+2. Owner team, contact role and recipient scope.
+3. The exact lifecycle-event allow-list.
+4. The change-request ID and independent reviewer identities.
+5. Review and expiry timestamps.
+6. Evidence from a controlled local receiver or fake transport.
+7. Rollback instructions that set activation and delivery back to disabled.
+8. Confirmation that the endpoint value remains outside the repository.
+
+This contract records review authority; it does not itself authorize the existing
+webhook sender. A later P4d increment must bind initial delivery and manual retry
+execution to the exact active destination fingerprint.
+
+## Boundary
+
+This increment performs no external request, delivery attempt, acknowledgement,
+outbox mutation, provider request, cloud scheduling, infrastructure deployment or
+`terraform apply`. It does not create a recipient, provision a webhook or store an
+endpoint URL.

--- a/src/orchestration/portfolio_risk_notification_destination_contract.py
+++ b/src/orchestration/portfolio_risk_notification_destination_contract.py
@@ -1,0 +1,424 @@
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import sys
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+from src.common.config import load_yaml
+from src.common.exceptions import StorageError, ValidationError
+
+MODEL_VERSION = "portfolio-risk-notification-destination-v1"
+CHANNEL = "webhook"
+MAX_DESTINATIONS = 20
+MAX_PURPOSE_LENGTH = 256
+MAX_REVIEW_DAYS = 366
+EVENT_TYPES = frozenset(
+    {
+        "breach_opened",
+        "breach_escalated",
+        "breach_deescalated",
+        "breach_resolved",
+    }
+)
+SAFE_SEGMENT = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$")
+ENVIRONMENT_NAME = re.compile(r"^[A-Z][A-Z0-9_]{2,127}$")
+
+
+@dataclass(frozen=True, slots=True)
+class DestinationOwner:
+    team: str
+    contact: str
+
+
+@dataclass(frozen=True, slots=True)
+class DestinationActivation:
+    enabled: bool
+    change_request_id: str | None
+    reviewed_by: tuple[str, ...]
+    reviewed_at: datetime | None
+    review_expires_at: datetime | None
+
+
+@dataclass(frozen=True, slots=True)
+class NotificationDestination:
+    destination_id: str
+    channel: str
+    endpoint_env: str
+    owner: DestinationOwner
+    purpose: str
+    recipient_scope: str
+    data_classification: str
+    allowed_event_types: tuple[str, ...]
+    activation: DestinationActivation
+
+    @property
+    def fingerprint(self) -> str:
+        payload = {
+            "activation": {
+                "change_request_id": self.activation.change_request_id,
+                "enabled": self.activation.enabled,
+                "review_expires_at": _iso(self.activation.review_expires_at),
+                "reviewed_at": _iso(self.activation.reviewed_at),
+                "reviewed_by": list(self.activation.reviewed_by),
+            },
+            "allowed_event_types": list(self.allowed_event_types),
+            "channel": self.channel,
+            "data_classification": self.data_classification,
+            "destination_id": self.destination_id,
+            "endpoint_env": self.endpoint_env,
+            "model_version": MODEL_VERSION,
+            "owner": {
+                "contact": self.owner.contact,
+                "team": self.owner.team,
+            },
+            "purpose": self.purpose,
+            "recipient_scope": self.recipient_scope,
+        }
+        digest = hashlib.sha256(
+            json.dumps(
+                payload,
+                sort_keys=True,
+                separators=(",", ":"),
+                allow_nan=False,
+            ).encode("utf-8")
+        ).hexdigest()[:24]
+        return f"{MODEL_VERSION}-destination-{digest}"
+
+
+def _exact_mapping(value: Any, label: str, keys: set[str]) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        raise ValidationError(f"{label} must be a mapping")
+    actual = set(value)
+    if actual != keys:
+        missing = sorted(keys - actual)
+        unknown = sorted(actual - keys)
+        raise ValidationError(
+            f"{label} fields are invalid; missing={missing}, unknown={unknown}"
+        )
+    return value
+
+
+def _segment(value: Any, label: str) -> str:
+    if not isinstance(value, str) or not SAFE_SEGMENT.fullmatch(value):
+        raise ValidationError(f"{label} must be one safe text segment")
+    return value
+
+
+def _optional_segment(value: Any, label: str) -> str | None:
+    if value is None:
+        return None
+    return _segment(value, label)
+
+
+def _purpose(value: Any) -> str:
+    if not isinstance(value, str) or not value or value != value.strip():
+        raise ValidationError("purpose must be canonical non-empty text")
+    if len(value) > MAX_PURPOSE_LENGTH or any(ord(character) < 32 for character in value):
+        raise ValidationError("purpose is invalid")
+    return value
+
+
+def _aware_utc(value: Any, label: str) -> datetime:
+    if isinstance(value, datetime):
+        parsed = value
+    elif isinstance(value, str):
+        try:
+            parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        except ValueError:
+            raise ValidationError(f"{label} must be ISO-8601") from None
+    else:
+        raise ValidationError(f"{label} must be timezone-aware")
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise ValidationError(f"{label} must be timezone-aware")
+    return parsed.astimezone(timezone.utc)
+
+
+def _optional_aware_utc(value: Any, label: str) -> datetime | None:
+    if value is None:
+        return None
+    return _aware_utc(value, label)
+
+
+def _iso(value: datetime | None) -> str | None:
+    return value.isoformat() if value is not None else None
+
+
+def _sorted_unique_segments(value: Any, label: str) -> tuple[str, ...]:
+    if not isinstance(value, list):
+        raise ValidationError(f"{label} must be an array")
+    parsed = tuple(_segment(item, f"{label} item") for item in value)
+    if list(parsed) != sorted(parsed) or len(parsed) != len(set(parsed)):
+        raise ValidationError(f"{label} must be sorted and contain no duplicates")
+    return parsed
+
+
+def _event_types(value: Any) -> tuple[str, ...]:
+    parsed = _sorted_unique_segments(value, "allowed_event_types")
+    if not parsed or not set(parsed).issubset(EVENT_TYPES):
+        raise ValidationError("allowed_event_types contains an unsupported event type")
+    return parsed
+
+
+def _parse_activation(value: Any, *, owner: DestinationOwner) -> DestinationActivation:
+    activation = _exact_mapping(
+        value,
+        "activation",
+        {
+            "enabled",
+            "change_request_id",
+            "reviewed_by",
+            "reviewed_at",
+            "review_expires_at",
+        },
+    )
+    enabled = activation["enabled"]
+    if type(enabled) is not bool:
+        raise ValidationError("activation.enabled must be boolean")
+    change_request_id = _optional_segment(
+        activation["change_request_id"],
+        "activation.change_request_id",
+    )
+    reviewed_by = _sorted_unique_segments(
+        activation["reviewed_by"],
+        "activation.reviewed_by",
+    )
+    reviewed_at = _optional_aware_utc(
+        activation["reviewed_at"],
+        "activation.reviewed_at",
+    )
+    review_expires_at = _optional_aware_utc(
+        activation["review_expires_at"],
+        "activation.review_expires_at",
+    )
+
+    evidence = (change_request_id, reviewed_at, review_expires_at)
+    if not enabled:
+        if any(item is not None for item in evidence) or reviewed_by:
+            raise ValidationError(
+                "disabled destination activation must not retain approval evidence"
+            )
+    else:
+        if any(item is None for item in evidence) or not reviewed_by:
+            raise ValidationError(
+                "enabled destination activation requires complete review evidence"
+            )
+        assert reviewed_at is not None and review_expires_at is not None
+        if review_expires_at <= reviewed_at:
+            raise ValidationError("review_expires_at must follow reviewed_at")
+        if review_expires_at - reviewed_at > timedelta(days=MAX_REVIEW_DAYS):
+            raise ValidationError("destination review may not exceed 366 days")
+        if reviewed_by == (owner.contact,):
+            raise ValidationError(
+                "destination owner contact may not be the sole activation reviewer"
+            )
+    return DestinationActivation(
+        enabled=enabled,
+        change_request_id=change_request_id,
+        reviewed_by=reviewed_by,
+        reviewed_at=reviewed_at,
+        review_expires_at=review_expires_at,
+    )
+
+
+def _parse_destination(destination_id: str, value: Any) -> NotificationDestination:
+    destination = _exact_mapping(
+        value,
+        f"destination {destination_id}",
+        {
+            "channel",
+            "endpoint_env",
+            "owner",
+            "purpose",
+            "recipient_scope",
+            "data_classification",
+            "allowed_event_types",
+            "activation",
+        },
+    )
+    channel = destination["channel"]
+    if channel != CHANNEL:
+        raise ValidationError("notification destination channel must be webhook")
+    endpoint_env = destination["endpoint_env"]
+    if not isinstance(endpoint_env, str) or not ENVIRONMENT_NAME.fullmatch(endpoint_env):
+        raise ValidationError(
+            "endpoint_env must name a local environment variable, not contain a URL"
+        )
+    owner_payload = _exact_mapping(
+        destination["owner"],
+        f"destination {destination_id} owner",
+        {"team", "contact"},
+    )
+    owner = DestinationOwner(
+        team=_segment(owner_payload["team"], "owner.team"),
+        contact=_segment(owner_payload["contact"], "owner.contact"),
+    )
+    data_classification = destination["data_classification"]
+    if data_classification != "internal":
+        raise ValidationError("data_classification must be internal")
+    return NotificationDestination(
+        destination_id=_segment(destination_id, "destination_id"),
+        channel=channel,
+        endpoint_env=endpoint_env,
+        owner=owner,
+        purpose=_purpose(destination["purpose"]),
+        recipient_scope=_segment(
+            destination["recipient_scope"],
+            "recipient_scope",
+        ),
+        data_classification=data_classification,
+        allowed_event_types=_event_types(destination["allowed_event_types"]),
+        activation=_parse_activation(destination["activation"], owner=owner),
+    )
+
+
+def load_notification_destinations(path: Path) -> dict[str, NotificationDestination]:
+    try:
+        payload = load_yaml(path)
+    except Exception:
+        raise ValidationError(
+            "notification destination configuration could not be loaded"
+        ) from None
+    root = _exact_mapping(
+        payload,
+        "notification destination configuration",
+        {"model_version", "destinations"},
+    )
+    if root["model_version"] != MODEL_VERSION:
+        raise ValidationError("notification destination model_version is unsupported")
+    destinations = root["destinations"]
+    if not isinstance(destinations, Mapping) or not destinations:
+        raise ValidationError("destinations must be a non-empty mapping")
+    if len(destinations) > MAX_DESTINATIONS:
+        raise ValidationError("destination count exceeds the reviewed maximum")
+    parsed = {
+        destination_id: _parse_destination(destination_id, value)
+        for destination_id, value in destinations.items()
+    }
+    if list(parsed) != sorted(parsed):
+        raise ValidationError("destination IDs must be sorted")
+    return parsed
+
+
+def evaluate_destination_activation(
+    destination: NotificationDestination,
+    *,
+    evaluated_at: datetime | str,
+) -> dict[str, Any]:
+    as_of = _aware_utc(evaluated_at, "evaluated_at")
+    activation = destination.activation
+    if not activation.enabled:
+        status = "disabled"
+    else:
+        assert activation.reviewed_at is not None
+        assert activation.review_expires_at is not None
+        if as_of < activation.reviewed_at:
+            status = "not_yet_reviewed"
+        elif as_of >= activation.review_expires_at:
+            status = "review_expired"
+        else:
+            status = "active"
+    return {
+        "destination_id": destination.destination_id,
+        "model_version": MODEL_VERSION,
+        "fingerprint": destination.fingerprint,
+        "evaluated_at": as_of.isoformat(),
+        "channel": destination.channel,
+        "endpoint": {
+            "environment_variable": destination.endpoint_env,
+            "value_recorded": False,
+        },
+        "owner": {
+            "team": destination.owner.team,
+            "contact": destination.owner.contact,
+        },
+        "recipient_scope": destination.recipient_scope,
+        "data_classification": destination.data_classification,
+        "allowed_event_types": list(destination.allowed_event_types),
+        "activation": {
+            "enabled": activation.enabled,
+            "status": status,
+            "change_request_id": activation.change_request_id,
+            "reviewed_by": list(activation.reviewed_by),
+            "reviewed_at": _iso(activation.reviewed_at),
+            "review_expires_at": _iso(activation.review_expires_at),
+        },
+        "external_request_performed": False,
+        "delivery_attempt_written": False,
+        "outbox_mutated": False,
+        "acknowledgement_mutated": False,
+    }
+
+
+def _write_summary(path: Path, summary: Mapping[str, Any]) -> None:
+    if path.is_symlink():
+        raise StorageError("destination contract summary must not be a symbolic link")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_suffix(path.suffix + ".tmp")
+    try:
+        temporary.write_text(
+            json.dumps(summary, indent=2, sort_keys=True, allow_nan=False) + "\n",
+            encoding="utf-8",
+        )
+        temporary.replace(path)
+    except (OSError, TypeError, ValueError):
+        temporary.unlink(missing_ok=True)
+        raise StorageError("unable to write destination contract summary") from None
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Validate one reviewed portfolio-risk notification destination "
+            "without resolving its endpoint or performing delivery."
+        )
+    )
+    parser.add_argument(
+        "--config",
+        type=Path,
+        default=Path("config/notification_destinations.yaml"),
+    )
+    parser.add_argument("--destination-id", required=True)
+    parser.add_argument("--evaluated-at", required=True)
+    parser.add_argument("--summary-json", type=Path)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    try:
+        destinations = load_notification_destinations(args.config)
+        destination_id = _segment(args.destination_id, "destination_id")
+        destination = destinations.get(destination_id)
+        if destination is None:
+            raise ValidationError("notification destination does not exist")
+        summary = evaluate_destination_activation(
+            destination,
+            evaluated_at=args.evaluated_at,
+        )
+        if args.summary_json is not None:
+            _write_summary(args.summary_json, summary)
+    except ValidationError as exc:
+        print(f"Notification destination rejected: {exc}", file=sys.stderr)
+        return 1
+    except StorageError as exc:
+        print(f"Notification destination validation failed: {exc}", file=sys.stderr)
+        return 1
+    except Exception:
+        print(
+            "Notification destination validation failed: unexpected local failure",
+            file=sys.stderr,
+        )
+        return 1
+    print(json.dumps(summary, sort_keys=True, allow_nan=False))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/test_portfolio_risk_notification_destination_architecture_contract.py
+++ b/tests/unit/test_portfolio_risk_notification_destination_architecture_contract.py
@@ -1,0 +1,48 @@
+from pathlib import Path
+
+
+def test_destination_contract_is_secret_free_reviewed_and_delivery_free() -> None:
+    source = Path(
+        "src/orchestration/portfolio_risk_notification_destination_contract.py"
+    ).read_text(encoding="utf-8")
+    config = Path("config/notification_destinations.yaml").read_text(
+        encoding="utf-8"
+    )
+    docs = Path(
+        "docs/portfolio-risk-notification-destination-ownership.md"
+    ).read_text(encoding="utf-8")
+    normalized_docs = " ".join(docs.split()).casefold()
+
+    for required in (
+        "portfolio-risk-notification-destination-v1",
+        "endpoint_env",
+        "owner",
+        "recipient_scope",
+        "allowed_event_types",
+        "change_request_id",
+        "review_expires_at",
+        "external_request_performed",
+        "delivery_attempt_written",
+        "outbox_mutated",
+        "acknowledgement_mutated",
+    ):
+        assert required in source
+
+    assert "--execute" not in source
+    assert "urllib" not in source
+    assert "requests" not in source
+    assert "https://" not in config
+    assert "enabled: false" in config
+    assert "RISK_NOTIFICATION_WEBHOOK_URL" in config
+
+    for required in (
+        "primary arc42 block: `governance`",
+        "secret-free endpoint reference",
+        "disabled-by-default activation",
+        "independent reviewer",
+        "controlled local receiver or fake transport",
+        "does not itself authorize",
+        "no external request",
+        "terraform apply",
+    ):
+        assert required in normalized_docs

--- a/tests/unit/test_portfolio_risk_notification_destination_contract.py
+++ b/tests/unit/test_portfolio_risk_notification_destination_contract.py
@@ -1,0 +1,197 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+from src.common.exceptions import StorageError, ValidationError
+from src.orchestration.portfolio_risk_notification_destination_contract import (
+    _build_parser,
+    _write_summary,
+    evaluate_destination_activation,
+    load_notification_destinations,
+)
+
+EVALUATED_AT = datetime(2026, 4, 1, 12, tzinfo=timezone.utc)
+
+
+def _payload(*, enabled: bool = False) -> dict[str, Any]:
+    activation: dict[str, Any]
+    if enabled:
+        activation = {
+            "enabled": True,
+            "change_request_id": "CHG-2026-001",
+            "reviewed_by": ["platform-owner"],
+            "reviewed_at": "2026-03-01T12:00:00Z",
+            "review_expires_at": "2026-06-01T12:00:00Z",
+        }
+    else:
+        activation = {
+            "enabled": False,
+            "change_request_id": None,
+            "reviewed_by": [],
+            "reviewed_at": None,
+            "review_expires_at": None,
+        }
+    return {
+        "model_version": "portfolio-risk-notification-destination-v1",
+        "destinations": {
+            "risk-operations-webhook": {
+                "channel": "webhook",
+                "endpoint_env": "RISK_NOTIFICATION_WEBHOOK_URL",
+                "owner": {
+                    "team": "risk-operations",
+                    "contact": "risk-operations-oncall",
+                },
+                "purpose": "portfolio-risk-breach-lifecycle",
+                "recipient_scope": "risk-operations",
+                "data_classification": "internal",
+                "allowed_event_types": [
+                    "breach_escalated",
+                    "breach_opened",
+                    "breach_resolved",
+                ],
+                "activation": activation,
+            }
+        },
+    }
+
+
+def _write(tmp_path: Path, payload: dict[str, Any]) -> Path:
+    path = tmp_path / "notification-destinations.yaml"
+    path.write_text(yaml.safe_dump(payload, sort_keys=False), encoding="utf-8")
+    return path
+
+
+def test_disabled_contract_is_deterministic_and_delivery_free(tmp_path: Path) -> None:
+    path = _write(tmp_path, _payload())
+    first = load_notification_destinations(path)["risk-operations-webhook"]
+    second = load_notification_destinations(path)["risk-operations-webhook"]
+    summary = evaluate_destination_activation(first, evaluated_at=EVALUATED_AT)
+
+    assert first.fingerprint == second.fingerprint
+    assert summary["activation"]["status"] == "disabled"
+    assert summary["external_request_performed"] is False
+    assert summary["delivery_attempt_written"] is False
+    assert summary["outbox_mutated"] is False
+    assert summary["acknowledgement_mutated"] is False
+    assert summary["endpoint"] == {
+        "environment_variable": "RISK_NOTIFICATION_WEBHOOK_URL",
+        "value_recorded": False,
+    }
+    rendered = json.dumps(summary, sort_keys=True)
+    assert "https://" not in rendered
+
+
+def test_enabled_contract_has_independent_bounded_review(tmp_path: Path) -> None:
+    destination = load_notification_destinations(
+        _write(tmp_path, _payload(enabled=True))
+    )["risk-operations-webhook"]
+
+    assert evaluate_destination_activation(
+        destination,
+        evaluated_at=EVALUATED_AT,
+    )["activation"]["status"] == "active"
+    assert evaluate_destination_activation(
+        destination,
+        evaluated_at="2026-07-01T12:00:00Z",
+    )["activation"]["status"] == "review_expired"
+
+    owner_only = _payload(enabled=True)
+    owner_only["destinations"]["risk-operations-webhook"]["activation"][
+        "reviewed_by"
+    ] = ["risk-operations-oncall"]
+    with pytest.raises(ValidationError, match="owner contact"):
+        load_notification_destinations(_write(tmp_path, owner_only))
+
+    independently_reviewed = _payload(enabled=True)
+    independently_reviewed["destinations"]["risk-operations-webhook"][
+        "activation"
+    ]["reviewed_by"] = ["platform-owner", "risk-operations-oncall"]
+    accepted = load_notification_destinations(
+        _write(tmp_path, independently_reviewed)
+    )["risk-operations-webhook"]
+    assert accepted.activation.reviewed_by == (
+        "platform-owner",
+        "risk-operations-oncall",
+    )
+
+
+def test_committed_endpoint_must_be_an_environment_name(tmp_path: Path) -> None:
+    payload = _payload()
+    payload["destinations"]["risk-operations-webhook"]["endpoint_env"] = (
+        "https://alerts.example.test/risk"
+    )
+    with pytest.raises(ValidationError, match="environment variable"):
+        load_notification_destinations(_write(tmp_path, payload))
+
+
+def test_unknown_fields_and_unsorted_allow_lists_fail_closed(tmp_path: Path) -> None:
+    unknown = _payload()
+    unknown["destinations"]["risk-operations-webhook"]["endpoint"] = "secret"
+    with pytest.raises(ValidationError, match="unknown"):
+        load_notification_destinations(_write(tmp_path, unknown))
+
+    unsorted = _payload()
+    unsorted["destinations"]["risk-operations-webhook"][
+        "allowed_event_types"
+    ] = ["breach_resolved", "breach_opened"]
+    with pytest.raises(ValidationError, match="sorted"):
+        load_notification_destinations(_write(tmp_path, unsorted))
+
+
+def test_incomplete_enabled_activation_fails_closed(tmp_path: Path) -> None:
+    payload = _payload(enabled=True)
+    payload["destinations"]["risk-operations-webhook"]["activation"][
+        "change_request_id"
+    ] = None
+    with pytest.raises(ValidationError, match="complete review evidence"):
+        load_notification_destinations(_write(tmp_path, payload))
+
+
+def test_cli_has_no_execution_switch() -> None:
+    parser = _build_parser()
+    with pytest.raises(SystemExit):
+        parser.parse_args(
+            [
+                "--destination-id",
+                "risk-operations-webhook",
+                "--evaluated-at",
+                EVALUATED_AT.isoformat(),
+                "--execute",
+            ]
+        )
+
+
+def test_summary_writer_rejects_symbolic_links(tmp_path: Path) -> None:
+    target = tmp_path / "target.json"
+    target.write_text("{}", encoding="utf-8")
+    link = tmp_path / "summary.json"
+    link.symlink_to(target)
+    with pytest.raises(StorageError, match="symbolic link"):
+        _write_summary(link, {"safe": True})
+
+
+def test_review_duration_is_bounded_by_elapsed_time(tmp_path: Path) -> None:
+    accepted = _payload(enabled=True)
+    accepted["destinations"]["risk-operations-webhook"]["activation"].update(
+        {
+            "reviewed_at": "2026-01-01T00:00:00Z",
+            "review_expires_at": "2027-01-02T00:00:00Z",
+        }
+    )
+    load_notification_destinations(_write(tmp_path, accepted))
+
+    too_long = _payload(enabled=True)
+    too_long["destinations"]["risk-operations-webhook"]["activation"].update(
+        {
+            "reviewed_at": "2026-01-01T00:00:00Z",
+            "review_expires_at": "2027-01-02T00:00:01Z",
+        }
+    )
+    with pytest.raises(ValidationError, match="366 days"):
+        load_notification_destinations(_write(tmp_path, too_long))


### PR DESCRIPTION
## Goal

Complete the destination-governance slice of P4d by defining one deterministic, secret-free ownership and activation contract for portfolio-risk notification destinations.

```text
committed destination metadata
  + accountable owner and contact
  + bounded recipient scope
  + explicit event allow-list
  + change-controlled activation review
  -> deterministic destination fingerprint
  -> credential-free activation evidence
  -> no endpoint resolution or delivery
```

## Controls

- Stores only an endpoint environment-variable name, never an endpoint URL or credential.
- Requires exact destination fields, one owner team, one contact role, bounded recipient scope and `internal` classification.
- Requires a sorted lifecycle-event allow-list.
- Keeps committed activation disabled and free of approval evidence.
- Enabled activation requires a change request, independent reviewer evidence, timezone-aware review dates and a review expiry of no more than 366 elapsed days.
- Exposes deterministic `disabled`, `not_yet_reviewed`, `active` and `review_expired` states.
- Provides no `--execute` option and performs no network request, attempt write, outbox mutation or acknowledgement.

## Scope

Five new files, 814 additions. Branch is directly based on `main`, five working commits ahead and zero behind; squash merge will retain one coherent increment.

## Exact-head validation

GitHub Actions run **335** passed on head `6ffbabdba0512b5fa07f5169126b5a04e70d672e`:

- Security guardrails passed.
- Ruff passed.
- mypy passed across **113 source files**.
- **805 tests passed** in the quality run and **805 passed again** in readiness.
- Dependency integrity and the standard replay demonstration passed.
- PostgreSQL 16 contract passed.
- Kubernetes rendering and Terraform format/init/validate passed without apply.

No external delivery, provider request, deployment, cloud scheduling, credential change or `terraform apply` occurred. There are no review submissions or unresolved threads.

## Acceptance boundary

Validated and ready for squash merge. A later PR will bind the sender and retry executor to an exact current active destination fingerprint.