### PR TITLE
Persist append-only notification retry execution history

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,7 @@ services:
       - ./sql/operational_review_schema.sql:/docker-entrypoint-initdb.d/16_operational_review_schema.sql:ro
       - ./sql/operational_readiness_overrides_schema.sql:/docker-entrypoint-initdb.d/17_operational_readiness_overrides_schema.sql:ro
       - ./sql/local_schedule_runs_schema.sql:/docker-entrypoint-initdb.d/18_local_schedule_runs_schema.sql:ro
+      - ./sql/portfolio_risk_notification_retry_execution_schema.sql:/docker-entrypoint-initdb.d/19_portfolio_risk_notification_retry_execution_schema.sql:ro
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U risk_user -d risk_platform"]
       interval: 5s

--- a/docs/portfolio-risk-notification-retry-execution-history.md
+++ b/docs/portfolio-risk-notification-retry-execution-history.md
@@ -25,10 +25,11 @@ The recorded operator entry point is:
 src/orchestration/run_recorded_portfolio_risk_notification_retries.py
 ```
 
-The record contract and recorder are:
+The record contract, preflight reader and recorder are:
 
 ```text
 src/warehouse/notification_retry_execution_contract.py
+src/warehouse/notification_retry_execution_reader.py
 src/warehouse/notification_retry_execution_recorder.py
 ```
 
@@ -96,13 +97,25 @@ validation_error
 
 ## Recorded execution ordering
 
-The wrapper starts a local clock-bound execution record, invokes the existing exact
-P4c executor with tracking transport and attempt-writer interfaces, and records one
-terminal document after the executor returns or raises.
+The wrapper validates explicit execution and exact plan confirmation before reading
+terminal history. A previously retained request is resolved before any clock,
+configuration, delivery-lock, evidence-reader or transport work:
 
 ```text
-validate retained plan and request identity
-  -> invoke exact P4c executor
+validate retained plan, --execute and exact confirmation
+  -> read terminal history by request_id
+  -> completed same-plan record: return retained evidence
+  -> failed same-plan record: return the retained terminal failure
+  -> different-plan reuse: reject
+  -> no retained record: begin new clock-bound P4c execution
+```
+
+For a new request, the wrapper invokes the existing exact P4c executor with tracking
+transport and attempt-writer interfaces, then records one terminal document after
+the executor returns or raises.
+
+```text
+invoke exact P4c executor
   -> observe each external request identity
   -> observe each successful append-only attempt persistence
   -> classify terminal boundary
@@ -111,7 +124,9 @@ validate retained plan and request identity
 ```
 
 The wrapper does not replace P4c plan validation, current-evidence revalidation or
-delivery locking. It delegates all delivery authority to the existing executor.
+delivery locking. It delegates all new delivery authority to the existing executor.
+The history lookup only prevents a terminal operator request from being executed a
+second time.
 
 ## Append-only PostgreSQL history
 
@@ -121,12 +136,16 @@ The history table is:
 risk_platform.portfolio_risk_notification_retry_executions
 ```
 
-`request_id` is the idempotency identity for terminal recording:
+`request_id` is the idempotency identity for terminal recording and execution:
 
-- an exact retry converges on the retained row;
-- conflicting reuse of the request ID fails closed;
+- an exact completed retry returns the retained row before another external request;
+- an exact failed retry returns the same retained terminal failure;
+- conflicting reuse of the request ID for another plan fails closed;
 - a completed execution ID is unique; and
 - direct UPDATE and DELETE operations are rejected by a trigger.
+
+The preflight reader revalidates the canonical record and its stored SHA-256 before
+using it. Corrupt or mismatched retained evidence fails before side effects.
 
 The canonical JSON document and SHA-256 are stored alongside queryable scalar and
 array fields. PostgreSQL checks enforce status-specific request/persistence counts,
@@ -149,16 +168,17 @@ directly when durable terminal history is required:
 ```
 
 The wrapper retains terminal failure history before returning a non-zero exit code.
-If PostgreSQL itself is unavailable, durable history cannot be claimed and the
-command fails explicitly.
+If PostgreSQL itself is unavailable, durable history and safe request replay cannot
+be established, so the command fails before executing a new request.
 
 ## Validation boundary
 
-Unit tests use fake transports, attempt writers, clocks, executors and history
-recorders. The PostgreSQL 16 contract proves:
+Unit tests use fake transports, attempt writers, clocks, executors, history readers
+and recorders. The PostgreSQL 16 contract proves:
 
 - one terminal row is created;
 - an exact retry converges;
+- the pre-execution reader validates the retained record and digest;
 - conflicting request reuse fails;
 - direct mutation is rejected; and
 - retained evidence remains credential-free.

--- a/docs/portfolio-risk-notification-retry-execution-history.md
+++ b/docs/portfolio-risk-notification-retry-execution-history.md
@@ -1,0 +1,177 @@
+# Append-only Notification Retry Execution History
+
+## Outcome
+
+This increment retains one canonical terminal record for every governed manual retry
+execution invoked through the recorded operator path:
+
+```text
+exact P4b retry plan
+  + clock-bound P4c execution
+  + shared PostgreSQL delivery lock
+  + request and append-only attempt evidence
+  -> completed or bounded failure classification
+  -> canonical terminal execution record
+  -> append-only PostgreSQL history
+  -> exact retry convergence
+```
+
+Primary arc42 block: `warehouse`, with the existing orchestration executor providing
+the source execution evidence.
+
+The recorded operator entry point is:
+
+```text
+src/orchestration/run_recorded_portfolio_risk_notification_retries.py
+```
+
+The record contract and recorder are:
+
+```text
+src/warehouse/notification_retry_execution_contract.py
+src/warehouse/notification_retry_execution_recorder.py
+```
+
+## Terminal statuses
+
+Every retained request has exactly one terminal status:
+
+```text
+completed
+failed_before_request
+failed_after_request
+persistence_uncertain
+```
+
+`completed` means every recorded external request has matching append-only attempt
+evidence and the exact P4c summary confirms that the delivery lock was held through
+revalidation and persistence, then released.
+
+`failed_before_request` means no external request was observed and no attempt row was
+persisted. Examples include stale plan evidence, disabled configuration, lock
+contention and endpoint validation failure.
+
+`failed_after_request` means one or more requests occurred and every request has a
+matching append-only attempt row, but a later local step failed. Retained attempt
+outcomes remain the source of truth; the terminal execution is not reported as
+completed.
+
+`persistence_uncertain` means an external request was observed without matching
+local attempt persistence. The exact requested event IDs are retained separately
+from persisted event IDs so an operator can identify the ambiguous remote outcome.
+The system does not claim success. The receiver must continue deduplicating by the
+stable notification `Idempotency-Key`.
+
+## Exact evidence
+
+The `portfolio-risk-notification-retry-execution-record-v1` document binds:
+
+- deterministic record ID;
+- exact operator request ID and retained retry-plan ID;
+- P4c execution ID when completed;
+- terminal status and bounded failure code;
+- start, finish and recording timestamps;
+- external request count;
+- persisted attempt count and succeeded/failed counts;
+- ordered requested event IDs;
+- ordered persisted event IDs;
+- deterministic attempt IDs;
+- endpoint host only;
+- delivery, retry and retry-execution policy fingerprints;
+- delivery-lock model and credential-free key fingerprint;
+- lock acquisition/release evidence when known; and
+- the exact P4c execution summary for completed runs.
+
+Full endpoint URLs, payload bodies, response bodies, PostgreSQL DSNs, environment
+values, credentials and arbitrary exception text are not stored.
+
+For failed executions, exception types are reduced to one bounded code:
+
+```text
+overlap_error
+storage_error
+unexpected_error
+validation_error
+```
+
+## Recorded execution ordering
+
+The wrapper starts a local clock-bound execution record, invokes the existing exact
+P4c executor with tracking transport and attempt-writer interfaces, and records one
+terminal document after the executor returns or raises.
+
+```text
+validate retained plan and request identity
+  -> invoke exact P4c executor
+  -> observe each external request identity
+  -> observe each successful append-only attempt persistence
+  -> classify terminal boundary
+  -> validate canonical record
+  -> append terminal history
+```
+
+The wrapper does not replace P4c plan validation, current-evidence revalidation or
+delivery locking. It delegates all delivery authority to the existing executor.
+
+## Append-only PostgreSQL history
+
+The history table is:
+
+```text
+risk_platform.portfolio_risk_notification_retry_executions
+```
+
+`request_id` is the idempotency identity for terminal recording:
+
+- an exact retry converges on the retained row;
+- conflicting reuse of the request ID fails closed;
+- a completed execution ID is unique; and
+- direct UPDATE and DELETE operations are rejected by a trigger.
+
+The canonical JSON document and SHA-256 are stored alongside queryable scalar and
+array fields. PostgreSQL checks enforce status-specific request/persistence counts,
+completed lock evidence and the distinct requested-versus-persisted event sets used
+for ambiguous outcomes.
+
+## Operator command
+
+Use the recorded wrapper rather than invoking the lower-level retry executor
+directly when durable terminal history is required:
+
+```bash
+.venv/bin/python \
+  -m src.orchestration.run_recorded_portfolio_risk_notification_retries \
+  --plan .demo/notification-retry-plan.json \
+  --confirm-plan-id '<exact-plan-id>' \
+  --request-id 'RETRY-2026-001' \
+  --execute \
+  --summary-json .demo/recorded-notification-retry.json
+```
+
+The wrapper retains terminal failure history before returning a non-zero exit code.
+If PostgreSQL itself is unavailable, durable history cannot be claimed and the
+command fails explicitly.
+
+## Validation boundary
+
+Unit tests use fake transports, attempt writers, clocks, executors and history
+recorders. The PostgreSQL 16 contract proves:
+
+- one terminal row is created;
+- an exact retry converges;
+- conflicting request reuse fails;
+- direct mutation is rejected; and
+- retained evidence remains credential-free.
+
+Ordinary CI performs no webhook request. Committed webhook and retry-execution
+activation remain disabled.
+
+## Boundary
+
+This increment does not schedule retries, activate a destination, provision a
+webhook, change notification recipients, mutate outbox or acknowledgement evidence,
+change portfolio positions, deploy infrastructure or run `terraform apply`.
+
+Current delivery-failure, ambiguous-outcome and retry-follow-up serving views are a
+separate follow-up PR so persistence and query semantics remain independently
+reviewable.

--- a/sql/portfolio_risk_notification_retry_execution_schema.sql
+++ b/sql/portfolio_risk_notification_retry_execution_schema.sql
@@ -1,0 +1,184 @@
+-- Append-only terminal history for governed portfolio-risk notification retries.
+-- Apply after sql/portfolio_risk_notification_delivery_schema.sql.
+
+CREATE SCHEMA IF NOT EXISTS risk_platform;
+
+CREATE TABLE IF NOT EXISTS
+risk_platform.portfolio_risk_notification_retry_executions (
+    record_id TEXT PRIMARY KEY,
+    model_version TEXT NOT NULL CHECK (
+        model_version = 'portfolio-risk-notification-retry-execution-record-v1'
+    ),
+    request_id TEXT NOT NULL UNIQUE,
+    execution_id TEXT,
+    plan_id TEXT NOT NULL,
+    terminal_status TEXT NOT NULL CHECK (
+        terminal_status IN (
+            'completed',
+            'failed_before_request',
+            'failed_after_request',
+            'persistence_uncertain'
+        )
+    ),
+    failure_code TEXT CHECK (
+        failure_code IS NULL
+        OR failure_code IN (
+            'overlap_error',
+            'storage_error',
+            'unexpected_error',
+            'validation_error'
+        )
+    ),
+    channel TEXT NOT NULL CHECK (channel = 'webhook'),
+    endpoint_host TEXT,
+    started_at TIMESTAMPTZ NOT NULL,
+    finished_at TIMESTAMPTZ NOT NULL,
+    recorded_at TIMESTAMPTZ NOT NULL,
+    request_count INTEGER NOT NULL CHECK (
+        request_count >= 0 AND request_count <= 100
+    ),
+    attempts_persisted INTEGER NOT NULL CHECK (
+        attempts_persisted >= 0 AND attempts_persisted <= request_count
+    ),
+    succeeded_count INTEGER NOT NULL CHECK (
+        succeeded_count >= 0 AND succeeded_count <= 100
+    ),
+    failed_count INTEGER NOT NULL CHECK (
+        failed_count >= 0 AND failed_count <= 100
+    ),
+    attempt_ids_json JSONB NOT NULL CHECK (
+        jsonb_typeof(attempt_ids_json) = 'array'
+    ),
+    requested_event_ids_json JSONB NOT NULL CHECK (
+        jsonb_typeof(requested_event_ids_json) = 'array'
+    ),
+    persisted_event_ids_json JSONB NOT NULL CHECK (
+        jsonb_typeof(persisted_event_ids_json) = 'array'
+    ),
+    delivery_fingerprint TEXT,
+    retry_policy_fingerprint TEXT,
+    retry_execution_policy_fingerprint TEXT,
+    lock_model_version TEXT,
+    lock_key_fingerprint TEXT,
+    lock_acquired BOOLEAN,
+    lock_released BOOLEAN,
+    execution_summary_json JSONB,
+    record_json JSONB NOT NULL CHECK (jsonb_typeof(record_json) = 'object'),
+    document_sha256 TEXT NOT NULL CHECK (document_sha256 ~ '^[0-9a-f]{64}$'),
+    loaded_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    CHECK (record_id <> ''),
+    CHECK (request_id <> ''),
+    CHECK (plan_id <> ''),
+    CHECK (execution_id IS NULL OR execution_id <> ''),
+    CHECK (endpoint_host IS NULL OR endpoint_host <> ''),
+    CHECK (delivery_fingerprint IS NULL OR delivery_fingerprint <> ''),
+    CHECK (retry_policy_fingerprint IS NULL OR retry_policy_fingerprint <> ''),
+    CHECK (
+        retry_execution_policy_fingerprint IS NULL
+        OR retry_execution_policy_fingerprint <> ''
+    ),
+    CHECK (lock_model_version IS NULL OR lock_model_version <> ''),
+    CHECK (lock_key_fingerprint IS NULL OR lock_key_fingerprint <> ''),
+    CHECK (
+        (lock_model_version IS NULL AND lock_key_fingerprint IS NULL)
+        OR (lock_model_version IS NOT NULL AND lock_key_fingerprint IS NOT NULL)
+    ),
+    CHECK (lock_released IS NOT TRUE OR lock_acquired IS TRUE),
+    CHECK (finished_at >= started_at),
+    CHECK (recorded_at >= finished_at),
+    CHECK (jsonb_array_length(attempt_ids_json) = attempts_persisted),
+    CHECK (jsonb_array_length(requested_event_ids_json) = request_count),
+    CHECK (jsonb_array_length(persisted_event_ids_json) = attempts_persisted),
+    CHECK (succeeded_count + failed_count = attempts_persisted),
+    CHECK (
+        (terminal_status = 'completed' AND failure_code IS NULL)
+        OR (terminal_status <> 'completed' AND failure_code IS NOT NULL)
+    ),
+    CHECK (
+        terminal_status <> 'completed'
+        OR (
+            execution_id IS NOT NULL
+            AND endpoint_host IS NOT NULL
+            AND delivery_fingerprint IS NOT NULL
+            AND retry_policy_fingerprint IS NOT NULL
+            AND retry_execution_policy_fingerprint IS NOT NULL
+            AND lock_model_version IS NOT NULL
+            AND lock_key_fingerprint IS NOT NULL
+            AND lock_acquired
+            AND lock_released
+            AND execution_summary_json IS NOT NULL
+            AND request_count > 0
+            AND request_count = attempts_persisted
+            AND requested_event_ids_json = persisted_event_ids_json
+        )
+    ),
+    CHECK (
+        terminal_status <> 'failed_before_request'
+        OR (
+            execution_id IS NULL
+            AND request_count = 0
+            AND attempts_persisted = 0
+            AND execution_summary_json IS NULL
+        )
+    ),
+    CHECK (
+        terminal_status <> 'failed_after_request'
+        OR (
+            execution_id IS NULL
+            AND request_count > 0
+            AND request_count = attempts_persisted
+            AND requested_event_ids_json = persisted_event_ids_json
+            AND execution_summary_json IS NULL
+        )
+    ),
+    CHECK (
+        terminal_status <> 'persistence_uncertain'
+        OR (
+            execution_id IS NULL
+            AND request_count > attempts_persisted
+            AND execution_summary_json IS NULL
+        )
+    ),
+    CHECK (record_json ->> 'record_id' = record_id),
+    CHECK (record_json ->> 'model_version' = model_version),
+    CHECK (record_json ->> 'request_id' = request_id),
+    CHECK (record_json ->> 'plan_id' = plan_id),
+    CHECK (record_json ->> 'terminal_status' = terminal_status),
+    CHECK (record_json -> 'attempt_ids' = attempt_ids_json),
+    CHECK (record_json -> 'requested_event_ids' = requested_event_ids_json),
+    CHECK (record_json -> 'persisted_event_ids' = persisted_event_ids_json),
+    CHECK (record_json -> 'execution_summary' = execution_summary_json)
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS
+idx_notification_retry_execution_id_unique
+    ON risk_platform.portfolio_risk_notification_retry_executions (execution_id)
+    WHERE execution_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_notification_retry_execution_history
+    ON risk_platform.portfolio_risk_notification_retry_executions (
+        recorded_at DESC,
+        terminal_status,
+        request_id
+    );
+
+CREATE OR REPLACE FUNCTION
+risk_platform.reject_notification_retry_execution_mutation()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    RAISE EXCEPTION
+        'portfolio_risk_notification_retry_executions is append-only';
+END;
+$$;
+
+DROP TRIGGER IF EXISTS
+trg_notification_retry_execution_append_only
+ON risk_platform.portfolio_risk_notification_retry_executions;
+
+CREATE TRIGGER trg_notification_retry_execution_append_only
+BEFORE UPDATE OR DELETE
+ON risk_platform.portfolio_risk_notification_retry_executions
+FOR EACH ROW
+EXECUTE FUNCTION risk_platform.reject_notification_retry_execution_mutation();

--- a/src/orchestration/run_recorded_portfolio_risk_notification_retries.py
+++ b/src/orchestration/run_recorded_portfolio_risk_notification_retries.py
@@ -1,0 +1,372 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from collections.abc import Callable, Mapping, Sequence
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, cast
+
+from src.common.exceptions import OverlapError, StorageError, ValidationError
+from src.orchestration.deliver_portfolio_risk_notifications import (
+    AttemptWriter,
+    Transport,
+    _default_transport,
+    _endpoint,
+    write_delivery_attempt,
+)
+from src.orchestration.execute_portfolio_risk_notification_retries import (
+    execute_portfolio_risk_notification_retries,
+)
+from src.orchestration.portfolio_risk_notification_delivery_lock import (
+    LOCK_KEY_FINGERPRINT,
+    LOCK_MODEL_VERSION,
+)
+from src.orchestration.portfolio_risk_notification_retry_execution_policy import (
+    aware_utc,
+    load_retry_execution_contract,
+    safe_segment,
+)
+from src.orchestration.portfolio_risk_notification_retry_plan_contract import (
+    load_retry_plan,
+)
+from src.warehouse.notification_retry_execution_contract import (
+    build_retry_execution_record,
+)
+from src.warehouse.notification_retry_execution_recorder import (
+    record_notification_retry_execution,
+)
+from src.warehouse.postgres_loader import DEFAULT_POSTGRES_DSN
+
+Clock = Callable[[], datetime]
+Executor = Callable[..., dict[str, Any]]
+Recorder = Callable[..., dict[str, Any]]
+
+
+class RecordedRetryExecutionError(RuntimeError):
+    def __init__(
+        self,
+        *,
+        failure_code: str,
+        history: Mapping[str, Any],
+    ) -> None:
+        super().__init__(failure_code)
+        self.failure_code = failure_code
+        self.history = dict(history)
+
+
+def _failure_code(exc: BaseException) -> str:
+    if isinstance(exc, OverlapError):
+        return "overlap_error"
+    if isinstance(exc, ValidationError):
+        return "validation_error"
+    if isinstance(exc, StorageError):
+        return "storage_error"
+    return "unexpected_error"
+
+
+def _terminal_status(*, requests: int, attempts_persisted: int) -> str:
+    if requests == 0:
+        return "failed_before_request"
+    if requests > attempts_persisted:
+        return "persistence_uncertain"
+    return "failed_after_request"
+
+
+def _next_utc(clock: Clock, *, minimum: datetime, label: str) -> datetime:
+    value = aware_utc(clock(), label)
+    return value if value >= minimum else minimum
+
+
+def _retained_fingerprint(
+    retained_plan: Mapping[str, Any],
+    group: str,
+) -> str | None:
+    value = retained_plan.get(group)
+    if not isinstance(value, Mapping):
+        return None
+    fingerprint = value.get("fingerprint")
+    return fingerprint if isinstance(fingerprint, str) else None
+
+
+def execute_and_record_portfolio_risk_notification_retries(
+    *,
+    plan_path: Path,
+    confirm_plan_id: str,
+    request_id: str,
+    config_path: Path,
+    dsn: str,
+    execute: bool = False,
+    environment: Mapping[str, str] | None = None,
+    executor: Executor | None = None,
+    recorder: Recorder | None = None,
+    transport: Transport | None = None,
+    attempt_writer: AttemptWriter | None = None,
+    clock: Clock | None = None,
+    reader: Callable[..., list[dict[str, Any]]] | None = None,
+    lock_factory: Callable[..., Any] | None = None,
+) -> dict[str, Any]:
+    retained_plan = load_retry_plan(plan_path)
+    selected_request_id = safe_segment(request_id, "request_id")
+    assert selected_request_id is not None
+    plan_id = retained_plan["plan_id"]
+    assert isinstance(plan_id, str)
+
+    selected_clock = clock or (lambda: datetime.now(timezone.utc))
+    started_at = aware_utc(selected_clock(), "recorded execution started_at")
+    clock_calls = 0
+
+    def executor_clock() -> datetime:
+        nonlocal clock_calls
+        if clock_calls == 0:
+            clock_calls += 1
+            return started_at
+        clock_calls += 1
+        return _next_utc(
+            selected_clock,
+            minimum=started_at,
+            label="recorded execution clock",
+        )
+
+    selected_transport = transport or _default_transport
+    selected_writer = attempt_writer or (
+        lambda attempt: write_delivery_attempt(attempt, dsn=dsn)
+    )
+    selected_environment = environment if environment is not None else os.environ
+    selected_executor = executor or execute_portfolio_risk_notification_retries
+    selected_recorder = recorder or record_notification_retry_execution
+
+    requested_event_ids: list[str] = []
+    persisted_attempts: list[dict[str, Any]] = []
+
+    def tracking_transport(
+        endpoint: str,
+        payload: bytes,
+        headers: Mapping[str, str],
+        timeout_seconds: float,
+    ) -> int:
+        event_id = headers.get("Idempotency-Key")
+        if not isinstance(event_id, str) or not event_id:
+            raise ValidationError("retry transport is missing Idempotency-Key")
+        requested_event_ids.append(event_id)
+        return selected_transport(endpoint, payload, headers, timeout_seconds)
+
+    def tracking_writer(attempt: Mapping[str, Any]) -> None:
+        selected_writer(attempt)
+        persisted_attempts.append(dict(attempt))
+
+    endpoint_host: str | None = None
+    delivery_fingerprint = _retained_fingerprint(retained_plan, "delivery_config")
+    retry_policy_fingerprint = _retained_fingerprint(retained_plan, "retry_policy")
+    retry_execution_policy_fingerprint: str | None = None
+    execution_summary: dict[str, Any] | None = None
+
+    try:
+        delivery_config, retry_policy, execution_policy = load_retry_execution_contract(
+            config_path
+        )
+        delivery_fingerprint = delivery_config.fingerprint
+        retry_policy_fingerprint = retry_policy.fingerprint
+        retry_execution_policy_fingerprint = execution_policy.fingerprint
+        raw_endpoint = selected_environment.get(delivery_config.endpoint_env)
+        if raw_endpoint is not None:
+            _, endpoint_host = _endpoint(raw_endpoint)
+
+        execution_summary = selected_executor(
+            plan_path=plan_path,
+            confirm_plan_id=confirm_plan_id,
+            request_id=selected_request_id,
+            config_path=config_path,
+            dsn=dsn,
+            execute=execute,
+            environment=selected_environment,
+            reader=reader,
+            attempt_writer=tracking_writer,
+            transport=tracking_transport,
+            clock=executor_clock,
+            lock_factory=lock_factory,
+        )
+        outcomes = execution_summary.get("outcomes")
+        if not isinstance(outcomes, list):
+            raise ValidationError("retry execution summary outcomes are unavailable")
+        finished_at = _next_utc(
+            selected_clock,
+            minimum=started_at,
+            label="recorded execution finished_at",
+        )
+        recorded_at = _next_utc(
+            selected_clock,
+            minimum=finished_at,
+            label="recorded execution recorded_at",
+        )
+        attempt_ids = [str(outcome["attempt_id"]) for outcome in outcomes]
+        event_ids = [str(outcome["event_id"]) for outcome in outcomes]
+        succeeded = sum(outcome.get("outcome") == "succeeded" for outcome in outcomes)
+        failed = sum(outcome.get("outcome") == "failed" for outcome in outcomes)
+        record = build_retry_execution_record(
+            request_id=selected_request_id,
+            plan_id=plan_id,
+            started_at=started_at,
+            finished_at=finished_at,
+            recorded_at=recorded_at,
+            terminal_status="completed",
+            failure_code=None,
+            request_count=len(requested_event_ids),
+            attempts_persisted=len(persisted_attempts),
+            succeeded_count=succeeded,
+            failed_count=failed,
+            attempt_ids=attempt_ids,
+            requested_event_ids=event_ids,
+            persisted_event_ids=event_ids,
+            execution_summary=execution_summary,
+        )
+    except Exception as exc:
+        finished_at = _next_utc(
+            selected_clock,
+            minimum=started_at,
+            label="recorded execution finished_at",
+        )
+        recorded_at = _next_utc(
+            selected_clock,
+            minimum=finished_at,
+            label="recorded execution recorded_at",
+        )
+        attempt_ids = [
+            str(attempt["attempt_id"])
+            for attempt in persisted_attempts
+            if attempt.get("attempt_id") is not None
+        ]
+        persisted_event_ids = [
+            str(attempt["event_id"])
+            for attempt in persisted_attempts
+            if attempt.get("event_id") is not None
+        ]
+        succeeded = sum(
+            attempt.get("outcome") == "succeeded" for attempt in persisted_attempts
+        )
+        failed = sum(
+            attempt.get("outcome") == "failed" for attempt in persisted_attempts
+        )
+        record = build_retry_execution_record(
+            request_id=selected_request_id,
+            plan_id=plan_id,
+            started_at=started_at,
+            finished_at=finished_at,
+            recorded_at=recorded_at,
+            terminal_status=_terminal_status(
+                requests=len(requested_event_ids),
+                attempts_persisted=len(persisted_attempts),
+            ),
+            failure_code=_failure_code(exc),
+            request_count=len(requested_event_ids),
+            attempts_persisted=len(persisted_attempts),
+            succeeded_count=succeeded,
+            failed_count=failed,
+            attempt_ids=attempt_ids,
+            requested_event_ids=requested_event_ids,
+            persisted_event_ids=persisted_event_ids,
+            execution_summary=None,
+            endpoint_host=endpoint_host,
+            delivery_fingerprint=delivery_fingerprint,
+            retry_policy_fingerprint=retry_policy_fingerprint,
+            retry_execution_policy_fingerprint=(
+                retry_execution_policy_fingerprint
+            ),
+            lock_model_version=LOCK_MODEL_VERSION,
+            lock_key_fingerprint=LOCK_KEY_FINGERPRINT,
+            lock_acquired=True if requested_event_ids else None,
+            lock_released=None,
+        )
+        history = selected_recorder(dsn=dsn, record=record)
+        raise RecordedRetryExecutionError(
+            failure_code=cast(str, record["failure_code"]),
+            history=history,
+        ) from None
+
+    history = selected_recorder(dsn=dsn, record=record)
+    return {
+        "execution_summary": execution_summary,
+        "history": history,
+    }
+
+
+def _write_summary(path: Path, summary: Mapping[str, Any]) -> None:
+    if path.is_symlink():
+        raise StorageError("recorded retry summary must not be a symbolic link")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_suffix(path.suffix + ".tmp")
+    try:
+        temporary.write_text(
+            json.dumps(summary, indent=2, sort_keys=True, allow_nan=False) + "\n",
+            encoding="utf-8",
+        )
+        temporary.replace(path)
+    except (OSError, TypeError, ValueError):
+        temporary.unlink(missing_ok=True)
+        raise StorageError("unable to write recorded retry summary") from None
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Execute one exact notification retry plan and retain terminal "
+            "append-only PostgreSQL history."
+        )
+    )
+    parser.add_argument("--plan", required=True, type=Path)
+    parser.add_argument("--confirm-plan-id", required=True)
+    parser.add_argument("--request-id", required=True)
+    parser.add_argument(
+        "--config",
+        type=Path,
+        default=Path("config/notification_delivery.yaml"),
+    )
+    parser.add_argument(
+        "--dsn",
+        default=os.environ.get("WAREHOUSE_POSTGRES_DSN", DEFAULT_POSTGRES_DSN),
+    )
+    parser.add_argument("--execute", action="store_true")
+    parser.add_argument("--summary-json", type=Path)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    try:
+        result = execute_and_record_portfolio_risk_notification_retries(
+            plan_path=args.plan,
+            confirm_plan_id=args.confirm_plan_id,
+            request_id=args.request_id,
+            config_path=args.config,
+            dsn=args.dsn,
+            execute=args.execute,
+        )
+        if args.summary_json is not None:
+            _write_summary(args.summary_json, result)
+    except RecordedRetryExecutionError as exc:
+        print(
+            "Recorded notification retry failed with terminal evidence: "
+            f"{exc.failure_code}; record_id={exc.history['record_id']}",
+            file=sys.stderr,
+        )
+        return 1
+    except ValidationError as exc:
+        print(f"Recorded notification retry rejected: {exc}", file=sys.stderr)
+        return 1
+    except (StorageError, RuntimeError) as exc:
+        print(f"Recorded notification retry history failed: {exc}", file=sys.stderr)
+        return 1
+    except Exception:
+        print(
+            "Recorded notification retry failed: unexpected local failure",
+            file=sys.stderr,
+        )
+        return 1
+    print(json.dumps(result, sort_keys=True, allow_nan=False))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/orchestration/run_recorded_portfolio_risk_notification_retries.py
+++ b/src/orchestration/run_recorded_portfolio_risk_notification_retries.py
@@ -34,6 +34,10 @@ from src.orchestration.portfolio_risk_notification_retry_plan_contract import (
 )
 from src.warehouse.notification_retry_execution_contract import (
     build_retry_execution_record,
+    validate_retry_execution_record,
+)
+from src.warehouse.notification_retry_execution_reader import (
+    read_notification_retry_execution_request,
 )
 from src.warehouse.notification_retry_execution_recorder import (
     record_notification_retry_execution,
@@ -43,6 +47,7 @@ from src.warehouse.postgres_loader import DEFAULT_POSTGRES_DSN
 Clock = Callable[[], datetime]
 Executor = Callable[..., dict[str, Any]]
 Recorder = Callable[..., dict[str, Any]]
+HistoryReader = Callable[..., dict[str, Any] | None]
 
 
 class RecordedRetryExecutionError(RuntimeError):
@@ -57,7 +62,7 @@ class RecordedRetryExecutionError(RuntimeError):
         self.history = dict(history)
 
 
-def _failure_code(exc: BaseException) -> str:
+def _failure_code(exc: Exception) -> str:
     if isinstance(exc, OverlapError):
         return "overlap_error"
     if isinstance(exc, ValidationError):
@@ -91,6 +96,40 @@ def _retained_fingerprint(
     return fingerprint if isinstance(fingerprint, str) else None
 
 
+def _existing_terminal_result(
+    *,
+    existing: Mapping[str, Any],
+    request_id: str,
+    plan_id: str,
+) -> dict[str, Any]:
+    record_value = existing.get("record")
+    history_value = existing.get("history")
+    if not isinstance(record_value, Mapping) or not isinstance(history_value, Mapping):
+        raise StorageError("retained retry execution history is invalid")
+    record = validate_retry_execution_record(record_value)
+    if record["request_id"] != request_id:
+        raise StorageError("retained retry execution request identity changed")
+    if record["plan_id"] != plan_id:
+        raise ValidationError(
+            "request_id already exists for a different notification retry plan"
+        )
+    if record["terminal_status"] == "completed":
+        execution_summary = record["execution_summary"]
+        if not isinstance(execution_summary, Mapping):
+            raise StorageError("completed retry execution summary is unavailable")
+        return {
+            "execution_summary": dict(execution_summary),
+            "history": dict(history_value),
+        }
+    failure_code = record["failure_code"]
+    if not isinstance(failure_code, str):
+        raise StorageError("failed retry execution history lacks a failure code")
+    raise RecordedRetryExecutionError(
+        failure_code=failure_code,
+        history=history_value,
+    )
+
+
 def execute_and_record_portfolio_risk_notification_retries(
     *,
     plan_path: Path,
@@ -102,6 +141,7 @@ def execute_and_record_portfolio_risk_notification_retries(
     environment: Mapping[str, str] | None = None,
     executor: Executor | None = None,
     recorder: Recorder | None = None,
+    history_reader: HistoryReader | None = None,
     transport: Transport | None = None,
     attempt_writer: AttemptWriter | None = None,
     clock: Clock | None = None,
@@ -113,6 +153,26 @@ def execute_and_record_portfolio_risk_notification_retries(
     assert selected_request_id is not None
     plan_id = retained_plan["plan_id"]
     assert isinstance(plan_id, str)
+    if execute is not True:
+        raise ValidationError("explicit --execute is required for recorded retries")
+    selected_confirmation = safe_segment(confirm_plan_id, "confirm_plan_id")
+    if selected_confirmation != plan_id:
+        raise ValidationError("confirm_plan_id does not match the retained retry plan")
+
+    selected_history_reader = history_reader
+    if selected_history_reader is None and recorder is None:
+        selected_history_reader = read_notification_retry_execution_request
+    if selected_history_reader is not None:
+        existing = selected_history_reader(
+            dsn=dsn,
+            request_id=selected_request_id,
+        )
+        if existing is not None:
+            return _existing_terminal_result(
+                existing=existing,
+                request_id=selected_request_id,
+                plan_id=plan_id,
+            )
 
     selected_clock = clock or (lambda: datetime.now(timezone.utc))
     started_at = aware_utc(selected_clock(), "recorded execution started_at")

--- a/src/warehouse/notification_delivery_lock_contract_check.py
+++ b/src/warehouse/notification_delivery_lock_contract_check.py
@@ -5,6 +5,7 @@ import json
 import os
 import sys
 from collections.abc import Mapping, Sequence
+from datetime import datetime, timedelta, timezone
 from typing import Any
 
 from src.common.exceptions import OverlapError, StorageError, ValidationError
@@ -14,7 +15,120 @@ from src.orchestration.portfolio_risk_notification_delivery_lock import (
     LOCK_SCOPE,
     acquire_notification_delivery_lock,
 )
+from src.warehouse.notification_retry_execution_contract import (
+    build_retry_execution_record,
+)
+from src.warehouse.notification_retry_execution_recorder import (
+    record_notification_retry_execution,
+)
 from src.warehouse.postgres_loader import DEFAULT_POSTGRES_DSN
+
+
+def _history_contract(dsn: str) -> dict[str, Any]:
+    started = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    record = build_retry_execution_record(
+        request_id="RETRY-CONTRACT-001",
+        plan_id="retry-plan-contract-001",
+        started_at=started,
+        finished_at=started + timedelta(seconds=1),
+        recorded_at=started + timedelta(seconds=2),
+        terminal_status="failed_before_request",
+        failure_code="overlap_error",
+        request_count=0,
+        attempts_persisted=0,
+        succeeded_count=0,
+        failed_count=0,
+        attempt_ids=[],
+        requested_event_ids=[],
+        persisted_event_ids=[],
+        execution_summary=None,
+    )
+    first = record_notification_retry_execution(dsn=dsn, record=record)
+    second = record_notification_retry_execution(dsn=dsn, record=record)
+    if first["created"] is not True or second["created"] is not False:
+        raise AssertionError("notification retry history did not converge on retry")
+
+    conflict = build_retry_execution_record(
+        request_id="RETRY-CONTRACT-001",
+        plan_id="retry-plan-contract-001",
+        started_at=started,
+        finished_at=started + timedelta(seconds=2),
+        recorded_at=started + timedelta(seconds=3),
+        terminal_status="failed_before_request",
+        failure_code="validation_error",
+        request_count=0,
+        attempts_persisted=0,
+        succeeded_count=0,
+        failed_count=0,
+        attempt_ids=[],
+        requested_event_ids=[],
+        persisted_event_ids=[],
+        execution_summary=None,
+    )
+    conflict_rejected = False
+    try:
+        record_notification_retry_execution(dsn=dsn, record=conflict)
+    except ValidationError:
+        conflict_rejected = True
+    if not conflict_rejected:
+        raise AssertionError("conflicting retry execution request was not rejected")
+
+    try:
+        import psycopg
+    except ImportError as exc:  # pragma: no cover - dependency required in CI.
+        raise RuntimeError(
+            "Notification retry history contract requires psycopg"
+        ) from exc
+
+    mutation_rejected = False
+    row_count = 0
+    try:
+        with psycopg.connect(dsn) as connection:
+            with connection.cursor() as cursor:
+                cursor.execute(
+                    """
+                    SELECT COUNT(*)
+                    FROM risk_platform.portfolio_risk_notification_retry_executions
+                    WHERE request_id = %s
+                    """,
+                    (record["request_id"],),
+                )
+                row = cursor.fetchone()
+                row_count = int(row[0]) if row is not None else -1
+                try:
+                    cursor.execute(
+                        """
+                        UPDATE
+                            risk_platform.portfolio_risk_notification_retry_executions
+                        SET recorded_at = recorded_at
+                        WHERE record_id = %s
+                        """,
+                        (record["record_id"],),
+                    )
+                except Exception:
+                    connection.rollback()
+                    mutation_rejected = True
+    except Exception as exc:
+        if not mutation_rejected:
+            raise StorageError(
+                "Unable to verify notification retry execution history"
+            ) from exc
+
+    if row_count != 1:
+        raise AssertionError(
+            "notification retry history retained an unexpected row count"
+        )
+    if not mutation_rejected:
+        raise AssertionError("notification retry history allowed direct mutation")
+
+    return {
+        "retry_history_created": True,
+        "retry_history_exact_retry_converged": True,
+        "retry_history_conflict_rejected": True,
+        "retry_history_append_only": True,
+        "retry_history_rows": row_count,
+        "retry_history_record_id": record["record_id"],
+    }
 
 
 def run_contract_check(dsn: str) -> dict[str, Any]:
@@ -40,11 +154,12 @@ def run_contract_check(dsn: str) -> dict[str, Any]:
         "first_lock_acquired": True,
         "contender_rejected": True,
         "lock_reacquired_after_release": True,
+        **_history_contract(dsn),
         "external_request_performed": False,
         "delivery_attempt_written": False,
     }
     if not _summary_is_secret_safe(summary):
-        raise AssertionError("notification delivery lock summary is not secret-safe")
+        raise AssertionError("notification delivery contract summary is not secret-safe")
     return summary
 
 
@@ -57,8 +172,8 @@ def _summary_is_secret_safe(summary: Mapping[str, Any]) -> bool:
 def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         description=(
-            "Exercise real PostgreSQL contention and release for the global "
-            "portfolio risk notification delivery lock."
+            "Exercise PostgreSQL delivery locking and append-only retry execution "
+            "history."
         )
     )
     parser.add_argument(
@@ -73,11 +188,11 @@ def main(argv: Sequence[str] | None = None) -> int:
     try:
         summary = run_contract_check(args.dsn)
     except (ValidationError, StorageError, AssertionError) as exc:
-        print(f"Notification delivery lock contract failed: {exc}", file=sys.stderr)
+        print(f"Notification delivery contract failed: {exc}", file=sys.stderr)
         return 1
     except Exception:
         print(
-            "Notification delivery lock contract failed: unexpected local failure",
+            "Notification delivery contract failed: unexpected local failure",
             file=sys.stderr,
         )
         return 1

--- a/src/warehouse/notification_delivery_lock_contract_check.py
+++ b/src/warehouse/notification_delivery_lock_contract_check.py
@@ -18,6 +18,9 @@ from src.orchestration.portfolio_risk_notification_delivery_lock import (
 from src.warehouse.notification_retry_execution_contract import (
     build_retry_execution_record,
 )
+from src.warehouse.notification_retry_execution_reader import (
+    read_notification_retry_execution_request,
+)
 from src.warehouse.notification_retry_execution_recorder import (
     record_notification_retry_execution,
 )
@@ -47,6 +50,21 @@ def _history_contract(dsn: str) -> dict[str, Any]:
     second = record_notification_retry_execution(dsn=dsn, record=record)
     if first["created"] is not True or second["created"] is not False:
         raise AssertionError("notification retry history did not converge on retry")
+
+    retained = read_notification_retry_execution_request(
+        dsn=dsn,
+        request_id=record["request_id"],
+    )
+    if retained is None:
+        raise AssertionError("notification retry history preflight lookup returned no row")
+    if retained["record"] != record:
+        raise AssertionError("notification retry history preflight record changed")
+    retained_history = retained["history"]
+    if (
+        retained_history["record_id"] != record["record_id"]
+        or retained_history["created"] is not False
+    ):
+        raise AssertionError("notification retry history preflight summary is invalid")
 
     conflict = build_retry_execution_record(
         request_id="RETRY-CONTRACT-001",
@@ -124,6 +142,7 @@ def _history_contract(dsn: str) -> dict[str, Any]:
     return {
         "retry_history_created": True,
         "retry_history_exact_retry_converged": True,
+        "retry_history_preflight_read_validated": True,
         "retry_history_conflict_rejected": True,
         "retry_history_append_only": True,
         "retry_history_rows": row_count,

--- a/src/warehouse/notification_retry_execution_contract.py
+++ b/src/warehouse/notification_retry_execution_contract.py
@@ -1,0 +1,639 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from collections.abc import Mapping, Sequence
+from datetime import datetime, timezone
+from typing import Any
+
+from src.common.exceptions import ValidationError
+
+MODEL_VERSION = "portfolio-risk-notification-retry-execution-record-v1"
+EXECUTION_MODEL_VERSION = "portfolio-risk-manual-retry-execution-v1"
+CHANNEL = "webhook"
+MAX_EVENTS = 100
+TERMINAL_STATUSES = frozenset(
+    {
+        "completed",
+        "failed_before_request",
+        "failed_after_request",
+        "persistence_uncertain",
+    }
+)
+FAILURE_CODES = frozenset(
+    {
+        "overlap_error",
+        "storage_error",
+        "unexpected_error",
+        "validation_error",
+    }
+)
+SAFE_TEXT = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,511}$")
+SHA256_PATTERN = re.compile(r"^[0-9a-f]{64}$")
+
+
+def _exact_mapping(value: Any, label: str, keys: set[str]) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        raise ValidationError(f"{label} must be a mapping")
+    actual = set(value)
+    if actual != keys:
+        raise ValidationError(
+            f"{label} fields are invalid; "
+            f"missing={sorted(keys - actual)}, unknown={sorted(actual - keys)}"
+        )
+    return value
+
+
+def _safe_text(value: Any, label: str, *, optional: bool = False) -> str | None:
+    if value is None and optional:
+        return None
+    if not isinstance(value, str) or not SAFE_TEXT.fullmatch(value):
+        raise ValidationError(f"{label} must be one safe text segment")
+    return value
+
+
+def _aware_utc(value: Any, label: str) -> datetime:
+    if isinstance(value, datetime):
+        parsed = value
+    elif isinstance(value, str):
+        try:
+            parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        except ValueError:
+            raise ValidationError(f"{label} must be ISO-8601") from None
+    else:
+        raise ValidationError(f"{label} must be timezone-aware")
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise ValidationError(f"{label} must be timezone-aware")
+    return parsed.astimezone(timezone.utc)
+
+
+def _bounded_count(value: Any, label: str) -> int:
+    if type(value) is not int or not 0 <= value <= MAX_EVENTS:
+        raise ValidationError(
+            f"{label} must be an integer between 0 and {MAX_EVENTS}"
+        )
+    return value
+
+
+def _optional_boolean(value: Any, label: str) -> bool | None:
+    if value is None:
+        return None
+    if type(value) is not bool:
+        raise ValidationError(f"{label} must be boolean or null")
+    return value
+
+
+def _safe_id_list(value: Any, label: str) -> list[str]:
+    if not isinstance(value, list):
+        raise ValidationError(f"{label} must be an array")
+    parsed = [_safe_text(item, f"{label} item") for item in value]
+    result = [item for item in parsed if item is not None]
+    if len(result) != len(set(result)):
+        raise ValidationError(f"{label} must contain no duplicates")
+    return result
+
+
+def canonical_retry_execution_record_bytes(
+    record: Mapping[str, Any],
+) -> bytes:
+    try:
+        return json.dumps(
+            record,
+            sort_keys=True,
+            separators=(",", ":"),
+            allow_nan=False,
+        ).encode("utf-8")
+    except (TypeError, ValueError):
+        raise ValidationError("retry execution record is not canonical JSON") from None
+
+
+def _record_id(identity: Mapping[str, Any]) -> str:
+    digest = hashlib.sha256(canonical_retry_execution_record_bytes(identity)).hexdigest()
+    return f"{MODEL_VERSION}-record-{digest[:24]}"
+
+
+def _validate_outcome(
+    value: Any,
+    *,
+    index: int,
+    executed_at: datetime,
+) -> tuple[str, str, str]:
+    outcome = _exact_mapping(
+        value,
+        f"execution summary outcome {index}",
+        {
+            "attempt_id",
+            "attempt_number",
+            "attempted_at",
+            "error_code",
+            "event_id",
+            "http_status",
+            "outcome",
+            "payload_sha256",
+        },
+    )
+    attempt_id = _safe_text(outcome["attempt_id"], "outcome.attempt_id")
+    event_id = _safe_text(outcome["event_id"], "outcome.event_id")
+    assert attempt_id is not None and event_id is not None
+    attempt_number = outcome["attempt_number"]
+    if type(attempt_number) is not int or not 1 <= attempt_number <= 10:
+        raise ValidationError("outcome.attempt_number is invalid")
+    attempted_at = _aware_utc(outcome["attempted_at"], "outcome.attempted_at")
+    if attempted_at < executed_at:
+        raise ValidationError("outcome.attempted_at precedes execution start")
+    http_status = outcome["http_status"]
+    if http_status is not None and (
+        type(http_status) is not int or not 100 <= http_status <= 599
+    ):
+        raise ValidationError("outcome.http_status is invalid")
+    error_code = _safe_text(
+        outcome["error_code"],
+        "outcome.error_code",
+        optional=True,
+    )
+    outcome_name = outcome["outcome"]
+    if outcome_name == "succeeded":
+        if http_status is None or not 200 <= http_status <= 299 or error_code is not None:
+            raise ValidationError("succeeded outcome evidence is inconsistent")
+    elif outcome_name == "failed":
+        if error_code is None or (
+            http_status is not None and 200 <= http_status <= 299
+        ):
+            raise ValidationError("failed outcome evidence is inconsistent")
+    else:
+        raise ValidationError("outcome.outcome is invalid")
+    payload_sha256 = outcome["payload_sha256"]
+    if not isinstance(payload_sha256, str) or not SHA256_PATTERN.fullmatch(
+        payload_sha256
+    ):
+        raise ValidationError("outcome.payload_sha256 is invalid")
+    return attempt_id, event_id, outcome_name
+
+
+def _execution_summary_fields(summary: Mapping[str, Any]) -> dict[str, Any]:
+    exact = _exact_mapping(
+        summary,
+        "execution summary",
+        {
+            "execution_id",
+            "model_version",
+            "request_id",
+            "plan_id",
+            "executed_at",
+            "channel",
+            "endpoint",
+            "configuration",
+            "revalidation",
+            "selection",
+            "outcomes",
+            "outcome_counts",
+            "execution",
+            "concurrency_control",
+            "response_bodies_recorded",
+            "plan_mutated",
+            "acknowledgement_mutated",
+            "dead_letter_mutated",
+        },
+    )
+    if exact["model_version"] != EXECUTION_MODEL_VERSION:
+        raise ValidationError("execution summary model_version is unsupported")
+    if exact["channel"] != CHANNEL:
+        raise ValidationError("execution summary channel is unsupported")
+    if any(
+        exact[key] is not False
+        for key in (
+            "response_bodies_recorded",
+            "plan_mutated",
+            "acknowledgement_mutated",
+            "dead_letter_mutated",
+        )
+    ):
+        raise ValidationError("execution summary side-effect declarations are invalid")
+
+    executed_at = _aware_utc(exact["executed_at"], "executed_at")
+    execution = _exact_mapping(
+        exact["execution"],
+        "execution summary execution",
+        {
+            "requested",
+            "performed",
+            "external_requests_performed",
+            "delivery_attempts_written",
+        },
+    )
+    counts = _exact_mapping(
+        exact["outcome_counts"],
+        "execution summary outcome_counts",
+        {"succeeded", "failed"},
+    )
+    concurrency = _exact_mapping(
+        exact["concurrency_control"],
+        "execution summary concurrency_control",
+        {
+            "performed",
+            "acquired",
+            "released",
+            "held_through_revalidation",
+            "held_through_attempt_persistence",
+            "model_version",
+            "scope",
+            "key_fingerprint",
+        },
+    )
+    configuration = _exact_mapping(
+        exact["configuration"],
+        "execution summary configuration",
+        {
+            "delivery_fingerprint",
+            "retry_execution_policy_fingerprint",
+            "retry_policy_fingerprint",
+        },
+    )
+    endpoint = _exact_mapping(
+        exact["endpoint"],
+        "execution summary endpoint",
+        {"host", "full_url_recorded"},
+    )
+    revalidation = _exact_mapping(
+        exact["revalidation"],
+        "execution summary revalidation",
+        {
+            "performed",
+            "current_plan_id",
+            "events_checked",
+            "exact_event_evidence_unchanged",
+        },
+    )
+    selection = _exact_mapping(
+        exact["selection"],
+        "execution summary selection",
+        {"planned_retryable_events", "executed_events", "max_events"},
+    )
+    outcomes = exact["outcomes"]
+    if not isinstance(outcomes, list):
+        raise ValidationError("execution summary outcomes must be an array")
+
+    attempt_ids: list[str] = []
+    event_ids: list[str] = []
+    outcome_names: list[str] = []
+    for index, outcome in enumerate(outcomes):
+        attempt_id, event_id, outcome_name = _validate_outcome(
+            outcome,
+            index=index,
+            executed_at=executed_at,
+        )
+        attempt_ids.append(attempt_id)
+        event_ids.append(event_id)
+        outcome_names.append(outcome_name)
+    if len(attempt_ids) != len(set(attempt_ids)):
+        raise ValidationError("execution summary attempt IDs must be unique")
+    if len(event_ids) != len(set(event_ids)):
+        raise ValidationError("execution summary event IDs must be unique")
+
+    external_requests = _bounded_count(
+        execution["external_requests_performed"],
+        "external_requests_performed",
+    )
+    attempts_written = _bounded_count(
+        execution["delivery_attempts_written"],
+        "delivery_attempts_written",
+    )
+    succeeded = _bounded_count(counts["succeeded"], "succeeded")
+    failed = _bounded_count(counts["failed"], "failed")
+    planned = _bounded_count(
+        selection["planned_retryable_events"],
+        "planned_retryable_events",
+    )
+    executed = _bounded_count(selection["executed_events"], "executed_events")
+    max_events = _bounded_count(selection["max_events"], "max_events")
+    events_checked = _bounded_count(revalidation["events_checked"], "events_checked")
+    if execution["requested"] is not True or execution["performed"] is not True:
+        raise ValidationError("completed execution summary must be performed")
+    if external_requests != len(outcomes) or attempts_written != len(outcomes):
+        raise ValidationError("execution summary request and attempt counts disagree")
+    if succeeded != outcome_names.count("succeeded"):
+        raise ValidationError("execution summary succeeded count disagrees")
+    if failed != outcome_names.count("failed"):
+        raise ValidationError("execution summary failed count disagrees")
+    if planned != executed or executed != len(outcomes) or max_events < executed:
+        raise ValidationError("execution summary selection counts disagree")
+    if events_checked < executed:
+        raise ValidationError("execution summary revalidation count is too small")
+    if revalidation["performed"] is not True:
+        raise ValidationError("execution summary must retain revalidation evidence")
+    if revalidation["exact_event_evidence_unchanged"] is not True:
+        raise ValidationError("execution summary event evidence was not unchanged")
+    if revalidation["current_plan_id"] != exact["plan_id"]:
+        raise ValidationError("execution summary current plan identity disagrees")
+    if any(
+        concurrency[key] is not True
+        for key in (
+            "performed",
+            "acquired",
+            "released",
+            "held_through_revalidation",
+            "held_through_attempt_persistence",
+        )
+    ):
+        raise ValidationError("completed execution must retain released lock evidence")
+    if endpoint["full_url_recorded"] is not False:
+        raise ValidationError("execution summary must not retain the full endpoint URL")
+
+    return {
+        "execution_id": _safe_text(exact["execution_id"], "execution_id"),
+        "request_id": _safe_text(exact["request_id"], "request_id"),
+        "plan_id": _safe_text(exact["plan_id"], "plan_id"),
+        "executed_at": executed_at,
+        "endpoint_host": _safe_text(endpoint["host"], "endpoint.host"),
+        "delivery_fingerprint": _safe_text(
+            configuration["delivery_fingerprint"],
+            "delivery_fingerprint",
+        ),
+        "retry_policy_fingerprint": _safe_text(
+            configuration["retry_policy_fingerprint"],
+            "retry_policy_fingerprint",
+        ),
+        "retry_execution_policy_fingerprint": _safe_text(
+            configuration["retry_execution_policy_fingerprint"],
+            "retry_execution_policy_fingerprint",
+        ),
+        "lock_model_version": _safe_text(
+            concurrency["model_version"],
+            "lock.model_version",
+        ),
+        "lock_key_fingerprint": _safe_text(
+            concurrency["key_fingerprint"],
+            "lock.key_fingerprint",
+        ),
+        "lock_acquired": True,
+        "lock_released": True,
+        "request_count": external_requests,
+        "attempts_persisted": attempts_written,
+        "succeeded_count": succeeded,
+        "failed_count": failed,
+        "attempt_ids": attempt_ids,
+        "event_ids": event_ids,
+    }
+
+
+def build_retry_execution_record(
+    *,
+    request_id: str,
+    plan_id: str,
+    started_at: datetime | str,
+    finished_at: datetime | str,
+    recorded_at: datetime | str,
+    terminal_status: str,
+    failure_code: str | None,
+    request_count: int,
+    attempts_persisted: int,
+    succeeded_count: int,
+    failed_count: int,
+    attempt_ids: Sequence[str],
+    requested_event_ids: Sequence[str],
+    persisted_event_ids: Sequence[str],
+    execution_summary: Mapping[str, Any] | None,
+    endpoint_host: str | None = None,
+    delivery_fingerprint: str | None = None,
+    retry_policy_fingerprint: str | None = None,
+    retry_execution_policy_fingerprint: str | None = None,
+    lock_model_version: str | None = None,
+    lock_key_fingerprint: str | None = None,
+    lock_acquired: bool | None = None,
+    lock_released: bool | None = None,
+) -> dict[str, Any]:
+    selected_request_id = _safe_text(request_id, "request_id")
+    selected_plan_id = _safe_text(plan_id, "plan_id")
+    assert selected_request_id is not None and selected_plan_id is not None
+    started = _aware_utc(started_at, "started_at")
+    finished = _aware_utc(finished_at, "finished_at")
+    recorded = _aware_utc(recorded_at, "recorded_at")
+    if finished < started:
+        raise ValidationError("finished_at must not precede started_at")
+    if recorded < finished:
+        raise ValidationError("recorded_at must not precede finished_at")
+    if terminal_status not in TERMINAL_STATUSES:
+        raise ValidationError("terminal_status is invalid")
+    if failure_code is not None and failure_code not in FAILURE_CODES:
+        raise ValidationError("failure_code is invalid")
+
+    requests = _bounded_count(request_count, "request_count")
+    persisted = _bounded_count(attempts_persisted, "attempts_persisted")
+    succeeded = _bounded_count(succeeded_count, "succeeded_count")
+    failed = _bounded_count(failed_count, "failed_count")
+    selected_attempt_ids = _safe_id_list(list(attempt_ids), "attempt_ids")
+    selected_requested_events = _safe_id_list(
+        list(requested_event_ids),
+        "requested_event_ids",
+    )
+    selected_persisted_events = _safe_id_list(
+        list(persisted_event_ids),
+        "persisted_event_ids",
+    )
+    if requests != len(selected_requested_events):
+        raise ValidationError("request_count must match requested_event_ids")
+    if persisted != len(selected_attempt_ids):
+        raise ValidationError("attempts_persisted must match attempt_ids")
+    if persisted != len(selected_persisted_events):
+        raise ValidationError("attempts_persisted must match persisted_event_ids")
+    if persisted > requests:
+        raise ValidationError("attempts_persisted must not exceed request_count")
+    if selected_persisted_events != selected_requested_events[:persisted]:
+        raise ValidationError(
+            "persisted_event_ids must be the persisted prefix of requested_event_ids"
+        )
+    if succeeded + failed != persisted:
+        raise ValidationError("persisted attempt outcome counts disagree")
+
+    selected_endpoint_host = _safe_text(
+        endpoint_host,
+        "endpoint_host",
+        optional=True,
+    )
+    selected_delivery_fingerprint = _safe_text(
+        delivery_fingerprint,
+        "delivery_fingerprint",
+        optional=True,
+    )
+    selected_retry_policy_fingerprint = _safe_text(
+        retry_policy_fingerprint,
+        "retry_policy_fingerprint",
+        optional=True,
+    )
+    selected_execution_policy_fingerprint = _safe_text(
+        retry_execution_policy_fingerprint,
+        "retry_execution_policy_fingerprint",
+        optional=True,
+    )
+    selected_lock_model = _safe_text(
+        lock_model_version,
+        "lock_model_version",
+        optional=True,
+    )
+    selected_lock_key = _safe_text(
+        lock_key_fingerprint,
+        "lock_key_fingerprint",
+        optional=True,
+    )
+    selected_lock_acquired = _optional_boolean(lock_acquired, "lock_acquired")
+    selected_lock_released = _optional_boolean(lock_released, "lock_released")
+    if (selected_lock_model is None) != (selected_lock_key is None):
+        raise ValidationError("lock identity must be complete or absent")
+    if selected_lock_released is True and selected_lock_acquired is not True:
+        raise ValidationError("released lock evidence requires acquired lock evidence")
+
+    execution_id: str | None = None
+    canonical_summary: dict[str, Any] | None = None
+    if terminal_status == "completed":
+        if failure_code is not None or execution_summary is None:
+            raise ValidationError("completed execution requires a summary and no failure")
+        summary = dict(execution_summary)
+        fields = _execution_summary_fields(summary)
+        if fields["request_id"] != selected_request_id:
+            raise ValidationError("execution summary request_id does not match")
+        if fields["plan_id"] != selected_plan_id:
+            raise ValidationError("execution summary plan_id does not match")
+        if fields["executed_at"] != started:
+            raise ValidationError("execution summary executed_at does not match started_at")
+        if fields["request_count"] != requests:
+            raise ValidationError("execution summary request count does not match")
+        if fields["attempts_persisted"] != persisted:
+            raise ValidationError("execution summary attempt count does not match")
+        if fields["succeeded_count"] != succeeded or fields["failed_count"] != failed:
+            raise ValidationError("execution summary outcome counts do not match")
+        if fields["attempt_ids"] != selected_attempt_ids:
+            raise ValidationError("execution summary attempt IDs do not match")
+        if fields["event_ids"] != selected_requested_events:
+            raise ValidationError("execution summary requested event IDs do not match")
+        if selected_requested_events != selected_persisted_events:
+            raise ValidationError("completed execution must persist every request")
+        execution_id = fields["execution_id"]
+        selected_endpoint_host = fields["endpoint_host"]
+        selected_delivery_fingerprint = fields["delivery_fingerprint"]
+        selected_retry_policy_fingerprint = fields["retry_policy_fingerprint"]
+        selected_execution_policy_fingerprint = fields[
+            "retry_execution_policy_fingerprint"
+        ]
+        selected_lock_model = fields["lock_model_version"]
+        selected_lock_key = fields["lock_key_fingerprint"]
+        selected_lock_acquired = True
+        selected_lock_released = True
+        canonical_summary = summary
+    else:
+        if failure_code is None or execution_summary is not None:
+            raise ValidationError("failed execution requires a bounded failure only")
+        if terminal_status == "failed_before_request" and (
+            requests != 0 or persisted != 0
+        ):
+            raise ValidationError("failed_before_request must have zero side effects")
+        if terminal_status == "failed_after_request" and not (
+            requests > 0 and requests == persisted
+        ):
+            raise ValidationError(
+                "failed_after_request requires every request to have attempt evidence"
+            )
+        if terminal_status == "persistence_uncertain" and not requests > persisted:
+            raise ValidationError(
+                "persistence_uncertain requires a request without attempt evidence"
+            )
+
+    identity = {
+        "attempt_ids": selected_attempt_ids,
+        "attempts_persisted": persisted,
+        "channel": CHANNEL,
+        "delivery_fingerprint": selected_delivery_fingerprint,
+        "endpoint_host": selected_endpoint_host,
+        "execution_id": execution_id,
+        "execution_summary": canonical_summary,
+        "failed_count": failed,
+        "failure_code": failure_code,
+        "finished_at": finished.isoformat(),
+        "lock_acquired": selected_lock_acquired,
+        "lock_key_fingerprint": selected_lock_key,
+        "lock_model_version": selected_lock_model,
+        "lock_released": selected_lock_released,
+        "model_version": MODEL_VERSION,
+        "persisted_event_ids": selected_persisted_events,
+        "plan_id": selected_plan_id,
+        "recorded_at": recorded.isoformat(),
+        "request_count": requests,
+        "request_id": selected_request_id,
+        "requested_event_ids": selected_requested_events,
+        "retry_execution_policy_fingerprint": selected_execution_policy_fingerprint,
+        "retry_policy_fingerprint": selected_retry_policy_fingerprint,
+        "started_at": started.isoformat(),
+        "succeeded_count": succeeded,
+        "terminal_status": terminal_status,
+    }
+    return {"record_id": _record_id(identity), **identity}
+
+
+def validate_retry_execution_record(record: Mapping[str, Any]) -> dict[str, Any]:
+    exact = _exact_mapping(
+        record,
+        "retry execution record",
+        {
+            "record_id",
+            "attempt_ids",
+            "attempts_persisted",
+            "channel",
+            "delivery_fingerprint",
+            "endpoint_host",
+            "execution_id",
+            "execution_summary",
+            "failed_count",
+            "failure_code",
+            "finished_at",
+            "lock_acquired",
+            "lock_key_fingerprint",
+            "lock_model_version",
+            "lock_released",
+            "model_version",
+            "persisted_event_ids",
+            "plan_id",
+            "recorded_at",
+            "request_count",
+            "request_id",
+            "requested_event_ids",
+            "retry_execution_policy_fingerprint",
+            "retry_policy_fingerprint",
+            "started_at",
+            "succeeded_count",
+            "terminal_status",
+        },
+    )
+    if exact["model_version"] != MODEL_VERSION or exact["channel"] != CHANNEL:
+        raise ValidationError("retry execution record contract is unsupported")
+    rebuilt = build_retry_execution_record(
+        request_id=exact["request_id"],
+        plan_id=exact["plan_id"],
+        started_at=exact["started_at"],
+        finished_at=exact["finished_at"],
+        recorded_at=exact["recorded_at"],
+        terminal_status=exact["terminal_status"],
+        failure_code=exact["failure_code"],
+        request_count=exact["request_count"],
+        attempts_persisted=exact["attempts_persisted"],
+        succeeded_count=exact["succeeded_count"],
+        failed_count=exact["failed_count"],
+        attempt_ids=exact["attempt_ids"],
+        requested_event_ids=exact["requested_event_ids"],
+        persisted_event_ids=exact["persisted_event_ids"],
+        execution_summary=exact["execution_summary"],
+        endpoint_host=exact["endpoint_host"],
+        delivery_fingerprint=exact["delivery_fingerprint"],
+        retry_policy_fingerprint=exact["retry_policy_fingerprint"],
+        retry_execution_policy_fingerprint=exact[
+            "retry_execution_policy_fingerprint"
+        ],
+        lock_model_version=exact["lock_model_version"],
+        lock_key_fingerprint=exact["lock_key_fingerprint"],
+        lock_acquired=exact["lock_acquired"],
+        lock_released=exact["lock_released"],
+    )
+    if exact["record_id"] != rebuilt["record_id"]:
+        raise ValidationError("retry execution record_id does not match content")
+    if dict(exact) != rebuilt:
+        raise ValidationError("retry execution record is not canonical")
+    return rebuilt

--- a/src/warehouse/notification_retry_execution_reader.py
+++ b/src/warehouse/notification_retry_execution_reader.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import hashlib
+import re
+from typing import Any
+
+from src.common.exceptions import StorageError, ValidationError
+from src.warehouse.notification_retry_execution_contract import (
+    canonical_retry_execution_record_bytes,
+    validate_retry_execution_record,
+)
+
+SAFE_REQUEST_ID = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,511}$")
+
+
+def _history_summary(
+    record: dict[str, Any],
+    *,
+    digest: str,
+) -> dict[str, Any]:
+    return {
+        "record_id": record["record_id"],
+        "request_id": record["request_id"],
+        "execution_id": record["execution_id"],
+        "plan_id": record["plan_id"],
+        "terminal_status": record["terminal_status"],
+        "failure_code": record["failure_code"],
+        "request_count": record["request_count"],
+        "attempts_persisted": record["attempts_persisted"],
+        "requested_events": len(record["requested_event_ids"]),
+        "document_sha256": digest,
+        "created": False,
+    }
+
+
+def read_notification_retry_execution_request(
+    *,
+    dsn: str,
+    request_id: str,
+) -> dict[str, Any] | None:
+    """Return one validated terminal request record before retry side effects."""
+
+    if not isinstance(request_id, str) or not SAFE_REQUEST_ID.fullmatch(request_id):
+        raise ValidationError("request_id must be one safe text segment")
+    try:
+        import psycopg
+    except ImportError as exc:  # pragma: no cover - required in CI.
+        raise RuntimeError("Notification retry history requires psycopg") from exc
+
+    try:
+        with psycopg.connect(dsn) as connection:
+            with connection.cursor() as cursor:
+                cursor.execute(
+                    """
+                    SELECT record_json, document_sha256
+                    FROM risk_platform.portfolio_risk_notification_retry_executions
+                    WHERE request_id = %s
+                    """,
+                    (request_id,),
+                )
+                row = cursor.fetchone()
+    except Exception:
+        raise StorageError(
+            "notification retry history lookup failed before execution"
+        ) from None
+
+    if row is None:
+        return None
+    record_json, stored_digest = row
+    validated = validate_retry_execution_record(record_json)
+    canonical = canonical_retry_execution_record_bytes(validated)
+    digest = hashlib.sha256(canonical).hexdigest()
+    if stored_digest != digest:
+        raise ValidationError("retained retry execution document digest is invalid")
+    if validated["request_id"] != request_id:
+        raise ValidationError("retained retry execution request identity is invalid")
+    return {
+        "record": validated,
+        "history": _history_summary(validated, digest=digest),
+    }

--- a/src/warehouse/notification_retry_execution_recorder.py
+++ b/src/warehouse/notification_retry_execution_recorder.py
@@ -1,0 +1,234 @@
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import sys
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+from src.common.exceptions import StorageError, ValidationError
+from src.warehouse.notification_retry_execution_contract import (
+    canonical_retry_execution_record_bytes,
+    validate_retry_execution_record,
+)
+from src.warehouse.postgres_loader import DEFAULT_POSTGRES_DSN
+
+
+def _summary(
+    record: Mapping[str, Any],
+    *,
+    created: bool,
+    digest: str,
+) -> dict[str, Any]:
+    return {
+        "record_id": record["record_id"],
+        "request_id": record["request_id"],
+        "execution_id": record["execution_id"],
+        "plan_id": record["plan_id"],
+        "terminal_status": record["terminal_status"],
+        "failure_code": record["failure_code"],
+        "request_count": record["request_count"],
+        "attempts_persisted": record["attempts_persisted"],
+        "requested_events": len(record["requested_event_ids"]),
+        "document_sha256": digest,
+        "created": created,
+    }
+
+
+def record_notification_retry_execution(
+    *,
+    dsn: str,
+    record: Mapping[str, Any],
+) -> dict[str, Any]:
+    validated = validate_retry_execution_record(record)
+    canonical = canonical_retry_execution_record_bytes(validated)
+    digest = hashlib.sha256(canonical).hexdigest()
+    try:
+        import psycopg
+        from psycopg.types.json import Jsonb
+    except ImportError as exc:  # pragma: no cover - required in CI.
+        raise RuntimeError("Notification retry history requires psycopg") from exc
+
+    created = False
+    stored: dict[str, Any] | None = None
+    try:
+        with psycopg.connect(dsn) as connection:
+            with connection.cursor() as cursor:
+                cursor.execute(
+                    """
+                    SELECT record_json, document_sha256
+                    FROM risk_platform.portfolio_risk_notification_retry_executions
+                    WHERE request_id = %s
+                    """,
+                    (validated["request_id"],),
+                )
+                existing = cursor.fetchone()
+                if existing is not None:
+                    existing_json, existing_digest = existing
+                    if existing_digest != digest or existing_json != validated:
+                        raise ValidationError(
+                            "request_id already exists with different retry evidence"
+                        )
+                    return _summary(validated, created=False, digest=digest)
+
+                cursor.execute(
+                    """
+                    INSERT INTO
+                        risk_platform.portfolio_risk_notification_retry_executions (
+                            record_id,
+                            model_version,
+                            request_id,
+                            execution_id,
+                            plan_id,
+                            terminal_status,
+                            failure_code,
+                            channel,
+                            endpoint_host,
+                            started_at,
+                            finished_at,
+                            recorded_at,
+                            request_count,
+                            attempts_persisted,
+                            succeeded_count,
+                            failed_count,
+                            attempt_ids_json,
+                            requested_event_ids_json,
+                            persisted_event_ids_json,
+                            delivery_fingerprint,
+                            retry_policy_fingerprint,
+                            retry_execution_policy_fingerprint,
+                            lock_model_version,
+                            lock_key_fingerprint,
+                            lock_acquired,
+                            lock_released,
+                            execution_summary_json,
+                            record_json,
+                            document_sha256
+                        )
+                    VALUES (
+                        %s, %s, %s, %s, %s, %s, %s, %s, %s, %s,
+                        %s, %s, %s, %s, %s, %s, %s, %s, %s, %s,
+                        %s, %s, %s, %s, %s, %s, %s, %s, %s
+                    )
+                    ON CONFLICT DO NOTHING
+                    RETURNING record_id
+                    """,
+                    (
+                        validated["record_id"],
+                        validated["model_version"],
+                        validated["request_id"],
+                        validated["execution_id"],
+                        validated["plan_id"],
+                        validated["terminal_status"],
+                        validated["failure_code"],
+                        validated["channel"],
+                        validated["endpoint_host"],
+                        validated["started_at"],
+                        validated["finished_at"],
+                        validated["recorded_at"],
+                        validated["request_count"],
+                        validated["attempts_persisted"],
+                        validated["succeeded_count"],
+                        validated["failed_count"],
+                        Jsonb(validated["attempt_ids"]),
+                        Jsonb(validated["requested_event_ids"]),
+                        Jsonb(validated["persisted_event_ids"]),
+                        validated["delivery_fingerprint"],
+                        validated["retry_policy_fingerprint"],
+                        validated["retry_execution_policy_fingerprint"],
+                        validated["lock_model_version"],
+                        validated["lock_key_fingerprint"],
+                        validated["lock_acquired"],
+                        validated["lock_released"],
+                        (
+                            None
+                            if validated["execution_summary"] is None
+                            else Jsonb(validated["execution_summary"])
+                        ),
+                        Jsonb(validated),
+                        digest,
+                    ),
+                )
+                created = cursor.fetchone() is not None
+                cursor.execute(
+                    """
+                    SELECT record_json, document_sha256
+                    FROM risk_platform.portfolio_risk_notification_retry_executions
+                    WHERE record_id = %s
+                    """,
+                    (validated["record_id"],),
+                )
+                row = cursor.fetchone()
+                if row is None:
+                    raise StorageError(
+                        "notification retry record could not be read after insert"
+                    )
+                stored_json, stored_digest = row
+                if stored_digest != digest or stored_json != validated:
+                    raise ValidationError(
+                        "record_id already exists with different retry evidence"
+                    )
+                stored = dict(stored_json)
+            connection.commit()
+    except (ValidationError, StorageError):
+        raise
+    except Exception:
+        raise StorageError(
+            "notification retry history database operation failed"
+        ) from None
+
+    if stored is None:  # pragma: no cover - guarded by the transaction.
+        raise StorageError("notification retry history result is unavailable")
+    return _summary(stored, created=created, digest=digest)
+
+
+def _read_record(path: Path) -> dict[str, Any]:
+    if path.is_symlink():
+        raise ValidationError("retry execution record must not be a symbolic link")
+    if not path.is_file():
+        raise ValidationError("retry execution record must be a regular file")
+    if path.stat().st_size > 1_048_576:
+        raise ValidationError("retry execution record exceeds 1 MB")
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, ValueError):
+        raise ValidationError("retry execution record could not be read") from None
+    if not isinstance(value, Mapping):
+        raise ValidationError("retry execution record must be a JSON object")
+    return dict(value)
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Append one terminal notification retry execution to PostgreSQL."
+    )
+    parser.add_argument("--record", required=True, type=Path)
+    parser.add_argument(
+        "--dsn",
+        default=os.environ.get("WAREHOUSE_POSTGRES_DSN", DEFAULT_POSTGRES_DSN),
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    try:
+        result = record_notification_retry_execution(
+            dsn=args.dsn,
+            record=_read_record(args.record),
+        )
+    except ValidationError as exc:
+        print(f"Notification retry execution rejected: {exc}", file=sys.stderr)
+        return 1
+    except (StorageError, RuntimeError) as exc:
+        print(f"Notification retry history failed: {exc}", file=sys.stderr)
+        return 1
+    print(json.dumps(result, sort_keys=True, allow_nan=False))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/test_docker_compose_contract.py
+++ b/tests/unit/test_docker_compose_contract.py
@@ -43,6 +43,7 @@ def test_local_database_seed_mounts_are_read_only_and_ordered() -> None:
         "./sql/operational_review_schema.sql:/docker-entrypoint-initdb.d/16_operational_review_schema.sql:ro",
         "./sql/operational_readiness_overrides_schema.sql:/docker-entrypoint-initdb.d/17_operational_readiness_overrides_schema.sql:ro",
         "./sql/local_schedule_runs_schema.sql:/docker-entrypoint-initdb.d/18_local_schedule_runs_schema.sql:ro",
+        "./sql/portfolio_risk_notification_retry_execution_schema.sql:/docker-entrypoint-initdb.d/19_portfolio_risk_notification_retry_execution_schema.sql:ro",
     ]
     assert services["mongo"]["volumes"] == [
         "./mongo/init:/docker-entrypoint-initdb.d:ro"

--- a/tests/unit/test_notification_retry_execution_history.py
+++ b/tests/unit/test_notification_retry_execution_history.py
@@ -1,0 +1,451 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+from src.common.exceptions import StorageError, ValidationError
+from src.orchestration.plan_portfolio_risk_notification_retries import (
+    plan_portfolio_risk_notification_retries,
+)
+from src.orchestration.run_recorded_portfolio_risk_notification_retries import (
+    RecordedRetryExecutionError,
+    _write_summary,
+    execute_and_record_portfolio_risk_notification_retries,
+)
+from src.warehouse.notification_retry_execution_contract import (
+    MODEL_VERSION,
+    build_retry_execution_record,
+    validate_retry_execution_record,
+)
+
+PLANNED_AT = datetime(2026, 1, 10, 12, tzinfo=timezone.utc)
+STARTED_AT = PLANNED_AT + timedelta(minutes=1)
+
+
+def _config_payload() -> dict[str, Any]:
+    return {
+        "delivery": {
+            "webhook": {
+                "enabled": True,
+                "endpoint_env": "RISK_NOTIFICATION_WEBHOOK_URL",
+                "timeout_seconds": 5,
+                "max_batch_events": 25,
+                "max_attempts_per_event": 3,
+                "initial_backoff_seconds": 1,
+            },
+            "retry_planning": {
+                "max_candidate_rows": 500,
+                "max_plan_events": 25,
+                "max_event_age_seconds": 7 * 24 * 60 * 60,
+                "max_backoff_seconds": 3600,
+                "retryable_http_statuses": [408, 425, 429, 500, 502, 503, 504],
+                "retryable_error_codes": ["network_error"],
+            },
+            "retry_execution": {
+                "enabled": True,
+                "max_plan_age_seconds": 3600,
+                "max_events": 25,
+            },
+        }
+    }
+
+
+def _write_config(tmp_path: Path) -> Path:
+    path = tmp_path / "notification-delivery.yaml"
+    path.write_text(
+        yaml.safe_dump(_config_payload(), sort_keys=False),
+        encoding="utf-8",
+    )
+    return path
+
+
+def _candidate() -> dict[str, Any]:
+    event_time = PLANNED_AT - timedelta(hours=2)
+    return {
+        "event_id": "event-1",
+        "outbox_model_version": "portfolio-risk-notification-outbox-v1",
+        "event_type": "breach_opened",
+        "transition_type": "opened",
+        "delivery_disposition": "pending",
+        "source_evaluation_calculation_id": "evaluation-event-1",
+        "policy_id": "us-tech-standard",
+        "policy_fingerprint": "policy-fingerprint",
+        "portfolio_id": "us-tech-equal",
+        "definition_fingerprint": "definition-fingerprint",
+        "metric_name": "portfolio_volatility_annualized",
+        "subject_type": "portfolio",
+        "subject_key": "us-tech-equal",
+        "current_status": "critical",
+        "ts_event": event_time,
+        "ts_ingest": event_time + timedelta(seconds=1),
+        "payload_json": {"event_id": "event-1", "severity": "critical"},
+        "attempt_count": 1,
+        "last_attempt_id": "attempt-event-1-1",
+        "last_attempt_number": 1,
+        "last_attempted_at": PLANNED_AT - timedelta(minutes=10),
+        "last_attempt_outcome": "failed",
+        "last_http_status": 503,
+        "last_error_code": "http_503",
+        "acknowledgement_id": None,
+        "acknowledged_at": None,
+        "acknowledgement_disposition": None,
+    }
+
+
+def _write_plan(tmp_path: Path, config_path: Path) -> tuple[Path, dict[str, Any]]:
+    plan = plan_portfolio_risk_notification_retries(
+        config_path=config_path,
+        dsn="not-used",
+        planned_at=PLANNED_AT,
+        policy_id="us-tech-standard",
+        portfolio_id="us-tech-equal",
+        reader=lambda **_: [_candidate()],
+    )
+    path = tmp_path / "retry-plan.json"
+    path.write_text(json.dumps(plan, sort_keys=True), encoding="utf-8")
+    return path, plan
+
+
+def _clock(*values: datetime):
+    iterator = iter(values)
+    return lambda: next(iterator)
+
+
+def _completed_summary(
+    *,
+    plan_id: str,
+    request_id: str,
+    executed_at: datetime,
+) -> dict[str, Any]:
+    return {
+        "execution_id": "portfolio-risk-manual-retry-execution-v1-execution-abc",
+        "model_version": "portfolio-risk-manual-retry-execution-v1",
+        "request_id": request_id,
+        "plan_id": plan_id,
+        "executed_at": executed_at.isoformat(),
+        "channel": "webhook",
+        "endpoint": {
+            "host": "alerts.example.test",
+            "full_url_recorded": False,
+        },
+        "configuration": {
+            "delivery_fingerprint": "delivery-fingerprint",
+            "retry_execution_policy_fingerprint": "execution-fingerprint",
+            "retry_policy_fingerprint": "retry-fingerprint",
+        },
+        "revalidation": {
+            "performed": True,
+            "current_plan_id": plan_id,
+            "events_checked": 1,
+            "exact_event_evidence_unchanged": True,
+        },
+        "selection": {
+            "planned_retryable_events": 1,
+            "executed_events": 1,
+            "max_events": 25,
+        },
+        "outcomes": [
+            {
+                "attempt_id": "attempt-event-1-2",
+                "attempt_number": 2,
+                "attempted_at": executed_at.isoformat(),
+                "error_code": None,
+                "event_id": "event-1",
+                "http_status": 204,
+                "outcome": "succeeded",
+                "payload_sha256": "a" * 64,
+            }
+        ],
+        "outcome_counts": {"succeeded": 1, "failed": 0},
+        "execution": {
+            "requested": True,
+            "performed": True,
+            "external_requests_performed": 1,
+            "delivery_attempts_written": 1,
+        },
+        "concurrency_control": {
+            "performed": True,
+            "acquired": True,
+            "released": True,
+            "held_through_revalidation": True,
+            "held_through_attempt_persistence": True,
+            "model_version": "portfolio-risk-notification-delivery-lock-v1",
+            "scope": "portfolio-risk-notification-delivery",
+            "key_fingerprint": "lock-fingerprint",
+        },
+        "response_bodies_recorded": False,
+        "plan_mutated": False,
+        "acknowledgement_mutated": False,
+        "dead_letter_mutated": False,
+    }
+
+
+def test_completed_record_is_deterministic_and_canonical() -> None:
+    summary = _completed_summary(
+        plan_id="plan-1",
+        request_id="request-1",
+        executed_at=STARTED_AT,
+    )
+    kwargs = {
+        "request_id": "request-1",
+        "plan_id": "plan-1",
+        "started_at": STARTED_AT,
+        "finished_at": STARTED_AT + timedelta(seconds=1),
+        "recorded_at": STARTED_AT + timedelta(seconds=2),
+        "terminal_status": "completed",
+        "failure_code": None,
+        "request_count": 1,
+        "attempts_persisted": 1,
+        "succeeded_count": 1,
+        "failed_count": 0,
+        "attempt_ids": ["attempt-event-1-2"],
+        "requested_event_ids": ["event-1"],
+        "persisted_event_ids": ["event-1"],
+        "execution_summary": summary,
+    }
+    first = build_retry_execution_record(**kwargs)
+    second = build_retry_execution_record(**kwargs)
+
+    assert first == second
+    assert first["model_version"] == MODEL_VERSION
+    assert validate_retry_execution_record(first) == first
+    assert first["terminal_status"] == "completed"
+
+
+def test_failure_statuses_preserve_ambiguous_requested_event_identity() -> None:
+    before = build_retry_execution_record(
+        request_id="request-before",
+        plan_id="plan-1",
+        started_at=STARTED_AT,
+        finished_at=STARTED_AT,
+        recorded_at=STARTED_AT,
+        terminal_status="failed_before_request",
+        failure_code="validation_error",
+        request_count=0,
+        attempts_persisted=0,
+        succeeded_count=0,
+        failed_count=0,
+        attempt_ids=[],
+        requested_event_ids=[],
+        persisted_event_ids=[],
+        execution_summary=None,
+    )
+    assert before["terminal_status"] == "failed_before_request"
+
+    uncertain = build_retry_execution_record(
+        request_id="request-uncertain",
+        plan_id="plan-1",
+        started_at=STARTED_AT,
+        finished_at=STARTED_AT,
+        recorded_at=STARTED_AT,
+        terminal_status="persistence_uncertain",
+        failure_code="storage_error",
+        request_count=1,
+        attempts_persisted=0,
+        succeeded_count=0,
+        failed_count=0,
+        attempt_ids=[],
+        requested_event_ids=["event-1"],
+        persisted_event_ids=[],
+        execution_summary=None,
+        endpoint_host="alerts.example.test",
+        delivery_fingerprint="delivery-fingerprint",
+        retry_policy_fingerprint="retry-fingerprint",
+        retry_execution_policy_fingerprint="execution-fingerprint",
+        lock_model_version="portfolio-risk-notification-delivery-lock-v1",
+        lock_key_fingerprint="lock-fingerprint",
+        lock_acquired=True,
+        lock_released=None,
+    )
+    assert uncertain["requested_event_ids"] == ["event-1"]
+    assert uncertain["persisted_event_ids"] == []
+
+    with pytest.raises(ValidationError, match="request without attempt"):
+        build_retry_execution_record(
+            request_id="request-invalid",
+            plan_id="plan-1",
+            started_at=STARTED_AT,
+            finished_at=STARTED_AT,
+            recorded_at=STARTED_AT,
+            terminal_status="persistence_uncertain",
+            failure_code="storage_error",
+            request_count=1,
+            attempts_persisted=1,
+            succeeded_count=1,
+            failed_count=0,
+            attempt_ids=["attempt-1"],
+            requested_event_ids=["event-1"],
+            persisted_event_ids=["event-1"],
+            execution_summary=None,
+        )
+
+
+def test_completed_summary_rejects_unknown_fields() -> None:
+    summary = _completed_summary(
+        plan_id="plan-1",
+        request_id="request-1",
+        executed_at=STARTED_AT,
+    )
+    summary["unknown"] = True
+    with pytest.raises(ValidationError, match="unknown"):
+        build_retry_execution_record(
+            request_id="request-1",
+            plan_id="plan-1",
+            started_at=STARTED_AT,
+            finished_at=STARTED_AT,
+            recorded_at=STARTED_AT,
+            terminal_status="completed",
+            failure_code=None,
+            request_count=1,
+            attempts_persisted=1,
+            succeeded_count=1,
+            failed_count=0,
+            attempt_ids=["attempt-event-1-2"],
+            requested_event_ids=["event-1"],
+            persisted_event_ids=["event-1"],
+            execution_summary=summary,
+        )
+
+
+def test_recorded_wrapper_persists_completed_execution(tmp_path: Path) -> None:
+    config_path = _write_config(tmp_path)
+    plan_path, plan = _write_plan(tmp_path, config_path)
+    records: list[dict[str, Any]] = []
+
+    def executor(**kwargs: Any) -> dict[str, Any]:
+        started = kwargs["clock"]()
+        kwargs["transport"](
+            "https://alerts.example.test/risk",
+            b"{}",
+            {"Idempotency-Key": "event-1"},
+            5.0,
+        )
+        kwargs["attempt_writer"](
+            {
+                "attempt_id": "attempt-event-1-2",
+                "event_id": "event-1",
+                "outcome": "succeeded",
+            }
+        )
+        return _completed_summary(
+            plan_id=plan["plan_id"],
+            request_id="RETRY-2026-001",
+            executed_at=started,
+        )
+
+    result = execute_and_record_portfolio_risk_notification_retries(
+        plan_path=plan_path,
+        confirm_plan_id=plan["plan_id"],
+        request_id="RETRY-2026-001",
+        config_path=config_path,
+        dsn="postgresql://secret-value",
+        execute=True,
+        environment={"RISK_NOTIFICATION_WEBHOOK_URL": "https://example.test"},
+        executor=executor,
+        recorder=lambda **kwargs: (
+            records.append(validate_retry_execution_record(kwargs["record"]))
+            or {
+                "record_id": kwargs["record"]["record_id"],
+                "created": True,
+            }
+        ),
+        transport=lambda *_: 204,
+        attempt_writer=lambda _: None,
+        clock=_clock(
+            STARTED_AT,
+            STARTED_AT + timedelta(seconds=1),
+            STARTED_AT + timedelta(seconds=2),
+        ),
+    )
+
+    assert records[0]["terminal_status"] == "completed"
+    assert records[0]["attempt_ids"] == ["attempt-event-1-2"]
+    assert records[0]["requested_event_ids"] == ["event-1"]
+    assert result["history"]["created"] is True
+    assert "postgresql://secret-value" not in json.dumps(result)
+
+
+def test_recorded_wrapper_classifies_failure_boundaries(tmp_path: Path) -> None:
+    config_path = _write_config(tmp_path)
+    plan_path, plan = _write_plan(tmp_path, config_path)
+
+    def run(executor: Any, request_id: str) -> dict[str, Any]:
+        records: list[dict[str, Any]] = []
+        with pytest.raises(RecordedRetryExecutionError) as raised:
+            execute_and_record_portfolio_risk_notification_retries(
+                plan_path=plan_path,
+                confirm_plan_id=plan["plan_id"],
+                request_id=request_id,
+                config_path=config_path,
+                dsn="dsn",
+                execute=True,
+                executor=executor,
+                recorder=lambda **kwargs: (
+                    records.append(validate_retry_execution_record(kwargs["record"]))
+                    or {
+                        "record_id": kwargs["record"]["record_id"],
+                        "created": True,
+                    }
+                ),
+                transport=lambda *_: 204,
+                attempt_writer=lambda _: None,
+                clock=_clock(STARTED_AT, STARTED_AT, STARTED_AT),
+            )
+        assert raised.value.history["created"] is True
+        return records[0]
+
+    before = run(
+        lambda **_: (_ for _ in ()).throw(ValidationError("bad")),
+        "REQUEST-BEFORE",
+    )
+    assert before["terminal_status"] == "failed_before_request"
+
+    def uncertain_executor(**kwargs: Any) -> dict[str, Any]:
+        kwargs["transport"](
+            "https://alerts.example.test/risk",
+            b"{}",
+            {"Idempotency-Key": "event-1"},
+            5.0,
+        )
+        raise StorageError("write uncertain")
+
+    uncertain = run(uncertain_executor, "REQUEST-UNCERTAIN")
+    assert uncertain["terminal_status"] == "persistence_uncertain"
+    assert uncertain["requested_event_ids"] == ["event-1"]
+    assert uncertain["persisted_event_ids"] == []
+    assert uncertain["endpoint_host"] is None
+
+    def after_executor(**kwargs: Any) -> dict[str, Any]:
+        kwargs["transport"](
+            "https://alerts.example.test/risk",
+            b"{}",
+            {"Idempotency-Key": "event-1"},
+            5.0,
+        )
+        kwargs["attempt_writer"](
+            {
+                "attempt_id": "attempt-event-1-2",
+                "event_id": "event-1",
+                "outcome": "failed",
+            }
+        )
+        raise ValidationError("later failure")
+
+    after = run(after_executor, "REQUEST-AFTER")
+    assert after["terminal_status"] == "failed_after_request"
+    assert after["failed_count"] == 1
+    assert after["requested_event_ids"] == after["persisted_event_ids"]
+
+
+def test_recorded_summary_writer_rejects_symbolic_links(tmp_path: Path) -> None:
+    target = tmp_path / "target.json"
+    target.write_text("{}", encoding="utf-8")
+    link = tmp_path / "summary.json"
+    link.symlink_to(target)
+    with pytest.raises(StorageError, match="symbolic link"):
+        _write_summary(link, {"safe": True})

--- a/tests/unit/test_notification_retry_execution_history_architecture_contract.py
+++ b/tests/unit/test_notification_retry_execution_history_architecture_contract.py
@@ -5,6 +5,9 @@ def test_retry_execution_history_is_append_only_bounded_and_secret_safe() -> Non
     contract = Path(
         "src/warehouse/notification_retry_execution_contract.py"
     ).read_text(encoding="utf-8")
+    reader = Path(
+        "src/warehouse/notification_retry_execution_reader.py"
+    ).read_text(encoding="utf-8")
     recorder = Path(
         "src/warehouse/notification_retry_execution_recorder.py"
     ).read_text(encoding="utf-8")
@@ -37,6 +40,15 @@ def test_retry_execution_history_is_append_only_bounded_and_secret_safe() -> Non
         assert required in contract
 
     for required in (
+        "read_notification_retry_execution_request",
+        "where request_id = %s",
+        "document_sha256",
+        "validate_retry_execution_record",
+        "lookup failed before execution",
+    ):
+        assert required in reader.casefold()
+
+    for required in (
         "record_notification_retry_execution",
         "request_id already exists with different retry evidence",
         "record_id already exists with different retry evidence",
@@ -46,14 +58,22 @@ def test_retry_execution_history_is_append_only_bounded_and_secret_safe() -> Non
 
     for required in (
         "execute_portfolio_risk_notification_retries",
+        "read_notification_retry_execution_request",
         "tracking_transport",
         "tracking_writer",
         "record_notification_retry_execution",
         "RecordedRetryExecutionError",
+        "request_id already exists for a different notification retry plan",
         "--execute",
     ):
         assert required in wrapper
 
+    assert wrapper.index("if execute is not True") < wrapper.index(
+        "selected_history_reader"
+    )
+    assert wrapper.index("selected_history_reader") < wrapper.index(
+        "selected_clock ="
+    )
     assert "except BaseException" not in wrapper
     assert "response body" not in wrapper.casefold()
 
@@ -69,6 +89,7 @@ def test_retry_execution_history_is_append_only_bounded_and_secret_safe() -> Non
 
     assert "19_portfolio_risk_notification_retry_execution_schema.sql" in compose
     assert "retry_history_exact_retry_converged" in lock_check
+    assert "retry_history_preflight_read_validated" in lock_check
     assert "retry_history_append_only" in lock_check
 
     for required in (

--- a/tests/unit/test_notification_retry_execution_history_architecture_contract.py
+++ b/tests/unit/test_notification_retry_execution_history_architecture_contract.py
@@ -54,7 +54,7 @@ def test_retry_execution_history_is_append_only_bounded_and_secret_safe() -> Non
     ):
         assert required in wrapper
 
-    assert "BaseException" not in wrapper
+    assert "except BaseException" not in wrapper
     assert "response body" not in wrapper.casefold()
 
     for required in (

--- a/tests/unit/test_notification_retry_execution_history_architecture_contract.py
+++ b/tests/unit/test_notification_retry_execution_history_architecture_contract.py
@@ -1,0 +1,85 @@
+from pathlib import Path
+
+
+def test_retry_execution_history_is_append_only_bounded_and_secret_safe() -> None:
+    contract = Path(
+        "src/warehouse/notification_retry_execution_contract.py"
+    ).read_text(encoding="utf-8")
+    recorder = Path(
+        "src/warehouse/notification_retry_execution_recorder.py"
+    ).read_text(encoding="utf-8")
+    wrapper = Path(
+        "src/orchestration/run_recorded_portfolio_risk_notification_retries.py"
+    ).read_text(encoding="utf-8")
+    lock_check = Path(
+        "src/warehouse/notification_delivery_lock_contract_check.py"
+    ).read_text(encoding="utf-8")
+    schema = Path(
+        "sql/portfolio_risk_notification_retry_execution_schema.sql"
+    ).read_text(encoding="utf-8")
+    compose = Path("docker-compose.yml").read_text(encoding="utf-8")
+    docs = Path(
+        "docs/portfolio-risk-notification-retry-execution-history.md"
+    ).read_text(encoding="utf-8")
+    normalized_docs = " ".join(docs.split()).casefold()
+
+    for required in (
+        "portfolio-risk-notification-retry-execution-record-v1",
+        "failed_before_request",
+        "failed_after_request",
+        "persistence_uncertain",
+        "requested_event_ids",
+        "persisted_event_ids",
+        "execution_summary",
+        "lock_key_fingerprint",
+        "validate_retry_execution_record",
+    ):
+        assert required in contract
+
+    for required in (
+        "record_notification_retry_execution",
+        "request_id already exists with different retry evidence",
+        "record_id already exists with different retry evidence",
+        "document_sha256",
+    ):
+        assert required in recorder
+
+    for required in (
+        "execute_portfolio_risk_notification_retries",
+        "tracking_transport",
+        "tracking_writer",
+        "record_notification_retry_execution",
+        "RecordedRetryExecutionError",
+        "--execute",
+    ):
+        assert required in wrapper
+
+    assert "BaseException" not in wrapper
+    assert "response body" not in wrapper.casefold()
+
+    for required in (
+        "portfolio_risk_notification_retry_executions",
+        "requested_event_ids_json",
+        "persisted_event_ids_json",
+        "reject_notification_retry_execution_mutation",
+        "before update or delete",
+        "request_id text not null unique",
+    ):
+        assert required in schema.casefold()
+
+    assert "19_portfolio_risk_notification_retry_execution_schema.sql" in compose
+    assert "retry_history_exact_retry_converged" in lock_check
+    assert "retry_history_append_only" in lock_check
+
+    for required in (
+        "primary arc42 block: `warehouse`",
+        "exact retry convergence",
+        "persistence_uncertain",
+        "does not claim success",
+        "stable notification `idempotency-key`",
+        "full endpoint urls",
+        "ordinary ci performs no webhook request",
+        "terraform apply",
+        "separate follow-up pr",
+    ):
+        assert required in normalized_docs

--- a/tests/unit/test_notification_retry_execution_preflight.py
+++ b/tests/unit/test_notification_retry_execution_preflight.py
@@ -1,0 +1,335 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+from src.common.exceptions import ValidationError
+from src.orchestration.plan_portfolio_risk_notification_retries import (
+    plan_portfolio_risk_notification_retries,
+)
+from src.orchestration.run_recorded_portfolio_risk_notification_retries import (
+    RecordedRetryExecutionError,
+    execute_and_record_portfolio_risk_notification_retries,
+)
+from src.warehouse.notification_retry_execution_contract import (
+    build_retry_execution_record,
+)
+
+PLANNED_AT = datetime(2026, 1, 10, 12, tzinfo=timezone.utc)
+EXECUTED_AT = PLANNED_AT + timedelta(minutes=1)
+
+
+def _write_config(tmp_path: Path) -> Path:
+    path = tmp_path / "notification-delivery.yaml"
+    path.write_text(
+        yaml.safe_dump(
+            {
+                "delivery": {
+                    "webhook": {
+                        "enabled": True,
+                        "endpoint_env": "RISK_NOTIFICATION_WEBHOOK_URL",
+                        "timeout_seconds": 5,
+                        "max_batch_events": 25,
+                        "max_attempts_per_event": 3,
+                        "initial_backoff_seconds": 1,
+                    },
+                    "retry_planning": {
+                        "max_candidate_rows": 500,
+                        "max_plan_events": 25,
+                        "max_event_age_seconds": 604800,
+                        "max_backoff_seconds": 3600,
+                        "retryable_http_statuses": [
+                            408,
+                            425,
+                            429,
+                            500,
+                            502,
+                            503,
+                            504,
+                        ],
+                        "retryable_error_codes": ["network_error"],
+                    },
+                    "retry_execution": {
+                        "enabled": True,
+                        "max_plan_age_seconds": 3600,
+                        "max_events": 25,
+                    },
+                }
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+    return path
+
+
+def _candidate() -> dict[str, Any]:
+    event_time = PLANNED_AT - timedelta(hours=2)
+    return {
+        "event_id": "event-1",
+        "outbox_model_version": "portfolio-risk-notification-outbox-v1",
+        "event_type": "breach_opened",
+        "transition_type": "opened",
+        "delivery_disposition": "pending",
+        "source_evaluation_calculation_id": "evaluation-event-1",
+        "policy_id": "us-tech-standard",
+        "policy_fingerprint": "policy-fingerprint",
+        "portfolio_id": "us-tech-equal",
+        "definition_fingerprint": "definition-fingerprint",
+        "metric_name": "portfolio_volatility_annualized",
+        "subject_type": "portfolio",
+        "subject_key": "us-tech-equal",
+        "current_status": "critical",
+        "ts_event": event_time,
+        "ts_ingest": event_time + timedelta(seconds=1),
+        "payload_json": {"event_id": "event-1", "severity": "critical"},
+        "attempt_count": 1,
+        "last_attempt_id": "attempt-event-1-1",
+        "last_attempt_number": 1,
+        "last_attempted_at": PLANNED_AT - timedelta(minutes=10),
+        "last_attempt_outcome": "failed",
+        "last_http_status": 503,
+        "last_error_code": "http_503",
+        "acknowledgement_id": None,
+        "acknowledged_at": None,
+        "acknowledgement_disposition": None,
+    }
+
+
+def _write_plan(tmp_path: Path, config_path: Path) -> tuple[Path, dict[str, Any]]:
+    plan = plan_portfolio_risk_notification_retries(
+        config_path=config_path,
+        dsn="not-used",
+        planned_at=PLANNED_AT,
+        policy_id="us-tech-standard",
+        portfolio_id="us-tech-equal",
+        reader=lambda **_: [_candidate()],
+    )
+    path = tmp_path / "retry-plan.json"
+    path.write_text(json.dumps(plan, sort_keys=True), encoding="utf-8")
+    return path, plan
+
+
+def _completed_summary(plan_id: str, request_id: str) -> dict[str, Any]:
+    return {
+        "execution_id": "portfolio-risk-manual-retry-execution-v1-execution-abc",
+        "model_version": "portfolio-risk-manual-retry-execution-v1",
+        "request_id": request_id,
+        "plan_id": plan_id,
+        "executed_at": EXECUTED_AT.isoformat(),
+        "channel": "webhook",
+        "endpoint": {"host": "alerts.example.test", "full_url_recorded": False},
+        "configuration": {
+            "delivery_fingerprint": "delivery-fingerprint",
+            "retry_execution_policy_fingerprint": "execution-fingerprint",
+            "retry_policy_fingerprint": "retry-fingerprint",
+        },
+        "revalidation": {
+            "performed": True,
+            "current_plan_id": plan_id,
+            "events_checked": 1,
+            "exact_event_evidence_unchanged": True,
+        },
+        "selection": {
+            "planned_retryable_events": 1,
+            "executed_events": 1,
+            "max_events": 25,
+        },
+        "outcomes": [
+            {
+                "attempt_id": "attempt-event-1-2",
+                "attempt_number": 2,
+                "attempted_at": EXECUTED_AT.isoformat(),
+                "error_code": None,
+                "event_id": "event-1",
+                "http_status": 204,
+                "outcome": "succeeded",
+                "payload_sha256": "a" * 64,
+            }
+        ],
+        "outcome_counts": {"succeeded": 1, "failed": 0},
+        "execution": {
+            "requested": True,
+            "performed": True,
+            "external_requests_performed": 1,
+            "delivery_attempts_written": 1,
+        },
+        "concurrency_control": {
+            "performed": True,
+            "acquired": True,
+            "released": True,
+            "held_through_revalidation": True,
+            "held_through_attempt_persistence": True,
+            "model_version": "portfolio-risk-notification-delivery-lock-v1",
+            "scope": "portfolio-risk-notification-delivery",
+            "key_fingerprint": "lock-fingerprint",
+        },
+        "response_bodies_recorded": False,
+        "plan_mutated": False,
+        "acknowledgement_mutated": False,
+        "dead_letter_mutated": False,
+    }
+
+
+def _completed_record(plan_id: str, request_id: str) -> dict[str, Any]:
+    summary = _completed_summary(plan_id, request_id)
+    return build_retry_execution_record(
+        request_id=request_id,
+        plan_id=plan_id,
+        started_at=EXECUTED_AT,
+        finished_at=EXECUTED_AT,
+        recorded_at=EXECUTED_AT,
+        terminal_status="completed",
+        failure_code=None,
+        request_count=1,
+        attempts_persisted=1,
+        succeeded_count=1,
+        failed_count=0,
+        attempt_ids=["attempt-event-1-2"],
+        requested_event_ids=["event-1"],
+        persisted_event_ids=["event-1"],
+        execution_summary=summary,
+    )
+
+
+def test_completed_request_replay_returns_history_before_side_effects(
+    tmp_path: Path,
+) -> None:
+    config_path = _write_config(tmp_path)
+    plan_path, plan = _write_plan(tmp_path, config_path)
+    record = _completed_record(plan["plan_id"], "RETRY-2026-001")
+    calls: list[str] = []
+
+    result = execute_and_record_portfolio_risk_notification_retries(
+        plan_path=plan_path,
+        confirm_plan_id=plan["plan_id"],
+        request_id="RETRY-2026-001",
+        config_path=config_path,
+        dsn="not-used",
+        execute=True,
+        history_reader=lambda **_: {
+            "record": record,
+            "history": {"record_id": record["record_id"], "created": False},
+        },
+        executor=lambda **_: calls.append("executor") or {},
+        recorder=lambda **_: calls.append("recorder") or {},
+        transport=lambda *_: calls.append("transport") or 204,
+        attempt_writer=lambda _: calls.append("writer"),
+    )
+
+    assert calls == []
+    assert result["history"] == {"record_id": record["record_id"], "created": False}
+    assert result["execution_summary"] == record["execution_summary"]
+
+
+def test_failed_request_replay_returns_same_terminal_failure_without_execution(
+    tmp_path: Path,
+) -> None:
+    config_path = _write_config(tmp_path)
+    plan_path, plan = _write_plan(tmp_path, config_path)
+    record = build_retry_execution_record(
+        request_id="RETRY-2026-002",
+        plan_id=plan["plan_id"],
+        started_at=EXECUTED_AT,
+        finished_at=EXECUTED_AT,
+        recorded_at=EXECUTED_AT,
+        terminal_status="failed_before_request",
+        failure_code="validation_error",
+        request_count=0,
+        attempts_persisted=0,
+        succeeded_count=0,
+        failed_count=0,
+        attempt_ids=[],
+        requested_event_ids=[],
+        persisted_event_ids=[],
+        execution_summary=None,
+    )
+    calls: list[str] = []
+
+    with pytest.raises(RecordedRetryExecutionError) as raised:
+        execute_and_record_portfolio_risk_notification_retries(
+            plan_path=plan_path,
+            confirm_plan_id=plan["plan_id"],
+            request_id="RETRY-2026-002",
+            config_path=config_path,
+            dsn="not-used",
+            execute=True,
+            history_reader=lambda **_: {
+                "record": record,
+                "history": {"record_id": record["record_id"], "created": False},
+            },
+            executor=lambda **_: calls.append("executor") or {},
+        )
+
+    assert calls == []
+    assert raised.value.failure_code == "validation_error"
+    assert raised.value.history["record_id"] == record["record_id"]
+
+
+def test_request_id_plan_conflict_and_missing_authority_fail_before_lookup(
+    tmp_path: Path,
+) -> None:
+    config_path = _write_config(tmp_path)
+    plan_path, plan = _write_plan(tmp_path, config_path)
+    reads: list[str] = []
+
+    with pytest.raises(ValidationError, match="explicit --execute"):
+        execute_and_record_portfolio_risk_notification_retries(
+            plan_path=plan_path,
+            confirm_plan_id=plan["plan_id"],
+            request_id="RETRY-2026-003",
+            config_path=config_path,
+            dsn="not-used",
+            execute=False,
+            history_reader=lambda **_: reads.append("read") or None,
+        )
+    with pytest.raises(ValidationError, match="confirm_plan_id"):
+        execute_and_record_portfolio_risk_notification_retries(
+            plan_path=plan_path,
+            confirm_plan_id="wrong-plan",
+            request_id="RETRY-2026-003",
+            config_path=config_path,
+            dsn="not-used",
+            execute=True,
+            history_reader=lambda **_: reads.append("read") or None,
+        )
+    assert reads == []
+
+    conflicting = build_retry_execution_record(
+        request_id="RETRY-2026-003",
+        plan_id="different-plan",
+        started_at=EXECUTED_AT,
+        finished_at=EXECUTED_AT,
+        recorded_at=EXECUTED_AT,
+        terminal_status="failed_before_request",
+        failure_code="validation_error",
+        request_count=0,
+        attempts_persisted=0,
+        succeeded_count=0,
+        failed_count=0,
+        attempt_ids=[],
+        requested_event_ids=[],
+        persisted_event_ids=[],
+        execution_summary=None,
+    )
+    with pytest.raises(ValidationError, match="different notification retry plan"):
+        execute_and_record_portfolio_risk_notification_retries(
+            plan_path=plan_path,
+            confirm_plan_id=plan["plan_id"],
+            request_id="RETRY-2026-003",
+            config_path=config_path,
+            dsn="not-used",
+            execute=True,
+            history_reader=lambda **_: {
+                "record": conflicting,
+                "history": {"record_id": conflicting["record_id"], "created": False},
+            },
+            executor=lambda **_: (_ for _ in ()).throw(
+                AssertionError("executor must not run")
+            ),
+        )


### PR DESCRIPTION
## Goal

Complete **P4d2a — append-only notification retry execution history** by retaining one canonical terminal record for every governed retry invocation.

```text
exact retained retry plan
  + explicit execution and plan confirmation
  + pre-execution request-id history lookup
  + current-evidence revalidation
  + shared PostgreSQL delivery lock
  + observed requests and attempt persistence
  -> completed | failed_before_request | failed_after_request
     | persistence_uncertain
  -> append-only PostgreSQL history
```

## Controls

- `portfolio-risk-notification-retry-execution-record-v1` strictly validates terminal evidence.
- `request_id` is checked before clock, configuration, lock, reader, transport or attempt-writer work.
- Same request and plan with completed history returns retained evidence without another external request.
- Same request and plan with failed history returns the same terminal failure without execution.
- Reusing a request ID for a different plan fails before side effects.
- Retained records and stored SHA-256 values are revalidated before replay.
- Completed records bind exact P4c configuration fingerprints, delivery-lock identity and attempt IDs.
- `persistence_uncertain` preserves requested event IDs separately from successfully persisted events and does not claim remote success.
- PostgreSQL UPDATE and DELETE are rejected by append-only triggers.
- Full endpoint URLs, DSNs, payloads, response bodies, credentials and arbitrary exception messages are not retained.

## Repair history

Closed PR #109 passed security, PostgreSQL and infrastructure validation but failed two Python contract tests. This replacement restores its implementation and applies the smallest safe repairs:

1. the ordered Compose contract includes intentional read-only schema layer 19; and
2. the architecture test detects actual broad exception handling instead of matching a type annotation.

Deeper review then closed a substantive idempotency gap by adding the pre-execution terminal-history lookup described above.

## Scope

Twelve files, 2,799 additions and five deletions. The branch is directly based on current `main`, zero commits behind, and its connector-produced working commits are intended for one squash merge.

## Exact-head validation

GitHub Actions run **344** (`32853091948`) passed on head `58213e83aba3b0264e696db3cee886d084a1fb60`:

- Security guardrails passed.
- Ruff passed.
- mypy passed across **117 source files**.
- **815 tests passed** in the quality run and **815 passed again** in readiness.
- Dependency integrity and the standard replay demonstration passed.
- PostgreSQL 16 contract passed, including lock contention, terminal-history convergence, preflight digest validation, conflicting request rejection and append-only mutation rejection.
- Kubernetes rendering and Terraform format/init/validate passed without apply.

No live webhook request, provider request, cloud schedule activation, deployment, position mutation or `terraform apply` occurred. There are no review submissions or unresolved threads.

## Acceptance boundary

Validated and ready for squash merge. The dependent next PR adds read-only delivery-failure, ambiguity and retry-follow-up views without changing this history contract.