### PR TITLE
Add notification destination execution authority

### DIFF
--- a/docs/portfolio-risk-notification-destination-authority.md
+++ b/docs/portfolio-risk-notification-destination-authority.md
@@ -1,0 +1,82 @@
+# Notification Destination Execution Authority
+
+## Outcome
+
+This increment defines one reusable, secret-free authority contract for notification
+execution:
+
+```text
+reviewed destination metadata
+  + exact destination fingerprint
+  + clock-derived evaluation time
+  + delivery endpoint-environment identity
+  + selected event types
+  -> active or rejected destination authority
+  -> no endpoint resolution and no delivery
+```
+
+Primary arc42 block: `orchestration`.
+
+The contract is implemented in:
+
+```text
+src/orchestration/portfolio_risk_notification_destination_authority.py
+```
+
+## Authority boundary
+
+`portfolio-risk-notification-destination-authority-v1` resolves one destination by
+its stable ID and requires the delivery configuration to name the same endpoint
+environment variable as the destination contract.
+
+For executable use, the destination must be `active` at the supplied clock-derived
+evaluation time. `disabled`, `not_yet_reviewed`, and `review_expired` destinations
+fail closed.
+
+The contract also compares every selected notification event type with the
+destination event allow-list before an execution path may make its first request.
+Duplicate event types are collapsed into a sorted canonical set for deterministic
+evidence.
+
+## Deterministic evidence
+
+The authority ID binds:
+
+- authority model version;
+- destination ID;
+- destination fingerprint;
+- endpoint-environment identity;
+- exact evaluation time; and
+- canonical selected event types.
+
+The destination fingerprint already binds ownership, recipient scope, data
+classification, event allow-list, activation review identity, review time, and
+expiry. A reviewed change therefore creates a different authority identity.
+
+Evidence records the endpoint environment-variable name but no endpoint value,
+full URL, credential, payload, response body, or database DSN.
+
+## Plan and execution use
+
+Callers may evaluate an inactive destination with `require_active=False` to produce
+read-only plan evidence. Any path that can perform delivery must use the default
+`require_active=True` behavior immediately before side effects.
+
+Binding the initial-delivery and retry-execution adapters to this shared authority is
+a separate dependent PR. This keeps the reusable authority contract independently
+reviewable before it changes an existing side-effect boundary.
+
+## Safety
+
+This increment:
+
+- performs no network request;
+- resolves no endpoint value;
+- writes no delivery attempt;
+- mutates no outbox or acknowledgement;
+- activates no cloud schedule;
+- deploys no infrastructure; and
+- does not run `terraform apply`.
+
+Ordinary CI performs no external request. Committed destination activation,
+webhook delivery, and retry execution remain disabled.

--- a/src/orchestration/portfolio_risk_notification_destination_authority.py
+++ b/src/orchestration/portfolio_risk_notification_destination_authority.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from collections.abc import Sequence
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from src.common.exceptions import ValidationError
+from src.orchestration.portfolio_risk_notification_destination_contract import (
+    CHANNEL,
+    evaluate_destination_activation,
+    load_notification_destinations,
+)
+
+MODEL_VERSION = "portfolio-risk-notification-destination-authority-v1"
+ENVIRONMENT_NAME = re.compile(r"^[A-Z][A-Z0-9_]{2,127}$")
+SAFE_EVENT_TYPE = re.compile(r"^[a-z][a-z0-9_]{0,63}$")
+
+
+def _endpoint_environment(value: Any) -> str:
+    if not isinstance(value, str) or not ENVIRONMENT_NAME.fullmatch(value):
+        raise ValidationError(
+            "delivery endpoint environment variable identity is invalid"
+        )
+    return value
+
+
+def _event_types(values: Sequence[str]) -> tuple[str, ...]:
+    if isinstance(values, (str, bytes)):
+        raise ValidationError("event_types must be a sequence of event type names")
+    parsed: list[str] = []
+    for value in values:
+        if not isinstance(value, str) or not SAFE_EVENT_TYPE.fullmatch(value):
+            raise ValidationError("event_types contains an invalid event type")
+        parsed.append(value)
+    return tuple(sorted(set(parsed)))
+
+
+def _authority_id(identity: dict[str, Any]) -> str:
+    digest = hashlib.sha256(
+        json.dumps(
+            identity,
+            sort_keys=True,
+            separators=(",", ":"),
+            allow_nan=False,
+        ).encode("utf-8")
+    ).hexdigest()[:24]
+    return f"{MODEL_VERSION}-authority-{digest}"
+
+
+def resolve_notification_destination_authority(
+    *,
+    destination_config_path: Path,
+    destination_id: str,
+    delivery_endpoint_env: str,
+    evaluated_at: datetime | str,
+    event_types: Sequence[str] = (),
+    require_active: bool = True,
+) -> dict[str, Any]:
+    """Resolve one secret-free destination authority for notification execution."""
+
+    destinations = load_notification_destinations(destination_config_path)
+    destination = destinations.get(destination_id)
+    if destination is None:
+        raise ValidationError("notification destination does not exist")
+
+    endpoint_env = _endpoint_environment(delivery_endpoint_env)
+    if endpoint_env != destination.endpoint_env:
+        raise ValidationError(
+            "notification destination endpoint environment does not match "
+            "delivery configuration"
+        )
+
+    evaluated_event_types = _event_types(event_types)
+    unsupported = sorted(
+        set(evaluated_event_types) - set(destination.allowed_event_types)
+    )
+    if unsupported:
+        raise ValidationError(
+            "notification destination does not allow event types: "
+            + ", ".join(unsupported)
+        )
+
+    activation = evaluate_destination_activation(
+        destination,
+        evaluated_at=evaluated_at,
+    )
+    status = activation["activation"]["status"]
+    if require_active and status != "active":
+        raise ValidationError(
+            f"notification destination is not active: {status}"
+        )
+
+    identity = {
+        "destination_fingerprint": destination.fingerprint,
+        "destination_id": destination.destination_id,
+        "endpoint_environment_variable": destination.endpoint_env,
+        "evaluated_at": activation["evaluated_at"],
+        "evaluated_event_types": list(evaluated_event_types),
+        "model_version": MODEL_VERSION,
+    }
+    return {
+        "authority_id": _authority_id(identity),
+        **identity,
+        "channel": CHANNEL,
+        "activation": {
+            "enabled": destination.activation.enabled,
+            "status": status,
+            "change_request_id": destination.activation.change_request_id,
+            "reviewed_at": (
+                None
+                if destination.activation.reviewed_at is None
+                else destination.activation.reviewed_at.isoformat()
+            ),
+            "review_expires_at": (
+                None
+                if destination.activation.review_expires_at is None
+                else destination.activation.review_expires_at.isoformat()
+            ),
+        },
+        "allowed_event_types": list(destination.allowed_event_types),
+        "active": status == "active",
+        "endpoint_value_recorded": False,
+        "external_request_performed": False,
+        "delivery_attempt_written": False,
+        "outbox_mutated": False,
+        "acknowledgement_mutated": False,
+    }

--- a/tests/unit/test_portfolio_risk_notification_destination_authority.py
+++ b/tests/unit/test_portfolio_risk_notification_destination_authority.py
@@ -1,0 +1,196 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+from src.common.exceptions import ValidationError
+from src.orchestration.portfolio_risk_notification_destination_authority import (
+    MODEL_VERSION,
+    resolve_notification_destination_authority,
+)
+
+
+def _payload(*, enabled: bool = True) -> dict[str, Any]:
+    activation: dict[str, Any]
+    if enabled:
+        activation = {
+            "enabled": True,
+            "change_request_id": "CHG-2026-001",
+            "reviewed_by": ["risk-control-reviewer"],
+            "reviewed_at": "2026-01-01T00:00:00Z",
+            "review_expires_at": "2026-12-31T00:00:00Z",
+        }
+    else:
+        activation = {
+            "enabled": False,
+            "change_request_id": None,
+            "reviewed_by": [],
+            "reviewed_at": None,
+            "review_expires_at": None,
+        }
+    return {
+        "model_version": "portfolio-risk-notification-destination-v1",
+        "destinations": {
+            "risk-operations-webhook": {
+                "channel": "webhook",
+                "endpoint_env": "RISK_NOTIFICATION_WEBHOOK_URL",
+                "owner": {
+                    "team": "risk-operations",
+                    "contact": "risk-operations-oncall",
+                },
+                "purpose": "portfolio-risk-breach-lifecycle",
+                "recipient_scope": "risk-operations",
+                "data_classification": "internal",
+                "allowed_event_types": [
+                    "breach_escalated",
+                    "breach_opened",
+                    "breach_resolved",
+                ],
+                "activation": activation,
+            }
+        },
+    }
+
+
+def _write_config(tmp_path: Path, *, enabled: bool = True) -> Path:
+    path = tmp_path / "destinations.yaml"
+    path.write_text(
+        yaml.safe_dump(_payload(enabled=enabled), sort_keys=False),
+        encoding="utf-8",
+    )
+    return path
+
+
+def test_active_destination_authority_is_deterministic_and_secret_free(
+    tmp_path: Path,
+) -> None:
+    path = _write_config(tmp_path)
+    kwargs = {
+        "destination_config_path": path,
+        "destination_id": "risk-operations-webhook",
+        "delivery_endpoint_env": "RISK_NOTIFICATION_WEBHOOK_URL",
+        "evaluated_at": datetime(2026, 6, 1, tzinfo=timezone.utc),
+        "event_types": ["breach_opened", "breach_opened", "breach_resolved"],
+    }
+
+    first = resolve_notification_destination_authority(**kwargs)
+    second = resolve_notification_destination_authority(**kwargs)
+
+    assert first == second
+    assert first["model_version"] == MODEL_VERSION
+    assert first["active"] is True
+    assert first["activation"]["status"] == "active"
+    assert first["evaluated_event_types"] == [
+        "breach_opened",
+        "breach_resolved",
+    ]
+    rendered = json.dumps(first, sort_keys=True)
+    assert "https://" not in rendered
+    assert "RISK_NOTIFICATION_WEBHOOK_URL" in rendered
+    assert first["endpoint_value_recorded"] is False
+    assert first["external_request_performed"] is False
+
+
+def test_execution_authority_rejects_inactive_destination(tmp_path: Path) -> None:
+    path = _write_config(tmp_path, enabled=False)
+
+    with pytest.raises(ValidationError, match="not active: disabled"):
+        resolve_notification_destination_authority(
+            destination_config_path=path,
+            destination_id="risk-operations-webhook",
+            delivery_endpoint_env="RISK_NOTIFICATION_WEBHOOK_URL",
+            evaluated_at="2026-06-01T00:00:00Z",
+        )
+
+    evidence = resolve_notification_destination_authority(
+        destination_config_path=path,
+        destination_id="risk-operations-webhook",
+        delivery_endpoint_env="RISK_NOTIFICATION_WEBHOOK_URL",
+        evaluated_at="2026-06-01T00:00:00Z",
+        require_active=False,
+    )
+    assert evidence["active"] is False
+    assert evidence["activation"]["status"] == "disabled"
+
+
+def test_execution_authority_rejects_expired_or_future_review(
+    tmp_path: Path,
+) -> None:
+    path = _write_config(tmp_path)
+
+    with pytest.raises(ValidationError, match="review_expired"):
+        resolve_notification_destination_authority(
+            destination_config_path=path,
+            destination_id="risk-operations-webhook",
+            delivery_endpoint_env="RISK_NOTIFICATION_WEBHOOK_URL",
+            evaluated_at="2027-01-01T00:00:00Z",
+        )
+
+    with pytest.raises(ValidationError, match="not_yet_reviewed"):
+        resolve_notification_destination_authority(
+            destination_config_path=path,
+            destination_id="risk-operations-webhook",
+            delivery_endpoint_env="RISK_NOTIFICATION_WEBHOOK_URL",
+            evaluated_at="2025-12-31T23:59:59Z",
+        )
+
+
+def test_execution_authority_rejects_endpoint_identity_mismatch(
+    tmp_path: Path,
+) -> None:
+    path = _write_config(tmp_path)
+
+    with pytest.raises(ValidationError, match="does not match"):
+        resolve_notification_destination_authority(
+            destination_config_path=path,
+            destination_id="risk-operations-webhook",
+            delivery_endpoint_env="ANOTHER_WEBHOOK_URL",
+            evaluated_at="2026-06-01T00:00:00Z",
+        )
+
+
+def test_execution_authority_rejects_unreviewed_event_type(
+    tmp_path: Path,
+) -> None:
+    path = _write_config(tmp_path)
+
+    with pytest.raises(ValidationError, match="does not allow"):
+        resolve_notification_destination_authority(
+            destination_config_path=path,
+            destination_id="risk-operations-webhook",
+            delivery_endpoint_env="RISK_NOTIFICATION_WEBHOOK_URL",
+            evaluated_at="2026-06-01T00:00:00Z",
+            event_types=["breach_deescalated"],
+        )
+
+
+def test_authority_identity_changes_with_time_or_events(tmp_path: Path) -> None:
+    path = _write_config(tmp_path)
+    base = {
+        "destination_config_path": path,
+        "destination_id": "risk-operations-webhook",
+        "delivery_endpoint_env": "RISK_NOTIFICATION_WEBHOOK_URL",
+    }
+    first = resolve_notification_destination_authority(
+        **base,
+        evaluated_at="2026-06-01T00:00:00Z",
+        event_types=["breach_opened"],
+    )
+    later = resolve_notification_destination_authority(
+        **base,
+        evaluated_at="2026-06-01T00:00:01Z",
+        event_types=["breach_opened"],
+    )
+    other_event = resolve_notification_destination_authority(
+        **base,
+        evaluated_at="2026-06-01T00:00:00Z",
+        event_types=["breach_resolved"],
+    )
+
+    assert first["authority_id"] != later["authority_id"]
+    assert first["authority_id"] != other_event["authority_id"]

--- a/tests/unit/test_portfolio_risk_notification_destination_authority_architecture_contract.py
+++ b/tests/unit/test_portfolio_risk_notification_destination_authority_architecture_contract.py
@@ -1,0 +1,44 @@
+from pathlib import Path
+
+
+def test_destination_authority_is_secret_free_and_side_effect_free() -> None:
+    source = Path(
+        "src/orchestration/portfolio_risk_notification_destination_authority.py"
+    ).read_text(encoding="utf-8")
+    docs = Path(
+        "docs/portfolio-risk-notification-destination-authority.md"
+    ).read_text(encoding="utf-8")
+    normalized_docs = " ".join(docs.split()).casefold()
+
+    for required in (
+        "portfolio-risk-notification-destination-authority-v1",
+        "resolve_notification_destination_authority",
+        "delivery_endpoint_env",
+        "require_active",
+        "evaluated_event_types",
+        "destination_fingerprint",
+        "endpoint_value_recorded",
+        "external_request_performed",
+    ):
+        assert required in source
+
+    for forbidden in (
+        "urllib.request",
+        "requests.post(",
+        "httpx.",
+        "--execute",
+        "terraform apply",
+    ):
+        assert forbidden not in source.casefold()
+
+    for required in (
+        "primary arc42 block: `orchestration`",
+        "clock-derived",
+        "endpoint-environment identity",
+        "event allow-list",
+        "no endpoint value",
+        "ordinary ci performs no external request",
+        "terraform apply",
+        "separate dependent pr",
+    ):
+        assert required in normalized_docs


### PR DESCRIPTION
## Goal

Add a deterministic, secret-free authority contract that validates a notification destination before later delivery-path integration.

The authority binds the reviewed destination ID and fingerprint, a clock-derived evaluation time, the delivery endpoint environment-variable identity, and the selected event types. Executable use requires active review status; inactive, expired, future-reviewed, mismatched endpoint identity, and unapproved event types fail closed.

## Scope

Exactly four additive files: one orchestration contract, focused tests, an architecture boundary test, and documentation. The branch is one commit ahead and zero behind `main`.

No endpoint value, credential, payload, response body, or DSN is retained. The increment performs no network request, delivery-attempt write, infrastructure deployment, or `terraform apply`. Committed notification activation remains disabled.

## Exact-head validation

GitHub Actions run **350** passed on head `f5066e6d87cc613820a5f262699ababc1437da7f`:

- Security guardrails passed.
- Ruff passed.
- mypy passed across **120 source files**.
- **823 tests passed** in quality and **823 passed again** in readiness.
- Dependency integrity and the standard replay demonstration passed.
- PostgreSQL 16 contract passed.
- Kubernetes rendering and Terraform format/init/validate passed without apply.

There are no review submissions or unresolved threads.

## Acceptance boundary

Validated and ready for squash merge. The next dependent PR binds initial delivery to this authority and persists destination identity in new v2 delivery-attempt evidence.