### PR TITLE
Bind initial delivery to active notification destination

### DIFF
--- a/docs/manual-webhook-delivery.md
+++ b/docs/manual-webhook-delivery.md
@@ -8,156 +8,139 @@ notifications while retaining append-only evidence:
 ```text
 current pending notification outbox
   -> acquire shared PostgreSQL delivery lock
-  -> exclude delivered events and every event with an existing attempt
-  -> bounded manual batch
-  -> one HTTPS POST with stable Idempotency-Key
-  -> append-only PostgreSQL delivery attempt
+  -> select zero-attempt events
+  -> resolve one active reviewed destination
+  -> verify endpoint-environment identity and event allow-list
+  -> one bounded HTTPS request per event
+  -> append-only delivery attempt
   -> release shared delivery lock
-  -> pending or succeeded operational views
 ```
 
 The implementation is
-`src/orchestration/deliver_portfolio_risk_notifications.py`. The committed
-configuration is `config/notification_delivery.yaml`.
+`src/orchestration/deliver_portfolio_risk_notifications.py`. Delivery configuration
+is in `config/notification_delivery.yaml`; destination ownership and review evidence
+is in `config/notification_destinations.yaml`.
 
 ## Disabled-by-default activation
 
-The committed webhook configuration has `enabled: false` and contains no endpoint
-or recipient. Normal invocation is plan-only. External delivery requires both:
+Committed webhook delivery and destination activation both remain disabled.
+External delivery requires all of the following:
 
-1. a reviewed configuration change setting `enabled: true`; and
-2. an explicit `--execute` invocation with `RISK_NOTIFICATION_WEBHOOK_URL` set
-   locally.
+1. reviewed webhook enablement;
+2. reviewed destination activation with unexpired approval evidence;
+3. an explicit `--execute` invocation;
+4. an exact destination ID;
+5. matching endpoint-environment identity; and
+6. the endpoint value supplied locally through the reviewed environment variable.
 
-The endpoint must be HTTPS and may not contain embedded credentials or a URL
-fragment. Only the endpoint host is recorded in evidence. The full URL and
-environment value are not written to summaries or the database.
+The endpoint must be HTTPS without embedded credentials or a fragment. Only its host
+is recorded. The full endpoint URL and environment value are never retained.
+
+## Active destination authority
+
+Before the first request, the sender resolves
+`portfolio-risk-notification-destination-authority-v1` at a clock-derived execution
+time. The authority binds:
+
+- destination ID and fingerprint;
+- review status and expiry;
+- endpoint environment-variable identity; and
+- the canonical event types selected for the batch.
+
+The destination must be `active`. Disabled, future-reviewed and expired
+destinations fail closed. The destination endpoint environment variable must match
+the delivery configuration, and every selected event type must be present in the
+reviewed allow-list.
+
+The validation runs after candidate selection while the shared delivery lock is
+held, but before transport or attempt persistence. A failing destination check
+therefore performs no webhook request.
+
+Plan-only invocation still evaluates the destination contract, but it may report an
+inactive state without granting delivery authority.
 
 ## Shared concurrency control
 
 Plan-only invocation performs no external request or mutation and does not acquire a
 lock. Explicit delivery acquires the non-blocking PostgreSQL advisory lock defined
-by:
+by `portfolio-risk-notification-delivery-lock-v1`.
 
-```text
-portfolio-risk-notification-delivery-lock-v1
-```
-
-The lock is acquired before candidate selection and held through every network
-request and append-only attempt insert. A second local operator or separate checkout
-using the same PostgreSQL database is rejected immediately while the lock is held.
-It performs no candidate read or webhook request.
-
-The summary exposes the lock model, scope and a credential-free key fingerprint.
-The raw advisory key and PostgreSQL DSN are not retained.
+The lock is acquired before candidate selection and held through destination
+validation, every network request and append-only attempt insert. A contending
+operator is rejected before candidate read or transport. Summary evidence exposes
+only the lock model, scope and credential-free key fingerprint.
 
 ## Initial-attempt boundary
 
-The default PostgreSQL reader selects only events with zero retained webhook
-attempts. A custom reader that supplies an event with any prior attempt is rejected
-before the first network request.
+The PostgreSQL reader selects only events with zero retained webhook attempts. A
+custom reader that supplies any prior attempt is rejected before the first request.
 
-The adapter therefore performs exactly one attempt numbered `1` per selected event.
-It has no internal retry loop and performs no retry sleep. A failed initial attempt
-must continue through the governed workflow:
+The adapter performs exactly one attempt numbered `1` per selected event. It has no
+hidden retry loop and no retry sleep. A failed initial attempt continues through:
 
 ```text
 P4b deterministic retry plan
   -> exact retained plan review
-  -> P4c explicit manual retry execution
+  -> P4c governed manual retry execution
 ```
 
-This prevents the older delivery command from bypassing current event,
-acknowledgement, attempt, expiry and backoff revalidation.
+## Idempotency and evidence
 
-The reviewed `max_attempts_per_event` and `initial_backoff_seconds` settings remain
-part of the delivery fingerprint and are consumed by retry planning and exact retry
-execution. They no longer authorize hidden retries inside this first-attempt
-adapter.
+Every request uses the notification `event_id` as its stable `Idempotency-Key`.
+Receivers must deduplicate this value because remote success can occur before local
+attempt persistence.
 
-## Idempotency
+Each append-only attempt stores:
 
-Every request uses the notification `event_id` as the `Idempotency-Key`. The first
-attempt and every later governed retry therefore carry the same remote
-deduplication identity.
-
-Attempt identity binds:
-
-```text
-notification event ID
-webhook channel
-attempt number
-portfolio-risk-webhook-delivery-v1
-```
-
-The shared lock prevents simultaneous local senders. There remains an unavoidable
-failure window in which the remote receiver accepts a request but local attempt
-persistence fails. The stable `Idempotency-Key` is the control for that ambiguity;
-receivers must deduplicate it.
-
-## Evidence boundary
-
-Each attempt stores:
-
-- attempt and notification IDs;
+- attempt and event IDs;
 - attempt number and timestamp;
-- outcome;
+- success or bounded failure evidence;
 - HTTP status or bounded error code;
 - endpoint host;
 - payload SHA-256; and
 - idempotency key.
 
-Response bodies, endpoint paths, credentials, headers containing secrets and
-arbitrary exception messages are never stored. Invalid transport status values fail
-before an attempt row is written.
+The initial-delivery summary additionally retains the exact destination authority,
+including destination ID, fingerprint, activation status, evaluation time and
+evaluated event types. No endpoint value is included.
 
-The execution summary also declares whether concurrency control was acquired,
-released and held through attempt persistence.
+Response bodies, endpoint paths, credentials, secret-bearing headers, database DSNs
+and arbitrary exception messages are never stored. Invalid transport status values
+fail before an attempt row is written.
 
 ## Operator commands
 
-Plan the current **initial-attempt** batch without network activity:
+Plan without network activity:
 
 ```bash
 .venv/bin/python -m src.orchestration.deliver_portfolio_risk_notifications \
+  --destination-id risk-operations-webhook \
   --summary-json .demo/webhook-delivery-plan.json
 ```
 
-After reviewing and enabling the configuration:
+After reviewed activation:
 
 ```bash
 export RISK_NOTIFICATION_WEBHOOK_URL='https://alerts.example.com/risk'
 
 .venv/bin/python -m src.orchestration.deliver_portfolio_risk_notifications \
+  --destination-id risk-operations-webhook \
   --execute \
   --summary-json .demo/webhook-delivery-run.json
 ```
 
-The PostgreSQL DSN comes from `WAREHOUSE_POSTGRES_DSN` or `--dsn`. It is not
-included in summaries.
-
-For an event that already has a failed attempt, generate and execute an exact retry
-plan instead of invoking this adapter again:
-
-```bash
-.venv/bin/python \
-  -m src.orchestration.plan_portfolio_risk_notification_retries \
-  --planned-at 2026-04-01T12:00:00Z \
-  --summary-json .demo/notification-retry-plan.json
-```
-
-The separate P4c command consumes the exact resulting plan and uses the same shared
-delivery lock before current-evidence revalidation.
+The PostgreSQL DSN comes from `WAREHOUSE_POSTGRES_DSN` or `--dsn` and is not placed
+in the summary.
 
 ## PostgreSQL serving
 
-The append-only table is:
+Append-only attempts remain in:
 
 ```text
 risk_platform.portfolio_risk_notification_delivery_attempts
 ```
 
-Operational views are:
+Operational views remain:
 
 ```text
 risk_platform.portfolio_risk_notification_delivery_status
@@ -165,12 +148,11 @@ risk_platform.portfolio_risk_notification_delivery_pending
 risk_platform.portfolio_risk_notification_delivery_succeeded
 ```
 
-The source outbox remains immutable. Delivery status is derived from attempts rather
-than written back to notification records.
+The source outbox stays immutable. Delivery status is derived from attempt history.
 
 ## Boundary
 
-This adapter does not schedule itself, retry an existing attempt, discover
-recipients, create webhook endpoints, rotate secrets, acknowledge or resolve
-breaches, mutate analytical evidence, block trading, deploy infrastructure, or run
+This adapter does not schedule itself, retry existing attempts, discover
+recipients, create endpoints, rotate secrets, acknowledge or resolve breaches,
+mutate analytical evidence, block trading, deploy infrastructure, or run
 `terraform apply`. CI uses fake transports and performs no network request.

--- a/src/orchestration/deliver_portfolio_risk_notifications.py
+++ b/src/orchestration/deliver_portfolio_risk_notifications.py
@@ -21,10 +21,15 @@ from src.orchestration.portfolio_risk_notification_delivery_lock import (
     DeliveryLockFactory,
     acquire_notification_delivery_lock,
 )
+from src.orchestration.portfolio_risk_notification_destination_authority import (
+    resolve_notification_destination_authority,
+)
 from src.warehouse.postgres_loader import DEFAULT_POSTGRES_DSN
 
 MODEL_VERSION = "portfolio-risk-webhook-delivery-v1"
 CHANNEL = "webhook"
+DEFAULT_DESTINATION_CONFIG = Path("config/notification_destinations.yaml")
+DEFAULT_DESTINATION_ID = "risk-operations-webhook"
 MAX_BATCH_EVENTS = 100
 MAX_ATTEMPTS_PER_EVENT = 10
 MAX_TIMEOUT_SECONDS = 30
@@ -33,6 +38,7 @@ MAX_BACKOFF_SECONDS = 60
 CandidateReader = Callable[..., list[dict[str, Any]]]
 AttemptWriter = Callable[[Mapping[str, Any]], None]
 Transport = Callable[[str, bytes, Mapping[str, str], float], int]
+Clock = Callable[[], datetime]
 
 
 class DeliveryTransportError(RuntimeError):
@@ -201,7 +207,6 @@ def read_pending_delivery_candidates(
         GROUP BY
             pending.event_id,
             pending.event_type,
-            pending.transition_type,
             pending.policy_id,
             pending.policy_fingerprint,
             pending.portfolio_id,
@@ -211,7 +216,8 @@ def read_pending_delivery_candidates(
             pending.subject_key,
             pending.current_status,
             pending.ts_event,
-            pending.payload_json
+            pending.payload_json,
+            pending.transition_type
         HAVING COALESCE(MAX(attempt.attempt_number), 0) = 0
         ORDER BY pending.ts_event, pending.event_id
         LIMIT %s
@@ -361,12 +367,20 @@ def _read_and_validate_candidates(
     return candidates
 
 
+def _event_types(candidates: Sequence[Mapping[str, Any]]) -> list[str]:
+    return [
+        _required_text(candidate.get("event_type"), "event_type")
+        for candidate in candidates
+    ]
+
+
 def _delivery_summary(
     *,
     config: WebhookDeliveryConfig,
     endpoint_host: str | None,
     candidates: list[dict[str, Any]],
     execute: bool,
+    destination_authority: Mapping[str, Any],
     lock_evidence: Mapping[str, Any] | None = None,
 ) -> dict[str, Any]:
     plan = [
@@ -396,6 +410,7 @@ def _delivery_summary(
         "run_id": str(uuid4()),
         "config_fingerprint": config.fingerprint,
         "channel": CHANNEL,
+        "destination_authority": dict(destination_authority),
         "endpoint": {
             "configured": endpoint_host is not None,
             "host": endpoint_host,
@@ -504,14 +519,28 @@ def deliver_portfolio_risk_notifications(
     config_path: Path,
     dsn: str,
     execute: bool = False,
+    destination_config_path: Path | None = None,
+    destination_id: str = DEFAULT_DESTINATION_ID,
     environment: Mapping[str, str] | None = None,
     reader: CandidateReader | None = None,
     attempt_writer: AttemptWriter | None = None,
     transport: Transport | None = None,
     lock_factory: DeliveryLockFactory | None = None,
+    clock: Clock | None = None,
 ) -> dict[str, Any]:
     config = load_webhook_delivery_config(config_path)
+    sibling_destination = config_path.parent / "notification_destinations.yaml"
+    selected_destination_path = (
+        destination_config_path
+        if destination_config_path is not None
+        else (
+            sibling_destination
+            if sibling_destination.is_file()
+            else DEFAULT_DESTINATION_CONFIG
+        )
+    )
     selected_environment = environment if environment is not None else os.environ
+    selected_clock = clock or (lambda: datetime.now(timezone.utc))
     raw_endpoint = selected_environment.get(config.endpoint_env)
     endpoint_host: str | None = None
     endpoint_value: str | None = None
@@ -534,11 +563,20 @@ def deliver_portfolio_risk_notifications(
             dsn=dsn,
             max_events=config.max_batch_events,
         )
+        destination_authority = resolve_notification_destination_authority(
+            destination_config_path=selected_destination_path,
+            destination_id=destination_id,
+            delivery_endpoint_env=config.endpoint_env,
+            evaluated_at=selected_clock(),
+            event_types=_event_types(candidates),
+            require_active=False,
+        )
         return _delivery_summary(
             config=config,
             endpoint_host=endpoint_host,
             candidates=candidates,
             execute=False,
+            destination_authority=destination_authority,
         )
 
     if endpoint_value is None or endpoint_host is None:
@@ -555,11 +593,20 @@ def deliver_portfolio_risk_notifications(
             dsn=dsn,
             max_events=config.max_batch_events,
         )
+        destination_authority = resolve_notification_destination_authority(
+            destination_config_path=selected_destination_path,
+            destination_id=destination_id,
+            delivery_endpoint_env=config.endpoint_env,
+            evaluated_at=selected_clock(),
+            event_types=_event_types(candidates),
+            require_active=True,
+        )
         summary = _delivery_summary(
             config=config,
             endpoint_host=endpoint_host,
             candidates=candidates,
             execute=True,
+            destination_authority=destination_authority,
             lock_evidence=lock_evidence,
         )
         summary["execution"] = _execute_initial_attempts(
@@ -588,6 +635,15 @@ def _build_parser() -> argparse.ArgumentParser:
         default=Path("config/notification_delivery.yaml"),
     )
     parser.add_argument(
+        "--destination-config",
+        type=Path,
+        default=DEFAULT_DESTINATION_CONFIG,
+    )
+    parser.add_argument(
+        "--destination-id",
+        default=DEFAULT_DESTINATION_ID,
+    )
+    parser.add_argument(
         "--dsn",
         default=os.environ.get(
             "WAREHOUSE_POSTGRES_DSN",
@@ -600,15 +656,17 @@ def _build_parser() -> argparse.ArgumentParser:
 
 
 def _write_summary(path: Path, summary: Mapping[str, Any]) -> None:
+    if path.is_symlink():
+        raise StorageError("webhook delivery summary must not be a symbolic link")
     path.parent.mkdir(parents=True, exist_ok=True)
     temporary = path.with_suffix(path.suffix + ".tmp")
     try:
         temporary.write_text(
-            json.dumps(summary, indent=2, sort_keys=True) + "\n",
+            json.dumps(summary, indent=2, sort_keys=True, allow_nan=False) + "\n",
             encoding="utf-8",
         )
         temporary.replace(path)
-    except OSError:
+    except (OSError, TypeError, ValueError):
         temporary.unlink(missing_ok=True)
         raise StorageError("Unable to write webhook delivery summary") from None
 
@@ -618,6 +676,8 @@ def main(argv: Sequence[str] | None = None) -> int:
     try:
         summary = deliver_portfolio_risk_notifications(
             config_path=args.config,
+            destination_config_path=args.destination_config,
+            destination_id=args.destination_id,
             dsn=args.dsn,
             execute=args.execute,
         )
@@ -632,8 +692,8 @@ def main(argv: Sequence[str] | None = None) -> int:
         return 1
     except ValidationError:
         print(
-            "Webhook delivery failed: configuration, endpoint, candidate, or "
-            "options were invalid",
+            "Webhook delivery failed: configuration, destination, endpoint, "
+            "candidate, or options were invalid",
             file=sys.stderr,
         )
         return 1
@@ -651,7 +711,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         )
         return 1
 
-    print(json.dumps(summary, sort_keys=True))
+    print(json.dumps(summary, sort_keys=True, allow_nan=False))
     return 0
 
 

--- a/tests/unit/test_manual_webhook_delivery_architecture_contract.py
+++ b/tests/unit/test_manual_webhook_delivery_architecture_contract.py
@@ -5,26 +5,38 @@ def test_manual_webhook_delivery_is_disabled_secret_safe_and_manual() -> None:
     source = Path(
         "src/orchestration/deliver_portfolio_risk_notifications.py"
     ).read_text(encoding="utf-8")
-    docs = Path("docs/manual-webhook-delivery.md").read_text(
-        encoding="utf-8"
-    )
-    config = Path("config/notification_delivery.yaml").read_text(
-        encoding="utf-8"
-    )
+    docs = Path("docs/manual-webhook-delivery.md").read_text(encoding="utf-8")
+    config = Path("config/notification_delivery.yaml").read_text(encoding="utf-8")
+    destination_config = Path(
+        "config/notification_destinations.yaml"
+    ).read_text(encoding="utf-8")
 
     assert "enabled: false" in config
+    assert "enabled: false" in destination_config
     assert "RISK_NOTIFICATION_WEBHOOK_URL" in config
+    assert "RISK_NOTIFICATION_WEBHOOK_URL" in destination_config
     assert "https://" not in config
+    assert "https://" not in destination_config
 
     for required in (
         "Idempotency-Key",
         "--execute",
+        "--destination-config",
+        "--destination-id",
         "response_bodies_recorded",
         "max_attempts_per_event",
         "initial_backoff_seconds",
         "portfolio_risk_notification_delivery_attempts",
+        "resolve_notification_destination_authority",
+        "destination_authority",
+        "require_active=True",
+        "event_types=_event_types(candidates)",
     ):
         assert required in source
+
+    assert source.index("resolve_notification_destination_authority(") < source.index(
+        'summary["execution"] = _execute_initial_attempts('
+    )
 
     for required in (
         "Disabled-by-default",
@@ -33,5 +45,9 @@ def test_manual_webhook_delivery_is_disabled_secret_safe_and_manual() -> None:
         "Response bodies",
         "CI uses fake transports",
         "does not schedule itself",
+        "clock-derived execution",
+        "endpoint-environment identity",
+        "reviewed allow-list",
+        "before the first request",
     ):
         assert required.lower() in docs.lower()

--- a/tests/unit/test_portfolio_risk_webhook_delivery.py
+++ b/tests/unit/test_portfolio_risk_webhook_delivery.py
@@ -38,6 +38,76 @@ def _config_payload(*, enabled: bool = False, attempts: int = 3):
     }
 
 
+def _destination_payload(
+    *,
+    enabled: bool,
+    endpoint_env: str = "RISK_NOTIFICATION_WEBHOOK_URL",
+    allowed_event_types: list[str] | None = None,
+) -> dict[str, Any]:
+    activation: dict[str, Any]
+    if enabled:
+        activation = {
+            "enabled": True,
+            "change_request_id": "CHG-2026-DELIVERY",
+            "reviewed_by": ["risk-control-reviewer"],
+            "reviewed_at": "2026-01-01T00:00:00Z",
+            "review_expires_at": "2027-01-01T00:00:00Z",
+        }
+    else:
+        activation = {
+            "enabled": False,
+            "change_request_id": None,
+            "reviewed_by": [],
+            "reviewed_at": None,
+            "review_expires_at": None,
+        }
+    return {
+        "model_version": "portfolio-risk-notification-destination-v1",
+        "destinations": {
+            "risk-operations-webhook": {
+                "channel": "webhook",
+                "endpoint_env": endpoint_env,
+                "owner": {
+                    "team": "risk-operations",
+                    "contact": "risk-operations-oncall",
+                },
+                "purpose": "portfolio-risk-breach-lifecycle",
+                "recipient_scope": "risk-operations",
+                "data_classification": "internal",
+                "allowed_event_types": allowed_event_types
+                or [
+                    "breach_escalated",
+                    "breach_opened",
+                    "breach_resolved",
+                ],
+                "activation": activation,
+            }
+        },
+    }
+
+
+def _write_destination(
+    tmp_path: Path,
+    *,
+    enabled: bool,
+    endpoint_env: str = "RISK_NOTIFICATION_WEBHOOK_URL",
+    allowed_event_types: list[str] | None = None,
+) -> Path:
+    path = tmp_path / "notification_destinations.yaml"
+    path.write_text(
+        yaml.safe_dump(
+            _destination_payload(
+                enabled=enabled,
+                endpoint_env=endpoint_env,
+                allowed_event_types=allowed_event_types,
+            ),
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+    return path
+
+
 def _write_config(tmp_path: Path, *, enabled: bool, attempts: int = 3) -> Path:
     path = tmp_path / "delivery.yaml"
     path.write_text(
@@ -47,13 +117,18 @@ def _write_config(tmp_path: Path, *, enabled: bool, attempts: int = 3) -> Path:
         ),
         encoding="utf-8",
     )
+    _write_destination(tmp_path, enabled=enabled)
     return path
 
 
-def _candidate(*, attempts_so_far: int = 0) -> dict[str, Any]:
+def _candidate(
+    *,
+    attempts_so_far: int = 0,
+    event_type: str = "breach_opened",
+) -> dict[str, Any]:
     return {
         "event_id": "event-1",
-        "event_type": "breach_opened",
+        "event_type": event_type,
         "transition_type": "opened",
         "policy_id": "us-tech-standard",
         "policy_fingerprint": "policy-1",
@@ -110,6 +185,7 @@ def test_plan_only_reads_initial_candidates_without_transport_attempt_or_lock(
         ),
         attempt_writer=lambda attempt: attempts.append(dict(attempt)),
         lock_factory=lock,
+        clock=lambda: datetime(2026, 6, 1, tzinfo=timezone.utc),
     )
 
     assert transports == []
@@ -119,6 +195,8 @@ def test_plan_only_reads_initial_candidates_without_transport_attempt_or_lock(
     assert summary["selection"]["initial_attempts_only"] is True
     assert summary["endpoint"] == {"configured": False, "host": None}
     assert summary["concurrency_control"]["performed"] is False
+    assert summary["destination_authority"]["active"] is False
+    assert summary["destination_authority"]["activation"]["status"] == "disabled"
     assert "dsn" not in json.dumps(summary)
 
 
@@ -173,6 +251,76 @@ def test_held_lock_rejects_before_candidate_read_or_transport(tmp_path: Path) ->
     assert sends == []
 
 
+def test_inactive_destination_rejects_before_transport(tmp_path: Path) -> None:
+    config_path = _write_config(tmp_path, enabled=True)
+    _write_destination(tmp_path, enabled=False)
+    sends: list[bool] = []
+    attempts: list[dict[str, Any]] = []
+
+    with pytest.raises(ValidationError, match="not active: disabled"):
+        deliver_portfolio_risk_notifications(
+            config_path=config_path,
+            dsn="dsn",
+            execute=True,
+            environment={
+                "RISK_NOTIFICATION_WEBHOOK_URL": "https://alerts.example.test/risk"
+            },
+            reader=lambda **_: [_candidate()],
+            attempt_writer=lambda attempt: attempts.append(dict(attempt)),
+            transport=lambda *_: sends.append(True) or 204,
+            lock_factory=_delivery_lock,
+            clock=lambda: datetime(2026, 6, 1, tzinfo=timezone.utc),
+        )
+
+    assert sends == []
+    assert attempts == []
+
+
+def test_destination_endpoint_identity_must_match_delivery_config(
+    tmp_path: Path,
+) -> None:
+    config_path = _write_config(tmp_path, enabled=True)
+    _write_destination(
+        tmp_path,
+        enabled=True,
+        endpoint_env="ANOTHER_NOTIFICATION_URL",
+    )
+    with pytest.raises(ValidationError, match="does not match"):
+        deliver_portfolio_risk_notifications(
+            config_path=config_path,
+            dsn="dsn",
+            execute=True,
+            environment={
+                "RISK_NOTIFICATION_WEBHOOK_URL": "https://alerts.example.test/risk"
+            },
+            reader=lambda **_: [_candidate()],
+            attempt_writer=lambda _: None,
+            transport=lambda *_: 204,
+            lock_factory=_delivery_lock,
+            clock=lambda: datetime(2026, 6, 1, tzinfo=timezone.utc),
+        )
+
+
+def test_unapproved_event_type_rejects_before_first_request(tmp_path: Path) -> None:
+    config_path = _write_config(tmp_path, enabled=True)
+    sends: list[bool] = []
+    with pytest.raises(ValidationError, match="does not allow"):
+        deliver_portfolio_risk_notifications(
+            config_path=config_path,
+            dsn="dsn",
+            execute=True,
+            environment={
+                "RISK_NOTIFICATION_WEBHOOK_URL": "https://alerts.example.test/risk"
+            },
+            reader=lambda **_: [_candidate(event_type="breach_deescalated")],
+            attempt_writer=lambda _: None,
+            transport=lambda *_: sends.append(True) or 204,
+            lock_factory=_delivery_lock,
+            clock=lambda: datetime(2026, 6, 1, tzinfo=timezone.utc),
+        )
+    assert sends == []
+
+
 def test_initial_delivery_failure_records_one_attempt_without_hidden_retry(
     tmp_path: Path,
 ) -> None:
@@ -206,6 +354,7 @@ def test_initial_delivery_failure_records_one_attempt_without_hidden_retry(
         attempt_writer=lambda attempt: attempts.append(dict(attempt)),
         transport=transport,
         lock_factory=_delivery_lock,
+        clock=lambda: datetime(2026, 6, 1, tzinfo=timezone.utc),
     )
 
     assert len(calls) == 1
@@ -232,7 +381,13 @@ def test_initial_delivery_failure_records_one_attempt_without_hidden_retry(
         "scope": LOCK_SCOPE,
         "key_fingerprint": LOCK_KEY_FINGERPRINT,
     }
-    assert "https://alerts.example.test/risk" not in json.dumps(summary)
+    authority = summary["destination_authority"]
+    assert authority["active"] is True
+    assert authority["destination_id"] == "risk-operations-webhook"
+    assert authority["evaluated_event_types"] == ["breach_opened"]
+    assert authority["endpoint_value_recorded"] is False
+    rendered = json.dumps(summary)
+    assert "https://alerts.example.test/risk" not in rendered
     assert summary["endpoint"]["host"] == "alerts.example.test"
 
 


### PR DESCRIPTION
## Goal

Complete the initial-delivery part of **P4d3** by requiring the existing sender to resolve one exact destination authority before its first request.

```text
reviewed webhook enablement
  + shared delivery lock
  + current zero-attempt candidates
  + active destination review
  + matching endpoint environment identity
  + approved event types
  -> bounded initial delivery
  -> destination-aware credential-free summary
```

## Controls

- Plan-only use evaluates destination status without granting authority.
- Explicit execution requires an active, unexpired destination at a clock-derived time.
- Destination validation occurs after candidate selection under the shared advisory lock and before transport.
- Endpoint environment-variable identities must match.
- Every selected event type must be in the destination allow-list.
- The execution summary retains destination ID, fingerprint, authority ID, evaluation time and event types, but no endpoint value.
- Existing first-attempt-only, stable Idempotency-Key, no-hidden-retry and append-only attempt behavior remains unchanged.

## Scope

Exactly four files, 323 additions and 110 deletions. The branch is one commit ahead and zero behind `main`.

Committed delivery and destination activation remain disabled. CI uses fake transports and performs no external request, provider call, deployment, cloud schedule activation or `terraform apply`.

## Exact-head validation

GitHub Actions run **352** (`32959628100`) passed on head `fc1ae547c3e2c05cc42ee94d88208fc7c3e91e46`:

- Security guardrails passed.
- Ruff passed.
- mypy passed across **120 source files**.
- **826 tests passed** in quality and **826 passed again** in readiness.
- Dependency integrity and the standard replay demonstration passed.
- PostgreSQL 16 contract passed.
- Kubernetes rendering and Terraform format/init/validate passed without apply.

There are no review submissions or unresolved threads.

## Acceptance boundary

Validated and ready for squash merge. The next dependent PR binds governed retry execution and durable terminal history to the same destination authority.