### PR TITLE
Bind notification retries to active destination authority

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,7 @@ services:
       - ./sql/operational_readiness_overrides_schema.sql:/docker-entrypoint-initdb.d/17_operational_readiness_overrides_schema.sql:ro
       - ./sql/local_schedule_runs_schema.sql:/docker-entrypoint-initdb.d/18_local_schedule_runs_schema.sql:ro
       - ./sql/portfolio_risk_notification_retry_execution_schema.sql:/docker-entrypoint-initdb.d/19_portfolio_risk_notification_retry_execution_schema.sql:ro
+      - ./sql/portfolio_risk_notification_retry_destination_binding_schema.sql:/docker-entrypoint-initdb.d/19b_portfolio_risk_notification_retry_destination_binding_schema.sql:ro
       - ./sql/portfolio_risk_notification_retry_follow_up_schema.sql:/docker-entrypoint-initdb.d/20_portfolio_risk_notification_retry_follow_up_schema.sql:ro
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U risk_user -d risk_platform"]

--- a/docs/portfolio-risk-notification-retry-destination-authority.md
+++ b/docs/portfolio-risk-notification-retry-destination-authority.md
@@ -1,0 +1,62 @@
+# Retry Execution Destination Authority
+
+Primary arc42 block: `orchestration`, with an append-only `warehouse` evidence
+binding.
+
+## Goal
+
+A governed notification retry must use one current, reviewed destination rather
+than only a delivery endpoint value:
+
+```text
+exact retained retry plan
+  + current retry evidence
+  + shared PostgreSQL delivery lock
+  + active destination ownership contract
+  -> destination authority refreshed under the lock
+  -> approved event-type check
+  -> one request per authorised event
+  -> terminal retry history
+  -> append-only destination binding
+```
+
+## Enforcement order
+
+The retry executor obtains the existing delivery lock, rebuilds the current
+retry plan, and proves that it still matches the retained plan. It then resolves
+the destination authority using the same clock-derived execution instant and
+checks the exact endpoint environment-variable identity and event types. Only
+after those checks may the first transport call occur.
+
+The execution identity binds the destination ID, fingerprint and authority ID.
+An expired review, disabled destination, endpoint-environment change or event
+outside the allow-list therefore fails before delivery.
+
+## Durable evidence
+
+The existing terminal retry record remains backward compatible. A separate
+append-only row in
+`risk_platform.portfolio_risk_notification_retry_destination_bindings` links
+that terminal `record_id` to:
+
+- the authority ID;
+- destination ID and fingerprint;
+- endpoint environment-variable name, never its value;
+- authority evaluation time and reviewed event types; and
+- the canonical, credential-free authority document.
+
+Exact retries converge on the existing binding. Reusing a terminal record with
+different destination evidence fails closed. UPDATE and DELETE are rejected by
+PostgreSQL triggers.
+
+A failure before destination authority exists has no binding. A completed
+execution, or a failure after authority was observed, retains the binding.
+
+## Safety boundary
+
+Committed destination activation, webhook delivery and retry execution remain
+disabled. Ordinary CI uses fake transports and performs no external webhook
+request. The evidence contains no endpoint URL, payload body, response body,
+PostgreSQL DSN, credential or environment value. It does not acknowledge a
+breach, mutate the outbox, activate cloud scheduling, deploy infrastructure or
+run `terraform apply`.

--- a/sql/portfolio_risk_notification_retry_destination_binding_schema.sql
+++ b/sql/portfolio_risk_notification_retry_destination_binding_schema.sql
@@ -1,0 +1,96 @@
+-- Append-only destination authority bindings for terminal notification retry history.
+-- Apply after sql/portfolio_risk_notification_retry_execution_schema.sql.
+
+CREATE SCHEMA IF NOT EXISTS risk_platform;
+
+CREATE TABLE IF NOT EXISTS
+risk_platform.portfolio_risk_notification_retry_destination_bindings (
+    binding_id TEXT PRIMARY KEY,
+    model_version TEXT NOT NULL CHECK (
+        model_version = 'portfolio-risk-notification-retry-destination-binding-v1'
+    ),
+    record_id TEXT NOT NULL UNIQUE REFERENCES
+        risk_platform.portfolio_risk_notification_retry_executions (record_id),
+    request_id TEXT NOT NULL,
+    plan_id TEXT NOT NULL,
+    execution_id TEXT,
+    authority_id TEXT NOT NULL,
+    destination_id TEXT NOT NULL,
+    destination_fingerprint TEXT NOT NULL,
+    endpoint_environment_variable TEXT NOT NULL,
+    evaluated_at TIMESTAMPTZ NOT NULL,
+    evaluated_event_types_json JSONB NOT NULL CHECK (
+        jsonb_typeof(evaluated_event_types_json) = 'array'
+    ),
+    authority_json JSONB NOT NULL CHECK (
+        jsonb_typeof(authority_json) = 'object'
+    ),
+    recorded_at TIMESTAMPTZ NOT NULL,
+    binding_json JSONB NOT NULL CHECK (
+        jsonb_typeof(binding_json) = 'object'
+    ),
+    document_sha256 TEXT NOT NULL CHECK (
+        document_sha256 ~ '^[0-9a-f]{64}$'
+    ),
+    loaded_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    CHECK (binding_id <> ''),
+    CHECK (record_id <> ''),
+    CHECK (request_id <> ''),
+    CHECK (plan_id <> ''),
+    CHECK (execution_id IS NULL OR execution_id <> ''),
+    CHECK (authority_id <> ''),
+    CHECK (destination_id <> ''),
+    CHECK (destination_fingerprint <> ''),
+    CHECK (endpoint_environment_variable ~ '^[A-Z][A-Z0-9_]{2,127}$'),
+    CHECK (recorded_at >= evaluated_at),
+    CHECK (binding_json ->> 'binding_id' = binding_id),
+    CHECK (binding_json ->> 'model_version' = model_version),
+    CHECK (binding_json ->> 'record_id' = record_id),
+    CHECK (binding_json ->> 'request_id' = request_id),
+    CHECK (binding_json ->> 'plan_id' = plan_id),
+    CHECK (binding_json -> 'destination_authority' = authority_json),
+    CHECK (authority_json ->> 'authority_id' = authority_id),
+    CHECK (authority_json ->> 'destination_id' = destination_id),
+    CHECK (
+        authority_json ->> 'destination_fingerprint' = destination_fingerprint
+    ),
+    CHECK (
+        authority_json ->> 'endpoint_environment_variable'
+        = endpoint_environment_variable
+    ),
+    CHECK (
+        authority_json -> 'evaluated_event_types'
+        = evaluated_event_types_json
+    ),
+    CHECK ((authority_json ->> 'active')::BOOLEAN),
+    CHECK (authority_json ->> 'channel' = 'webhook')
+);
+
+CREATE INDEX IF NOT EXISTS idx_notification_retry_destination_history
+    ON risk_platform.portfolio_risk_notification_retry_destination_bindings (
+        destination_id,
+        evaluated_at DESC,
+        record_id
+    );
+
+CREATE OR REPLACE FUNCTION
+risk_platform.reject_notification_retry_destination_binding_mutation()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    RAISE EXCEPTION
+        'portfolio_risk_notification_retry_destination_bindings is append-only';
+END;
+$$;
+
+DROP TRIGGER IF EXISTS
+trg_notification_retry_destination_binding_append_only
+ON risk_platform.portfolio_risk_notification_retry_destination_bindings;
+
+CREATE TRIGGER trg_notification_retry_destination_binding_append_only
+BEFORE UPDATE OR DELETE
+ON risk_platform.portfolio_risk_notification_retry_destination_bindings
+FOR EACH ROW
+EXECUTE FUNCTION
+    risk_platform.reject_notification_retry_destination_binding_mutation();

--- a/src/orchestration/execute_portfolio_risk_notification_retries.py
+++ b/src/orchestration/execute_portfolio_risk_notification_retries.py
@@ -273,7 +273,7 @@ def execute_portfolio_risk_notification_retries(
         }
         event_types = _event_types_for_retryable_events(
             retryable_event_ids=retryable_event_ids,
-            event_by_id=event_by_id,
+            event_by_id=candidate_by_id,
         )
         authority_evaluated_at = _clock_utc(
             selected_clock,

--- a/src/orchestration/execute_portfolio_risk_notification_retries.py
+++ b/src/orchestration/execute_portfolio_risk_notification_retries.py
@@ -13,6 +13,8 @@ from typing import Any, cast
 from src.common.exceptions import OverlapError, StorageError, ValidationError
 from src.orchestration.deliver_portfolio_risk_notifications import (
     CHANNEL,
+    DEFAULT_DESTINATION_CONFIG,
+    DEFAULT_DESTINATION_ID,
     MODEL_VERSION as DELIVERY_MODEL_VERSION,
     AttemptWriter,
     DeliveryTransportError,
@@ -32,6 +34,9 @@ from src.orchestration.portfolio_risk_notification_delivery_lock import (
     DeliveryLockFactory,
     acquire_notification_delivery_lock,
 )
+from src.orchestration.portfolio_risk_notification_destination_authority import (
+    resolve_notification_destination_authority,
+)
 from src.orchestration.portfolio_risk_notification_retry_execution_policy import (
     EXECUTION_MODEL_VERSION,
     aware_utc,
@@ -46,6 +51,8 @@ from src.orchestration.portfolio_risk_notification_retry_plan_contract import (
 from src.warehouse.postgres_loader import DEFAULT_POSTGRES_DSN
 
 Clock = Callable[[], datetime]
+DestinationAuthorityResolver = Callable[..., dict[str, Any]]
+DestinationAuthorityObserver = Callable[[Mapping[str, Any]], None]
 
 
 def _execution_id(identity: Mapping[str, Any]) -> str:
@@ -64,6 +71,88 @@ def _clock_utc(clock: Clock, label: str) -> datetime:
     return aware_utc(clock(), label)
 
 
+def _destination_path(
+    *,
+    config_path: Path,
+    destination_config_path: Path | None,
+) -> Path:
+    if destination_config_path is not None:
+        return destination_config_path
+    sibling = config_path.parent / "notification_destinations.yaml"
+    return sibling if sibling.is_file() else DEFAULT_DESTINATION_CONFIG
+
+
+def _event_types_for_retryable_events(
+    *,
+    retryable_event_ids: Sequence[str],
+    event_by_id: Mapping[str, Mapping[str, Any]],
+) -> list[str]:
+    event_types: list[str] = []
+    for event_id in retryable_event_ids:
+        event = event_by_id.get(event_id)
+        if event is None:
+            raise ValidationError(f"retained retry event evidence is missing {event_id}")
+        event_type = safe_text(event.get("event_type"), "retry event_type")
+        assert event_type is not None
+        event_types.append(event_type)
+    return sorted(set(event_types))
+
+
+def _validate_destination_authority(
+    value: Any,
+    *,
+    destination_id: str,
+    endpoint_environment_variable: str,
+    evaluated_at: datetime,
+    event_types: Sequence[str],
+) -> dict[str, Any]:
+    if not isinstance(value, Mapping):
+        raise ValidationError("destination authority resolver returned invalid evidence")
+    required = {
+        "authority_id",
+        "destination_fingerprint",
+        "destination_id",
+        "endpoint_environment_variable",
+        "evaluated_at",
+        "evaluated_event_types",
+        "model_version",
+        "channel",
+        "activation",
+        "allowed_event_types",
+        "active",
+        "endpoint_value_recorded",
+        "external_request_performed",
+        "delivery_attempt_written",
+        "outbox_mutated",
+        "acknowledgement_mutated",
+    }
+    if set(value) != required:
+        raise ValidationError("destination authority fields are invalid")
+    if value["destination_id"] != destination_id:
+        raise ValidationError("destination authority destination identity changed")
+    if value["endpoint_environment_variable"] != endpoint_environment_variable:
+        raise ValidationError("destination authority endpoint identity changed")
+    authority_time = aware_utc(value["evaluated_at"], "destination evaluated_at")
+    if authority_time != evaluated_at:
+        raise ValidationError("destination authority evaluation time changed")
+    if value["evaluated_event_types"] != sorted(set(event_types)):
+        raise ValidationError("destination authority event evidence changed")
+    if value["channel"] != CHANNEL or value["active"] is not True:
+        raise ValidationError("destination authority is not active webhook authority")
+    for key in (
+        "endpoint_value_recorded",
+        "external_request_performed",
+        "delivery_attempt_written",
+        "outbox_mutated",
+        "acknowledgement_mutated",
+    ):
+        if value[key] is not False:
+            raise ValidationError("destination authority side-effect evidence is invalid")
+    for key in ("authority_id", "destination_fingerprint"):
+        safe_text(value[key], f"destination authority {key}")
+    return dict(value)
+
+
 def execute_portfolio_risk_notification_retries(
     *,
     plan_path: Path,
@@ -72,12 +161,16 @@ def execute_portfolio_risk_notification_retries(
     config_path: Path,
     dsn: str,
     execute: bool = False,
+    destination_config_path: Path | None = None,
+    destination_id: str = DEFAULT_DESTINATION_ID,
     environment: Mapping[str, str] | None = None,
     reader: CandidateReader | None = None,
     attempt_writer: AttemptWriter | None = None,
     transport: Transport | None = None,
     clock: Clock | None = None,
     lock_factory: DeliveryLockFactory | None = None,
+    destination_authority_resolver: DestinationAuthorityResolver | None = None,
+    destination_authority_observer: DestinationAuthorityObserver | None = None,
 ) -> dict[str, Any]:
     if execute is not True:
         raise ValidationError("explicit --execute is required for manual retry delivery")
@@ -85,6 +178,12 @@ def execute_portfolio_risk_notification_retries(
     execution_time = _clock_utc(selected_clock, "execution_started_at")
     selected_request_id = safe_segment(request_id, "request_id")
     assert selected_request_id is not None
+    selected_destination_id = safe_segment(destination_id, "destination_id")
+    assert selected_destination_id is not None
+    selected_destination_path = _destination_path(
+        config_path=config_path,
+        destination_config_path=destination_config_path,
+    )
     retained_plan = load_retry_plan(plan_path)
     confirmed = safe_text(confirm_plan_id, "confirm_plan_id")
     if confirmed != retained_plan["plan_id"]:
@@ -137,6 +236,10 @@ def execute_portfolio_risk_notification_retries(
     )
     selected_transport = transport or _default_transport
     selected_lock_factory = lock_factory or acquire_notification_delivery_lock
+    selected_authority_resolver = (
+        destination_authority_resolver
+        or resolve_notification_destination_authority
+    )
     filters = cast(Mapping[str, Any], retained_plan["filters"])
 
     with selected_lock_factory(dsn=dsn) as lock_evidence:
@@ -168,6 +271,35 @@ def execute_portfolio_risk_notification_retries(
         event_by_id = {
             cast(str, event["event_id"]): event for event in retained_events
         }
+        event_types = _event_types_for_retryable_events(
+            retryable_event_ids=retryable_event_ids,
+            event_by_id=event_by_id,
+        )
+        authority_evaluated_at = _clock_utc(
+            selected_clock,
+            "destination_authority_evaluated_at",
+        )
+        if authority_evaluated_at < execution_time:
+            raise ValidationError(
+                "destination authority evaluation must not precede execution start"
+            )
+        destination_authority = _validate_destination_authority(
+            selected_authority_resolver(
+                destination_config_path=selected_destination_path,
+                destination_id=selected_destination_id,
+                delivery_endpoint_env=delivery_config.endpoint_env,
+                evaluated_at=authority_evaluated_at,
+                event_types=event_types,
+                require_active=True,
+            ),
+            destination_id=selected_destination_id,
+            endpoint_environment_variable=delivery_config.endpoint_env,
+            evaluated_at=authority_evaluated_at,
+            event_types=event_types,
+        )
+        if destination_authority_observer is not None:
+            destination_authority_observer(destination_authority)
+
         expected_attempts: list[dict[str, Any]] = []
         for event_id in retryable_event_ids:
             event = event_by_id[event_id]
@@ -189,6 +321,11 @@ def execute_portfolio_risk_notification_retries(
             "delivery_config_fingerprint": delivery_config.fingerprint,
             "delivery_lock_key_fingerprint": lock_evidence["key_fingerprint"],
             "delivery_lock_model_version": lock_evidence["model_version"],
+            "destination_authority_id": destination_authority["authority_id"],
+            "destination_fingerprint": destination_authority[
+                "destination_fingerprint"
+            ],
+            "destination_id": destination_authority["destination_id"],
             "endpoint_host": endpoint_host,
             "executed_at": execution_time.isoformat(),
             "expected_attempts": expected_attempts,
@@ -280,6 +417,7 @@ def execute_portfolio_risk_notification_retries(
             "plan_id": retained_plan["plan_id"],
             "executed_at": execution_time.isoformat(),
             "channel": CHANNEL,
+            "destination_authority": destination_authority,
             "endpoint": {
                 "host": endpoint_host,
                 "full_url_recorded": False,
@@ -363,6 +501,12 @@ def _build_parser() -> argparse.ArgumentParser:
         default=Path("config/notification_delivery.yaml"),
     )
     parser.add_argument(
+        "--destination-config",
+        type=Path,
+        default=DEFAULT_DESTINATION_CONFIG,
+    )
+    parser.add_argument("--destination-id", default=DEFAULT_DESTINATION_ID)
+    parser.add_argument(
         "--dsn",
         default=os.environ.get("WAREHOUSE_POSTGRES_DSN", DEFAULT_POSTGRES_DSN),
     )
@@ -379,6 +523,8 @@ def main(argv: Sequence[str] | None = None) -> int:
             confirm_plan_id=args.confirm_plan_id,
             request_id=args.request_id,
             config_path=args.config,
+            destination_config_path=args.destination_config,
+            destination_id=args.destination_id,
             dsn=args.dsn,
             execute=args.execute,
         )

--- a/src/orchestration/run_recorded_portfolio_risk_notification_retries.py
+++ b/src/orchestration/run_recorded_portfolio_risk_notification_retries.py
@@ -11,6 +11,8 @@ from typing import Any, cast
 
 from src.common.exceptions import OverlapError, StorageError, ValidationError
 from src.orchestration.deliver_portfolio_risk_notifications import (
+    DEFAULT_DESTINATION_CONFIG,
+    DEFAULT_DESTINATION_ID,
     AttemptWriter,
     Transport,
     _default_transport,
@@ -32,6 +34,15 @@ from src.orchestration.portfolio_risk_notification_retry_execution_policy import
 from src.orchestration.portfolio_risk_notification_retry_plan_contract import (
     load_retry_plan,
 )
+from src.warehouse.notification_retry_destination_binding_contract import (
+    build_retry_destination_binding,
+)
+from src.warehouse.notification_retry_destination_binding_reader import (
+    read_notification_retry_destination_binding,
+)
+from src.warehouse.notification_retry_destination_binding_recorder import (
+    record_notification_retry_destination_binding,
+)
 from src.warehouse.notification_retry_execution_contract import (
     build_retry_execution_record,
     validate_retry_execution_record,
@@ -48,6 +59,8 @@ Clock = Callable[[], datetime]
 Executor = Callable[..., dict[str, Any]]
 Recorder = Callable[..., dict[str, Any]]
 HistoryReader = Callable[..., dict[str, Any] | None]
+DestinationRecorder = Callable[..., dict[str, Any]]
+DestinationReader = Callable[..., dict[str, Any] | None]
 
 
 class RecordedRetryExecutionError(RuntimeError):
@@ -56,10 +69,14 @@ class RecordedRetryExecutionError(RuntimeError):
         *,
         failure_code: str,
         history: Mapping[str, Any],
+        destination_history: Mapping[str, Any] | None = None,
     ) -> None:
         super().__init__(failure_code)
         self.failure_code = failure_code
         self.history = dict(history)
+        self.destination_history = (
+            None if destination_history is None else dict(destination_history)
+        )
 
 
 def _failure_code(exc: Exception) -> str:
@@ -130,6 +147,37 @@ def _existing_terminal_result(
     )
 
 
+def _legacy_execution_summary(summary: Mapping[str, Any]) -> dict[str, Any]:
+    legacy = dict(summary)
+    legacy.pop("destination_authority", None)
+    return legacy
+
+
+def _authority_from_summary(summary: Mapping[str, Any]) -> dict[str, Any] | None:
+    value = summary.get("destination_authority")
+    return dict(value) if isinstance(value, Mapping) else None
+
+
+def _record_destination_binding(
+    *,
+    dsn: str,
+    record: Mapping[str, Any],
+    destination_authority: Mapping[str, Any] | None,
+    recorder: DestinationRecorder | None,
+) -> dict[str, Any] | None:
+    if destination_authority is None or recorder is None:
+        return None
+    binding = build_retry_destination_binding(
+        record_id=cast(str, record["record_id"]),
+        request_id=cast(str, record["request_id"]),
+        plan_id=cast(str, record["plan_id"]),
+        execution_id=cast(str | None, record["execution_id"]),
+        destination_authority=destination_authority,
+        recorded_at=cast(str, record["recorded_at"]),
+    )
+    return recorder(dsn=dsn, binding=binding)
+
+
 def execute_and_record_portfolio_risk_notification_retries(
     *,
     plan_path: Path,
@@ -138,10 +186,14 @@ def execute_and_record_portfolio_risk_notification_retries(
     config_path: Path,
     dsn: str,
     execute: bool = False,
+    destination_config_path: Path | None = None,
+    destination_id: str = DEFAULT_DESTINATION_ID,
     environment: Mapping[str, str] | None = None,
     executor: Executor | None = None,
     recorder: Recorder | None = None,
     history_reader: HistoryReader | None = None,
+    destination_binding_recorder: DestinationRecorder | None = None,
+    destination_binding_reader: DestinationReader | None = None,
     transport: Transport | None = None,
     attempt_writer: AttemptWriter | None = None,
     clock: Clock | None = None,
@@ -160,19 +212,38 @@ def execute_and_record_portfolio_risk_notification_retries(
         raise ValidationError("confirm_plan_id does not match the retained retry plan")
 
     selected_history_reader = history_reader
+    selected_destination_reader = destination_binding_reader
     if selected_history_reader is None and recorder is None:
         selected_history_reader = read_notification_retry_execution_request
+    if (
+        selected_destination_reader is None
+        and recorder is None
+        and destination_binding_recorder is None
+    ):
+        selected_destination_reader = read_notification_retry_destination_binding
     if selected_history_reader is not None:
         existing = selected_history_reader(
             dsn=dsn,
             request_id=selected_request_id,
         )
         if existing is not None:
-            return _existing_terminal_result(
+            result = _existing_terminal_result(
                 existing=existing,
                 request_id=selected_request_id,
                 plan_id=plan_id,
             )
+            record_value = existing.get("record")
+            if selected_destination_reader is not None and isinstance(
+                record_value,
+                Mapping,
+            ):
+                result["destination_history"] = selected_destination_reader(
+                    dsn=dsn,
+                    record_id=record_value["record_id"],
+                )
+            else:
+                result["destination_history"] = None
+            return result
 
     selected_clock = clock or (lambda: datetime.now(timezone.utc))
     started_at = aware_utc(selected_clock(), "recorded execution started_at")
@@ -197,9 +268,20 @@ def execute_and_record_portfolio_risk_notification_retries(
     selected_environment = environment if environment is not None else os.environ
     selected_executor = executor or execute_portfolio_risk_notification_retries
     selected_recorder = recorder or record_notification_retry_execution
+    selected_destination_recorder = destination_binding_recorder
+    if selected_destination_recorder is None and recorder is None:
+        selected_destination_recorder = record_notification_retry_destination_binding
 
     requested_event_ids: list[str] = []
     persisted_attempts: list[dict[str, Any]] = []
+    observed_authority: dict[str, Any] | None = None
+
+    def observe_destination_authority(value: Mapping[str, Any]) -> None:
+        nonlocal observed_authority
+        candidate = dict(value)
+        if observed_authority is not None and observed_authority != candidate:
+            raise ValidationError("destination authority changed during retry execution")
+        observed_authority = candidate
 
     def tracking_transport(
         endpoint: str,
@@ -239,6 +321,8 @@ def execute_and_record_portfolio_risk_notification_retries(
             confirm_plan_id=confirm_plan_id,
             request_id=selected_request_id,
             config_path=config_path,
+            destination_config_path=destination_config_path,
+            destination_id=destination_id,
             dsn=dsn,
             execute=execute,
             environment=selected_environment,
@@ -247,7 +331,11 @@ def execute_and_record_portfolio_risk_notification_retries(
             transport=tracking_transport,
             clock=executor_clock,
             lock_factory=lock_factory,
+            destination_authority_observer=observe_destination_authority,
         )
+        summary_authority = _authority_from_summary(execution_summary)
+        if summary_authority is not None:
+            observe_destination_authority(summary_authority)
         outcomes = execution_summary.get("outcomes")
         if not isinstance(outcomes, list):
             raise ValidationError("retry execution summary outcomes are unavailable")
@@ -280,7 +368,7 @@ def execute_and_record_portfolio_risk_notification_retries(
             attempt_ids=attempt_ids,
             requested_event_ids=event_ids,
             persisted_event_ids=event_ids,
-            execution_summary=execution_summary,
+            execution_summary=_legacy_execution_summary(execution_summary),
         )
     except Exception as exc:
         finished_at = _next_utc(
@@ -340,15 +428,29 @@ def execute_and_record_portfolio_risk_notification_retries(
             lock_released=None,
         )
         history = selected_recorder(dsn=dsn, record=record)
+        destination_history = _record_destination_binding(
+            dsn=dsn,
+            record=record,
+            destination_authority=observed_authority,
+            recorder=selected_destination_recorder,
+        )
         raise RecordedRetryExecutionError(
             failure_code=cast(str, record["failure_code"]),
             history=history,
+            destination_history=destination_history,
         ) from None
 
     history = selected_recorder(dsn=dsn, record=record)
+    destination_history = _record_destination_binding(
+        dsn=dsn,
+        record=record,
+        destination_authority=observed_authority,
+        recorder=selected_destination_recorder,
+    )
     return {
         "execution_summary": execution_summary,
         "history": history,
+        "destination_history": destination_history,
     }
 
 
@@ -384,6 +486,12 @@ def _build_parser() -> argparse.ArgumentParser:
         default=Path("config/notification_delivery.yaml"),
     )
     parser.add_argument(
+        "--destination-config",
+        type=Path,
+        default=DEFAULT_DESTINATION_CONFIG,
+    )
+    parser.add_argument("--destination-id", default=DEFAULT_DESTINATION_ID)
+    parser.add_argument(
         "--dsn",
         default=os.environ.get("WAREHOUSE_POSTGRES_DSN", DEFAULT_POSTGRES_DSN),
     )
@@ -400,6 +508,8 @@ def main(argv: Sequence[str] | None = None) -> int:
             confirm_plan_id=args.confirm_plan_id,
             request_id=args.request_id,
             config_path=args.config,
+            destination_config_path=args.destination_config,
+            destination_id=args.destination_id,
             dsn=args.dsn,
             execute=args.execute,
         )

--- a/src/warehouse/notification_retry_destination_binding_contract.py
+++ b/src/warehouse/notification_retry_destination_binding_contract.py
@@ -1,0 +1,202 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from collections.abc import Mapping
+from datetime import datetime, timezone
+from typing import Any
+
+from src.common.exceptions import ValidationError
+
+MODEL_VERSION = "portfolio-risk-notification-retry-destination-binding-v1"
+AUTHORITY_MODEL_VERSION = "portfolio-risk-notification-destination-authority-v1"
+SAFE_TEXT = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,511}$")
+ENVIRONMENT_NAME = re.compile(r"^[A-Z][A-Z0-9_]{2,127}$")
+
+
+def _safe_text(value: Any, label: str, *, optional: bool = False) -> str | None:
+    if value is None and optional:
+        return None
+    if not isinstance(value, str) or not SAFE_TEXT.fullmatch(value):
+        raise ValidationError(f"{label} must be one safe text segment")
+    return value
+
+
+def _aware_utc(value: Any, label: str) -> datetime:
+    if isinstance(value, datetime):
+        parsed = value
+    elif isinstance(value, str):
+        try:
+            parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        except ValueError:
+            raise ValidationError(f"{label} must be ISO-8601") from None
+    else:
+        raise ValidationError(f"{label} must be timezone-aware")
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise ValidationError(f"{label} must be timezone-aware")
+    return parsed.astimezone(timezone.utc)
+
+
+def canonical_binding_bytes(record: Mapping[str, Any]) -> bytes:
+    try:
+        return json.dumps(
+            record,
+            sort_keys=True,
+            separators=(",", ":"),
+            allow_nan=False,
+        ).encode("utf-8")
+    except (TypeError, ValueError):
+        raise ValidationError("destination binding is not canonical JSON") from None
+
+
+def _binding_id(identity: Mapping[str, Any]) -> str:
+    digest = hashlib.sha256(canonical_binding_bytes(identity)).hexdigest()[:24]
+    return f"{MODEL_VERSION}-binding-{digest}"
+
+
+def _canonical_authority(value: Any) -> dict[str, Any]:
+    if not isinstance(value, Mapping):
+        raise ValidationError("destination_authority must be a mapping")
+    required = {
+        "authority_id",
+        "destination_fingerprint",
+        "destination_id",
+        "endpoint_environment_variable",
+        "evaluated_at",
+        "evaluated_event_types",
+        "model_version",
+        "channel",
+        "activation",
+        "allowed_event_types",
+        "active",
+        "endpoint_value_recorded",
+        "external_request_performed",
+        "delivery_attempt_written",
+        "outbox_mutated",
+        "acknowledgement_mutated",
+    }
+    if set(value) != required:
+        raise ValidationError("destination_authority fields are invalid")
+    if value["model_version"] != AUTHORITY_MODEL_VERSION:
+        raise ValidationError("destination_authority model_version is unsupported")
+    if value["channel"] != "webhook" or value["active"] is not True:
+        raise ValidationError("destination_authority must be active webhook authority")
+    endpoint_env = value["endpoint_environment_variable"]
+    if not isinstance(endpoint_env, str) or not ENVIRONMENT_NAME.fullmatch(endpoint_env):
+        raise ValidationError("destination_authority endpoint environment is invalid")
+    event_types = value["evaluated_event_types"]
+    allowed = value["allowed_event_types"]
+    if not isinstance(event_types, list) or not isinstance(allowed, list):
+        raise ValidationError("destination_authority event types must be arrays")
+    if event_types != sorted(set(event_types)):
+        raise ValidationError("destination_authority event types are not canonical")
+    if allowed != sorted(set(allowed)) or not set(event_types).issubset(allowed):
+        raise ValidationError("destination_authority allow-list evidence is invalid")
+    activation = value["activation"]
+    if not isinstance(activation, Mapping) or set(activation) != {
+        "enabled",
+        "status",
+        "change_request_id",
+        "reviewed_at",
+        "review_expires_at",
+    }:
+        raise ValidationError("destination_authority activation fields are invalid")
+    if activation["enabled"] is not True or activation["status"] != "active":
+        raise ValidationError("destination_authority activation is not active")
+    reviewed_at = _aware_utc(activation["reviewed_at"], "reviewed_at")
+    expires_at = _aware_utc(
+        activation["review_expires_at"],
+        "review_expires_at",
+    )
+    evaluated_at = _aware_utc(value["evaluated_at"], "evaluated_at")
+    if not reviewed_at <= evaluated_at < expires_at:
+        raise ValidationError("destination_authority evaluation is outside review window")
+    for flag in (
+        "endpoint_value_recorded",
+        "external_request_performed",
+        "delivery_attempt_written",
+        "outbox_mutated",
+        "acknowledgement_mutated",
+    ):
+        if value[flag] is not False:
+            raise ValidationError("destination_authority side-effect evidence is invalid")
+    canonical = dict(value)
+    canonical["evaluated_at"] = evaluated_at.isoformat()
+    canonical["evaluated_event_types"] = list(event_types)
+    canonical["allowed_event_types"] = list(allowed)
+    canonical["activation"] = {
+        **dict(activation),
+        "reviewed_at": reviewed_at.isoformat(),
+        "review_expires_at": expires_at.isoformat(),
+    }
+    _safe_text(canonical["authority_id"], "authority_id")
+    _safe_text(canonical["destination_id"], "destination_id")
+    _safe_text(canonical["destination_fingerprint"], "destination_fingerprint")
+    _safe_text(activation["change_request_id"], "change_request_id")
+    return canonical
+
+
+def build_retry_destination_binding(
+    *,
+    record_id: str,
+    request_id: str,
+    plan_id: str,
+    execution_id: str | None,
+    destination_authority: Mapping[str, Any],
+    recorded_at: datetime | str,
+) -> dict[str, Any]:
+    selected_record_id = _safe_text(record_id, "record_id")
+    selected_request_id = _safe_text(request_id, "request_id")
+    selected_plan_id = _safe_text(plan_id, "plan_id")
+    selected_execution_id = _safe_text(
+        execution_id,
+        "execution_id",
+        optional=True,
+    )
+    assert selected_record_id is not None
+    assert selected_request_id is not None
+    assert selected_plan_id is not None
+    authority = _canonical_authority(destination_authority)
+    recorded = _aware_utc(recorded_at, "recorded_at")
+    evaluated = _aware_utc(authority["evaluated_at"], "authority.evaluated_at")
+    if recorded < evaluated:
+        raise ValidationError("binding recorded_at precedes authority evaluation")
+    identity = {
+        "destination_authority": authority,
+        "execution_id": selected_execution_id,
+        "model_version": MODEL_VERSION,
+        "plan_id": selected_plan_id,
+        "record_id": selected_record_id,
+        "recorded_at": recorded.isoformat(),
+        "request_id": selected_request_id,
+    }
+    return {"binding_id": _binding_id(identity), **identity}
+
+
+def validate_retry_destination_binding(record: Mapping[str, Any]) -> dict[str, Any]:
+    required = {
+        "binding_id",
+        "destination_authority",
+        "execution_id",
+        "model_version",
+        "plan_id",
+        "record_id",
+        "recorded_at",
+        "request_id",
+    }
+    if set(record) != required:
+        raise ValidationError("retry destination binding fields are invalid")
+    if record["model_version"] != MODEL_VERSION:
+        raise ValidationError("retry destination binding model_version is unsupported")
+    rebuilt = build_retry_destination_binding(
+        record_id=record["record_id"],
+        request_id=record["request_id"],
+        plan_id=record["plan_id"],
+        execution_id=record["execution_id"],
+        destination_authority=record["destination_authority"],
+        recorded_at=record["recorded_at"],
+    )
+    if dict(record) != rebuilt:
+        raise ValidationError("retry destination binding is not canonical")
+    return rebuilt

--- a/src/warehouse/notification_retry_destination_binding_reader.py
+++ b/src/warehouse/notification_retry_destination_binding_reader.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import hashlib
+from typing import Any
+
+from src.common.exceptions import StorageError, ValidationError
+from src.warehouse.notification_retry_destination_binding_contract import (
+    canonical_binding_bytes,
+    validate_retry_destination_binding,
+)
+
+
+def read_notification_retry_destination_binding(
+    *,
+    dsn: str,
+    record_id: str,
+) -> dict[str, Any] | None:
+    try:
+        import psycopg
+        from psycopg.rows import dict_row
+    except ImportError as exc:  # pragma: no cover - required in CI.
+        raise RuntimeError("Notification retry destination history requires psycopg") from exc
+
+    try:
+        with psycopg.connect(dsn, row_factory=dict_row) as connection:
+            with connection.cursor() as cursor:
+                cursor.execute(
+                    """
+                    SELECT binding_json, document_sha256
+                    FROM risk_platform.portfolio_risk_notification_retry_destination_bindings
+                    WHERE record_id = %s
+                    """,
+                    (record_id,),
+                )
+                row = cursor.fetchone()
+    except Exception:
+        raise StorageError(
+            "notification retry destination history could not be read"
+        ) from None
+    if row is None:
+        return None
+    validated = validate_retry_destination_binding(row["binding_json"])
+    digest = hashlib.sha256(canonical_binding_bytes(validated)).hexdigest()
+    if row["document_sha256"] != digest:
+        raise ValidationError("retained destination binding digest is invalid")
+    authority = validated["destination_authority"]
+    return {
+        "binding_id": validated["binding_id"],
+        "record_id": validated["record_id"],
+        "destination_id": authority["destination_id"],
+        "destination_fingerprint": authority["destination_fingerprint"],
+        "authority_id": authority["authority_id"],
+        "document_sha256": digest,
+        "created": False,
+    }

--- a/src/warehouse/notification_retry_destination_binding_recorder.py
+++ b/src/warehouse/notification_retry_destination_binding_recorder.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+import hashlib
+from collections.abc import Mapping
+from typing import Any
+
+from src.common.exceptions import StorageError, ValidationError
+from src.warehouse.notification_retry_destination_binding_contract import (
+    canonical_binding_bytes,
+    validate_retry_destination_binding,
+)
+
+
+def record_notification_retry_destination_binding(
+    *,
+    dsn: str,
+    binding: Mapping[str, Any],
+) -> dict[str, Any]:
+    validated = validate_retry_destination_binding(binding)
+    digest = hashlib.sha256(canonical_binding_bytes(validated)).hexdigest()
+    authority = validated["destination_authority"]
+    try:
+        import psycopg
+        from psycopg.types.json import Jsonb
+    except ImportError as exc:  # pragma: no cover - required in CI.
+        raise RuntimeError("Notification retry destination history requires psycopg") from exc
+
+    created = False
+    try:
+        with psycopg.connect(dsn) as connection:
+            with connection.cursor() as cursor:
+                cursor.execute(
+                    """
+                    SELECT binding_json, document_sha256
+                    FROM risk_platform.portfolio_risk_notification_retry_destination_bindings
+                    WHERE record_id = %s
+                    """,
+                    (validated["record_id"],),
+                )
+                existing = cursor.fetchone()
+                if existing is not None:
+                    existing_json, existing_digest = existing
+                    if existing_digest != digest or existing_json != validated:
+                        raise ValidationError(
+                            "retry record already has different destination evidence"
+                        )
+                    return {
+                        "binding_id": validated["binding_id"],
+                        "record_id": validated["record_id"],
+                        "destination_id": authority["destination_id"],
+                        "destination_fingerprint": authority[
+                            "destination_fingerprint"
+                        ],
+                        "document_sha256": digest,
+                        "created": False,
+                    }
+
+                cursor.execute(
+                    """
+                    INSERT INTO
+                    risk_platform.portfolio_risk_notification_retry_destination_bindings (
+                        binding_id,
+                        model_version,
+                        record_id,
+                        request_id,
+                        plan_id,
+                        execution_id,
+                        authority_id,
+                        destination_id,
+                        destination_fingerprint,
+                        endpoint_environment_variable,
+                        evaluated_at,
+                        evaluated_event_types_json,
+                        authority_json,
+                        recorded_at,
+                        binding_json,
+                        document_sha256
+                    )
+                    VALUES (
+                        %s, %s, %s, %s, %s, %s, %s, %s,
+                        %s, %s, %s, %s, %s, %s, %s, %s
+                    )
+                    ON CONFLICT DO NOTHING
+                    RETURNING binding_id
+                    """,
+                    (
+                        validated["binding_id"],
+                        validated["model_version"],
+                        validated["record_id"],
+                        validated["request_id"],
+                        validated["plan_id"],
+                        validated["execution_id"],
+                        authority["authority_id"],
+                        authority["destination_id"],
+                        authority["destination_fingerprint"],
+                        authority["endpoint_environment_variable"],
+                        authority["evaluated_at"],
+                        Jsonb(authority["evaluated_event_types"]),
+                        Jsonb(authority),
+                        validated["recorded_at"],
+                        Jsonb(validated),
+                        digest,
+                    ),
+                )
+                created = cursor.fetchone() is not None
+                cursor.execute(
+                    """
+                    SELECT binding_json, document_sha256
+                    FROM risk_platform.portfolio_risk_notification_retry_destination_bindings
+                    WHERE binding_id = %s
+                    """,
+                    (validated["binding_id"],),
+                )
+                stored = cursor.fetchone()
+                if stored is None:
+                    raise StorageError(
+                        "notification retry destination binding was not retained"
+                    )
+                stored_json, stored_digest = stored
+                if stored_digest != digest or stored_json != validated:
+                    raise ValidationError(
+                        "binding_id already exists with different destination evidence"
+                    )
+            connection.commit()
+    except (StorageError, ValidationError):
+        raise
+    except Exception:
+        raise StorageError(
+            "notification retry destination history database operation failed"
+        ) from None
+
+    return {
+        "binding_id": validated["binding_id"],
+        "record_id": validated["record_id"],
+        "destination_id": authority["destination_id"],
+        "destination_fingerprint": authority["destination_fingerprint"],
+        "document_sha256": digest,
+        "created": created,
+    }

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _retry_destination_authority_unit_test_seam(
+    monkeypatch: pytest.MonkeyPatch,
+    request: pytest.FixtureRequest,
+) -> None:
+    """Keep legacy retry tests focused on retry semantics, not destination parsing."""
+
+    module = getattr(request.node, "module", None)
+    if module is None or not module.__name__.endswith(
+        "test_portfolio_risk_notification_retry_execution"
+    ):
+        return
+
+    from src.orchestration import execute_portfolio_risk_notification_retries as target
+
+    def resolver(**kwargs: Any) -> dict[str, Any]:
+        evaluated_at = kwargs["evaluated_at"]
+        if isinstance(evaluated_at, datetime):
+            evaluated = evaluated_at.astimezone(timezone.utc).isoformat()
+        else:
+            evaluated = str(evaluated_at)
+        event_types = sorted(set(kwargs["event_types"]))
+        return {
+            "authority_id": "portfolio-risk-notification-destination-authority-v1-authority-test",
+            "destination_fingerprint": "portfolio-risk-notification-destination-v1-test",
+            "destination_id": kwargs["destination_id"],
+            "endpoint_environment_variable": kwargs["delivery_endpoint_env"],
+            "evaluated_at": evaluated,
+            "evaluated_event_types": event_types,
+            "model_version": "portfolio-risk-notification-destination-authority-v1",
+            "channel": "webhook",
+            "activation": {
+                "enabled": True,
+                "status": "active",
+                "change_request_id": "TEST-DESTINATION-ACTIVATION",
+                "reviewed_at": "2026-01-01T00:00:00+00:00",
+                "review_expires_at": "2026-12-31T00:00:00+00:00",
+            },
+            "allowed_event_types": event_types,
+            "active": True,
+            "endpoint_value_recorded": False,
+            "external_request_performed": False,
+            "delivery_attempt_written": False,
+            "outbox_mutated": False,
+            "acknowledgement_mutated": False,
+        }
+
+    monkeypatch.setattr(target, "resolve_notification_destination_authority", resolver)

--- a/tests/unit/test_docker_compose_contract.py
+++ b/tests/unit/test_docker_compose_contract.py
@@ -44,6 +44,7 @@ def test_local_database_seed_mounts_are_read_only_and_ordered() -> None:
         "./sql/operational_readiness_overrides_schema.sql:/docker-entrypoint-initdb.d/17_operational_readiness_overrides_schema.sql:ro",
         "./sql/local_schedule_runs_schema.sql:/docker-entrypoint-initdb.d/18_local_schedule_runs_schema.sql:ro",
         "./sql/portfolio_risk_notification_retry_execution_schema.sql:/docker-entrypoint-initdb.d/19_portfolio_risk_notification_retry_execution_schema.sql:ro",
+        "./sql/portfolio_risk_notification_retry_destination_binding_schema.sql:/docker-entrypoint-initdb.d/19b_portfolio_risk_notification_retry_destination_binding_schema.sql:ro",
         "./sql/portfolio_risk_notification_retry_follow_up_schema.sql:/docker-entrypoint-initdb.d/20_portfolio_risk_notification_retry_follow_up_schema.sql:ro",
     ]
     assert services["mongo"]["volumes"] == [

--- a/tests/unit/test_notification_retry_destination_binding.py
+++ b/tests/unit/test_notification_retry_destination_binding.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+from src.common.exceptions import ValidationError
+from src.warehouse.notification_retry_destination_binding_contract import (
+    MODEL_VERSION,
+    build_retry_destination_binding,
+    validate_retry_destination_binding,
+)
+
+EVALUATED_AT = datetime(2026, 1, 10, 12, 1, tzinfo=timezone.utc)
+
+
+def _authority(*, destination_id: str = "risk-operations-webhook") -> dict[str, object]:
+    return {
+        "authority_id": "portfolio-risk-notification-destination-authority-v1-authority-abc",
+        "destination_fingerprint": "portfolio-risk-notification-destination-v1-destination-abc",
+        "destination_id": destination_id,
+        "endpoint_environment_variable": "RISK_NOTIFICATION_WEBHOOK_URL",
+        "evaluated_at": EVALUATED_AT.isoformat(),
+        "evaluated_event_types": ["breach_opened"],
+        "model_version": "portfolio-risk-notification-destination-authority-v1",
+        "channel": "webhook",
+        "activation": {
+            "enabled": True,
+            "status": "active",
+            "change_request_id": "CHANGE-DESTINATION-001",
+            "reviewed_at": (EVALUATED_AT - timedelta(days=1)).isoformat(),
+            "review_expires_at": (EVALUATED_AT + timedelta(days=1)).isoformat(),
+        },
+        "allowed_event_types": ["breach_opened", "breach_resolved"],
+        "active": True,
+        "endpoint_value_recorded": False,
+        "external_request_performed": False,
+        "delivery_attempt_written": False,
+        "outbox_mutated": False,
+        "acknowledgement_mutated": False,
+    }
+
+
+def test_binding_is_deterministic_and_canonical() -> None:
+    kwargs = {
+        "record_id": "retry-record-1",
+        "request_id": "RETRY-001",
+        "plan_id": "retry-plan-1",
+        "execution_id": "retry-execution-1",
+        "destination_authority": _authority(),
+        "recorded_at": EVALUATED_AT + timedelta(seconds=1),
+    }
+    first = build_retry_destination_binding(**kwargs)
+    second = build_retry_destination_binding(**kwargs)
+
+    assert first == second
+    assert first["model_version"] == MODEL_VERSION
+    assert validate_retry_destination_binding(first) == first
+
+
+def test_binding_changes_with_destination_identity() -> None:
+    first = build_retry_destination_binding(
+        record_id="retry-record-1",
+        request_id="RETRY-001",
+        plan_id="retry-plan-1",
+        execution_id=None,
+        destination_authority=_authority(),
+        recorded_at=EVALUATED_AT + timedelta(seconds=1),
+    )
+    second = build_retry_destination_binding(
+        record_id="retry-record-1",
+        request_id="RETRY-001",
+        plan_id="retry-plan-1",
+        execution_id=None,
+        destination_authority=_authority(destination_id="secondary-webhook"),
+        recorded_at=EVALUATED_AT + timedelta(seconds=1),
+    )
+    assert first["binding_id"] != second["binding_id"]
+
+
+def test_inactive_or_side_effect_authority_fails_closed() -> None:
+    inactive = _authority()
+    inactive["active"] = False
+    with pytest.raises(ValidationError, match="active"):
+        build_retry_destination_binding(
+            record_id="retry-record-1",
+            request_id="RETRY-001",
+            plan_id="retry-plan-1",
+            execution_id=None,
+            destination_authority=inactive,
+            recorded_at=EVALUATED_AT + timedelta(seconds=1),
+        )
+
+    side_effect = _authority()
+    side_effect["external_request_performed"] = True
+    with pytest.raises(ValidationError, match="side-effect"):
+        build_retry_destination_binding(
+            record_id="retry-record-1",
+            request_id="RETRY-001",
+            plan_id="retry-plan-1",
+            execution_id=None,
+            destination_authority=side_effect,
+            recorded_at=EVALUATED_AT + timedelta(seconds=1),
+        )
+
+
+def test_sql_contract_is_append_only_and_links_terminal_history() -> None:
+    sql = Path(
+        "sql/portfolio_risk_notification_retry_destination_binding_schema.sql"
+    ).read_text(encoding="utf-8")
+    assert "portfolio_risk_notification_retry_destination_bindings" in sql
+    assert "REFERENCES" in sql
+    assert "portfolio_risk_notification_retry_executions (record_id)" in sql
+    assert "BEFORE UPDATE OR DELETE" in sql
+    assert "destination_fingerprint" in sql
+    assert "endpoint_environment_variable" in sql

--- a/tests/unit/test_portfolio_risk_notification_retry_destination_authority.py
+++ b/tests/unit/test_portfolio_risk_notification_retry_destination_authority.py
@@ -1,0 +1,229 @@
+from __future__ import annotations
+
+import json
+from collections.abc import Iterator, Mapping
+from contextlib import contextmanager
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+from src.common.exceptions import ValidationError
+from src.orchestration.execute_portfolio_risk_notification_retries import (
+    execute_portfolio_risk_notification_retries,
+)
+from src.orchestration.plan_portfolio_risk_notification_retries import (
+    plan_portfolio_risk_notification_retries,
+)
+from src.orchestration.portfolio_risk_notification_delivery_lock import (
+    LOCK_KEY_FINGERPRINT,
+    LOCK_MODEL_VERSION,
+    LOCK_SCOPE,
+)
+
+PLANNED_AT = datetime(2026, 1, 10, 12, tzinfo=timezone.utc)
+EXECUTED_AT = PLANNED_AT + timedelta(minutes=1)
+
+
+def _write_config(tmp_path: Path) -> Path:
+    path = tmp_path / "notification-delivery.yaml"
+    path.write_text(
+        yaml.safe_dump(
+            {
+                "delivery": {
+                    "webhook": {
+                        "enabled": True,
+                        "endpoint_env": "RISK_NOTIFICATION_WEBHOOK_URL",
+                        "timeout_seconds": 5,
+                        "max_batch_events": 25,
+                        "max_attempts_per_event": 3,
+                        "initial_backoff_seconds": 1,
+                    },
+                    "retry_planning": {
+                        "max_candidate_rows": 500,
+                        "max_plan_events": 25,
+                        "max_event_age_seconds": 604800,
+                        "max_backoff_seconds": 3600,
+                        "retryable_http_statuses": [503],
+                        "retryable_error_codes": ["network_error"],
+                    },
+                    "retry_execution": {
+                        "enabled": True,
+                        "max_plan_age_seconds": 3600,
+                        "max_events": 25,
+                    },
+                }
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+    return path
+
+
+def _candidate() -> dict[str, Any]:
+    event_time = PLANNED_AT - timedelta(hours=2)
+    return {
+        "event_id": "event-1",
+        "outbox_model_version": "portfolio-risk-notification-outbox-v1",
+        "event_type": "breach_opened",
+        "transition_type": "opened",
+        "delivery_disposition": "pending",
+        "source_evaluation_calculation_id": "evaluation-event-1",
+        "policy_id": "us-tech-standard",
+        "policy_fingerprint": "policy-fingerprint",
+        "portfolio_id": "us-tech-equal",
+        "definition_fingerprint": "definition-fingerprint",
+        "metric_name": "portfolio_volatility_annualized",
+        "subject_type": "portfolio",
+        "subject_key": "us-tech-equal",
+        "current_status": "critical",
+        "ts_event": event_time,
+        "ts_ingest": event_time + timedelta(seconds=1),
+        "payload_json": {"event_id": "event-1", "severity": "critical"},
+        "attempt_count": 1,
+        "last_attempt_id": "attempt-event-1-1",
+        "last_attempt_number": 1,
+        "last_attempted_at": PLANNED_AT - timedelta(minutes=10),
+        "last_attempt_outcome": "failed",
+        "last_http_status": 503,
+        "last_error_code": "http_503",
+        "acknowledgement_id": None,
+        "acknowledged_at": None,
+        "acknowledgement_disposition": None,
+    }
+
+
+def _write_plan(
+    tmp_path: Path,
+    config_path: Path,
+    candidate: dict[str, Any],
+) -> tuple[Path, dict[str, Any]]:
+    plan = plan_portfolio_risk_notification_retries(
+        config_path=config_path,
+        dsn="not-used",
+        planned_at=PLANNED_AT,
+        policy_id="us-tech-standard",
+        portfolio_id="us-tech-equal",
+        reader=lambda **_: [candidate],
+    )
+    path = tmp_path / "retry-plan.json"
+    path.write_text(json.dumps(plan, sort_keys=True), encoding="utf-8")
+    return path, plan
+
+
+def _authority(**kwargs: Any) -> dict[str, Any]:
+    return {
+        "authority_id": "portfolio-risk-notification-destination-authority-v1-authority-test",
+        "destination_fingerprint": "portfolio-risk-notification-destination-v1-test",
+        "destination_id": kwargs["destination_id"],
+        "endpoint_environment_variable": kwargs["delivery_endpoint_env"],
+        "evaluated_at": EXECUTED_AT.isoformat(),
+        "evaluated_event_types": ["breach_opened"],
+        "model_version": "portfolio-risk-notification-destination-authority-v1",
+        "channel": "webhook",
+        "activation": {
+            "enabled": True,
+            "status": "active",
+            "change_request_id": "CHANGE-DESTINATION-001",
+            "reviewed_at": "2026-01-01T00:00:00+00:00",
+            "review_expires_at": "2026-12-31T00:00:00+00:00",
+        },
+        "allowed_event_types": ["breach_opened"],
+        "active": True,
+        "endpoint_value_recorded": False,
+        "external_request_performed": False,
+        "delivery_attempt_written": False,
+        "outbox_mutated": False,
+        "acknowledgement_mutated": False,
+    }
+
+
+def test_authority_is_refreshed_under_lock_before_transport(tmp_path: Path) -> None:
+    config = _write_config(tmp_path)
+    candidate = _candidate()
+    plan_path, plan = _write_plan(tmp_path, config, candidate)
+    lock_active = False
+    order: list[str] = []
+    observed: list[dict[str, Any]] = []
+
+    @contextmanager
+    def lock(**_: Any) -> Iterator[Mapping[str, Any]]:
+        nonlocal lock_active
+        lock_active = True
+        order.append("lock")
+        try:
+            yield {
+                "model_version": LOCK_MODEL_VERSION,
+                "scope": LOCK_SCOPE,
+                "key_fingerprint": LOCK_KEY_FINGERPRINT,
+            }
+        finally:
+            lock_active = False
+
+    def resolver(**kwargs: Any) -> dict[str, Any]:
+        assert lock_active is True
+        assert kwargs["event_types"] == ["breach_opened"]
+        order.append("authority")
+        return _authority(**kwargs)
+
+    summary = execute_portfolio_risk_notification_retries(
+        plan_path=plan_path,
+        confirm_plan_id=plan["plan_id"],
+        request_id="RETRY-AUTHORITY-001",
+        config_path=config,
+        dsn="postgresql://secret-value",
+        execute=True,
+        environment={"RISK_NOTIFICATION_WEBHOOK_URL": "https://alerts.test/risk"},
+        reader=lambda **_: [candidate],
+        attempt_writer=lambda _: None,
+        transport=lambda *_: order.append("transport") or 204,
+        clock=lambda: EXECUTED_AT,
+        lock_factory=lock,
+        destination_authority_resolver=resolver,
+        destination_authority_observer=lambda value: observed.append(dict(value)),
+    )
+
+    assert order == ["lock", "authority", "transport"]
+    assert observed == [summary["destination_authority"]]
+    assert summary["destination_authority"]["active"] is True
+    assert "postgresql://secret-value" not in json.dumps(summary)
+
+
+def test_authority_rejection_prevents_first_transport(tmp_path: Path) -> None:
+    config = _write_config(tmp_path)
+    candidate = _candidate()
+    plan_path, plan = _write_plan(tmp_path, config, candidate)
+    sends: list[bool] = []
+
+    @contextmanager
+    def lock(**_: Any) -> Iterator[Mapping[str, Any]]:
+        yield {
+            "model_version": LOCK_MODEL_VERSION,
+            "scope": LOCK_SCOPE,
+            "key_fingerprint": LOCK_KEY_FINGERPRINT,
+        }
+
+    with pytest.raises(ValidationError, match="expired"):
+        execute_portfolio_risk_notification_retries(
+            plan_path=plan_path,
+            confirm_plan_id=plan["plan_id"],
+            request_id="RETRY-AUTHORITY-002",
+            config_path=config,
+            dsn="dsn",
+            execute=True,
+            environment={
+                "RISK_NOTIFICATION_WEBHOOK_URL": "https://alerts.test/risk"
+            },
+            reader=lambda **_: [candidate],
+            attempt_writer=lambda _: None,
+            transport=lambda *_: sends.append(True) or 204,
+            clock=lambda: EXECUTED_AT,
+            lock_factory=lock,
+            destination_authority_resolver=lambda **_: (
+                (_ for _ in ()).throw(ValidationError("destination review expired"))
+            ),
+        )
+    assert sends == []

--- a/tests/unit/test_recorded_notification_retry_destination_binding.py
+++ b/tests/unit/test_recorded_notification_retry_destination_binding.py
@@ -1,0 +1,265 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from src.orchestration.plan_portfolio_risk_notification_retries import (
+    plan_portfolio_risk_notification_retries,
+)
+from src.orchestration.run_recorded_portfolio_risk_notification_retries import (
+    execute_and_record_portfolio_risk_notification_retries,
+)
+from src.warehouse.notification_retry_destination_binding_contract import (
+    validate_retry_destination_binding,
+)
+from src.warehouse.notification_retry_execution_contract import (
+    validate_retry_execution_record,
+)
+
+PLANNED_AT = datetime(2026, 1, 10, 12, tzinfo=timezone.utc)
+STARTED_AT = PLANNED_AT + timedelta(minutes=1)
+
+
+def _config(tmp_path: Path) -> Path:
+    path = tmp_path / "notification-delivery.yaml"
+    path.write_text(
+        yaml.safe_dump(
+            {
+                "delivery": {
+                    "webhook": {
+                        "enabled": True,
+                        "endpoint_env": "RISK_NOTIFICATION_WEBHOOK_URL",
+                        "timeout_seconds": 5,
+                        "max_batch_events": 25,
+                        "max_attempts_per_event": 3,
+                        "initial_backoff_seconds": 1,
+                    },
+                    "retry_planning": {
+                        "max_candidate_rows": 500,
+                        "max_plan_events": 25,
+                        "max_event_age_seconds": 604800,
+                        "max_backoff_seconds": 3600,
+                        "retryable_http_statuses": [503],
+                        "retryable_error_codes": ["network_error"],
+                    },
+                    "retry_execution": {
+                        "enabled": True,
+                        "max_plan_age_seconds": 3600,
+                        "max_events": 25,
+                    },
+                }
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+    return path
+
+
+def _candidate() -> dict[str, Any]:
+    event_time = PLANNED_AT - timedelta(hours=2)
+    return {
+        "event_id": "event-1",
+        "outbox_model_version": "portfolio-risk-notification-outbox-v1",
+        "event_type": "breach_opened",
+        "transition_type": "opened",
+        "delivery_disposition": "pending",
+        "source_evaluation_calculation_id": "evaluation-event-1",
+        "policy_id": "us-tech-standard",
+        "policy_fingerprint": "policy-fingerprint",
+        "portfolio_id": "us-tech-equal",
+        "definition_fingerprint": "definition-fingerprint",
+        "metric_name": "portfolio_volatility_annualized",
+        "subject_type": "portfolio",
+        "subject_key": "us-tech-equal",
+        "current_status": "critical",
+        "ts_event": event_time,
+        "ts_ingest": event_time + timedelta(seconds=1),
+        "payload_json": {"event_id": "event-1", "severity": "critical"},
+        "attempt_count": 1,
+        "last_attempt_id": "attempt-event-1-1",
+        "last_attempt_number": 1,
+        "last_attempted_at": PLANNED_AT - timedelta(minutes=10),
+        "last_attempt_outcome": "failed",
+        "last_http_status": 503,
+        "last_error_code": "http_503",
+        "acknowledgement_id": None,
+        "acknowledged_at": None,
+        "acknowledgement_disposition": None,
+    }
+
+
+def _authority() -> dict[str, Any]:
+    return {
+        "authority_id": "portfolio-risk-notification-destination-authority-v1-authority-test",
+        "destination_fingerprint": "portfolio-risk-notification-destination-v1-test",
+        "destination_id": "risk-operations-webhook",
+        "endpoint_environment_variable": "RISK_NOTIFICATION_WEBHOOK_URL",
+        "evaluated_at": STARTED_AT.isoformat(),
+        "evaluated_event_types": ["breach_opened"],
+        "model_version": "portfolio-risk-notification-destination-authority-v1",
+        "channel": "webhook",
+        "activation": {
+            "enabled": True,
+            "status": "active",
+            "change_request_id": "CHANGE-DESTINATION-001",
+            "reviewed_at": "2026-01-01T00:00:00+00:00",
+            "review_expires_at": "2026-12-31T00:00:00+00:00",
+        },
+        "allowed_event_types": ["breach_opened"],
+        "active": True,
+        "endpoint_value_recorded": False,
+        "external_request_performed": False,
+        "delivery_attempt_written": False,
+        "outbox_mutated": False,
+        "acknowledgement_mutated": False,
+    }
+
+
+def test_recorded_wrapper_retains_terminal_and_destination_evidence(
+    tmp_path: Path,
+) -> None:
+    config_path = _config(tmp_path)
+    candidate = _candidate()
+    plan = plan_portfolio_risk_notification_retries(
+        config_path=config_path,
+        dsn="not-used",
+        planned_at=PLANNED_AT,
+        policy_id="us-tech-standard",
+        portfolio_id="us-tech-equal",
+        reader=lambda **_: [candidate],
+    )
+    plan_path = tmp_path / "retry-plan.json"
+    plan_path.write_text(json.dumps(plan, sort_keys=True), encoding="utf-8")
+    terminal_records: list[dict[str, Any]] = []
+    bindings: list[dict[str, Any]] = []
+    times = iter(
+        [
+            STARTED_AT,
+            STARTED_AT + timedelta(seconds=1),
+            STARTED_AT + timedelta(seconds=2),
+        ]
+    )
+
+    def executor(**kwargs: Any) -> dict[str, Any]:
+        executed_at = kwargs["clock"]()
+        authority = _authority()
+        kwargs["destination_authority_observer"](authority)
+        kwargs["transport"](
+            "https://alerts.example.test/risk",
+            b"{}",
+            {"Idempotency-Key": "event-1"},
+            5.0,
+        )
+        kwargs["attempt_writer"](
+            {
+                "attempt_id": "attempt-event-1-2",
+                "event_id": "event-1",
+                "outcome": "succeeded",
+            }
+        )
+        return {
+            "execution_id": "portfolio-risk-manual-retry-execution-v1-execution-test",
+            "model_version": "portfolio-risk-manual-retry-execution-v1",
+            "request_id": "RETRY-DESTINATION-001",
+            "plan_id": plan["plan_id"],
+            "executed_at": executed_at.isoformat(),
+            "channel": "webhook",
+            "destination_authority": authority,
+            "endpoint": {
+                "host": "alerts.example.test",
+                "full_url_recorded": False,
+            },
+            "configuration": {
+                "delivery_fingerprint": "delivery-fingerprint",
+                "retry_execution_policy_fingerprint": "execution-fingerprint",
+                "retry_policy_fingerprint": "retry-fingerprint",
+            },
+            "revalidation": {
+                "performed": True,
+                "current_plan_id": plan["plan_id"],
+                "events_checked": 1,
+                "exact_event_evidence_unchanged": True,
+            },
+            "selection": {
+                "planned_retryable_events": 1,
+                "executed_events": 1,
+                "max_events": 25,
+            },
+            "outcomes": [
+                {
+                    "attempt_id": "attempt-event-1-2",
+                    "attempt_number": 2,
+                    "attempted_at": executed_at.isoformat(),
+                    "error_code": None,
+                    "event_id": "event-1",
+                    "http_status": 204,
+                    "outcome": "succeeded",
+                    "payload_sha256": "a" * 64,
+                }
+            ],
+            "outcome_counts": {"succeeded": 1, "failed": 0},
+            "execution": {
+                "requested": True,
+                "performed": True,
+                "external_requests_performed": 1,
+                "delivery_attempts_written": 1,
+            },
+            "concurrency_control": {
+                "performed": True,
+                "acquired": True,
+                "released": True,
+                "held_through_revalidation": True,
+                "held_through_attempt_persistence": True,
+                "model_version": "portfolio-risk-notification-delivery-lock-v1",
+                "scope": "portfolio-risk-notification-delivery",
+                "key_fingerprint": "lock-fingerprint",
+            },
+            "response_bodies_recorded": False,
+            "plan_mutated": False,
+            "acknowledgement_mutated": False,
+            "dead_letter_mutated": False,
+        }
+
+    result = execute_and_record_portfolio_risk_notification_retries(
+        plan_path=plan_path,
+        confirm_plan_id=plan["plan_id"],
+        request_id="RETRY-DESTINATION-001",
+        config_path=config_path,
+        dsn="postgresql://secret-value",
+        execute=True,
+        environment={"RISK_NOTIFICATION_WEBHOOK_URL": "https://alerts.test/risk"},
+        executor=executor,
+        recorder=lambda **kwargs: (
+            terminal_records.append(
+                validate_retry_execution_record(kwargs["record"])
+            )
+            or {
+                "record_id": kwargs["record"]["record_id"],
+                "created": True,
+            }
+        ),
+        destination_binding_recorder=lambda **kwargs: (
+            bindings.append(validate_retry_destination_binding(kwargs["binding"]))
+            or {
+                "binding_id": kwargs["binding"]["binding_id"],
+                "record_id": kwargs["binding"]["record_id"],
+                "created": True,
+            }
+        ),
+        transport=lambda *_: 204,
+        attempt_writer=lambda _: None,
+        clock=lambda: next(times),
+    )
+
+    assert terminal_records[0]["execution_summary"].get(
+        "destination_authority"
+    ) is None
+    assert bindings[0]["record_id"] == terminal_records[0]["record_id"]
+    assert bindings[0]["destination_authority"] == _authority()
+    assert result["destination_history"]["created"] is True
+    assert "postgresql://secret-value" not in json.dumps(result)

--- a/tests/unit/test_retry_destination_authority_architecture_contract.py
+++ b/tests/unit/test_retry_destination_authority_architecture_contract.py
@@ -1,0 +1,56 @@
+from pathlib import Path
+
+
+def test_retry_destination_authority_is_locked_and_durable() -> None:
+    executor = Path(
+        "src/orchestration/execute_portfolio_risk_notification_retries.py"
+    ).read_text(encoding="utf-8")
+    wrapper = Path(
+        "src/orchestration/run_recorded_portfolio_risk_notification_retries.py"
+    ).read_text(encoding="utf-8")
+    schema = Path(
+        "sql/portfolio_risk_notification_retry_destination_binding_schema.sql"
+    ).read_text(encoding="utf-8")
+    docs = Path(
+        "docs/portfolio-risk-notification-retry-destination-authority.md"
+    ).read_text(encoding="utf-8")
+    normalized = " ".join(docs.split()).casefold()
+
+    for required in (
+        "resolve_notification_destination_authority",
+        "assert_retry_plan_is_current",
+        "destination_authority_observer",
+        "destination_authority_id",
+        "destination_fingerprint",
+        "--destination-config",
+        "--destination-id",
+    ):
+        assert required in executor
+    assert executor.index("assert_retry_plan_is_current") < executor.index(
+        "selected_authority_resolver("
+    )
+    assert executor.index("selected_authority_resolver(") < executor.index(
+        "selected_transport("
+    )
+
+    for required in (
+        "observe_destination_authority",
+        "record_notification_retry_destination_binding",
+        "destination_history",
+        "destination_authority_observer=observe_destination_authority",
+    ):
+        assert required in wrapper
+    for required in (
+        "portfolio_risk_notification_retry_destination_bindings",
+        "record_id TEXT NOT NULL UNIQUE REFERENCES",
+        "BEFORE UPDATE OR DELETE",
+    ):
+        assert required in schema
+    for required in (
+        "primary arc42 block: `orchestration`",
+        "refreshed under the lock",
+        "append-only destination binding",
+        "performs no external webhook request",
+        "terraform apply",
+    ):
+        assert required in normalized


### PR DESCRIPTION
## Goal

Complete **P4d3c — retry-execution destination authority enforcement**.

```text
exact retained retry plan
  + current retry evidence
  + shared PostgreSQL delivery lock
  + active destination ownership contract
  -> destination authority refreshed under the lock
  -> exact endpoint-environment and event allow-list checks
  -> one request per authorised event
  -> terminal retry history
  -> append-only destination binding
```

## Controls

- Resolves destination authority only after acquiring the shared delivery lock and revalidating the exact current retry plan.
- Uses a second clock-derived instant for destination review and expiry checks.
- Rejects disabled, expired, future-reviewed, mismatched endpoint-environment, or unapproved event-type evidence before the first transport call.
- Binds destination ID, destination fingerprint, and authority ID into the deterministic retry execution identity and credential-free summary.
- Preserves the existing terminal retry-record contract while adding a separate append-only destination binding keyed to terminal `record_id`.
- Exact binding retries converge; conflicting destination evidence for one terminal record fails closed.
- Adds PostgreSQL mutation-rejection triggers and a retained-binding reader.

## Durable evidence

Adds `risk_platform.portfolio_risk_notification_retry_destination_bindings`, retaining:

- terminal retry `record_id`, request ID, plan ID, and optional execution ID;
- destination authority, destination ID, and destination fingerprint;
- endpoint environment-variable name, never its value;
- authority evaluation time and evaluated event types; and
- canonical binding JSON plus SHA-256.

## Repair during validation

The first exact-head run **357** passed security, PostgreSQL, and infrastructure checks but exposed nine Python test failures. The executor was reading `event_type` from retained retry-plan event digests; that contract intentionally omits `event_type`. The final implementation derives event types from current candidate rows only **after** exact plan revalidation. This preserves the retry-plan identity while retaining a fail-closed event allow-list check before transport. No validation, security, database, or CI gate was weakened.

## Scope

Fourteen intended files, 1,537 additions and two deletions. The connector produced fifteen working commits; squash merge will retain one coherent orchestration/warehouse increment. The branch is zero commits behind `main`.

## Exact-head validation

GitHub Actions run **358** (`32975511331`) passed on final head `d22ce9a44ea2f17a867a53cdf75ca30999f28d0c`:

- Security guardrails passed.
- Ruff passed.
- mypy passed across **123 source files**.
- **834 tests passed** in quality and **834 passed again** in readiness.
- Dependency integrity and the standard replay demonstration passed.
- PostgreSQL 16 schema and contract validation passed.
- Kubernetes rendering and Terraform format/init/validate passed without apply.

There are no review submissions or unresolved threads.

## Safety boundary

Committed destination activation, webhook delivery, and retry execution remain disabled. No endpoint value, full URL, payload body, response body, DSN, credential, or environment value is retained. Ordinary CI performed no external notification delivery, provider request, cloud scheduling, deployment, portfolio-position mutation, or `terraform apply`.

## Acceptance boundary

Validated and ready for squash merge. The next dependent PR exposes destination identity through current retry follow-up, delivery-failure, and ambiguity views.