### PR TITLE
Add destination-aware notification retry follow-up views

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,6 +29,7 @@ services:
       - ./sql/portfolio_risk_notification_retry_execution_schema.sql:/docker-entrypoint-initdb.d/19_portfolio_risk_notification_retry_execution_schema.sql:ro
       - ./sql/portfolio_risk_notification_retry_destination_binding_schema.sql:/docker-entrypoint-initdb.d/19b_portfolio_risk_notification_retry_destination_binding_schema.sql:ro
       - ./sql/portfolio_risk_notification_retry_follow_up_schema.sql:/docker-entrypoint-initdb.d/20_portfolio_risk_notification_retry_follow_up_schema.sql:ro
+      - ./sql/portfolio_risk_notification_retry_destination_follow_up_schema.sql:/docker-entrypoint-initdb.d/21_portfolio_risk_notification_retry_destination_follow_up_schema.sql:ro
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U risk_user -d risk_platform"]
       interval: 5s

--- a/docs/portfolio-risk-notification-retry-destination-follow-up.md
+++ b/docs/portfolio-risk-notification-retry-destination-follow-up.md
@@ -1,0 +1,92 @@
+# Destination-Aware Notification Retry Follow-Up
+
+Primary arc42 block: `warehouse`.
+
+## Goal
+
+Expose the reviewed destination that governed each retained retry execution
+without changing notification delivery behaviour:
+
+```text
+append-only retry execution history
+  + append-only destination authority bindings
+  + current retry follow-up evidence
+  -> destination-aware execution history
+  -> one destination-aware current row per event
+  -> delivery-failure, ambiguity and missing-binding review queues
+```
+
+## Query grains
+
+`notification_retry_destination_execution_history` has one row per terminal
+retry record and requested event ordinal. It preserves unbound legacy history
+and exposes `destination_bound = false` rather than dropping it.
+
+`latest_notification_retry_destination_by_event` reuses the existing current
+retry selection. The current record is still selected by:
+
+```text
+finished_at DESC
+record_id DESC
+event_ordinal DESC
+```
+
+A destination binding attached to an older superseded retry record cannot leak
+into the current event row.
+
+`current_notification_retry_destination_follow_up` preserves one row per
+current pending notification and adds:
+
+- destination authority, destination ID and destination fingerprint;
+- endpoint environment-variable name, never its value;
+- destination evaluation and binding timestamps;
+- `destination_binding_status`; and
+- `destination_review_required`.
+
+The binding status is:
+
+```text
+no current retry execution                 -> not_applicable
+current execution with destination binding -> bound
+current execution without binding          -> destination_binding_missing
+```
+
+The missing-binding state is expected for retained legacy executions created
+before destination enforcement. It is surfaced for explicit operator review;
+it is not silently treated as a reviewed destination.
+
+## Operational queues
+
+The destination-aware failure and ambiguity views preserve the exact row counts
+and classifications of the existing current queues while adding destination
+drill-through evidence.
+
+`current_notification_retry_destination_binding_reviews` contains only current
+retry executions whose destination binding is absent. A bound ambiguity can
+therefore be reviewed with its exact destination identity, while an unbound
+legacy failure is clearly separated for governance review.
+
+## Reconciliation
+
+PostgreSQL checks prove that:
+
+- history and current grains are not multiplied or lost;
+- the destination-aware latest record matches the existing latest record;
+- bound rows contain complete destination evidence;
+- unbound rows contain no stray destination fields;
+- follow-up, delivery-failure and ambiguity partitions retain their counts;
+- binding-review rows are exactly the current executions without bindings; and
+- destination identity in current follow-up matches the selected execution.
+
+The transaction-scoped PostgreSQL fixture includes a bound current ambiguity,
+an unbound failed execution, and a superseded older binding. It proves that the
+current views select the right destination evidence and rolls all synthetic
+records back.
+
+## Safety boundary
+
+These are read-only serving views. Ordinary CI performs no external webhook
+request, delivery-attempt write outside the transaction fixture, outbox
+mutation, acknowledgement, provider request, cloud schedule activation,
+infrastructure deployment or `terraform apply`. No endpoint URL, credential,
+payload body, response body, DSN or environment value is exposed by the views.

--- a/sql/portfolio_risk_notification_retry_destination_follow_up_consistency_checks.sql
+++ b/sql/portfolio_risk_notification_retry_destination_follow_up_consistency_checks.sql
@@ -1,0 +1,352 @@
+-- Reconciliation for destination-aware notification retry serving views.
+
+WITH counts AS (
+    SELECT
+        (SELECT COUNT(*)
+         FROM risk_platform.notification_retry_execution_event_history)
+            AS expected_history_rows,
+        (SELECT COUNT(*)
+         FROM risk_platform.notification_retry_destination_execution_history)
+            AS history_rows,
+        (SELECT COUNT(*)
+         FROM risk_platform.notification_retry_execution_event_history history
+         JOIN risk_platform.portfolio_risk_notification_retry_destination_bindings binding
+           ON binding.record_id = history.record_id)
+            AS expected_bound_history_rows,
+        (SELECT COUNT(*)
+         FROM risk_platform.notification_retry_destination_execution_history
+         WHERE destination_bound)
+            AS bound_history_rows,
+        (SELECT COUNT(*)
+         FROM risk_platform.latest_notification_retry_execution_by_event)
+            AS expected_latest_rows,
+        (SELECT COUNT(*)
+         FROM risk_platform.latest_notification_retry_destination_by_event)
+            AS latest_rows,
+        (SELECT COUNT(*)
+         FROM risk_platform.current_notification_retry_follow_up)
+            AS expected_follow_up_rows,
+        (SELECT COUNT(*)
+         FROM risk_platform.current_notification_retry_destination_follow_up)
+            AS follow_up_rows,
+        (SELECT COUNT(*)
+         FROM risk_platform.current_notification_delivery_failures)
+            AS expected_failure_rows,
+        (SELECT COUNT(*)
+         FROM risk_platform.current_notification_retry_destination_failures)
+            AS failure_rows,
+        (SELECT COUNT(*)
+         FROM risk_platform.current_notification_ambiguous_outcomes)
+            AS expected_ambiguous_rows,
+        (SELECT COUNT(*)
+         FROM risk_platform.current_notification_retry_destination_ambiguities)
+            AS ambiguous_rows,
+        (SELECT COUNT(*)
+         FROM risk_platform.current_notification_retry_destination_follow_up
+         WHERE latest_execution_record_id IS NOT NULL
+           AND NOT destination_bound)
+            AS expected_binding_review_rows,
+        (SELECT COUNT(*)
+         FROM risk_platform.current_notification_retry_destination_binding_reviews)
+            AS binding_review_rows
+),
+integrity AS (
+    SELECT
+        (
+            SELECT COUNT(*)
+            FROM (
+                SELECT record_id, event_id
+                FROM risk_platform.notification_retry_destination_execution_history
+                GROUP BY record_id, event_id
+                HAVING COUNT(*) > 1
+            ) duplicated
+        ) AS duplicate_history_grains,
+        (
+            SELECT COUNT(*)
+            FROM (
+                SELECT event_id
+                FROM risk_platform.latest_notification_retry_destination_by_event
+                GROUP BY event_id
+                HAVING COUNT(*) > 1
+            ) duplicated
+        ) AS duplicate_latest_events,
+        (
+            SELECT COUNT(*)
+            FROM risk_platform.latest_notification_retry_destination_by_event destination
+            FULL JOIN risk_platform.latest_notification_retry_execution_by_event latest
+              ON latest.event_id = destination.event_id
+            WHERE latest.event_id IS NULL
+               OR destination.event_id IS NULL
+               OR destination.record_id <> latest.record_id
+               OR destination.finished_at <> latest.finished_at
+               OR destination.event_ordinal <> latest.event_ordinal
+        ) AS latest_selection_mismatches,
+        (
+            SELECT COUNT(*)
+            FROM risk_platform.notification_retry_destination_execution_history history
+            WHERE history.destination_bound
+              AND (
+                  history.binding_id IS NULL
+                  OR history.destination_authority_id IS NULL
+                  OR history.destination_id IS NULL
+                  OR history.destination_fingerprint IS NULL
+                  OR history.endpoint_environment_variable IS NULL
+                  OR history.destination_evaluated_at IS NULL
+                  OR history.destination_binding_recorded_at IS NULL
+                  OR history.evaluated_event_types_json IS NULL
+              )
+        ) AS incomplete_bound_history,
+        (
+            SELECT COUNT(*)
+            FROM risk_platform.notification_retry_destination_execution_history history
+            WHERE NOT history.destination_bound
+              AND (
+                  history.binding_id IS NOT NULL
+                  OR history.destination_authority_id IS NOT NULL
+                  OR history.destination_id IS NOT NULL
+                  OR history.destination_fingerprint IS NOT NULL
+                  OR history.endpoint_environment_variable IS NOT NULL
+                  OR history.destination_evaluated_at IS NOT NULL
+                  OR history.destination_binding_recorded_at IS NOT NULL
+                  OR history.evaluated_event_types_json IS NOT NULL
+              )
+        ) AS contaminated_unbound_history,
+        (
+            SELECT COUNT(*)
+            FROM (
+                SELECT event_id
+                FROM risk_platform.current_notification_retry_destination_follow_up
+                GROUP BY event_id
+                HAVING COUNT(*) > 1
+            ) duplicated
+        ) AS duplicate_follow_up_events,
+        (
+            SELECT COUNT(*)
+            FROM risk_platform.current_notification_retry_destination_follow_up follow_up
+            WHERE (
+                follow_up.latest_execution_record_id IS NULL
+                AND (
+                    follow_up.destination_binding_status <> 'not_applicable'
+                    OR follow_up.destination_bound
+                    OR follow_up.destination_review_required
+                )
+            ) OR (
+                follow_up.latest_execution_record_id IS NOT NULL
+                AND follow_up.destination_bound
+                AND (
+                    follow_up.destination_binding_status <> 'bound'
+                    OR follow_up.destination_review_required
+                    OR follow_up.binding_id IS NULL
+                )
+            ) OR (
+                follow_up.latest_execution_record_id IS NOT NULL
+                AND NOT follow_up.destination_bound
+                AND (
+                    follow_up.destination_binding_status
+                        <> 'destination_binding_missing'
+                    OR NOT follow_up.destination_review_required
+                    OR follow_up.binding_id IS NOT NULL
+                )
+            )
+        ) AS invalid_follow_up_statuses,
+        (
+            SELECT COUNT(*)
+            FROM risk_platform.current_notification_retry_destination_follow_up follow_up
+            JOIN risk_platform.latest_notification_retry_destination_by_event latest
+              ON latest.event_id = follow_up.event_id
+            WHERE follow_up.latest_execution_record_id <> latest.record_id
+               OR follow_up.destination_bound <> latest.destination_bound
+               OR follow_up.binding_id IS DISTINCT FROM latest.binding_id
+               OR follow_up.destination_id IS DISTINCT FROM latest.destination_id
+               OR follow_up.destination_fingerprint
+                    IS DISTINCT FROM latest.destination_fingerprint
+        ) AS follow_up_identity_mismatches,
+        (
+            SELECT COUNT(*)
+            FROM risk_platform.current_notification_retry_destination_binding_reviews review
+            WHERE review.latest_execution_record_id IS NULL
+               OR review.destination_bound
+               OR review.destination_binding_status
+                    <> 'destination_binding_missing'
+               OR NOT review.destination_review_required
+        ) AS invalid_binding_review_rows,
+        (
+            SELECT COUNT(*)
+            FROM risk_platform.current_notification_retry_destination_failures failure
+            WHERE NOT failure.delivery_failure
+        ) AS invalid_failure_rows,
+        (
+            SELECT COUNT(*)
+            FROM risk_platform.current_notification_retry_destination_ambiguities ambiguous
+            WHERE NOT ambiguous.ambiguous_outcome
+               OR ambiguous.follow_up_reason <> 'persistence_review_required'
+        ) AS invalid_ambiguous_rows
+)
+SELECT
+    'notification_retry_destination_history_preserves_grain' AS check_name,
+    expected_history_rows::TEXT AS expected,
+    history_rows::TEXT AS actual,
+    CASE WHEN expected_history_rows = history_rows THEN 'pass' ELSE 'fail' END
+        AS status
+FROM counts
+
+UNION ALL
+
+SELECT
+    'notification_retry_destination_bound_history_matches',
+    expected_bound_history_rows::TEXT,
+    bound_history_rows::TEXT,
+    CASE
+        WHEN expected_bound_history_rows = bound_history_rows THEN 'pass'
+        ELSE 'fail'
+    END
+FROM counts
+
+UNION ALL
+
+SELECT
+    'notification_retry_destination_history_grain_unique',
+    '0',
+    duplicate_history_grains::TEXT,
+    CASE WHEN duplicate_history_grains = 0 THEN 'pass' ELSE 'fail' END
+FROM integrity
+
+UNION ALL
+
+SELECT
+    'notification_retry_destination_latest_preserves_grain',
+    expected_latest_rows::TEXT,
+    latest_rows::TEXT,
+    CASE WHEN expected_latest_rows = latest_rows THEN 'pass' ELSE 'fail' END
+FROM counts
+
+UNION ALL
+
+SELECT
+    'notification_retry_destination_latest_grain_unique',
+    '0',
+    duplicate_latest_events::TEXT,
+    CASE WHEN duplicate_latest_events = 0 THEN 'pass' ELSE 'fail' END
+FROM integrity
+
+UNION ALL
+
+SELECT
+    'notification_retry_destination_latest_selection_matches',
+    '0',
+    latest_selection_mismatches::TEXT,
+    CASE WHEN latest_selection_mismatches = 0 THEN 'pass' ELSE 'fail' END
+FROM integrity
+
+UNION ALL
+
+SELECT
+    'notification_retry_destination_bound_history_complete',
+    '0',
+    incomplete_bound_history::TEXT,
+    CASE WHEN incomplete_bound_history = 0 THEN 'pass' ELSE 'fail' END
+FROM integrity
+
+UNION ALL
+
+SELECT
+    'notification_retry_destination_unbound_history_clean',
+    '0',
+    contaminated_unbound_history::TEXT,
+    CASE WHEN contaminated_unbound_history = 0 THEN 'pass' ELSE 'fail' END
+FROM integrity
+
+UNION ALL
+
+SELECT
+    'notification_retry_destination_follow_up_covers_current',
+    expected_follow_up_rows::TEXT,
+    follow_up_rows::TEXT,
+    CASE WHEN expected_follow_up_rows = follow_up_rows THEN 'pass' ELSE 'fail' END
+FROM counts
+
+UNION ALL
+
+SELECT
+    'notification_retry_destination_follow_up_grain_unique',
+    '0',
+    duplicate_follow_up_events::TEXT,
+    CASE WHEN duplicate_follow_up_events = 0 THEN 'pass' ELSE 'fail' END
+FROM integrity
+
+UNION ALL
+
+SELECT
+    'notification_retry_destination_follow_up_status_valid',
+    '0',
+    invalid_follow_up_statuses::TEXT,
+    CASE WHEN invalid_follow_up_statuses = 0 THEN 'pass' ELSE 'fail' END
+FROM integrity
+
+UNION ALL
+
+SELECT
+    'notification_retry_destination_follow_up_identity_matches',
+    '0',
+    follow_up_identity_mismatches::TEXT,
+    CASE WHEN follow_up_identity_mismatches = 0 THEN 'pass' ELSE 'fail' END
+FROM integrity
+
+UNION ALL
+
+SELECT
+    'notification_retry_destination_binding_review_partition_matches',
+    expected_binding_review_rows::TEXT,
+    binding_review_rows::TEXT,
+    CASE
+        WHEN expected_binding_review_rows = binding_review_rows THEN 'pass'
+        ELSE 'fail'
+    END
+FROM counts
+
+UNION ALL
+
+SELECT
+    'notification_retry_destination_binding_review_rows_valid',
+    '0',
+    invalid_binding_review_rows::TEXT,
+    CASE WHEN invalid_binding_review_rows = 0 THEN 'pass' ELSE 'fail' END
+FROM integrity
+
+UNION ALL
+
+SELECT
+    'notification_retry_destination_failure_partition_matches',
+    expected_failure_rows::TEXT,
+    failure_rows::TEXT,
+    CASE WHEN expected_failure_rows = failure_rows THEN 'pass' ELSE 'fail' END
+FROM counts
+
+UNION ALL
+
+SELECT
+    'notification_retry_destination_failure_rows_valid',
+    '0',
+    invalid_failure_rows::TEXT,
+    CASE WHEN invalid_failure_rows = 0 THEN 'pass' ELSE 'fail' END
+FROM integrity
+
+UNION ALL
+
+SELECT
+    'notification_retry_destination_ambiguity_partition_matches',
+    expected_ambiguous_rows::TEXT,
+    ambiguous_rows::TEXT,
+    CASE WHEN expected_ambiguous_rows = ambiguous_rows THEN 'pass' ELSE 'fail' END
+FROM counts
+
+UNION ALL
+
+SELECT
+    'notification_retry_destination_ambiguity_rows_valid',
+    '0',
+    invalid_ambiguous_rows::TEXT,
+    CASE WHEN invalid_ambiguous_rows = 0 THEN 'pass' ELSE 'fail' END
+FROM integrity
+
+ORDER BY check_name;

--- a/sql/portfolio_risk_notification_retry_destination_follow_up_schema.sql
+++ b/sql/portfolio_risk_notification_retry_destination_follow_up_schema.sql
@@ -1,0 +1,83 @@
+-- Destination-aware operational views for current notification retry evidence.
+-- Apply after retry destination bindings and retry follow-up views.
+
+CREATE OR REPLACE VIEW
+risk_platform.notification_retry_destination_execution_history AS
+SELECT
+    history.*,
+    binding.binding_id,
+    binding.authority_id AS destination_authority_id,
+    binding.destination_id,
+    binding.destination_fingerprint,
+    binding.endpoint_environment_variable,
+    binding.evaluated_at AS destination_evaluated_at,
+    binding.recorded_at AS destination_binding_recorded_at,
+    binding.evaluated_event_types_json,
+    binding.record_id IS NOT NULL AS destination_bound
+FROM risk_platform.notification_retry_execution_event_history history
+LEFT JOIN
+    risk_platform.portfolio_risk_notification_retry_destination_bindings binding
+  ON binding.record_id = history.record_id;
+
+CREATE OR REPLACE VIEW
+risk_platform.latest_notification_retry_destination_by_event AS
+SELECT
+    latest.*,
+    binding.binding_id,
+    binding.authority_id AS destination_authority_id,
+    binding.destination_id,
+    binding.destination_fingerprint,
+    binding.endpoint_environment_variable,
+    binding.evaluated_at AS destination_evaluated_at,
+    binding.recorded_at AS destination_binding_recorded_at,
+    binding.evaluated_event_types_json,
+    binding.record_id IS NOT NULL AS destination_bound
+FROM risk_platform.latest_notification_retry_execution_by_event latest
+LEFT JOIN
+    risk_platform.portfolio_risk_notification_retry_destination_bindings binding
+  ON binding.record_id = latest.record_id;
+
+CREATE OR REPLACE VIEW
+risk_platform.current_notification_retry_destination_follow_up AS
+SELECT
+    follow_up.*,
+    destination.binding_id,
+    destination.destination_authority_id,
+    destination.destination_id,
+    destination.destination_fingerprint,
+    destination.endpoint_environment_variable,
+    destination.destination_evaluated_at,
+    destination.destination_binding_recorded_at,
+    destination.evaluated_event_types_json,
+    COALESCE(destination.destination_bound, FALSE) AS destination_bound,
+    CASE
+        WHEN follow_up.latest_execution_record_id IS NULL
+            THEN 'not_applicable'
+        WHEN destination.destination_bound
+            THEN 'bound'
+        ELSE 'destination_binding_missing'
+    END AS destination_binding_status,
+    follow_up.latest_execution_record_id IS NOT NULL
+        AND NOT COALESCE(destination.destination_bound, FALSE)
+        AS destination_review_required
+FROM risk_platform.current_notification_retry_follow_up follow_up
+LEFT JOIN risk_platform.latest_notification_retry_destination_by_event destination
+  ON destination.event_id = follow_up.event_id;
+
+CREATE OR REPLACE VIEW
+risk_platform.current_notification_retry_destination_failures AS
+SELECT *
+FROM risk_platform.current_notification_retry_destination_follow_up
+WHERE delivery_failure;
+
+CREATE OR REPLACE VIEW
+risk_platform.current_notification_retry_destination_ambiguities AS
+SELECT *
+FROM risk_platform.current_notification_retry_destination_follow_up
+WHERE ambiguous_outcome;
+
+CREATE OR REPLACE VIEW
+risk_platform.current_notification_retry_destination_binding_reviews AS
+SELECT *
+FROM risk_platform.current_notification_retry_destination_follow_up
+WHERE destination_review_required;

--- a/src/warehouse/notification_retry_follow_up_postgres_contract_check.py
+++ b/src/warehouse/notification_retry_follow_up_postgres_contract_check.py
@@ -1,12 +1,18 @@
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import os
 import sys
 from datetime import datetime, timedelta, timezone
-from typing import Any
+from pathlib import Path
+from typing import Any, Mapping
 
+from src.warehouse.notification_retry_destination_binding_contract import (
+    build_retry_destination_binding,
+    canonical_binding_bytes,
+)
 from src.warehouse.notification_retry_follow_up_contract_check import (
     CHECK_PATH,
     _assert_follow_up_rows,
@@ -32,6 +38,183 @@ ATTRIBUTION_COLUMNS = (
     "ts_event",
     "ts_ingest",
 )
+DESTINATION_CHECK_PATH = Path(
+    "sql/portfolio_risk_notification_retry_destination_follow_up_consistency_checks.sql"
+)
+DESTINATION_ID = "risk-operations-webhook"
+DESTINATION_FINGERPRINT = "portfolio-risk-notification-destination-v1-contract"
+AUTHORITY_ID = "portfolio-risk-notification-destination-authority-v1-contract"
+
+
+def _destination_authority(*, evaluated_at: datetime) -> dict[str, Any]:
+    return {
+        "authority_id": AUTHORITY_ID,
+        "destination_fingerprint": DESTINATION_FINGERPRINT,
+        "destination_id": DESTINATION_ID,
+        "endpoint_environment_variable": "RISK_NOTIFICATION_WEBHOOK_URL",
+        "evaluated_at": evaluated_at.isoformat(),
+        "evaluated_event_types": ["breach_opened"],
+        "model_version": "portfolio-risk-notification-destination-authority-v1",
+        "channel": "webhook",
+        "activation": {
+            "enabled": True,
+            "status": "active",
+            "change_request_id": "FOLLOW-UP-DESTINATION-CONTRACT",
+            "reviewed_at": (evaluated_at - timedelta(days=1)).isoformat(),
+            "review_expires_at": (evaluated_at + timedelta(days=1)).isoformat(),
+        },
+        "allowed_event_types": [
+            "breach_escalated",
+            "breach_opened",
+            "breach_resolved",
+        ],
+        "active": True,
+        "endpoint_value_recorded": False,
+        "external_request_performed": False,
+        "delivery_attempt_written": False,
+        "outbox_mutated": False,
+        "acknowledgement_mutated": False,
+    }
+
+
+def _insert_destination_binding(
+    cursor: Any,
+    *,
+    record: Mapping[str, Any],
+    evaluated_at: datetime,
+    jsonb: Any,
+) -> dict[str, Any]:
+    binding = build_retry_destination_binding(
+        record_id=record["record_id"],
+        request_id=record["request_id"],
+        plan_id=record["plan_id"],
+        execution_id=record["execution_id"],
+        destination_authority=_destination_authority(evaluated_at=evaluated_at),
+        recorded_at=record["recorded_at"],
+    )
+    authority = binding["destination_authority"]
+    digest = hashlib.sha256(canonical_binding_bytes(binding)).hexdigest()
+    cursor.execute(
+        """
+        INSERT INTO
+        risk_platform.portfolio_risk_notification_retry_destination_bindings (
+            binding_id,
+            model_version,
+            record_id,
+            request_id,
+            plan_id,
+            execution_id,
+            authority_id,
+            destination_id,
+            destination_fingerprint,
+            endpoint_environment_variable,
+            evaluated_at,
+            evaluated_event_types_json,
+            authority_json,
+            recorded_at,
+            binding_json,
+            document_sha256
+        )
+        VALUES (
+            %s, %s, %s, %s, %s, %s, %s, %s,
+            %s, %s, %s, %s, %s, %s, %s, %s
+        )
+        """,
+        (
+            binding["binding_id"],
+            binding["model_version"],
+            binding["record_id"],
+            binding["request_id"],
+            binding["plan_id"],
+            binding["execution_id"],
+            authority["authority_id"],
+            authority["destination_id"],
+            authority["destination_fingerprint"],
+            authority["endpoint_environment_variable"],
+            authority["evaluated_at"],
+            jsonb(authority["evaluated_event_types"]),
+            jsonb(authority),
+            binding["recorded_at"],
+            jsonb(binding),
+            digest,
+        ),
+    )
+    return binding
+
+
+def _assert_destination_rows(cursor: Any) -> dict[str, str]:
+    cursor.execute(
+        """
+        SELECT
+            event_id,
+            destination_binding_status,
+            COALESCE(destination_id, '')
+        FROM risk_platform.current_notification_retry_destination_follow_up
+        WHERE event_id LIKE 'follow-up-event-%'
+        ORDER BY event_id
+        """
+    )
+    rows = cursor.fetchall()
+    actual = {
+        str(event_id): f"{status}:{destination_id}"
+        for event_id, status, destination_id in rows
+    }
+    expected = {
+        "follow-up-event-acknowledged": "not_applicable:",
+        "follow-up-event-delivered": "not_applicable:",
+        "follow-up-event-execution": "destination_binding_missing:",
+        "follow-up-event-initial": "not_applicable:",
+        "follow-up-event-retry": "not_applicable:",
+        "follow-up-event-superseded": "destination_binding_missing:",
+        "follow-up-event-uncertain": f"bound:{DESTINATION_ID}",
+    }
+    if actual != expected:
+        raise AssertionError(f"destination follow-up classifications changed: {actual!r}")
+
+    cursor.execute(
+        """
+        SELECT event_id, destination_id
+        FROM risk_platform.current_notification_retry_destination_ambiguities
+        WHERE event_id LIKE 'follow-up-event-%'
+        ORDER BY event_id
+        """
+    )
+    ambiguity_rows = cursor.fetchall()
+    if ambiguity_rows != [("follow-up-event-uncertain", DESTINATION_ID)]:
+        raise AssertionError(
+            f"destination ambiguity selection changed: {ambiguity_rows!r}"
+        )
+
+    cursor.execute(
+        """
+        SELECT event_id
+        FROM risk_platform.current_notification_retry_destination_binding_reviews
+        WHERE event_id LIKE 'follow-up-event-%'
+        ORDER BY event_id
+        """
+    )
+    review_rows = [str(row[0]) for row in cursor.fetchall()]
+    if review_rows != [
+        "follow-up-event-execution",
+        "follow-up-event-superseded",
+    ]:
+        raise AssertionError(
+            f"destination binding review selection changed: {review_rows!r}"
+        )
+
+    cursor.execute(
+        """
+        SELECT record_id, destination_bound, destination_id
+        FROM risk_platform.latest_notification_retry_destination_by_event
+        WHERE event_id = 'follow-up-event-superseded'
+        """
+    )
+    latest = cursor.fetchone()
+    if latest is None or latest[1:] != (False, None):
+        raise AssertionError(
+            f"superseded destination binding remained current: {latest!r}"
+        )
+    return {event_id: value for event_id, value in actual.items()}
 
 
 def run_contract_check(dsn: str) -> dict[str, Any]:
@@ -43,7 +226,9 @@ def run_contract_check(dsn: str) -> dict[str, Any]:
 
     connection = psycopg.connect(dsn)
     checks: list[tuple[Any, ...]] = []
+    destination_checks: list[tuple[Any, ...]] = []
     classifications: dict[str, str] = {}
+    destination_classifications: dict[str, str] = {}
     try:
         with connection.cursor() as cursor:
             cursor.execute(
@@ -112,17 +297,20 @@ def run_contract_check(dsn: str) -> dict[str, Any]:
                 succeeded=False,
             )
             uncertain_start = events["uncertain"]["ingest_time"] + timedelta(minutes=2)
-            _insert_execution_record(
+            uncertain_record = _failed_record(
+                request_id="FOLLOW-UP-UNCERTAIN",
+                plan_id="follow-up-plan-uncertain",
+                event_id=events["uncertain"]["event_id"],
+                started_at=uncertain_start,
+                finished_at=uncertain_start + timedelta(seconds=1),
+                terminal_status="persistence_uncertain",
+                attempt_id=None,
+            )
+            _insert_execution_record(cursor, record=uncertain_record, jsonb=Jsonb)
+            _insert_destination_binding(
                 cursor,
-                record=_failed_record(
-                    request_id="FOLLOW-UP-UNCERTAIN",
-                    plan_id="follow-up-plan-uncertain",
-                    event_id=events["uncertain"]["event_id"],
-                    started_at=uncertain_start,
-                    finished_at=uncertain_start + timedelta(seconds=1),
-                    terminal_status="persistence_uncertain",
-                    attempt_id=None,
-                ),
+                record=uncertain_record,
+                evaluated_at=uncertain_start,
                 jsonb=Jsonb,
             )
 
@@ -142,19 +330,16 @@ def run_contract_check(dsn: str) -> dict[str, Any]:
                 attempted_at=execution_time,
                 succeeded=False,
             )
-            _insert_execution_record(
-                cursor,
-                record=_failed_record(
-                    request_id="FOLLOW-UP-EXECUTION",
-                    plan_id="follow-up-plan-execution",
-                    event_id=events["execution"]["event_id"],
-                    started_at=execution_time,
-                    finished_at=execution_time + timedelta(seconds=1),
-                    terminal_status="failed_after_request",
-                    attempt_id=execution_attempt,
-                ),
-                jsonb=Jsonb,
+            execution_record = _failed_record(
+                request_id="FOLLOW-UP-EXECUTION",
+                plan_id="follow-up-plan-execution",
+                event_id=events["execution"]["event_id"],
+                started_at=execution_time,
+                finished_at=execution_time + timedelta(seconds=1),
+                terminal_status="failed_after_request",
+                attempt_id=execution_attempt,
             )
+            _insert_execution_record(cursor, record=execution_record, jsonb=Jsonb)
 
             _insert_attempt(
                 cursor,
@@ -180,17 +365,20 @@ def run_contract_check(dsn: str) -> dict[str, Any]:
                 succeeded=False,
             )
             old_start = events["superseded"]["ingest_time"] + timedelta(minutes=2)
-            _insert_execution_record(
+            old_record = _failed_record(
+                request_id="FOLLOW-UP-SUPERSEDED-OLD",
+                plan_id="follow-up-plan-superseded-old",
+                event_id=events["superseded"]["event_id"],
+                started_at=old_start,
+                finished_at=old_start + timedelta(seconds=1),
+                terminal_status="persistence_uncertain",
+                attempt_id=None,
+            )
+            _insert_execution_record(cursor, record=old_record, jsonb=Jsonb)
+            _insert_destination_binding(
                 cursor,
-                record=_failed_record(
-                    request_id="FOLLOW-UP-SUPERSEDED-OLD",
-                    plan_id="follow-up-plan-superseded-old",
-                    event_id=events["superseded"]["event_id"],
-                    started_at=old_start,
-                    finished_at=old_start + timedelta(seconds=1),
-                    terminal_status="persistence_uncertain",
-                    attempt_id=None,
-                ),
+                record=old_record,
+                evaluated_at=old_start,
                 jsonb=Jsonb,
             )
             _insert_attempt(
@@ -208,27 +396,37 @@ def run_contract_check(dsn: str) -> dict[str, Any]:
                 attempted_at=current_time,
                 succeeded=False,
             )
-            _insert_execution_record(
-                cursor,
-                record=_failed_record(
-                    request_id="FOLLOW-UP-SUPERSEDED-CURRENT",
-                    plan_id="follow-up-plan-superseded-current",
-                    event_id=events["superseded"]["event_id"],
-                    started_at=current_time,
-                    finished_at=current_time + timedelta(seconds=1),
-                    terminal_status="failed_after_request",
-                    attempt_id=current_attempt,
-                ),
-                jsonb=Jsonb,
+            current_record = _failed_record(
+                request_id="FOLLOW-UP-SUPERSEDED-CURRENT",
+                plan_id="follow-up-plan-superseded-current",
+                event_id=events["superseded"]["event_id"],
+                started_at=current_time,
+                finished_at=current_time + timedelta(seconds=1),
+                terminal_status="failed_after_request",
+                attempt_id=current_attempt,
             )
+            _insert_execution_record(cursor, record=current_record, jsonb=Jsonb)
 
             classifications = _assert_follow_up_rows(cursor)
+            destination_classifications = _assert_destination_rows(cursor)
             cursor.execute(CHECK_PATH.read_text(encoding="utf-8"))
             checks = list(cursor.fetchall())
-            failures = [row for row in checks if row[3] != "pass"]
+            failures = [check for check in checks if check[3] != "pass"]
             if failures:
-                names = ", ".join(str(row[0]) for row in failures)
+                names = ", ".join(str(check[0]) for check in failures)
                 raise AssertionError("retry follow-up reconciliation failed: " + names)
+            cursor.execute(DESTINATION_CHECK_PATH.read_text(encoding="utf-8"))
+            destination_checks = list(cursor.fetchall())
+            destination_failures = [
+                check for check in destination_checks if check[3] != "pass"
+            ]
+            if destination_failures:
+                names = ", ".join(
+                    str(check[0]) for check in destination_failures
+                )
+                raise AssertionError(
+                    "destination retry follow-up reconciliation failed: " + names
+                )
         connection.rollback()
     except Exception:
         connection.rollback()
@@ -237,13 +435,18 @@ def run_contract_check(dsn: str) -> dict[str, Any]:
         connection.close()
 
     return {
-        "model_version": "portfolio-risk-notification-retry-follow-up-v1",
+        "model_version": "portfolio-risk-notification-retry-follow-up-v2",
         "fixture_events": 7,
         "classifications": classifications,
+        "destination_classifications": destination_classifications,
+        "destination_bound_current_rows": 1,
+        "destination_binding_review_rows": 2,
         "delivery_failure_rows": 4,
         "ambiguous_outcome_rows": 1,
         "superseded_uncertainty_excluded": True,
+        "superseded_destination_binding_excluded": True,
         "consistency_checks": len(checks),
+        "destination_consistency_checks": len(destination_checks),
         "external_request_performed": False,
         "delivery_attempt_written_outside_fixture": False,
         "outbox_mutated_outside_fixture": False,
@@ -253,8 +456,8 @@ def run_contract_check(dsn: str) -> dict[str, Any]:
 def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         description=(
-            "Exercise current notification retry follow-up views against "
-            "PostgreSQL 16 using transaction-scoped fixtures."
+            "Exercise current notification retry and destination follow-up views "
+            "against PostgreSQL 16 using transaction-scoped fixtures."
         )
     )
     parser.add_argument(

--- a/tests/unit/test_docker_compose_contract.py
+++ b/tests/unit/test_docker_compose_contract.py
@@ -46,6 +46,7 @@ def test_local_database_seed_mounts_are_read_only_and_ordered() -> None:
         "./sql/portfolio_risk_notification_retry_execution_schema.sql:/docker-entrypoint-initdb.d/19_portfolio_risk_notification_retry_execution_schema.sql:ro",
         "./sql/portfolio_risk_notification_retry_destination_binding_schema.sql:/docker-entrypoint-initdb.d/19b_portfolio_risk_notification_retry_destination_binding_schema.sql:ro",
         "./sql/portfolio_risk_notification_retry_follow_up_schema.sql:/docker-entrypoint-initdb.d/20_portfolio_risk_notification_retry_follow_up_schema.sql:ro",
+        "./sql/portfolio_risk_notification_retry_destination_follow_up_schema.sql:/docker-entrypoint-initdb.d/21_portfolio_risk_notification_retry_destination_follow_up_schema.sql:ro",
     ]
     assert services["mongo"]["volumes"] == [
         "./mongo/init:/docker-entrypoint-initdb.d:ro"

--- a/tests/unit/test_notification_retry_destination_follow_up_architecture_contract.py
+++ b/tests/unit/test_notification_retry_destination_follow_up_architecture_contract.py
@@ -1,0 +1,80 @@
+from pathlib import Path
+
+
+def test_destination_retry_follow_up_is_current_read_only_and_reconciled() -> None:
+    schema = Path(
+        "sql/portfolio_risk_notification_retry_destination_follow_up_schema.sql"
+    ).read_text(encoding="utf-8")
+    checks = Path(
+        "sql/portfolio_risk_notification_retry_destination_follow_up_consistency_checks.sql"
+    ).read_text(encoding="utf-8")
+    fixture = Path(
+        "src/warehouse/notification_retry_follow_up_postgres_contract_check.py"
+    ).read_text(encoding="utf-8")
+    compose = Path("docker-compose.yml").read_text(encoding="utf-8")
+    docs = Path(
+        "docs/portfolio-risk-notification-retry-destination-follow-up.md"
+    ).read_text(encoding="utf-8")
+    normalized_docs = " ".join(docs.split()).casefold()
+
+    for view in (
+        "notification_retry_destination_execution_history",
+        "latest_notification_retry_destination_by_event",
+        "current_notification_retry_destination_follow_up",
+        "current_notification_retry_destination_failures",
+        "current_notification_retry_destination_ambiguities",
+        "current_notification_retry_destination_binding_reviews",
+    ):
+        assert f"risk_platform.{view}" in schema
+
+    for required in (
+        "binding.record_id = history.record_id",
+        "binding.record_id = latest.record_id",
+        "destination_binding_missing",
+        "destination_review_required",
+        "where delivery_failure",
+        "where ambiguous_outcome",
+    ):
+        assert required in schema.casefold()
+
+    for required in (
+        "notification_retry_destination_history_preserves_grain",
+        "notification_retry_destination_latest_selection_matches",
+        "notification_retry_destination_follow_up_covers_current",
+        "notification_retry_destination_binding_review_partition_matches",
+        "notification_retry_destination_failure_partition_matches",
+        "notification_retry_destination_ambiguity_partition_matches",
+    ):
+        assert required in checks
+
+    for required in (
+        "_insert_destination_binding",
+        "_assert_destination_rows",
+        "follow-up-event-uncertain",
+        "follow-up-event-superseded",
+        "superseded_destination_binding_excluded",
+        "connection.rollback()",
+    ):
+        assert required in fixture
+
+    assert (
+        "21_portfolio_risk_notification_retry_destination_follow_up_schema.sql:ro"
+        in compose
+    )
+
+    for required in (
+        "primary arc42 block: `warehouse`",
+        "one row per current pending notification",
+        "destination_binding_missing",
+        "older superseded retry record cannot leak",
+        "ordinary ci performs no external webhook request",
+        "terraform apply",
+    ):
+        assert required in normalized_docs
+
+    for forbidden in (
+        "requests.post(",
+        "urllib.request",
+        "httpx.",
+    ):
+        assert forbidden not in fixture.casefold()


### PR DESCRIPTION
## Goal

Complete the destination-serving half of **P4d3** by exposing the reviewed destination governing retained retry execution evidence.

```text
append-only retry execution history
  + append-only destination authority bindings
  + current retry follow-up evidence
  -> destination-aware execution history
  -> one destination-aware current row per event
  -> delivery-failure, ambiguity and missing-binding review queues
```

## Query contract

Adds:

- `notification_retry_destination_execution_history`;
- `latest_notification_retry_destination_by_event`;
- `current_notification_retry_destination_follow_up`;
- `current_notification_retry_destination_failures`;
- `current_notification_retry_destination_ambiguities`; and
- `current_notification_retry_destination_binding_reviews`.

Legacy current retry executions without bindings are retained and classified as `destination_binding_missing`; they are not silently dropped or treated as reviewed. Current selection reuses the existing `finished_at DESC`, `record_id DESC`, `event_ordinal DESC` contract, preventing an older bound record from leaking into a newer unbound current row.

## PostgreSQL evidence

The transaction-scoped PostgreSQL 16 fixture proves:

- one bound current persistence ambiguity;
- one unbound current failed execution;
- one older bound uncertainty superseded by an unbound newer execution;
- exact destination-aware follow-up, failure, ambiguity and review partitions; and
- **18 destination reconciliation checks**, in addition to the existing 19 retry follow-up checks.

The resulting current fixture has one bound destination row and two explicit destination-binding review rows, then rolls all synthetic evidence back.

## Scope

Seven intended files, 862 additions and 50 deletions. The connector produced seven working commits; squash merge will retain one coherent warehouse/query increment. The branch is zero commits behind `main`.

## Exact-head validation

GitHub Actions run **360** (`32977011165`) passed on head `40ccb6060cfdd91409d46ddea2691ec6c986a07b`:

- Security guardrails passed.
- Ruff passed.
- mypy passed across **123 source files**.
- **835 tests passed** in quality and **835 passed again** in readiness.
- Dependency integrity and the standard replay demonstration passed.
- PostgreSQL 16 startup, transaction fixture, and reconciliation passed.
- Kubernetes rendering and Terraform format/init/validate passed without apply.

There are no review submissions or unresolved threads.

## Safety boundary

The change is read-only outside transaction-scoped fixtures. It performed no external webhook request, provider request, cloud schedule activation, deployment, portfolio-position mutation or `terraform apply`, and exposes no endpoint URL, credential, payload body, response body, DSN or environment value.

## Acceptance boundary

Validated and ready for squash merge. P4d3 is complete after this PR: initial delivery and governed retries are bound to reviewed destination authority, and current operator queues expose the governing destination or an explicit missing-binding review state.