### PR TITLE
Add deterministic notification activation checklist

### DIFF
--- a/docs/notification-activation-checklist.md
+++ b/docs/notification-activation-checklist.md
@@ -1,0 +1,62 @@
+# Notification Activation Checklist
+
+Primary arc42 block: `orchestration`.
+
+## Goal
+
+Provide one deterministic, secret-free review package before notification delivery
+can move from disabled local governance evidence towards a controlled receiver
+exercise:
+
+```text
+reviewed destination authority
+  + accountable reviewers
+  + exact activation controls
+  + bounded review lifetime
+  -> canonical activation checklist
+  -> ready or visibly incomplete
+```
+
+The contract is implemented in
+`src/orchestration/notification_activation_checklist.py`.
+
+## Required controls
+
+The checklist requires an exact boolean decision for each of these controls:
+
+- recipient ownership has been signed off;
+- the destination review is active;
+- endpoint environment-variable identity is confirmed;
+- the event allow-list is confirmed;
+- receiver-side idempotency is confirmed;
+- rollback has been tested;
+- ambiguous-outcome handling is documented; and
+- credentials remain outside the repository.
+
+A checklist may be retained while incomplete, but `activation_ready` is true only
+when every required control is true. Missing, unknown or non-boolean controls fail
+closed.
+
+## Deterministic evidence
+
+The checklist identity binds:
+
+- destination ID and fingerprint;
+- destination authority ID;
+- canonical reviewer identities;
+- review and expiry timestamps; and
+- every control decision.
+
+Changing any review decision creates a different checklist ID. Duplicate reviewers,
+empty reviewer sets, naive timestamps and non-positive review windows are rejected.
+
+## Safety boundary
+
+The checklist records no endpoint URL, endpoint value, credential, payload body,
+response body, database DSN or environment value. Building or validating it performs
+no network request, notification delivery, attempt write, acknowledgement, cloud
+schedule activation, infrastructure deployment or `terraform apply`.
+
+Committed notification destination activation, webhook delivery and governed retry
+execution remain disabled. A later PR can consume this review package in a controlled,
+no-network receiver rehearsal without weakening the existing delivery gates.

--- a/src/orchestration/notification_activation_checklist.py
+++ b/src/orchestration/notification_activation_checklist.py
@@ -1,0 +1,182 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from collections.abc import Mapping, Sequence
+from datetime import datetime, timezone
+from typing import Any
+
+from src.common.exceptions import ValidationError
+
+MODEL_VERSION = "portfolio-risk-notification-activation-checklist-v1"
+SAFE_TEXT = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,511}$")
+MAX_REVIEWERS = 16
+CONTROL_NAMES = (
+    "ambiguous_outcome_runbook_confirmed",
+    "credentials_external_to_repository",
+    "destination_review_active",
+    "endpoint_environment_identity_confirmed",
+    "event_allow_list_confirmed",
+    "receiver_idempotency_confirmed",
+    "recipient_ownership_signed_off",
+    "rollback_tested",
+)
+
+
+def _safe_text(value: Any, label: str) -> str:
+    if not isinstance(value, str) or not SAFE_TEXT.fullmatch(value):
+        raise ValidationError(f"{label} must be one safe text segment")
+    return value
+
+
+def _aware_utc(value: datetime | str, label: str) -> datetime:
+    if isinstance(value, datetime):
+        parsed = value
+    elif isinstance(value, str):
+        try:
+            parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        except ValueError:
+            raise ValidationError(f"{label} must be ISO-8601") from None
+    else:  # pragma: no cover - retained for runtime callers without typing.
+        raise ValidationError(f"{label} must be timezone-aware")
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise ValidationError(f"{label} must be timezone-aware")
+    return parsed.astimezone(timezone.utc)
+
+
+def _reviewers(values: Sequence[str]) -> list[str]:
+    if isinstance(values, (str, bytes)):
+        raise ValidationError("reviewed_by must be an array of reviewer identities")
+    parsed = [_safe_text(value, "reviewed_by item") for value in values]
+    if not parsed or len(parsed) > MAX_REVIEWERS:
+        raise ValidationError(
+            f"reviewed_by must contain between 1 and {MAX_REVIEWERS} reviewers"
+        )
+    if len(parsed) != len(set(parsed)):
+        raise ValidationError("reviewed_by must contain no duplicates")
+    return sorted(parsed)
+
+
+def _controls(values: Mapping[str, Any]) -> dict[str, bool]:
+    if not isinstance(values, Mapping):
+        raise ValidationError("activation controls must be a mapping")
+    expected = set(CONTROL_NAMES)
+    actual = set(values)
+    if actual != expected:
+        raise ValidationError(
+            "activation control fields are invalid; "
+            f"missing={sorted(expected - actual)}, "
+            f"unknown={sorted(actual - expected)}"
+        )
+    parsed: dict[str, bool] = {}
+    for name in CONTROL_NAMES:
+        value = values[name]
+        if type(value) is not bool:
+            raise ValidationError(f"activation control {name} must be boolean")
+        parsed[name] = value
+    return parsed
+
+
+def canonical_activation_checklist_bytes(
+    checklist: Mapping[str, Any],
+) -> bytes:
+    try:
+        return json.dumps(
+            checklist,
+            sort_keys=True,
+            separators=(",", ":"),
+            allow_nan=False,
+        ).encode("utf-8")
+    except (TypeError, ValueError):
+        raise ValidationError("activation checklist is not canonical JSON") from None
+
+
+def _checklist_id(identity: Mapping[str, Any]) -> str:
+    digest = hashlib.sha256(canonical_activation_checklist_bytes(identity)).hexdigest()
+    return f"{MODEL_VERSION}-checklist-{digest[:24]}"
+
+
+def build_notification_activation_checklist(
+    *,
+    destination_id: str,
+    destination_fingerprint: str,
+    authority_id: str,
+    reviewed_by: Sequence[str],
+    reviewed_at: datetime | str,
+    review_expires_at: datetime | str,
+    controls: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Build one deterministic, secret-free notification activation review."""
+
+    reviewed = _aware_utc(reviewed_at, "reviewed_at")
+    expires = _aware_utc(review_expires_at, "review_expires_at")
+    if expires <= reviewed:
+        raise ValidationError("review_expires_at must be after reviewed_at")
+    parsed_controls = _controls(controls)
+    identity = {
+        "authority_id": _safe_text(authority_id, "authority_id"),
+        "controls": parsed_controls,
+        "destination_fingerprint": _safe_text(
+            destination_fingerprint,
+            "destination_fingerprint",
+        ),
+        "destination_id": _safe_text(destination_id, "destination_id"),
+        "model_version": MODEL_VERSION,
+        "review_expires_at": expires.isoformat(),
+        "reviewed_at": reviewed.isoformat(),
+        "reviewed_by": _reviewers(reviewed_by),
+    }
+    return {
+        "checklist_id": _checklist_id(identity),
+        **identity,
+        "activation_ready": all(parsed_controls.values()),
+        "credential_recorded": False,
+        "endpoint_value_recorded": False,
+        "external_request_performed": False,
+        "infrastructure_deployed": False,
+    }
+
+
+def validate_notification_activation_checklist(
+    checklist: Mapping[str, Any],
+) -> dict[str, Any]:
+    if not isinstance(checklist, Mapping):
+        raise ValidationError("activation checklist must be a mapping")
+    expected = {
+        "activation_ready",
+        "authority_id",
+        "checklist_id",
+        "controls",
+        "credential_recorded",
+        "destination_fingerprint",
+        "destination_id",
+        "endpoint_value_recorded",
+        "external_request_performed",
+        "infrastructure_deployed",
+        "model_version",
+        "review_expires_at",
+        "reviewed_at",
+        "reviewed_by",
+    }
+    actual = set(checklist)
+    if actual != expected:
+        raise ValidationError(
+            "activation checklist fields are invalid; "
+            f"missing={sorted(expected - actual)}, "
+            f"unknown={sorted(actual - expected)}"
+        )
+    if checklist["model_version"] != MODEL_VERSION:
+        raise ValidationError("activation checklist model_version is unsupported")
+    rebuilt = build_notification_activation_checklist(
+        destination_id=checklist["destination_id"],
+        destination_fingerprint=checklist["destination_fingerprint"],
+        authority_id=checklist["authority_id"],
+        reviewed_by=checklist["reviewed_by"],
+        reviewed_at=checklist["reviewed_at"],
+        review_expires_at=checklist["review_expires_at"],
+        controls=checklist["controls"],
+    )
+    if dict(checklist) != rebuilt:
+        raise ValidationError("activation checklist is not canonical")
+    return rebuilt

--- a/tests/unit/test_notification_activation_checklist.py
+++ b/tests/unit/test_notification_activation_checklist.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from typing import Any
+
+import pytest
+
+from src.common.exceptions import ValidationError
+from src.orchestration.notification_activation_checklist import (
+    CONTROL_NAMES,
+    MODEL_VERSION,
+    build_notification_activation_checklist,
+    validate_notification_activation_checklist,
+)
+
+REVIEWED_AT = datetime(2026, 8, 27, 22, tzinfo=timezone.utc)
+EXPIRES_AT = datetime(2026, 9, 27, 22, tzinfo=timezone.utc)
+
+
+def _controls(**overrides: bool) -> dict[str, bool]:
+    values = {name: True for name in CONTROL_NAMES}
+    values.update(overrides)
+    return values
+
+
+def _build(**overrides: Any) -> dict[str, Any]:
+    parameters: dict[str, Any] = {
+        "destination_id": "risk-operations-webhook",
+        "destination_fingerprint": "destination-fingerprint-v1",
+        "authority_id": "destination-authority-v1",
+        "reviewed_by": ["reviewer-b", "reviewer-a"],
+        "reviewed_at": REVIEWED_AT,
+        "review_expires_at": EXPIRES_AT,
+        "controls": _controls(),
+    }
+    parameters.update(overrides)
+    return build_notification_activation_checklist(**parameters)
+
+
+def test_ready_checklist_is_deterministic_canonical_and_secret_free() -> None:
+    first = _build()
+    second = _build(reviewed_by=["reviewer-a", "reviewer-b"])
+
+    assert first == second
+    assert first["model_version"] == MODEL_VERSION
+    assert first["activation_ready"] is True
+    assert first["reviewed_by"] == ["reviewer-a", "reviewer-b"]
+    assert validate_notification_activation_checklist(first) == first
+    assert first["credential_recorded"] is False
+    assert first["endpoint_value_recorded"] is False
+    assert first["external_request_performed"] is False
+    assert first["infrastructure_deployed"] is False
+
+    rendered = json.dumps(first, sort_keys=True)
+    assert "https://" not in rendered
+    assert "postgresql://" not in rendered
+    assert "secret" not in rendered.casefold()
+
+
+def test_incomplete_control_is_visible_and_changes_identity() -> None:
+    ready = _build()
+    incomplete = _build(
+        controls=_controls(receiver_idempotency_confirmed=False),
+    )
+
+    assert incomplete["activation_ready"] is False
+    assert incomplete["controls"]["receiver_idempotency_confirmed"] is False
+    assert incomplete["checklist_id"] != ready["checklist_id"]
+    assert validate_notification_activation_checklist(incomplete) == incomplete
+
+
+def test_control_and_reviewer_contracts_fail_closed() -> None:
+    missing = _controls()
+    missing.pop("rollback_tested")
+    with pytest.raises(ValidationError, match="missing"):
+        _build(controls=missing)
+
+    unknown = _controls()
+    unknown["unreviewed_control"] = True
+    with pytest.raises(ValidationError, match="unknown"):
+        _build(controls=unknown)
+
+    invalid_type: dict[str, Any] = _controls()
+    invalid_type["rollback_tested"] = "yes"
+    with pytest.raises(ValidationError, match="must be boolean"):
+        _build(controls=invalid_type)
+
+    with pytest.raises(ValidationError, match="no duplicates"):
+        _build(reviewed_by=["reviewer-a", "reviewer-a"])
+
+    with pytest.raises(ValidationError, match="between 1"):
+        _build(reviewed_by=[])
+
+
+def test_time_and_canonical_evidence_fail_closed() -> None:
+    with pytest.raises(ValidationError, match="timezone-aware"):
+        _build(reviewed_at=datetime(2026, 8, 27, 22))
+
+    with pytest.raises(ValidationError, match="after reviewed_at"):
+        _build(review_expires_at=REVIEWED_AT)
+
+    checklist = _build()
+    tampered = dict(checklist)
+    tampered["activation_ready"] = False
+    with pytest.raises(ValidationError, match="not canonical"):
+        validate_notification_activation_checklist(tampered)
+
+    unknown = dict(checklist)
+    unknown["endpoint_url"] = "https://example.test/secret"
+    with pytest.raises(ValidationError, match="unknown"):
+        validate_notification_activation_checklist(unknown)


### PR DESCRIPTION
## Goal

Begin **P4d4 — reviewed activation package and controlled receiver test** with one independently reviewable, no-network activation-checklist contract.

```text
reviewed destination authority
  + accountable reviewers
  + exact activation controls
  + bounded review lifetime
  -> canonical activation checklist
  -> ready or visibly incomplete
```

## Contract

Adds a deterministic `portfolio-risk-notification-activation-checklist-v1` document binding:

- destination ID, fingerprint and authority ID;
- canonical reviewer identities;
- review and expiry timestamps; and
- exact decisions for ownership, active review, endpoint identity, event allow-list, receiver idempotency, rollback, ambiguous-outcome handling and external credential storage.

`activation_ready` is true only when every exact required control is true. Missing, unknown or non-boolean controls, duplicate reviewers, naive timestamps and invalid review windows fail closed.

## Scope

Three additive files: implementation, focused tests and documentation. No existing gate or validation is weakened.

## Safety boundary

The checklist records no endpoint URL, endpoint value, credential, payload, response body, DSN or environment value. It performs no network request, notification delivery, attempt write, acknowledgement, scheduling, deployment or `terraform apply`. Committed destination activation, webhook delivery and retry execution remain disabled.

Fresh exact-head CI is required before squash merge.