### PR TITLE
Add controlled notification receiver rehearsal

### DIFF
--- a/docs/controlled-notification-receiver.md
+++ b/docs/controlled-notification-receiver.md
@@ -1,0 +1,84 @@
+# Controlled Notification Receiver Rehearsal
+
+Primary arc42 block: `orchestration`.
+
+## Goal
+
+Exercise the existing webhook transport boundary against a deterministic in-memory
+receiver before any external endpoint is activated:
+
+```text
+activation-ready checklist
+  + approved HTTPS host
+  + reviewed event allow-list
+  + canonical webhook request
+  + stable Idempotency-Key
+  -> controlled receiver validation
+  -> same-content duplicate handling
+  -> credential-free receipt evidence
+```
+
+The implementation is
+`src/orchestration/controlled_notification_receiver.py`. Instances are callable with
+the same endpoint, payload, headers and timeout arguments used by the existing
+notification delivery transport.
+
+## Receiver controls
+
+Construction requires a canonical activation checklist whose `activation_ready`
+state is true. The receiver also requires explicit approved hosts and event types,
+a bounded request count, a bounded payload size and a successful simulated HTTP
+status.
+
+Every request must satisfy all of the following before it is accepted:
+
+- the endpoint is HTTPS and contains no username, password or fragment;
+- the endpoint host is in the explicit controlled-host allow-list;
+- headers are exactly `Content-Type`, `Idempotency-Key` and `User-Agent`;
+- the content type is `application/json`;
+- the timeout is positive and no greater than 30 seconds;
+- the payload is canonical UTF-8 JSON and within 64 KiB;
+- the payload contains a safe event ID and reviewed event type; and
+- the `Idempotency-Key` equals the payload event ID.
+
+Unknown headers fail closed. This deliberately prevents an ordinary rehearsal from
+silently carrying an authorization token, cookie or other unreviewed request data.
+
+## Receiver-side idempotency
+
+The receiver retains only the SHA-256 associated with each accepted
+`Idempotency-Key`:
+
+```text
+same key + same payload SHA-256      -> accepted duplicate
+same key + different payload SHA-256 -> rejected conflict
+```
+
+This demonstrates the receiver control required for the distributed failure window
+where a remote request may have succeeded before local delivery-attempt persistence
+was confirmed.
+
+## Receipt evidence
+
+Each accepted request records:
+
+- request ordinal and controlled receive timestamp;
+- endpoint host, never path, query or full URL;
+- event ID and event type;
+- idempotency key;
+- payload SHA-256;
+- simulated HTTP status; and
+- whether it was a same-content duplicate.
+
+The summary derives a deterministic rehearsal ID from the activation checklist,
+receiver contract and receipts. It explicitly states that no payload body, response
+body, endpoint path, external request, socket, DNS lookup, delivery-attempt write,
+outbox mutation, acknowledgement, infrastructure deployment or `terraform apply`
+occurred.
+
+## Activation boundary
+
+This is executable local evidence, not authority to contact an external receiver.
+Committed destination activation, webhook delivery and governed retries remain
+disabled. A later increment may persist rehearsal results and expose reviewer-facing
+readiness views while keeping ordinary CI no-network.

--- a/src/orchestration/controlled_notification_receiver.py
+++ b/src/orchestration/controlled_notification_receiver.py
@@ -1,0 +1,325 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from collections.abc import Callable, Mapping, Sequence
+from datetime import datetime, timezone
+from typing import Any
+from urllib.parse import urlparse
+
+from src.common.exceptions import ValidationError
+from src.orchestration.notification_activation_checklist import (
+    validate_notification_activation_checklist,
+)
+
+MODEL_VERSION = "portfolio-risk-controlled-notification-receiver-v1"
+SAFE_TEXT = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,511}$")
+SAFE_EVENT_TYPE = re.compile(r"^[a-z][a-z0-9_]{0,63}$")
+SAFE_HOST = re.compile(r"^[a-z0-9][a-z0-9.-]{0,252}$")
+MAX_HOSTS = 16
+MAX_EVENT_TYPES = 64
+MAX_PAYLOAD_BYTES = 65_536
+MAX_REQUESTS = 100
+MAX_TIMEOUT_SECONDS = 30.0
+Clock = Callable[[], datetime]
+
+
+def _safe_text(value: Any, label: str) -> str:
+    if not isinstance(value, str) or not SAFE_TEXT.fullmatch(value):
+        raise ValidationError(f"{label} must be one safe text segment")
+    return value
+
+
+def _aware_utc(value: Any, label: str) -> datetime:
+    if not isinstance(value, datetime):
+        raise ValidationError(f"{label} must be timezone-aware")
+    if value.tzinfo is None or value.utcoffset() is None:
+        raise ValidationError(f"{label} must be timezone-aware")
+    return value.astimezone(timezone.utc)
+
+
+def _hosts(values: Sequence[str]) -> list[str]:
+    if isinstance(values, (str, bytes)):
+        raise ValidationError("allowed_hosts must be an array")
+    parsed: list[str] = []
+    for value in values:
+        if not isinstance(value, str):
+            raise ValidationError("allowed_hosts contains an invalid host")
+        host = value.strip().casefold()
+        if (
+            not SAFE_HOST.fullmatch(host)
+            or ".." in host
+            or host.endswith(".")
+        ):
+            raise ValidationError("allowed_hosts contains an invalid host")
+        parsed.append(host)
+    if not parsed or len(parsed) > MAX_HOSTS:
+        raise ValidationError(
+            f"allowed_hosts must contain between 1 and {MAX_HOSTS} hosts"
+        )
+    if len(parsed) != len(set(parsed)):
+        raise ValidationError("allowed_hosts must contain no duplicates")
+    return sorted(parsed)
+
+
+def _event_types(values: Sequence[str]) -> list[str]:
+    if isinstance(values, (str, bytes)):
+        raise ValidationError("allowed_event_types must be an array")
+    parsed: list[str] = []
+    for value in values:
+        if not isinstance(value, str) or not SAFE_EVENT_TYPE.fullmatch(value):
+            raise ValidationError(
+                "allowed_event_types contains an invalid event type"
+            )
+        parsed.append(value)
+    if not parsed or len(parsed) > MAX_EVENT_TYPES:
+        raise ValidationError(
+            "allowed_event_types must contain between 1 and "
+            f"{MAX_EVENT_TYPES} event types"
+        )
+    if len(parsed) != len(set(parsed)):
+        raise ValidationError("allowed_event_types must contain no duplicates")
+    return sorted(parsed)
+
+
+def _positive_integer(value: Any, label: str, maximum: int) -> int:
+    if type(value) is not int or not 1 <= value <= maximum:
+        raise ValidationError(
+            f"{label} must be an integer between 1 and {maximum}"
+        )
+    return value
+
+
+def _response_status(value: Any) -> int:
+    if type(value) is not int or not 200 <= value <= 299:
+        raise ValidationError("response_status must be a successful HTTP status")
+    return value
+
+
+def _endpoint_host(endpoint: Any, allowed_hosts: Sequence[str]) -> str:
+    if not isinstance(endpoint, str) or not endpoint:
+        raise ValidationError("controlled receiver endpoint must be non-empty text")
+    parsed = urlparse(endpoint)
+    if (
+        parsed.scheme != "https"
+        or parsed.hostname is None
+        or parsed.username is not None
+        or parsed.password is not None
+        or parsed.fragment
+    ):
+        raise ValidationError(
+            "controlled receiver endpoint must be HTTPS without credentials "
+            "or fragment"
+        )
+    host = parsed.hostname.casefold()
+    if host not in allowed_hosts:
+        raise ValidationError("controlled receiver endpoint host is not approved")
+    return host
+
+
+def _headers(values: Mapping[str, str]) -> dict[str, str]:
+    if not isinstance(values, Mapping):
+        raise ValidationError("controlled receiver headers must be a mapping")
+    parsed: dict[str, str] = {}
+    for key, value in values.items():
+        if not isinstance(key, str) or not isinstance(value, str):
+            raise ValidationError("controlled receiver headers are invalid")
+        normalized = key.strip().casefold()
+        if normalized in parsed:
+            raise ValidationError("controlled receiver headers contain duplicates")
+        parsed[normalized] = value.strip()
+    expected = {"content-type", "idempotency-key", "user-agent"}
+    if set(parsed) != expected:
+        raise ValidationError(
+            "controlled receiver header fields are invalid; "
+            f"missing={sorted(expected - set(parsed))}, "
+            f"unknown={sorted(set(parsed) - expected)}"
+        )
+    if parsed["content-type"].casefold() != "application/json":
+        raise ValidationError("controlled receiver Content-Type is unsupported")
+    _safe_text(parsed["idempotency-key"], "Idempotency-Key")
+    if not parsed["user-agent"]:
+        raise ValidationError("controlled receiver User-Agent must be non-empty")
+    return parsed
+
+
+def _payload(
+    value: Any,
+    *,
+    max_payload_bytes: int,
+) -> tuple[dict[str, Any], str]:
+    if not isinstance(value, bytes) or not value:
+        raise ValidationError("controlled receiver payload must be non-empty bytes")
+    if len(value) > max_payload_bytes:
+        raise ValidationError("controlled receiver payload exceeds the byte limit")
+    try:
+        decoded = value.decode("utf-8")
+        document = json.loads(decoded)
+    except (UnicodeError, ValueError):
+        raise ValidationError("controlled receiver payload is invalid JSON") from None
+    if not isinstance(document, Mapping):
+        raise ValidationError("controlled receiver payload must be a JSON object")
+    try:
+        canonical = json.dumps(
+            dict(document),
+            sort_keys=True,
+            separators=(",", ":"),
+            allow_nan=False,
+        ).encode("utf-8")
+    except (TypeError, ValueError):
+        raise ValidationError(
+            "controlled receiver payload is not canonical JSON"
+        ) from None
+    if canonical != value:
+        raise ValidationError("controlled receiver payload must be canonical JSON")
+    return dict(document), hashlib.sha256(value).hexdigest()
+
+
+def _rehearsal_id(identity: Mapping[str, Any]) -> str:
+    digest = hashlib.sha256(
+        json.dumps(
+            identity,
+            sort_keys=True,
+            separators=(",", ":"),
+            allow_nan=False,
+        ).encode("utf-8")
+    ).hexdigest()
+    return f"{MODEL_VERSION}-rehearsal-{digest[:24]}"
+
+
+class ControlledNotificationReceiver:
+    """In-memory webhook transport with receiver-side idempotency evidence."""
+
+    def __init__(
+        self,
+        *,
+        activation_checklist: Mapping[str, Any],
+        allowed_hosts: Sequence[str],
+        allowed_event_types: Sequence[str],
+        response_status: int = 204,
+        max_requests: int = MAX_REQUESTS,
+        max_payload_bytes: int = MAX_PAYLOAD_BYTES,
+        clock: Clock | None = None,
+    ) -> None:
+        checklist = validate_notification_activation_checklist(
+            activation_checklist
+        )
+        if checklist["activation_ready"] is not True:
+            raise ValidationError(
+                "controlled receiver requires an activation-ready checklist"
+            )
+        self._checklist = checklist
+        self._allowed_hosts = _hosts(allowed_hosts)
+        self._allowed_event_types = _event_types(allowed_event_types)
+        self._response_status = _response_status(response_status)
+        self._max_requests = _positive_integer(
+            max_requests,
+            "max_requests",
+            MAX_REQUESTS,
+        )
+        self._max_payload_bytes = _positive_integer(
+            max_payload_bytes,
+            "max_payload_bytes",
+            MAX_PAYLOAD_BYTES,
+        )
+        self._clock = clock or (lambda: datetime.now(timezone.utc))
+        self._seen_payloads: dict[str, str] = {}
+        self._receipts: list[dict[str, Any]] = []
+
+    def __call__(
+        self,
+        endpoint: str,
+        payload: bytes,
+        headers: Mapping[str, str],
+        timeout_seconds: float,
+    ) -> int:
+        if len(self._receipts) >= self._max_requests:
+            raise ValidationError(
+                "controlled receiver request limit has been reached"
+            )
+        if (
+            isinstance(timeout_seconds, bool)
+            or not isinstance(timeout_seconds, (int, float))
+            or not 0 < float(timeout_seconds) <= MAX_TIMEOUT_SECONDS
+        ):
+            raise ValidationError("controlled receiver timeout is invalid")
+
+        host = _endpoint_host(endpoint, self._allowed_hosts)
+        parsed_headers = _headers(headers)
+        document, payload_sha256 = _payload(
+            payload,
+            max_payload_bytes=self._max_payload_bytes,
+        )
+        event_id = _safe_text(document.get("event_id"), "payload event_id")
+        event_type_value = document.get("event_type")
+        if (
+            not isinstance(event_type_value, str)
+            or not SAFE_EVENT_TYPE.fullmatch(event_type_value)
+        ):
+            raise ValidationError("payload event_type is invalid")
+        if event_type_value not in self._allowed_event_types:
+            raise ValidationError("payload event_type is not approved")
+        idempotency_key = parsed_headers["idempotency-key"]
+        if idempotency_key != event_id:
+            raise ValidationError(
+                "Idempotency-Key must equal the payload event_id"
+            )
+
+        previous_sha256 = self._seen_payloads.get(idempotency_key)
+        duplicate = previous_sha256 is not None
+        if duplicate and previous_sha256 != payload_sha256:
+            raise ValidationError(
+                "Idempotency-Key was reused with a different payload"
+            )
+        self._seen_payloads.setdefault(idempotency_key, payload_sha256)
+        received_at = _aware_utc(self._clock(), "received_at")
+        self._receipts.append(
+            {
+                "endpoint_host": host,
+                "event_id": event_id,
+                "event_type": event_type_value,
+                "http_status": self._response_status,
+                "idempotency_key": idempotency_key,
+                "payload_sha256": payload_sha256,
+                "received_at": received_at.isoformat(),
+                "request_ordinal": len(self._receipts) + 1,
+                "same_content_duplicate": duplicate,
+            }
+        )
+        return self._response_status
+
+    def summary(self) -> dict[str, Any]:
+        receipts = [dict(receipt) for receipt in self._receipts]
+        identity = {
+            "activation_checklist_id": self._checklist["checklist_id"],
+            "allowed_event_types": list(self._allowed_event_types),
+            "allowed_hosts": list(self._allowed_hosts),
+            "authority_id": self._checklist["authority_id"],
+            "destination_fingerprint": self._checklist[
+                "destination_fingerprint"
+            ],
+            "destination_id": self._checklist["destination_id"],
+            "model_version": MODEL_VERSION,
+            "receipts": receipts,
+            "response_status": self._response_status,
+        }
+        return {
+            "rehearsal_id": _rehearsal_id(identity),
+            **identity,
+            "request_count": len(receipts),
+            "same_content_duplicate_count": sum(
+                receipt["same_content_duplicate"] for receipt in receipts
+            ),
+            "unique_idempotency_keys": len(self._seen_payloads),
+            "acknowledgement_mutated": False,
+            "delivery_attempt_written": False,
+            "dns_lookup_performed": False,
+            "endpoint_paths_recorded": False,
+            "external_request_performed": False,
+            "infrastructure_deployed": False,
+            "outbox_mutated": False,
+            "payload_bodies_recorded": False,
+            "response_bodies_recorded": False,
+            "socket_opened": False,
+        }

--- a/tests/unit/test_controlled_notification_receiver.py
+++ b/tests/unit/test_controlled_notification_receiver.py
@@ -1,0 +1,201 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+import pytest
+
+from src.common.exceptions import ValidationError
+from src.orchestration.controlled_notification_receiver import (
+    MODEL_VERSION,
+    ControlledNotificationReceiver,
+)
+from src.orchestration.notification_activation_checklist import (
+    CONTROL_NAMES,
+    build_notification_activation_checklist,
+)
+
+REVIEWED_AT = datetime(2026, 8, 27, 22, tzinfo=timezone.utc)
+EXPIRES_AT = REVIEWED_AT + timedelta(days=30)
+RECEIVED_AT = REVIEWED_AT + timedelta(minutes=5)
+ENDPOINT = "https://receiver.test/risk?mode=controlled"
+
+
+def _controls(**overrides: bool) -> dict[str, bool]:
+    controls = {name: True for name in CONTROL_NAMES}
+    controls.update(overrides)
+    return controls
+
+
+def _checklist(**overrides: Any) -> dict[str, Any]:
+    parameters: dict[str, Any] = {
+        "destination_id": "risk-operations-webhook",
+        "destination_fingerprint": "destination-fingerprint-v1",
+        "authority_id": "destination-authority-v1",
+        "reviewed_by": ["risk-reviewer", "receiver-owner"],
+        "reviewed_at": REVIEWED_AT,
+        "review_expires_at": EXPIRES_AT,
+        "controls": _controls(),
+    }
+    parameters.update(overrides)
+    return build_notification_activation_checklist(**parameters)
+
+
+def _payload(
+    event_id: str = "event-1",
+    *,
+    event_type: str = "breach_opened",
+    severity: str = "critical",
+) -> bytes:
+    document = {
+        "event_id": event_id,
+        "event_type": event_type,
+        "metric_name": "portfolio_volatility_annualized",
+        "payload": {"severity": severity},
+        "policy_id": "us-tech-standard",
+        "portfolio_id": "us-tech-equal",
+        "status": severity,
+        "subject_key": "us-tech-equal",
+        "ts_event": "2026-08-27T22:00:00+00:00",
+    }
+    return json.dumps(
+        document,
+        sort_keys=True,
+        separators=(",", ":"),
+        allow_nan=False,
+    ).encode("utf-8")
+
+
+def _headers(event_id: str = "event-1") -> dict[str, str]:
+    return {
+        "Content-Type": "application/json",
+        "Idempotency-Key": event_id,
+        "User-Agent": "financial-risk-data-platform/1",
+    }
+
+
+def _clock(*values: datetime):
+    iterator = iter(values)
+    return lambda: next(iterator)
+
+
+def _receiver(**overrides: Any) -> ControlledNotificationReceiver:
+    parameters: dict[str, Any] = {
+        "activation_checklist": _checklist(),
+        "allowed_hosts": ["receiver.test"],
+        "allowed_event_types": ["breach_opened", "breach_resolved"],
+        "clock": _clock(RECEIVED_AT, RECEIVED_AT + timedelta(seconds=1)),
+    }
+    parameters.update(overrides)
+    return ControlledNotificationReceiver(**parameters)
+
+
+def test_receiver_accepts_same_content_duplicate_without_network() -> None:
+    receiver = _receiver()
+    payload = _payload()
+
+    assert receiver(ENDPOINT, payload, _headers(), 5.0) == 204
+    assert receiver(ENDPOINT, payload, _headers(), 5.0) == 204
+
+    summary = receiver.summary()
+    assert summary["model_version"] == MODEL_VERSION
+    assert summary["request_count"] == 2
+    assert summary["unique_idempotency_keys"] == 1
+    assert summary["same_content_duplicate_count"] == 1
+    assert summary["receipts"][0]["same_content_duplicate"] is False
+    assert summary["receipts"][1]["same_content_duplicate"] is True
+    assert summary["external_request_performed"] is False
+    assert summary["socket_opened"] is False
+    assert summary["dns_lookup_performed"] is False
+    assert summary["delivery_attempt_written"] is False
+
+    rendered = json.dumps(summary, sort_keys=True)
+    assert "https://" not in rendered
+    assert "/risk" not in rendered
+    assert '"severity"' not in rendered
+    assert "postgresql://" not in rendered
+
+
+def test_receiver_summary_is_deterministic_for_exact_evidence() -> None:
+    first = _receiver()
+    second = _receiver()
+    for receiver in (first, second):
+        receiver(ENDPOINT, _payload(), _headers(), 5.0)
+        receiver(ENDPOINT, _payload(), _headers(), 5.0)
+
+    assert first.summary() == second.summary()
+
+
+def test_idempotency_key_reuse_with_changed_payload_fails_closed() -> None:
+    receiver = _receiver()
+    receiver(ENDPOINT, _payload(), _headers(), 5.0)
+
+    with pytest.raises(ValidationError, match="different payload"):
+        receiver(
+            ENDPOINT,
+            _payload(severity="warning"),
+            _headers(),
+            5.0,
+        )
+
+    assert receiver.summary()["request_count"] == 1
+
+
+def test_checklist_endpoint_and_header_controls_fail_closed() -> None:
+    incomplete = _checklist(
+        controls=_controls(receiver_idempotency_confirmed=False),
+    )
+    with pytest.raises(ValidationError, match="activation-ready"):
+        _receiver(activation_checklist=incomplete)
+
+    receiver = _receiver()
+    with pytest.raises(ValidationError, match="must be HTTPS"):
+        receiver("http://receiver.test/risk", _payload(), _headers(), 5.0)
+    with pytest.raises(ValidationError, match="not approved"):
+        receiver("https://other.test/risk", _payload(), _headers(), 5.0)
+    with pytest.raises(ValidationError, match="credentials"):
+        receiver(
+            "https://user:password@receiver.test/risk",
+            _payload(),
+            _headers(),
+            5.0,
+        )
+
+    secret_headers = _headers()
+    secret_headers["Authorization"] = "Bearer must-not-be-accepted"
+    with pytest.raises(ValidationError, match="unknown"):
+        receiver(ENDPOINT, _payload(), secret_headers, 5.0)
+
+
+def test_payload_event_and_bound_controls_fail_closed() -> None:
+    receiver = _receiver()
+    noncanonical = json.dumps(json.loads(_payload()), indent=2).encode("utf-8")
+    with pytest.raises(ValidationError, match="canonical JSON"):
+        receiver(ENDPOINT, noncanonical, _headers(), 5.0)
+
+    with pytest.raises(ValidationError, match="not approved"):
+        receiver(
+            ENDPOINT,
+            _payload(event_type="unreviewed_event"),
+            _headers(),
+            5.0,
+        )
+
+    with pytest.raises(ValidationError, match="must equal"):
+        receiver(ENDPOINT, _payload(), _headers("another-event"), 5.0)
+
+    one_request = _receiver(
+        max_requests=1,
+        clock=_clock(RECEIVED_AT),
+    )
+    one_request(ENDPOINT, _payload(), _headers(), 5.0)
+    with pytest.raises(ValidationError, match="request limit"):
+        one_request(ENDPOINT, _payload(), _headers(), 5.0)
+
+    small_payload = _receiver(max_payload_bytes=8)
+    with pytest.raises(ValidationError, match="byte limit"):
+        small_payload(ENDPOINT, _payload(), _headers(), 5.0)
+
+    with pytest.raises(ValidationError, match="timeout"):
+        receiver(ENDPOINT, _payload(), _headers(), 31.0)

--- a/tests/unit/test_controlled_notification_receiver_architecture_contract.py
+++ b/tests/unit/test_controlled_notification_receiver_architecture_contract.py
@@ -1,0 +1,56 @@
+from pathlib import Path
+
+
+def test_controlled_receiver_is_no_network_bounded_and_documented() -> None:
+    source = Path(
+        "src/orchestration/controlled_notification_receiver.py"
+    ).read_text(encoding="utf-8")
+    tests = Path(
+        "tests/unit/test_controlled_notification_receiver.py"
+    ).read_text(encoding="utf-8")
+    docs = Path("docs/controlled-notification-receiver.md").read_text(
+        encoding="utf-8"
+    )
+    normalized_docs = " ".join(docs.split()).casefold()
+
+    for required in (
+        "ControlledNotificationReceiver",
+        "validate_notification_activation_checklist",
+        "Idempotency-Key must equal the payload event_id",
+        "Idempotency-Key was reused with a different payload",
+        "MAX_PAYLOAD_BYTES = 65_536",
+        "MAX_REQUESTS = 100",
+        "MAX_TIMEOUT_SECONDS = 30.0",
+        '"external_request_performed": False',
+        '"socket_opened": False',
+        '"dns_lookup_performed": False',
+        '"delivery_attempt_written": False',
+    ):
+        assert required in source
+
+    for forbidden in (
+        "urllib.request",
+        "requests.",
+        "httpx.",
+        "socket.create_connection",
+        "asyncio.open_connection",
+    ):
+        assert forbidden not in source.casefold()
+
+    for required in (
+        "same-content duplicate",
+        "same key + different payload sha-256",
+        "headers are exactly",
+        "no payload body",
+        "ordinary ci no-network",
+        "terraform apply",
+    ):
+        assert required in normalized_docs
+
+    for required in (
+        "test_receiver_accepts_same_content_duplicate_without_network",
+        "test_idempotency_key_reuse_with_changed_payload_fails_closed",
+        "test_checklist_endpoint_and_header_controls_fail_closed",
+        "test_payload_event_and_bound_controls_fail_closed",
+    ):
+        assert required in tests


### PR DESCRIPTION
## Goal

Continue **P4d4 — reviewed activation package and controlled receiver test** with an executable, transport-compatible receiver rehearsal that performs no network activity.

```text
activation-ready checklist
  + approved HTTPS host
  + reviewed event allow-list
  + canonical webhook request
  + stable Idempotency-Key
  -> controlled receiver validation
  -> same-content duplicate handling
  -> credential-free receipt evidence
```

## Receiver contract

Adds `ControlledNotificationReceiver`, a callable matching the existing webhook transport boundary. It validates:

- an activation-ready checklist from PR #122;
- explicit controlled HTTPS hosts without credentials or fragments;
- an exact reviewed event allow-list;
- exactly `Content-Type`, `Idempotency-Key` and `User-Agent` headers;
- canonical UTF-8 JSON bounded to 64 KiB;
- a positive timeout no greater than 30 seconds;
- a safe event ID and approved event type; and
- `Idempotency-Key == payload.event_id`.

Unknown headers fail closed, preventing the rehearsal from silently carrying authorization tokens, cookies or other unreviewed data.

## Idempotency evidence

The in-memory receiver demonstrates the distributed-outcome control required by webhook delivery:

```text
same key + same payload SHA-256       -> accepted duplicate
same key + different payload SHA-256  -> rejected conflict
```

Receipts retain only controlled timestamps, host, event identity, idempotency key, payload SHA-256, simulated status and duplicate classification. Endpoint paths, query strings, payload bodies and response bodies are not retained.

## Scope

Four additive files, 666 additions, zero deletions. The branch is four commits ahead and zero behind `main`; squash merge will retain one coherent orchestration increment.

## Exact-head validation

GitHub Actions run **364** (`33126069289`) passed on head `62445bb015971118272135acde8742e0874a3354`:

- Security guardrails passed.
- Ruff passed.
- mypy passed across **125 source files**.
- **845 tests passed** in quality and **845 passed again** in readiness.
- Dependency integrity and the standard replay demonstration passed.
- PostgreSQL 16 schema and contract validation passed.
- Kubernetes rendering and Terraform format/init/validate passed without apply.

## Safety boundary

The implementation imports no network client and opens no socket. It performed no DNS lookup, external request, delivery-attempt write, outbox mutation, acknowledgement, scheduling, deployment or `terraform apply`. Committed destination activation, webhook delivery and governed retries remain disabled.

## Acceptance boundary

Validated and ready for squash merge. The next dependency-safe increment can persist controlled-receiver rehearsal evidence and expose current reviewer-facing readiness without enabling external delivery.