### PR TITLE
Persist append-only controlled receiver rehearsal history

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -265,6 +265,8 @@ postgres-contract-check:
 		--check sql/portfolio_risk_limits_consistency_checks.sql
 	$(PYTHON) -m src.warehouse.notification_retry_follow_up_postgres_contract_check \
 		--dsn "$(LOCAL_POSTGRES_DSN)"
+	$(PYTHON) -m src.warehouse.controlled_receiver_rehearsal_postgres_contract_check \
+		--dsn "$(LOCAL_POSTGRES_DSN)"
 
 local-db-up:
 	docker compose up -d postgres mongo

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,6 +30,7 @@ services:
       - ./sql/portfolio_risk_notification_retry_destination_binding_schema.sql:/docker-entrypoint-initdb.d/19b_portfolio_risk_notification_retry_destination_binding_schema.sql:ro
       - ./sql/portfolio_risk_notification_retry_follow_up_schema.sql:/docker-entrypoint-initdb.d/20_portfolio_risk_notification_retry_follow_up_schema.sql:ro
       - ./sql/portfolio_risk_notification_retry_destination_follow_up_schema.sql:/docker-entrypoint-initdb.d/21_portfolio_risk_notification_retry_destination_follow_up_schema.sql:ro
+      - ./sql/controlled_notification_receiver_rehearsal_schema.sql:/docker-entrypoint-initdb.d/22_controlled_notification_receiver_rehearsal_schema.sql:ro
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U risk_user -d risk_platform"]
       interval: 5s

--- a/docs/controlled-notification-receiver-rehearsal-history.md
+++ b/docs/controlled-notification-receiver-rehearsal-history.md
@@ -1,0 +1,98 @@
+# Append-Only Controlled Receiver Rehearsal History
+
+Primary arc42 blocks: `orchestration` and `warehouse`.
+
+## Goal
+
+Retain the outcome of each controlled receiver rehearsal without turning the
+in-memory receiver into an external delivery path:
+
+```text
+activation-ready checklist
+  + controlled receiver configuration
+  + accepted receipt evidence
+  + bounded terminal outcome
+  -> canonical rehearsal record
+  -> append-only PostgreSQL history
+  -> exact request replay convergence
+```
+
+The record model is
+`portfolio-risk-controlled-receiver-rehearsal-record-v1`.
+
+## Retained evidence
+
+Every record binds:
+
+- an operator request ID;
+- the complete canonical activation checklist;
+- destination, authority and checklist identities;
+- the controlled receiver model version;
+- sorted host and event-type allow-lists;
+- the simulated successful response status;
+- ordered accepted receipts;
+- attempted, accepted, unique-key and duplicate counts;
+- start, finish and record timestamps; and
+- a terminal outcome and bounded failure code.
+
+The activation checklist is retained separately in
+`risk_platform.notification_activation_checklists`. Rehearsals reference it by
+`checklist_id`, allowing a later review view to show a checklist even when no
+successful rehearsal exists.
+
+## Terminal outcomes
+
+```text
+completed
+rejected_before_request
+failed_during_rehearsal
+```
+
+A completed record requires at least one accepted request and an exact receiver
+summary. A rejected-before-request record has no accepted request or receiver
+summary. A failed-during-rehearsal record retains the partial summary and proves
+that one selected request was rejected after zero or more accepted requests.
+
+Arbitrary exception text is not retained. Failure evidence is limited to:
+
+```text
+validation_error
+storage_error
+unexpected_error
+```
+
+## Replay and conflict behaviour
+
+The operator `request_id` is the append-only idempotency boundary:
+
+```text
+same request ID + same canonical evidence
+  -> return the retained record
+
+same request ID + different evidence
+  -> reject
+```
+
+The checklist and rehearsal tables both reject UPDATE and DELETE operations
+through PostgreSQL triggers. Exact checklist retries converge by deterministic
+`checklist_id` and SHA-256.
+
+## PostgreSQL contract
+
+The PostgreSQL 16 contract records one example of each terminal state, repeats
+the completed request, rejects conflicting request reuse, verifies mutation
+rejection and runs the full reconciliation suite.
+
+The reconciliation checks cover checklist references, count arithmetic, terminal
+status rules, review-window alignment and every no-side-effect declaration.
+
+## Safety boundary
+
+Rehearsal history records host names and payload SHA-256 values only. It records
+no endpoint URL or path, endpoint value, credential, environment value, payload
+body, response body or PostgreSQL DSN.
+
+Ordinary validation performs no DNS lookup, socket open, external request,
+delivery-attempt write, outbox mutation, acknowledgement, cloud scheduling,
+infrastructure deployment or `terraform apply`. Committed destination activation,
+webhook delivery and governed retry execution remain disabled.

--- a/sql/controlled_notification_receiver_rehearsal_consistency_checks.sql
+++ b/sql/controlled_notification_receiver_rehearsal_consistency_checks.sql
@@ -1,0 +1,194 @@
+-- Reconciliation for append-only activation checklists and receiver rehearsals.
+
+WITH counts AS (
+    SELECT
+        (SELECT COUNT(*)
+         FROM risk_platform.notification_activation_checklists)
+            AS checklist_rows,
+        (SELECT COUNT(DISTINCT checklist_id)
+         FROM risk_platform.notification_activation_checklists)
+            AS distinct_checklist_ids,
+        (SELECT COUNT(*)
+         FROM risk_platform.controlled_notification_receiver_rehearsals)
+            AS rehearsal_rows,
+        (SELECT COUNT(DISTINCT request_id)
+         FROM risk_platform.controlled_notification_receiver_rehearsals)
+            AS distinct_request_ids
+),
+integrity AS (
+    SELECT
+        (
+            SELECT COUNT(*)
+            FROM risk_platform.controlled_notification_receiver_rehearsals rehearsal
+            LEFT JOIN risk_platform.notification_activation_checklists checklist
+              ON checklist.checklist_id = rehearsal.checklist_id
+            WHERE checklist.checklist_id IS NULL
+               OR checklist.destination_id <> rehearsal.destination_id
+               OR checklist.destination_fingerprint
+                    <> rehearsal.destination_fingerprint
+               OR checklist.authority_id <> rehearsal.authority_id
+        ) AS missing_or_mismatched_checklists,
+        (
+            SELECT COUNT(*)
+            FROM risk_platform.controlled_notification_receiver_rehearsals
+            WHERE jsonb_array_length(receipts_json) <> request_count
+               OR unique_idempotency_keys
+                    + same_content_duplicate_count <> request_count
+        ) AS invalid_receipt_counts,
+        (
+            SELECT COUNT(*)
+            FROM risk_platform.controlled_notification_receiver_rehearsals
+            WHERE terminal_status = 'completed'
+              AND (
+                  failure_code IS NOT NULL
+                  OR rehearsal_id IS NULL
+                  OR receiver_summary_json IS NULL
+                  OR request_count = 0
+                  OR attempted_request_count <> request_count
+              )
+        ) AS invalid_completed_rows,
+        (
+            SELECT COUNT(*)
+            FROM risk_platform.controlled_notification_receiver_rehearsals
+            WHERE terminal_status = 'rejected_before_request'
+              AND (
+                  failure_code IS NULL
+                  OR rehearsal_id IS NOT NULL
+                  OR receiver_summary_json IS NOT NULL
+                  OR attempted_request_count <> 0
+                  OR request_count <> 0
+              )
+        ) AS invalid_rejected_rows,
+        (
+            SELECT COUNT(*)
+            FROM risk_platform.controlled_notification_receiver_rehearsals
+            WHERE terminal_status = 'failed_during_rehearsal'
+              AND (
+                  failure_code IS NULL
+                  OR rehearsal_id IS NULL
+                  OR receiver_summary_json IS NULL
+                  OR attempted_request_count <= request_count
+              )
+        ) AS invalid_failed_rows,
+        (
+            SELECT COUNT(*)
+            FROM risk_platform.controlled_notification_receiver_rehearsals
+            WHERE (record_json ->> 'credential_recorded')::BOOLEAN
+               OR (record_json ->> 'endpoint_value_recorded')::BOOLEAN
+               OR (record_json ->> 'payload_bodies_recorded')::BOOLEAN
+               OR (record_json ->> 'response_bodies_recorded')::BOOLEAN
+               OR (record_json ->> 'external_request_performed')::BOOLEAN
+               OR (record_json ->> 'socket_opened')::BOOLEAN
+               OR (record_json ->> 'dns_lookup_performed')::BOOLEAN
+               OR (record_json ->> 'delivery_attempt_written')::BOOLEAN
+               OR (record_json ->> 'outbox_mutated')::BOOLEAN
+               OR (record_json ->> 'acknowledgement_mutated')::BOOLEAN
+               OR (record_json ->> 'infrastructure_deployed')::BOOLEAN
+        ) AS unsafe_rehearsal_rows,
+        (
+            SELECT COUNT(*)
+            FROM risk_platform.notification_activation_checklists
+            WHERE (checklist_json ->> 'credential_recorded')::BOOLEAN
+               OR (checklist_json ->> 'endpoint_value_recorded')::BOOLEAN
+               OR (checklist_json ->> 'external_request_performed')::BOOLEAN
+               OR (checklist_json ->> 'infrastructure_deployed')::BOOLEAN
+        ) AS unsafe_checklist_rows,
+        (
+            SELECT COUNT(*)
+            FROM risk_platform.controlled_notification_receiver_rehearsals rehearsal
+            JOIN risk_platform.notification_activation_checklists checklist
+              ON checklist.checklist_id = rehearsal.checklist_id
+            WHERE rehearsal.started_at < checklist.reviewed_at
+               OR rehearsal.started_at >= checklist.review_expires_at
+        ) AS rehearsals_outside_review_window
+)
+SELECT
+    'notification_activation_checklist_ids_unique' AS check_name,
+    checklist_rows::TEXT AS expected,
+    distinct_checklist_ids::TEXT AS actual,
+    CASE WHEN checklist_rows = distinct_checklist_ids THEN 'pass' ELSE 'fail' END
+        AS status
+FROM counts
+
+UNION ALL
+
+SELECT
+    'controlled_receiver_request_ids_unique',
+    rehearsal_rows::TEXT,
+    distinct_request_ids::TEXT,
+    CASE WHEN rehearsal_rows = distinct_request_ids THEN 'pass' ELSE 'fail' END
+FROM counts
+
+UNION ALL
+
+SELECT
+    'controlled_receiver_checklist_references_match',
+    '0',
+    missing_or_mismatched_checklists::TEXT,
+    CASE WHEN missing_or_mismatched_checklists = 0 THEN 'pass' ELSE 'fail' END
+FROM integrity
+
+UNION ALL
+
+SELECT
+    'controlled_receiver_receipt_counts_match',
+    '0',
+    invalid_receipt_counts::TEXT,
+    CASE WHEN invalid_receipt_counts = 0 THEN 'pass' ELSE 'fail' END
+FROM integrity
+
+UNION ALL
+
+SELECT
+    'controlled_receiver_completed_rows_valid',
+    '0',
+    invalid_completed_rows::TEXT,
+    CASE WHEN invalid_completed_rows = 0 THEN 'pass' ELSE 'fail' END
+FROM integrity
+
+UNION ALL
+
+SELECT
+    'controlled_receiver_rejected_rows_valid',
+    '0',
+    invalid_rejected_rows::TEXT,
+    CASE WHEN invalid_rejected_rows = 0 THEN 'pass' ELSE 'fail' END
+FROM integrity
+
+UNION ALL
+
+SELECT
+    'controlled_receiver_failed_rows_valid',
+    '0',
+    invalid_failed_rows::TEXT,
+    CASE WHEN invalid_failed_rows = 0 THEN 'pass' ELSE 'fail' END
+FROM integrity
+
+UNION ALL
+
+SELECT
+    'controlled_receiver_rehearsal_side_effects_safe',
+    '0',
+    unsafe_rehearsal_rows::TEXT,
+    CASE WHEN unsafe_rehearsal_rows = 0 THEN 'pass' ELSE 'fail' END
+FROM integrity
+
+UNION ALL
+
+SELECT
+    'notification_activation_checklist_side_effects_safe',
+    '0',
+    unsafe_checklist_rows::TEXT,
+    CASE WHEN unsafe_checklist_rows = 0 THEN 'pass' ELSE 'fail' END
+FROM integrity
+
+UNION ALL
+
+SELECT
+    'controlled_receiver_rehearsals_inside_review_window',
+    '0',
+    rehearsals_outside_review_window::TEXT,
+    CASE WHEN rehearsals_outside_review_window = 0 THEN 'pass' ELSE 'fail' END
+FROM integrity
+
+ORDER BY check_name;

--- a/sql/controlled_notification_receiver_rehearsal_schema.sql
+++ b/sql/controlled_notification_receiver_rehearsal_schema.sql
@@ -1,0 +1,253 @@
+-- Append-only notification activation checklists and controlled receiver rehearsals.
+-- Apply after notification retry destination follow-up serving views.
+
+CREATE SCHEMA IF NOT EXISTS risk_platform;
+
+CREATE TABLE IF NOT EXISTS risk_platform.notification_activation_checklists (
+    checklist_id TEXT PRIMARY KEY,
+    model_version TEXT NOT NULL CHECK (
+        model_version = 'portfolio-risk-notification-activation-checklist-v1'
+    ),
+    destination_id TEXT NOT NULL,
+    destination_fingerprint TEXT NOT NULL,
+    authority_id TEXT NOT NULL,
+    reviewed_at TIMESTAMPTZ NOT NULL,
+    review_expires_at TIMESTAMPTZ NOT NULL,
+    reviewed_by_json JSONB NOT NULL CHECK (
+        jsonb_typeof(reviewed_by_json) = 'array'
+    ),
+    controls_json JSONB NOT NULL CHECK (
+        jsonb_typeof(controls_json) = 'object'
+    ),
+    activation_ready BOOLEAN NOT NULL,
+    checklist_json JSONB NOT NULL CHECK (
+        jsonb_typeof(checklist_json) = 'object'
+    ),
+    document_sha256 TEXT NOT NULL CHECK (
+        document_sha256 ~ '^[0-9a-f]{64}$'
+    ),
+    loaded_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    CHECK (checklist_id <> ''),
+    CHECK (destination_id <> ''),
+    CHECK (destination_fingerprint <> ''),
+    CHECK (authority_id <> ''),
+    CHECK (review_expires_at > reviewed_at),
+    CHECK (jsonb_array_length(reviewed_by_json) BETWEEN 1 AND 16),
+    CHECK (checklist_json ->> 'checklist_id' = checklist_id),
+    CHECK (checklist_json ->> 'model_version' = model_version),
+    CHECK (checklist_json ->> 'destination_id' = destination_id),
+    CHECK (
+        checklist_json ->> 'destination_fingerprint'
+        = destination_fingerprint
+    ),
+    CHECK (checklist_json ->> 'authority_id' = authority_id),
+    CHECK (checklist_json -> 'reviewed_by' = reviewed_by_json),
+    CHECK (checklist_json -> 'controls' = controls_json),
+    CHECK (
+        (checklist_json ->> 'activation_ready')::BOOLEAN = activation_ready
+    ),
+    CHECK (NOT (checklist_json ->> 'credential_recorded')::BOOLEAN),
+    CHECK (NOT (checklist_json ->> 'endpoint_value_recorded')::BOOLEAN),
+    CHECK (NOT (checklist_json ->> 'external_request_performed')::BOOLEAN),
+    CHECK (NOT (checklist_json ->> 'infrastructure_deployed')::BOOLEAN)
+);
+
+CREATE INDEX IF NOT EXISTS idx_notification_activation_checklist_history
+    ON risk_platform.notification_activation_checklists (
+        destination_id,
+        reviewed_at DESC,
+        checklist_id DESC
+    );
+
+CREATE TABLE IF NOT EXISTS
+risk_platform.controlled_notification_receiver_rehearsals (
+    record_id TEXT PRIMARY KEY,
+    model_version TEXT NOT NULL CHECK (
+        model_version
+            = 'portfolio-risk-controlled-receiver-rehearsal-record-v1'
+    ),
+    request_id TEXT NOT NULL UNIQUE,
+    terminal_status TEXT NOT NULL CHECK (
+        terminal_status IN (
+            'completed',
+            'rejected_before_request',
+            'failed_during_rehearsal'
+        )
+    ),
+    failure_code TEXT CHECK (
+        failure_code IS NULL
+        OR failure_code IN (
+            'storage_error',
+            'unexpected_error',
+            'validation_error'
+        )
+    ),
+    checklist_id TEXT NOT NULL REFERENCES
+        risk_platform.notification_activation_checklists (checklist_id),
+    destination_id TEXT NOT NULL,
+    destination_fingerprint TEXT NOT NULL,
+    authority_id TEXT NOT NULL,
+    receiver_model_version TEXT NOT NULL CHECK (
+        receiver_model_version
+            = 'portfolio-risk-controlled-notification-receiver-v1'
+    ),
+    rehearsal_id TEXT,
+    allowed_hosts_json JSONB NOT NULL CHECK (
+        jsonb_typeof(allowed_hosts_json) = 'array'
+    ),
+    allowed_event_types_json JSONB NOT NULL CHECK (
+        jsonb_typeof(allowed_event_types_json) = 'array'
+    ),
+    response_status INTEGER NOT NULL CHECK (
+        response_status BETWEEN 200 AND 299
+    ),
+    started_at TIMESTAMPTZ NOT NULL,
+    finished_at TIMESTAMPTZ NOT NULL,
+    recorded_at TIMESTAMPTZ NOT NULL,
+    attempted_request_count INTEGER NOT NULL CHECK (
+        attempted_request_count BETWEEN 0 AND 100
+    ),
+    request_count INTEGER NOT NULL CHECK (
+        request_count BETWEEN 0 AND attempted_request_count
+    ),
+    unique_idempotency_keys INTEGER NOT NULL CHECK (
+        unique_idempotency_keys BETWEEN 0 AND request_count
+    ),
+    same_content_duplicate_count INTEGER NOT NULL CHECK (
+        same_content_duplicate_count BETWEEN 0 AND request_count
+    ),
+    receipts_json JSONB NOT NULL CHECK (
+        jsonb_typeof(receipts_json) = 'array'
+    ),
+    receiver_summary_json JSONB,
+    record_json JSONB NOT NULL CHECK (
+        jsonb_typeof(record_json) = 'object'
+    ),
+    document_sha256 TEXT NOT NULL CHECK (
+        document_sha256 ~ '^[0-9a-f]{64}$'
+    ),
+    loaded_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    CHECK (record_id <> ''),
+    CHECK (request_id <> ''),
+    CHECK (destination_id <> ''),
+    CHECK (destination_fingerprint <> ''),
+    CHECK (authority_id <> ''),
+    CHECK (finished_at >= started_at),
+    CHECK (recorded_at >= finished_at),
+    CHECK (jsonb_array_length(allowed_hosts_json) BETWEEN 1 AND 16),
+    CHECK (jsonb_array_length(allowed_event_types_json) BETWEEN 1 AND 64),
+    CHECK (jsonb_array_length(receipts_json) = request_count),
+    CHECK (unique_idempotency_keys + same_content_duplicate_count = request_count),
+    CHECK (
+        (terminal_status = 'completed' AND failure_code IS NULL)
+        OR (terminal_status <> 'completed' AND failure_code IS NOT NULL)
+    ),
+    CHECK (
+        terminal_status <> 'completed'
+        OR (
+            rehearsal_id IS NOT NULL
+            AND receiver_summary_json IS NOT NULL
+            AND request_count > 0
+            AND attempted_request_count = request_count
+        )
+    ),
+    CHECK (
+        terminal_status <> 'rejected_before_request'
+        OR (
+            rehearsal_id IS NULL
+            AND receiver_summary_json IS NULL
+            AND attempted_request_count = 0
+            AND request_count = 0
+        )
+    ),
+    CHECK (
+        terminal_status <> 'failed_during_rehearsal'
+        OR (
+            rehearsal_id IS NOT NULL
+            AND receiver_summary_json IS NOT NULL
+            AND attempted_request_count > request_count
+        )
+    ),
+    CHECK (record_json ->> 'record_id' = record_id),
+    CHECK (record_json ->> 'model_version' = model_version),
+    CHECK (record_json ->> 'request_id' = request_id),
+    CHECK (record_json ->> 'terminal_status' = terminal_status),
+    CHECK (record_json -> 'activation_checklist' ->> 'checklist_id' = checklist_id),
+    CHECK (
+        record_json -> 'activation_checklist' ->> 'destination_id'
+        = destination_id
+    ),
+    CHECK (
+        record_json -> 'activation_checklist' ->> 'destination_fingerprint'
+        = destination_fingerprint
+    ),
+    CHECK (
+        record_json -> 'activation_checklist' ->> 'authority_id'
+        = authority_id
+    ),
+    CHECK (record_json -> 'allowed_hosts' = allowed_hosts_json),
+    CHECK (record_json -> 'allowed_event_types' = allowed_event_types_json),
+    CHECK (record_json -> 'receipts' = receipts_json),
+    CHECK (record_json -> 'receiver_summary' = receiver_summary_json),
+    CHECK (NOT (record_json ->> 'credential_recorded')::BOOLEAN),
+    CHECK (NOT (record_json ->> 'endpoint_value_recorded')::BOOLEAN),
+    CHECK (NOT (record_json ->> 'payload_bodies_recorded')::BOOLEAN),
+    CHECK (NOT (record_json ->> 'response_bodies_recorded')::BOOLEAN),
+    CHECK (NOT (record_json ->> 'external_request_performed')::BOOLEAN),
+    CHECK (NOT (record_json ->> 'socket_opened')::BOOLEAN),
+    CHECK (NOT (record_json ->> 'dns_lookup_performed')::BOOLEAN),
+    CHECK (NOT (record_json ->> 'delivery_attempt_written')::BOOLEAN),
+    CHECK (NOT (record_json ->> 'outbox_mutated')::BOOLEAN),
+    CHECK (NOT (record_json ->> 'acknowledgement_mutated')::BOOLEAN),
+    CHECK (NOT (record_json ->> 'infrastructure_deployed')::BOOLEAN)
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS
+idx_controlled_notification_receiver_rehearsal_id_unique
+    ON risk_platform.controlled_notification_receiver_rehearsals (rehearsal_id)
+    WHERE rehearsal_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_controlled_notification_receiver_history
+    ON risk_platform.controlled_notification_receiver_rehearsals (
+        destination_id,
+        recorded_at DESC,
+        record_id DESC
+    );
+
+CREATE OR REPLACE FUNCTION
+risk_platform.reject_notification_activation_checklist_mutation()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    RAISE EXCEPTION 'notification_activation_checklists is append-only';
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_notification_activation_checklist_append_only
+ON risk_platform.notification_activation_checklists;
+
+CREATE TRIGGER trg_notification_activation_checklist_append_only
+BEFORE UPDATE OR DELETE
+ON risk_platform.notification_activation_checklists
+FOR EACH ROW
+EXECUTE FUNCTION risk_platform.reject_notification_activation_checklist_mutation();
+
+CREATE OR REPLACE FUNCTION
+risk_platform.reject_controlled_receiver_rehearsal_mutation()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    RAISE EXCEPTION 'controlled_notification_receiver_rehearsals is append-only';
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_controlled_receiver_rehearsal_append_only
+ON risk_platform.controlled_notification_receiver_rehearsals;
+
+CREATE TRIGGER trg_controlled_receiver_rehearsal_append_only
+BEFORE UPDATE OR DELETE
+ON risk_platform.controlled_notification_receiver_rehearsals
+FOR EACH ROW
+EXECUTE FUNCTION risk_platform.reject_controlled_receiver_rehearsal_mutation();

--- a/src/warehouse/controlled_receiver_rehearsal_contract.py
+++ b/src/warehouse/controlled_receiver_rehearsal_contract.py
@@ -1,0 +1,511 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from collections.abc import Mapping, Sequence
+from datetime import datetime, timezone
+from typing import Any
+
+from src.common.exceptions import ValidationError
+from src.orchestration.notification_activation_checklist import (
+    canonical_activation_checklist_bytes,
+    validate_notification_activation_checklist,
+)
+
+MODEL_VERSION = "portfolio-risk-controlled-receiver-rehearsal-record-v1"
+RECEIVER_MODEL_VERSION = "portfolio-risk-controlled-notification-receiver-v1"
+TERMINAL_STATUSES = frozenset(
+    {"completed", "rejected_before_request", "failed_during_rehearsal"}
+)
+FAILURE_CODES = frozenset({"storage_error", "unexpected_error", "validation_error"})
+SAFE_TEXT = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,511}$")
+SAFE_EVENT_TYPE = re.compile(r"^[a-z][a-z0-9_]{0,63}$")
+SAFE_HOST = re.compile(r"^[a-z0-9][a-z0-9.-]{0,252}$")
+SHA256_PATTERN = re.compile(r"^[0-9a-f]{64}$")
+MAX_EVENTS = 100
+MAX_HOSTS = 16
+MAX_EVENT_TYPES = 64
+SIDE_EFFECT_FLAGS = (
+    "acknowledgement_mutated",
+    "delivery_attempt_written",
+    "dns_lookup_performed",
+    "endpoint_paths_recorded",
+    "external_request_performed",
+    "infrastructure_deployed",
+    "outbox_mutated",
+    "payload_bodies_recorded",
+    "response_bodies_recorded",
+    "socket_opened",
+)
+
+
+def _exact_mapping(value: Any, label: str, keys: set[str]) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        raise ValidationError(f"{label} must be a mapping")
+    actual = set(value)
+    if actual != keys:
+        raise ValidationError(
+            f"{label} fields are invalid; "
+            f"missing={sorted(keys - actual)}, unknown={sorted(actual - keys)}"
+        )
+    return value
+
+
+def _safe_text(value: Any, label: str, *, optional: bool = False) -> str | None:
+    if value is None and optional:
+        return None
+    if not isinstance(value, str) or not SAFE_TEXT.fullmatch(value):
+        raise ValidationError(f"{label} must be one safe text segment")
+    return value
+
+
+def _aware_utc(value: Any, label: str) -> datetime:
+    if isinstance(value, datetime):
+        parsed = value
+    elif isinstance(value, str):
+        try:
+            parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        except ValueError:
+            raise ValidationError(f"{label} must be ISO-8601") from None
+    else:
+        raise ValidationError(f"{label} must be timezone-aware")
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise ValidationError(f"{label} must be timezone-aware")
+    return parsed.astimezone(timezone.utc)
+
+
+def _bounded_count(value: Any, label: str) -> int:
+    if type(value) is not int or not 0 <= value <= MAX_EVENTS:
+        raise ValidationError(
+            f"{label} must be an integer between 0 and {MAX_EVENTS}"
+        )
+    return value
+
+
+def _hosts(values: Any) -> list[str]:
+    if not isinstance(values, list):
+        raise ValidationError("allowed_hosts must be an array")
+    parsed: list[str] = []
+    for value in values:
+        if not isinstance(value, str):
+            raise ValidationError("allowed_hosts contains an invalid host")
+        host = value.casefold()
+        if (
+            value != host
+            or not SAFE_HOST.fullmatch(host)
+            or ".." in host
+            or host.endswith(".")
+        ):
+            raise ValidationError("allowed_hosts contains an invalid host")
+        parsed.append(host)
+    if not parsed or len(parsed) > MAX_HOSTS:
+        raise ValidationError(
+            f"allowed_hosts must contain between 1 and {MAX_HOSTS} hosts"
+        )
+    if parsed != sorted(set(parsed)):
+        raise ValidationError("allowed_hosts must be sorted with no duplicates")
+    return parsed
+
+
+def _event_types(values: Any) -> list[str]:
+    if not isinstance(values, list):
+        raise ValidationError("allowed_event_types must be an array")
+    parsed: list[str] = []
+    for value in values:
+        if not isinstance(value, str) or not SAFE_EVENT_TYPE.fullmatch(value):
+            raise ValidationError("allowed_event_types contains an invalid event type")
+        parsed.append(value)
+    if not parsed or len(parsed) > MAX_EVENT_TYPES:
+        raise ValidationError(
+            "allowed_event_types must contain between 1 and "
+            f"{MAX_EVENT_TYPES} event types"
+        )
+    if parsed != sorted(set(parsed)):
+        raise ValidationError(
+            "allowed_event_types must be sorted with no duplicates"
+        )
+    return parsed
+
+
+def _response_status(value: Any) -> int:
+    if type(value) is not int or not 200 <= value <= 299:
+        raise ValidationError("response_status must be a successful HTTP status")
+    return value
+
+
+def canonical_controlled_receiver_rehearsal_bytes(
+    record: Mapping[str, Any],
+) -> bytes:
+    try:
+        return json.dumps(
+            record,
+            sort_keys=True,
+            separators=(",", ":"),
+            allow_nan=False,
+        ).encode("utf-8")
+    except (TypeError, ValueError):
+        raise ValidationError("controlled receiver record is not canonical JSON") from None
+
+
+def _record_id(identity: Mapping[str, Any]) -> str:
+    digest = hashlib.sha256(
+        canonical_controlled_receiver_rehearsal_bytes(identity)
+    ).hexdigest()[:24]
+    return f"{MODEL_VERSION}-record-{digest}"
+
+
+def _rehearsal_id(identity: Mapping[str, Any]) -> str:
+    digest = hashlib.sha256(
+        json.dumps(
+            identity,
+            sort_keys=True,
+            separators=(",", ":"),
+            allow_nan=False,
+        ).encode("utf-8")
+    ).hexdigest()[:24]
+    return f"{RECEIVER_MODEL_VERSION}-rehearsal-{digest}"
+
+
+def _canonical_receipts(
+    values: Any,
+    *,
+    allowed_hosts: Sequence[str],
+    allowed_event_types: Sequence[str],
+    response_status: int,
+    started_at: datetime,
+    finished_at: datetime,
+) -> list[dict[str, Any]]:
+    if not isinstance(values, list) or len(values) > MAX_EVENTS:
+        raise ValidationError("receiver receipts must be a bounded array")
+    receipts: list[dict[str, Any]] = []
+    seen_payloads: dict[str, str] = {}
+    for index, raw in enumerate(values, start=1):
+        receipt = _exact_mapping(
+            raw,
+            f"receiver receipt {index}",
+            {
+                "endpoint_host",
+                "event_id",
+                "event_type",
+                "http_status",
+                "idempotency_key",
+                "payload_sha256",
+                "received_at",
+                "request_ordinal",
+                "same_content_duplicate",
+            },
+        )
+        endpoint_host = receipt["endpoint_host"]
+        if endpoint_host not in allowed_hosts:
+            raise ValidationError("receiver receipt host is outside the allow-list")
+        event_id = _safe_text(receipt["event_id"], "receipt.event_id")
+        idempotency_key = _safe_text(
+            receipt["idempotency_key"],
+            "receipt.idempotency_key",
+        )
+        assert event_id is not None and idempotency_key is not None
+        if event_id != idempotency_key:
+            raise ValidationError("receiver receipt idempotency identity changed")
+        event_type = receipt["event_type"]
+        if event_type not in allowed_event_types:
+            raise ValidationError("receiver receipt event type is not approved")
+        if receipt["http_status"] != response_status:
+            raise ValidationError("receiver receipt HTTP status changed")
+        payload_sha256 = receipt["payload_sha256"]
+        if not isinstance(payload_sha256, str) or not SHA256_PATTERN.fullmatch(
+            payload_sha256
+        ):
+            raise ValidationError("receiver receipt payload SHA-256 is invalid")
+        received_at = _aware_utc(receipt["received_at"], "receipt.received_at")
+        if not started_at <= received_at <= finished_at:
+            raise ValidationError("receiver receipt timestamp is outside the run")
+        if receipt["request_ordinal"] != index:
+            raise ValidationError("receiver receipt ordinals must be contiguous")
+        duplicate = receipt["same_content_duplicate"]
+        if type(duplicate) is not bool:
+            raise ValidationError("receiver duplicate evidence must be boolean")
+        previous = seen_payloads.get(idempotency_key)
+        if duplicate != (previous is not None):
+            raise ValidationError("receiver duplicate evidence is inconsistent")
+        if previous is not None and previous != payload_sha256:
+            raise ValidationError("receiver idempotency evidence conflicts")
+        seen_payloads.setdefault(idempotency_key, payload_sha256)
+        receipts.append(
+            {
+                **dict(receipt),
+                "received_at": received_at.isoformat(),
+            }
+        )
+    return receipts
+
+
+def _canonical_receiver_summary(
+    value: Any,
+    *,
+    checklist: Mapping[str, Any],
+    allowed_hosts: Sequence[str],
+    allowed_event_types: Sequence[str],
+    response_status: int,
+    started_at: datetime,
+    finished_at: datetime,
+) -> dict[str, Any]:
+    summary = _exact_mapping(
+        value,
+        "controlled receiver summary",
+        {
+            "rehearsal_id",
+            "activation_checklist_id",
+            "allowed_event_types",
+            "allowed_hosts",
+            "authority_id",
+            "destination_fingerprint",
+            "destination_id",
+            "model_version",
+            "receipts",
+            "response_status",
+            "request_count",
+            "same_content_duplicate_count",
+            "unique_idempotency_keys",
+            *SIDE_EFFECT_FLAGS,
+        },
+    )
+    if summary["model_version"] != RECEIVER_MODEL_VERSION:
+        raise ValidationError("controlled receiver model_version is unsupported")
+    if summary["activation_checklist_id"] != checklist["checklist_id"]:
+        raise ValidationError("controlled receiver checklist identity changed")
+    if summary["authority_id"] != checklist["authority_id"]:
+        raise ValidationError("controlled receiver authority identity changed")
+    if summary["destination_id"] != checklist["destination_id"]:
+        raise ValidationError("controlled receiver destination identity changed")
+    if summary["destination_fingerprint"] != checklist["destination_fingerprint"]:
+        raise ValidationError("controlled receiver destination fingerprint changed")
+    if summary["allowed_hosts"] != list(allowed_hosts):
+        raise ValidationError("controlled receiver host allow-list changed")
+    if summary["allowed_event_types"] != list(allowed_event_types):
+        raise ValidationError("controlled receiver event allow-list changed")
+    if summary["response_status"] != response_status:
+        raise ValidationError("controlled receiver response status changed")
+    for flag in SIDE_EFFECT_FLAGS:
+        if summary[flag] is not False:
+            raise ValidationError("controlled receiver side-effect evidence is invalid")
+
+    receipts = _canonical_receipts(
+        summary["receipts"],
+        allowed_hosts=allowed_hosts,
+        allowed_event_types=allowed_event_types,
+        response_status=response_status,
+        started_at=started_at,
+        finished_at=finished_at,
+    )
+    request_count = _bounded_count(summary["request_count"], "request_count")
+    duplicate_count = _bounded_count(
+        summary["same_content_duplicate_count"],
+        "same_content_duplicate_count",
+    )
+    unique_keys = _bounded_count(
+        summary["unique_idempotency_keys"],
+        "unique_idempotency_keys",
+    )
+    if request_count != len(receipts):
+        raise ValidationError("controlled receiver request count disagrees")
+    if duplicate_count != sum(
+        receipt["same_content_duplicate"] for receipt in receipts
+    ):
+        raise ValidationError("controlled receiver duplicate count disagrees")
+    if unique_keys != len({receipt["idempotency_key"] for receipt in receipts}):
+        raise ValidationError("controlled receiver unique key count disagrees")
+
+    rehearsal_identity = {
+        "activation_checklist_id": checklist["checklist_id"],
+        "allowed_event_types": list(allowed_event_types),
+        "allowed_hosts": list(allowed_hosts),
+        "authority_id": checklist["authority_id"],
+        "destination_fingerprint": checklist["destination_fingerprint"],
+        "destination_id": checklist["destination_id"],
+        "model_version": RECEIVER_MODEL_VERSION,
+        "receipts": receipts,
+        "response_status": response_status,
+    }
+    if summary["rehearsal_id"] != _rehearsal_id(rehearsal_identity):
+        raise ValidationError("controlled receiver rehearsal_id does not match content")
+    return {
+        **dict(summary),
+        "receipts": receipts,
+    }
+
+
+def build_controlled_receiver_rehearsal_record(
+    *,
+    request_id: str,
+    terminal_status: str,
+    failure_code: str | None,
+    activation_checklist: Mapping[str, Any],
+    allowed_hosts: Sequence[str],
+    allowed_event_types: Sequence[str],
+    response_status: int,
+    started_at: datetime | str,
+    finished_at: datetime | str,
+    recorded_at: datetime | str,
+    attempted_request_count: int,
+    receiver_summary: Mapping[str, Any] | None,
+) -> dict[str, Any]:
+    selected_request_id = _safe_text(request_id, "request_id")
+    assert selected_request_id is not None
+    if terminal_status not in TERMINAL_STATUSES:
+        raise ValidationError("terminal_status is invalid")
+    if failure_code is not None and failure_code not in FAILURE_CODES:
+        raise ValidationError("failure_code is invalid")
+    checklist = validate_notification_activation_checklist(activation_checklist)
+    if checklist["activation_ready"] is not True:
+        raise ValidationError("rehearsal history requires an activation-ready checklist")
+    started = _aware_utc(started_at, "started_at")
+    finished = _aware_utc(finished_at, "finished_at")
+    recorded = _aware_utc(recorded_at, "recorded_at")
+    if finished < started or recorded < finished:
+        raise ValidationError("rehearsal timestamps are not ordered")
+    reviewed_at = _aware_utc(checklist["reviewed_at"], "checklist.reviewed_at")
+    expires_at = _aware_utc(
+        checklist["review_expires_at"],
+        "checklist.review_expires_at",
+    )
+    if not reviewed_at <= started < expires_at:
+        raise ValidationError("rehearsal start is outside the checklist review window")
+    hosts = _hosts(list(allowed_hosts))
+    event_types = _event_types(list(allowed_event_types))
+    status = _response_status(response_status)
+    attempted = _bounded_count(
+        attempted_request_count,
+        "attempted_request_count",
+    )
+    summary: dict[str, Any] | None = None
+    if receiver_summary is not None:
+        summary = _canonical_receiver_summary(
+            receiver_summary,
+            checklist=checklist,
+            allowed_hosts=hosts,
+            allowed_event_types=event_types,
+            response_status=status,
+            started_at=started,
+            finished_at=finished,
+        )
+    request_count = 0 if summary is None else summary["request_count"]
+    unique_keys = 0 if summary is None else summary["unique_idempotency_keys"]
+    duplicate_count = (
+        0 if summary is None else summary["same_content_duplicate_count"]
+    )
+    receipts = [] if summary is None else summary["receipts"]
+    rehearsal_id = None if summary is None else summary["rehearsal_id"]
+
+    if terminal_status == "completed":
+        if failure_code is not None or summary is None:
+            raise ValidationError("completed rehearsal requires summary and no failure")
+        if request_count == 0 or attempted != request_count:
+            raise ValidationError("completed rehearsal request counts disagree")
+    elif terminal_status == "rejected_before_request":
+        if failure_code is None or summary is not None or attempted != 0:
+            raise ValidationError(
+                "rejected_before_request must have bounded failure and no requests"
+            )
+    else:
+        if failure_code is None or summary is None or attempted <= request_count:
+            raise ValidationError(
+                "failed_during_rehearsal requires one rejected request"
+            )
+
+    identity = {
+        "activation_checklist": checklist,
+        "allowed_event_types": event_types,
+        "allowed_hosts": hosts,
+        "attempted_request_count": attempted,
+        "failure_code": failure_code,
+        "finished_at": finished.isoformat(),
+        "model_version": MODEL_VERSION,
+        "receiver_model_version": RECEIVER_MODEL_VERSION,
+        "receiver_summary": summary,
+        "recorded_at": recorded.isoformat(),
+        "rehearsal_id": rehearsal_id,
+        "request_count": request_count,
+        "request_id": selected_request_id,
+        "response_status": status,
+        "same_content_duplicate_count": duplicate_count,
+        "started_at": started.isoformat(),
+        "terminal_status": terminal_status,
+        "unique_idempotency_keys": unique_keys,
+        "receipts": receipts,
+        "credential_recorded": False,
+        "endpoint_value_recorded": False,
+        "payload_bodies_recorded": False,
+        "response_bodies_recorded": False,
+        "external_request_performed": False,
+        "socket_opened": False,
+        "dns_lookup_performed": False,
+        "delivery_attempt_written": False,
+        "outbox_mutated": False,
+        "acknowledgement_mutated": False,
+        "infrastructure_deployed": False,
+    }
+    return {"record_id": _record_id(identity), **identity}
+
+
+def validate_controlled_receiver_rehearsal_record(
+    record: Mapping[str, Any],
+) -> dict[str, Any]:
+    expected = {
+        "record_id",
+        "activation_checklist",
+        "allowed_event_types",
+        "allowed_hosts",
+        "attempted_request_count",
+        "failure_code",
+        "finished_at",
+        "model_version",
+        "receiver_model_version",
+        "receiver_summary",
+        "recorded_at",
+        "rehearsal_id",
+        "request_count",
+        "request_id",
+        "response_status",
+        "same_content_duplicate_count",
+        "started_at",
+        "terminal_status",
+        "unique_idempotency_keys",
+        "receipts",
+        "credential_recorded",
+        "endpoint_value_recorded",
+        "payload_bodies_recorded",
+        "response_bodies_recorded",
+        "external_request_performed",
+        "socket_opened",
+        "dns_lookup_performed",
+        "delivery_attempt_written",
+        "outbox_mutated",
+        "acknowledgement_mutated",
+        "infrastructure_deployed",
+    }
+    exact = _exact_mapping(record, "controlled receiver record", expected)
+    if exact["model_version"] != MODEL_VERSION:
+        raise ValidationError("controlled receiver record model_version is unsupported")
+    rebuilt = build_controlled_receiver_rehearsal_record(
+        request_id=exact["request_id"],
+        terminal_status=exact["terminal_status"],
+        failure_code=exact["failure_code"],
+        activation_checklist=exact["activation_checklist"],
+        allowed_hosts=exact["allowed_hosts"],
+        allowed_event_types=exact["allowed_event_types"],
+        response_status=exact["response_status"],
+        started_at=exact["started_at"],
+        finished_at=exact["finished_at"],
+        recorded_at=exact["recorded_at"],
+        attempted_request_count=exact["attempted_request_count"],
+        receiver_summary=exact["receiver_summary"],
+    )
+    if dict(exact) != rebuilt:
+        raise ValidationError("controlled receiver record is not canonical")
+    return rebuilt
+
+
+def activation_checklist_sha256(checklist: Mapping[str, Any]) -> str:
+    validated = validate_notification_activation_checklist(checklist)
+    return hashlib.sha256(canonical_activation_checklist_bytes(validated)).hexdigest()

--- a/src/warehouse/controlled_receiver_rehearsal_postgres_contract_check.py
+++ b/src/warehouse/controlled_receiver_rehearsal_postgres_contract_check.py
@@ -1,0 +1,284 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+from src.common.exceptions import ValidationError
+from src.orchestration.controlled_notification_receiver import (
+    ControlledNotificationReceiver,
+)
+from src.orchestration.notification_activation_checklist import (
+    CONTROL_NAMES,
+    build_notification_activation_checklist,
+)
+from src.warehouse.controlled_receiver_rehearsal_contract import (
+    build_controlled_receiver_rehearsal_record,
+)
+from src.warehouse.controlled_receiver_rehearsal_recorder import (
+    record_controlled_receiver_rehearsal,
+)
+from src.warehouse.postgres_loader import DEFAULT_POSTGRES_DSN
+
+CHECK_PATH = Path(
+    "sql/controlled_notification_receiver_rehearsal_consistency_checks.sql"
+)
+STARTED = datetime(2026, 8, 28, 10, tzinfo=timezone.utc)
+
+
+def _checklist() -> dict[str, Any]:
+    return build_notification_activation_checklist(
+        destination_id="risk-operations-webhook",
+        destination_fingerprint="contract-destination-fingerprint",
+        authority_id="contract-destination-authority",
+        reviewed_by=["contract-reviewer", "receiver-owner"],
+        reviewed_at=STARTED - timedelta(days=1),
+        review_expires_at=STARTED + timedelta(days=1),
+        controls={name: True for name in CONTROL_NAMES},
+    )
+
+
+def _payload(*, severity: str = "critical") -> bytes:
+    document = {
+        "event_id": "contract-event-1",
+        "event_type": "breach_opened",
+        "metric_name": "portfolio_volatility_annualized",
+        "payload": {"severity": severity},
+        "policy_id": "us-tech-standard",
+        "portfolio_id": "us-tech-equal",
+        "status": severity,
+        "subject_key": "us-tech-equal",
+        "ts_event": "2026-08-28T09:00:00+00:00",
+    }
+    return json.dumps(
+        document,
+        sort_keys=True,
+        separators=(",", ":"),
+        allow_nan=False,
+    ).encode("utf-8")
+
+
+def _headers() -> dict[str, str]:
+    return {
+        "Content-Type": "application/json",
+        "Idempotency-Key": "contract-event-1",
+        "User-Agent": "financial-risk-data-platform/1",
+    }
+
+
+def _clock(*values: datetime) -> Any:
+    iterator = iter(values)
+    return lambda: next(iterator)
+
+
+def _completed_record() -> dict[str, Any]:
+    receiver = ControlledNotificationReceiver(
+        activation_checklist=_checklist(),
+        allowed_hosts=["receiver.test"],
+        allowed_event_types=["breach_opened"],
+        clock=_clock(
+            STARTED + timedelta(seconds=1),
+            STARTED + timedelta(seconds=2),
+        ),
+    )
+    endpoint = "https://receiver.test/controlled"
+    receiver(endpoint, _payload(), _headers(), 5.0)
+    receiver(endpoint, _payload(), _headers(), 5.0)
+    return build_controlled_receiver_rehearsal_record(
+        request_id="CONTRACT-REHEARSAL-COMPLETED",
+        terminal_status="completed",
+        failure_code=None,
+        activation_checklist=_checklist(),
+        allowed_hosts=["receiver.test"],
+        allowed_event_types=["breach_opened"],
+        response_status=204,
+        started_at=STARTED,
+        finished_at=STARTED + timedelta(seconds=3),
+        recorded_at=STARTED + timedelta(seconds=4),
+        attempted_request_count=2,
+        receiver_summary=receiver.summary(),
+    )
+
+
+def _failed_record() -> dict[str, Any]:
+    receiver = ControlledNotificationReceiver(
+        activation_checklist=_checklist(),
+        allowed_hosts=["receiver.test"],
+        allowed_event_types=["breach_opened"],
+        clock=_clock(STARTED + timedelta(minutes=1, seconds=1)),
+    )
+    endpoint = "https://receiver.test/controlled"
+    receiver(endpoint, _payload(), _headers(), 5.0)
+    try:
+        receiver(endpoint, _payload(severity="warning"), _headers(), 5.0)
+    except ValidationError:
+        pass
+    else:  # pragma: no cover - receiver contract guarantees rejection.
+        raise AssertionError("conflicting idempotency evidence was accepted")
+    return build_controlled_receiver_rehearsal_record(
+        request_id="CONTRACT-REHEARSAL-FAILED",
+        terminal_status="failed_during_rehearsal",
+        failure_code="validation_error",
+        activation_checklist=_checklist(),
+        allowed_hosts=["receiver.test"],
+        allowed_event_types=["breach_opened"],
+        response_status=204,
+        started_at=STARTED + timedelta(minutes=1),
+        finished_at=STARTED + timedelta(minutes=1, seconds=3),
+        recorded_at=STARTED + timedelta(minutes=1, seconds=4),
+        attempted_request_count=2,
+        receiver_summary=receiver.summary(),
+    )
+
+
+def _rejected_record() -> dict[str, Any]:
+    return build_controlled_receiver_rehearsal_record(
+        request_id="CONTRACT-REHEARSAL-REJECTED",
+        terminal_status="rejected_before_request",
+        failure_code="validation_error",
+        activation_checklist=_checklist(),
+        allowed_hosts=["receiver.test"],
+        allowed_event_types=["breach_opened"],
+        response_status=204,
+        started_at=STARTED + timedelta(minutes=2),
+        finished_at=STARTED + timedelta(minutes=2),
+        recorded_at=STARTED + timedelta(minutes=2, seconds=1),
+        attempted_request_count=0,
+        receiver_summary=None,
+    )
+
+
+def _mutation_rejected(dsn: str, statement: str) -> bool:
+    try:
+        import psycopg
+    except ImportError as exc:  # pragma: no cover - required in CI.
+        raise RuntimeError("Controlled receiver contract requires psycopg") from exc
+    try:
+        with psycopg.connect(dsn) as connection:
+            with connection.cursor() as cursor:
+                cursor.execute(statement)
+            connection.commit()
+    except Exception:
+        return True
+    return False
+
+
+def run_contract_check(dsn: str) -> dict[str, Any]:
+    completed = _completed_record()
+    failed = _failed_record()
+    rejected = _rejected_record()
+    created = [
+        record_controlled_receiver_rehearsal(dsn=dsn, record=record)
+        for record in (completed, failed, rejected)
+    ]
+    replay = record_controlled_receiver_rehearsal(dsn=dsn, record=completed)
+    if replay["created"] is not False:
+        raise AssertionError("exact controlled receiver retry did not converge")
+
+    conflicting = build_controlled_receiver_rehearsal_record(
+        request_id=completed["request_id"],
+        terminal_status="completed",
+        failure_code=None,
+        activation_checklist=completed["activation_checklist"],
+        allowed_hosts=completed["allowed_hosts"],
+        allowed_event_types=completed["allowed_event_types"],
+        response_status=completed["response_status"],
+        started_at=completed["started_at"],
+        finished_at=completed["finished_at"],
+        recorded_at=(
+            datetime.fromisoformat(completed["recorded_at"])
+            + timedelta(seconds=1)
+        ),
+        attempted_request_count=completed["attempted_request_count"],
+        receiver_summary=completed["receiver_summary"],
+    )
+    try:
+        record_controlled_receiver_rehearsal(dsn=dsn, record=conflicting)
+    except ValidationError:
+        conflict_rejected = True
+    else:
+        conflict_rejected = False
+    if not conflict_rejected:
+        raise AssertionError("conflicting rehearsal request identity was accepted")
+
+    update_rejected = _mutation_rejected(
+        dsn,
+        """
+        UPDATE risk_platform.controlled_notification_receiver_rehearsals
+        SET terminal_status = 'completed'
+        WHERE request_id = 'CONTRACT-REHEARSAL-FAILED'
+        """,
+    )
+    delete_rejected = _mutation_rejected(
+        dsn,
+        """
+        DELETE FROM risk_platform.notification_activation_checklists
+        WHERE checklist_id LIKE
+            'portfolio-risk-notification-activation-checklist-v1-%'
+        """,
+    )
+    if not update_rejected or not delete_rejected:
+        raise AssertionError("append-only rehearsal mutation was accepted")
+
+    try:
+        import psycopg
+    except ImportError as exc:  # pragma: no cover - required in CI.
+        raise RuntimeError("Controlled receiver contract requires psycopg") from exc
+    with psycopg.connect(dsn) as connection:
+        with connection.cursor() as cursor:
+            cursor.execute(CHECK_PATH.read_text(encoding="utf-8"))
+            checks = list(cursor.fetchall())
+    failures = [check for check in checks if check[3] != "pass"]
+    if failures:
+        names = ", ".join(str(check[0]) for check in failures)
+        raise AssertionError("controlled receiver reconciliation failed: " + names)
+
+    return {
+        "model_version": "portfolio-risk-controlled-receiver-contract-v1",
+        "terminal_records": len(created),
+        "terminal_statuses": sorted(
+            record["terminal_status"]
+            for record in (completed, failed, rejected)
+        ),
+        "exact_retry_converged": True,
+        "conflicting_request_rejected": True,
+        "update_rejected": update_rejected,
+        "delete_rejected": delete_rejected,
+        "consistency_checks": len(checks),
+        "external_request_performed": False,
+        "payload_bodies_recorded": False,
+        "response_bodies_recorded": False,
+    }
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Exercise append-only controlled receiver rehearsal history "
+            "against PostgreSQL 16."
+        )
+    )
+    parser.add_argument(
+        "--dsn",
+        default=os.environ.get("WAREHOUSE_POSTGRES_DSN", DEFAULT_POSTGRES_DSN),
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    try:
+        summary = run_contract_check(args.dsn)
+    except Exception as exc:
+        print(f"Controlled receiver contract failed: {exc}", file=sys.stderr)
+        return 1
+    print(json.dumps(summary, sort_keys=True, allow_nan=False))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/warehouse/controlled_receiver_rehearsal_postgres_contract_check.py
+++ b/src/warehouse/controlled_receiver_rehearsal_postgres_contract_check.py
@@ -162,7 +162,9 @@ def _mutation_rejected(dsn: str, statement: str) -> bool:
             with connection.cursor() as cursor:
                 cursor.execute(statement)
             connection.commit()
-    except Exception:
+    except Exception as exc:
+        if "append-only" not in str(exc):
+            raise
         return True
     return False
 

--- a/src/warehouse/controlled_receiver_rehearsal_recorder.py
+++ b/src/warehouse/controlled_receiver_rehearsal_recorder.py
@@ -1,0 +1,313 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import sys
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+from src.common.exceptions import StorageError, ValidationError
+from src.warehouse.controlled_receiver_rehearsal_contract import (
+    activation_checklist_sha256,
+    canonical_controlled_receiver_rehearsal_bytes,
+    validate_controlled_receiver_rehearsal_record,
+)
+from src.warehouse.postgres_loader import DEFAULT_POSTGRES_DSN
+
+
+def _summary(
+    record: Mapping[str, Any],
+    *,
+    created: bool,
+    digest: str,
+    checklist_created: bool,
+) -> dict[str, Any]:
+    checklist = record["activation_checklist"]
+    return {
+        "record_id": record["record_id"],
+        "request_id": record["request_id"],
+        "rehearsal_id": record["rehearsal_id"],
+        "terminal_status": record["terminal_status"],
+        "failure_code": record["failure_code"],
+        "checklist_id": checklist["checklist_id"],
+        "destination_id": checklist["destination_id"],
+        "request_count": record["request_count"],
+        "document_sha256": digest,
+        "checklist_created": checklist_created,
+        "created": created,
+    }
+
+
+def record_controlled_receiver_rehearsal(
+    *,
+    dsn: str,
+    record: Mapping[str, Any],
+) -> dict[str, Any]:
+    validated = validate_controlled_receiver_rehearsal_record(record)
+    canonical = canonical_controlled_receiver_rehearsal_bytes(validated)
+    digest = hashlib.sha256(canonical).hexdigest()
+    checklist = validated["activation_checklist"]
+    checklist_digest = activation_checklist_sha256(checklist)
+    try:
+        import psycopg
+        from psycopg.types.json import Jsonb
+    except ImportError as exc:  # pragma: no cover - required in CI.
+        raise RuntimeError("Controlled receiver rehearsal history requires psycopg") from exc
+
+    created = False
+    checklist_created = False
+    try:
+        with psycopg.connect(dsn) as connection:
+            with connection.cursor() as cursor:
+                cursor.execute(
+                    """
+                    SELECT checklist_json, document_sha256
+                    FROM risk_platform.notification_activation_checklists
+                    WHERE checklist_id = %s
+                    """,
+                    (checklist["checklist_id"],),
+                )
+                existing_checklist = cursor.fetchone()
+                if existing_checklist is not None:
+                    stored_json, stored_digest = existing_checklist
+                    if stored_json != checklist or stored_digest != checklist_digest:
+                        raise ValidationError(
+                            "checklist_id already exists with different evidence"
+                        )
+                else:
+                    cursor.execute(
+                        """
+                        INSERT INTO risk_platform.notification_activation_checklists (
+                            checklist_id,
+                            model_version,
+                            destination_id,
+                            destination_fingerprint,
+                            authority_id,
+                            reviewed_at,
+                            review_expires_at,
+                            reviewed_by_json,
+                            controls_json,
+                            activation_ready,
+                            checklist_json,
+                            document_sha256
+                        )
+                        VALUES (
+                            %s, %s, %s, %s, %s, %s,
+                            %s, %s, %s, %s, %s, %s
+                        )
+                        ON CONFLICT DO NOTHING
+                        RETURNING checklist_id
+                        """,
+                        (
+                            checklist["checklist_id"],
+                            checklist["model_version"],
+                            checklist["destination_id"],
+                            checklist["destination_fingerprint"],
+                            checklist["authority_id"],
+                            checklist["reviewed_at"],
+                            checklist["review_expires_at"],
+                            Jsonb(checklist["reviewed_by"]),
+                            Jsonb(checklist["controls"]),
+                            checklist["activation_ready"],
+                            Jsonb(checklist),
+                            checklist_digest,
+                        ),
+                    )
+                    checklist_created = cursor.fetchone() is not None
+                    cursor.execute(
+                        """
+                        SELECT checklist_json, document_sha256
+                        FROM risk_platform.notification_activation_checklists
+                        WHERE checklist_id = %s
+                        """,
+                        (checklist["checklist_id"],),
+                    )
+                    stored_checklist = cursor.fetchone()
+                    if stored_checklist is None:
+                        raise StorageError(
+                            "activation checklist could not be read after insert"
+                        )
+                    stored_json, stored_digest = stored_checklist
+                    if stored_json != checklist or stored_digest != checklist_digest:
+                        raise ValidationError(
+                            "checklist_id already exists with different evidence"
+                        )
+
+                cursor.execute(
+                    """
+                    SELECT record_json, document_sha256
+                    FROM risk_platform.controlled_notification_receiver_rehearsals
+                    WHERE request_id = %s
+                    """,
+                    (validated["request_id"],),
+                )
+                existing = cursor.fetchone()
+                if existing is not None:
+                    stored_json, stored_digest = existing
+                    if stored_json != validated or stored_digest != digest:
+                        raise ValidationError(
+                            "request_id already exists with different rehearsal evidence"
+                        )
+                    return _summary(
+                        validated,
+                        created=False,
+                        digest=digest,
+                        checklist_created=False,
+                    )
+
+                cursor.execute(
+                    """
+                    INSERT INTO
+                    risk_platform.controlled_notification_receiver_rehearsals (
+                        record_id,
+                        model_version,
+                        request_id,
+                        terminal_status,
+                        failure_code,
+                        checklist_id,
+                        destination_id,
+                        destination_fingerprint,
+                        authority_id,
+                        receiver_model_version,
+                        rehearsal_id,
+                        allowed_hosts_json,
+                        allowed_event_types_json,
+                        response_status,
+                        started_at,
+                        finished_at,
+                        recorded_at,
+                        attempted_request_count,
+                        request_count,
+                        unique_idempotency_keys,
+                        same_content_duplicate_count,
+                        receipts_json,
+                        receiver_summary_json,
+                        record_json,
+                        document_sha256
+                    )
+                    VALUES (
+                        %s, %s, %s, %s, %s, %s, %s, %s, %s,
+                        %s, %s, %s, %s, %s, %s, %s, %s, %s,
+                        %s, %s, %s, %s, %s, %s, %s
+                    )
+                    ON CONFLICT DO NOTHING
+                    RETURNING record_id
+                    """,
+                    (
+                        validated["record_id"],
+                        validated["model_version"],
+                        validated["request_id"],
+                        validated["terminal_status"],
+                        validated["failure_code"],
+                        checklist["checklist_id"],
+                        checklist["destination_id"],
+                        checklist["destination_fingerprint"],
+                        checklist["authority_id"],
+                        validated["receiver_model_version"],
+                        validated["rehearsal_id"],
+                        Jsonb(validated["allowed_hosts"]),
+                        Jsonb(validated["allowed_event_types"]),
+                        validated["response_status"],
+                        validated["started_at"],
+                        validated["finished_at"],
+                        validated["recorded_at"],
+                        validated["attempted_request_count"],
+                        validated["request_count"],
+                        validated["unique_idempotency_keys"],
+                        validated["same_content_duplicate_count"],
+                        Jsonb(validated["receipts"]),
+                        (
+                            None
+                            if validated["receiver_summary"] is None
+                            else Jsonb(validated["receiver_summary"])
+                        ),
+                        Jsonb(validated),
+                        digest,
+                    ),
+                )
+                created = cursor.fetchone() is not None
+                cursor.execute(
+                    """
+                    SELECT record_json, document_sha256
+                    FROM risk_platform.controlled_notification_receiver_rehearsals
+                    WHERE record_id = %s
+                    """,
+                    (validated["record_id"],),
+                )
+                stored = cursor.fetchone()
+                if stored is None:
+                    raise StorageError(
+                        "controlled receiver rehearsal could not be read after insert"
+                    )
+                stored_json, stored_digest = stored
+                if stored_json != validated or stored_digest != digest:
+                    raise ValidationError(
+                        "record_id already exists with different rehearsal evidence"
+                    )
+            connection.commit()
+    except (StorageError, ValidationError):
+        raise
+    except Exception:
+        raise StorageError(
+            "controlled receiver rehearsal database operation failed"
+        ) from None
+
+    return _summary(
+        validated,
+        created=created,
+        digest=digest,
+        checklist_created=checklist_created,
+    )
+
+
+def _read_record(path: Path) -> dict[str, Any]:
+    if path.is_symlink():
+        raise ValidationError("controlled receiver record must not be a symbolic link")
+    if not path.is_file():
+        raise ValidationError("controlled receiver record must be a regular file")
+    if path.stat().st_size > 1_048_576:
+        raise ValidationError("controlled receiver record exceeds 1 MB")
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, ValueError):
+        raise ValidationError("controlled receiver record could not be read") from None
+    if not isinstance(value, Mapping):
+        raise ValidationError("controlled receiver record must be a JSON object")
+    return dict(value)
+
+
+def _build_parser() -> Any:
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="Append one controlled receiver rehearsal to PostgreSQL."
+    )
+    parser.add_argument("--record", required=True, type=Path)
+    parser.add_argument(
+        "--dsn",
+        default=os.environ.get("WAREHOUSE_POSTGRES_DSN", DEFAULT_POSTGRES_DSN),
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    try:
+        result = record_controlled_receiver_rehearsal(
+            dsn=args.dsn,
+            record=_read_record(args.record),
+        )
+    except ValidationError as exc:
+        print(f"Controlled receiver rehearsal rejected: {exc}", file=sys.stderr)
+        return 1
+    except (StorageError, RuntimeError) as exc:
+        print(f"Controlled receiver rehearsal history failed: {exc}", file=sys.stderr)
+        return 1
+    print(json.dumps(result, sort_keys=True, allow_nan=False))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/test_controlled_receiver_rehearsal_contract.py
+++ b/tests/unit/test_controlled_receiver_rehearsal_contract.py
@@ -1,0 +1,200 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+import pytest
+
+from src.common.exceptions import ValidationError
+from src.orchestration.notification_activation_checklist import (
+    CONTROL_NAMES,
+    build_notification_activation_checklist,
+)
+from src.warehouse.controlled_receiver_rehearsal_contract import (
+    RECEIVER_MODEL_VERSION,
+    build_controlled_receiver_rehearsal_record,
+    validate_controlled_receiver_rehearsal_record,
+)
+
+STARTED = datetime(2026, 8, 28, 10, tzinfo=timezone.utc)
+FINISHED = STARTED + timedelta(seconds=3)
+RECORDED = FINISHED + timedelta(seconds=1)
+
+
+def checklist() -> dict[str, Any]:
+    return build_notification_activation_checklist(
+        destination_id="risk-operations-webhook",
+        destination_fingerprint="destination-fingerprint-v1",
+        authority_id="destination-authority-v1",
+        reviewed_by=["reviewer-a", "reviewer-b"],
+        reviewed_at=STARTED - timedelta(days=1),
+        review_expires_at=STARTED + timedelta(days=1),
+        controls={name: True for name in CONTROL_NAMES},
+    )
+
+
+def summary() -> dict[str, Any]:
+    receipts = [
+        {
+            "endpoint_host": "receiver.test",
+            "event_id": "event-1",
+            "event_type": "breach_opened",
+            "http_status": 204,
+            "idempotency_key": "event-1",
+            "payload_sha256": "a" * 64,
+            "received_at": (STARTED + timedelta(seconds=1)).isoformat(),
+            "request_ordinal": 1,
+            "same_content_duplicate": False,
+        },
+        {
+            "endpoint_host": "receiver.test",
+            "event_id": "event-1",
+            "event_type": "breach_opened",
+            "http_status": 204,
+            "idempotency_key": "event-1",
+            "payload_sha256": "a" * 64,
+            "received_at": (STARTED + timedelta(seconds=2)).isoformat(),
+            "request_ordinal": 2,
+            "same_content_duplicate": True,
+        },
+    ]
+    identity = {
+        "activation_checklist_id": checklist()["checklist_id"],
+        "allowed_event_types": ["breach_opened"],
+        "allowed_hosts": ["receiver.test"],
+        "authority_id": "destination-authority-v1",
+        "destination_fingerprint": "destination-fingerprint-v1",
+        "destination_id": "risk-operations-webhook",
+        "model_version": RECEIVER_MODEL_VERSION,
+        "receipts": receipts,
+        "response_status": 204,
+    }
+    digest = hashlib.sha256(
+        json.dumps(identity, sort_keys=True, separators=(",", ":")).encode()
+    ).hexdigest()[:24]
+    return {
+        "rehearsal_id": f"{RECEIVER_MODEL_VERSION}-rehearsal-{digest}",
+        **identity,
+        "request_count": 2,
+        "same_content_duplicate_count": 1,
+        "unique_idempotency_keys": 1,
+        "acknowledgement_mutated": False,
+        "delivery_attempt_written": False,
+        "dns_lookup_performed": False,
+        "endpoint_paths_recorded": False,
+        "external_request_performed": False,
+        "infrastructure_deployed": False,
+        "outbox_mutated": False,
+        "payload_bodies_recorded": False,
+        "response_bodies_recorded": False,
+        "socket_opened": False,
+    }
+
+
+def build(**overrides: Any) -> dict[str, Any]:
+    values: dict[str, Any] = {
+        "request_id": "REHEARSAL-001",
+        "terminal_status": "completed",
+        "failure_code": None,
+        "activation_checklist": checklist(),
+        "allowed_hosts": ["receiver.test"],
+        "allowed_event_types": ["breach_opened"],
+        "response_status": 204,
+        "started_at": STARTED,
+        "finished_at": FINISHED,
+        "recorded_at": RECORDED,
+        "attempted_request_count": 2,
+        "receiver_summary": summary(),
+    }
+    values.update(overrides)
+    return build_controlled_receiver_rehearsal_record(**values)
+
+
+def test_completed_record_is_deterministic_canonical_and_secret_free() -> None:
+    first = build()
+    second = build()
+    assert first == second
+    assert validate_controlled_receiver_rehearsal_record(first) == first
+    assert first["request_count"] == 2
+    rendered = json.dumps(first)
+    assert "https://" not in rendered
+    assert "postgresql://" not in rendered
+    assert '"payload"' not in rendered
+
+
+def test_rejected_and_failed_statuses_are_distinct() -> None:
+    rejected = build(
+        request_id="REHEARSAL-REJECTED",
+        terminal_status="rejected_before_request",
+        failure_code="validation_error",
+        attempted_request_count=0,
+        receiver_summary=None,
+    )
+    assert rejected["request_count"] == 0
+    assert rejected["rehearsal_id"] is None
+
+    partial = summary()
+    partial["receipts"] = partial["receipts"][:1]
+    partial["request_count"] = 1
+    partial["same_content_duplicate_count"] = 0
+    partial["unique_idempotency_keys"] = 1
+    identity = {
+        key: partial[key]
+        for key in (
+            "activation_checklist_id",
+            "allowed_event_types",
+            "allowed_hosts",
+            "authority_id",
+            "destination_fingerprint",
+            "destination_id",
+            "model_version",
+            "receipts",
+            "response_status",
+        )
+    }
+    digest = hashlib.sha256(
+        json.dumps(identity, sort_keys=True, separators=(",", ":")).encode()
+    ).hexdigest()[:24]
+    partial["rehearsal_id"] = f"{RECEIVER_MODEL_VERSION}-rehearsal-{digest}"
+    failed = build(
+        request_id="REHEARSAL-FAILED",
+        terminal_status="failed_during_rehearsal",
+        failure_code="validation_error",
+        attempted_request_count=2,
+        receiver_summary=partial,
+    )
+    assert failed["request_count"] == 1
+    assert failed["attempted_request_count"] == 2
+
+
+def test_tampered_counts_and_side_effects_fail_closed() -> None:
+    record = build()
+    record["request_count"] = 1
+    with pytest.raises(ValidationError, match="not canonical"):
+        validate_controlled_receiver_rehearsal_record(record)
+
+    changed = summary()
+    changed["external_request_performed"] = True
+    with pytest.raises(ValidationError, match="side-effect"):
+        build(receiver_summary=changed)
+
+
+def test_review_window_and_status_rules_fail_closed() -> None:
+    with pytest.raises(ValidationError, match="review window"):
+        build(
+            started_at=STARTED + timedelta(days=2),
+            finished_at=FINISHED + timedelta(days=2),
+            recorded_at=RECORDED + timedelta(days=2),
+        )
+
+    with pytest.raises(ValidationError, match="completed rehearsal"):
+        build(attempted_request_count=3)
+
+    with pytest.raises(ValidationError, match="one rejected request"):
+        build(
+            terminal_status="failed_during_rehearsal",
+            failure_code="validation_error",
+            attempted_request_count=2,
+        )

--- a/tests/unit/test_controlled_receiver_rehearsal_history_architecture_contract.py
+++ b/tests/unit/test_controlled_receiver_rehearsal_history_architecture_contract.py
@@ -1,0 +1,103 @@
+from pathlib import Path
+
+
+def test_controlled_receiver_rehearsal_history_is_append_only_and_no_network() -> None:
+    contract = Path(
+        "src/warehouse/controlled_receiver_rehearsal_contract.py"
+    ).read_text(encoding="utf-8")
+    recorder = Path(
+        "src/warehouse/controlled_receiver_rehearsal_recorder.py"
+    ).read_text(encoding="utf-8")
+    checker = Path(
+        "src/warehouse/controlled_receiver_rehearsal_postgres_contract_check.py"
+    ).read_text(encoding="utf-8")
+    checks = Path(
+        "sql/controlled_notification_receiver_rehearsal_consistency_checks.sql"
+    ).read_text(encoding="utf-8")
+    schema = Path(
+        "sql/controlled_notification_receiver_rehearsal_schema.sql"
+    ).read_text(encoding="utf-8")
+    compose = Path("docker-compose.yml").read_text(encoding="utf-8")
+    makefile = Path("Makefile").read_text(encoding="utf-8")
+    docs = Path(
+        "docs/controlled-notification-receiver-rehearsal-history.md"
+    ).read_text(encoding="utf-8")
+    normalized_docs = " ".join(docs.split()).casefold()
+
+    for status in (
+        "completed",
+        "rejected_before_request",
+        "failed_during_rehearsal",
+    ):
+        assert status in contract
+        assert status in schema
+        assert status in checker
+        assert status in docs
+
+    for required in (
+        "validate_notification_activation_checklist",
+        "same_content_duplicate_count",
+        "review window",
+        "payload_bodies_recorded",
+        "external_request_performed",
+    ):
+        assert required in contract
+
+    for required in (
+        "notification_activation_checklists",
+        "controlled_notification_receiver_rehearsals",
+        "ON CONFLICT DO NOTHING",
+        "request_id already exists with different rehearsal evidence",
+    ):
+        assert required in recorder
+
+    for required in (
+        "reject_notification_activation_checklist_mutation",
+        "reject_controlled_receiver_rehearsal_mutation",
+        "BEFORE UPDATE OR DELETE",
+        "document_sha256",
+    ):
+        assert required in schema
+
+    for required in (
+        "CONTRACT-REHEARSAL-COMPLETED",
+        "CONTRACT-REHEARSAL-FAILED",
+        "CONTRACT-REHEARSAL-REJECTED",
+        "exact controlled receiver retry did not converge",
+        "append-only rehearsal mutation was accepted",
+        "external_request_performed",
+    ):
+        assert required in checker
+
+    for required in (
+        "controlled_receiver_completed_rows_valid",
+        "controlled_receiver_failed_rows_valid",
+        "controlled_receiver_rejected_rows_valid",
+        "controlled_receiver_rehearsal_side_effects_safe",
+        "controlled_receiver_rehearsals_inside_review_window",
+    ):
+        assert required in checks
+
+    assert (
+        "22_controlled_notification_receiver_rehearsal_schema.sql:ro"
+        in compose
+    )
+    assert "controlled_receiver_rehearsal_postgres_contract_check" in makefile
+
+    for required in (
+        "primary arc42 blocks: `orchestration` and `warehouse`",
+        "exact request replay convergence",
+        "append-only postgresql history",
+        "ordinary validation performs no dns lookup",
+        "terraform apply",
+    ):
+        assert required in normalized_docs
+
+    for forbidden in (
+        "urllib.request",
+        "requests.post(",
+        "httpx.",
+    ):
+        assert forbidden not in contract.casefold()
+        assert forbidden not in recorder.casefold()
+        assert forbidden not in checker.casefold()

--- a/tests/unit/test_docker_compose_contract.py
+++ b/tests/unit/test_docker_compose_contract.py
@@ -47,6 +47,7 @@ def test_local_database_seed_mounts_are_read_only_and_ordered() -> None:
         "./sql/portfolio_risk_notification_retry_destination_binding_schema.sql:/docker-entrypoint-initdb.d/19b_portfolio_risk_notification_retry_destination_binding_schema.sql:ro",
         "./sql/portfolio_risk_notification_retry_follow_up_schema.sql:/docker-entrypoint-initdb.d/20_portfolio_risk_notification_retry_follow_up_schema.sql:ro",
         "./sql/portfolio_risk_notification_retry_destination_follow_up_schema.sql:/docker-entrypoint-initdb.d/21_portfolio_risk_notification_retry_destination_follow_up_schema.sql:ro",
+        "./sql/controlled_notification_receiver_rehearsal_schema.sql:/docker-entrypoint-initdb.d/22_controlled_notification_receiver_rehearsal_schema.sql:ro",
     ]
     assert services["mongo"]["volumes"] == [
         "./mongo/init:/docker-entrypoint-initdb.d:ro"


### PR DESCRIPTION
## Goal

Complete **P4d4c — append-only controlled-receiver rehearsal history**.

```text
activation-ready checklist
  + controlled receiver configuration
  + accepted receipt evidence
  + bounded terminal outcome
  -> canonical rehearsal record
  -> append-only PostgreSQL history
  -> exact request replay convergence
```

## Contract

Adds canonical `portfolio-risk-controlled-receiver-rehearsal-record-v1` evidence with three terminal states: `completed`, `rejected_before_request`, and `failed_during_rehearsal`.

Each record binds the complete activation checklist, destination and authority identities, receiver model, sorted host and event allow-lists, simulated response status, ordered accepted receipts, attempted/accepted/unique/duplicate counts, timestamps and a bounded failure code.

## Durable history

Adds `risk_platform.notification_activation_checklists` and `risk_platform.controlled_notification_receiver_rehearsals`, deterministic SHA-256 values, request-ID replay convergence, conflicting reuse rejection, and append-only UPDATE/DELETE triggers.

The PostgreSQL contract records each terminal state, repeats an exact request, rejects conflicting request reuse, accepts only the trigger's explicit `append-only` mutation error and runs ten reconciliation checks.

## Administrative replacement

This PR points to the exact same validated head as closed draft PR #124: `b77941798d70cd8c0530f23fef11355f8f710749`. #124 was closed only because the connected app’s GitHub GraphQL ready-state mutation is currently broken; no code changed in the replacement.

## Existing exact-head evidence

Run **366** (`33217534542`) already passed on this exact commit:

- Security guardrails passed.
- Ruff passed.
- mypy passed across 128 source files.
- 850 tests passed in quality and 850 passed again in readiness.
- PostgreSQL 16 proved all three terminal states, exact retry convergence, conflict rejection, append-only triggers, and ten new checks.
- Kubernetes rendering and Terraform format/init/validate passed without apply.

A fresh PR run is still required before merge.

## Safety boundary

The history retains host names and payload SHA-256 values but no endpoint URL or path, endpoint value, credential, environment value, payload body, response body or PostgreSQL DSN. Ordinary validation performs no DNS lookup, socket open, external request, delivery-attempt write, outbox mutation, acknowledgement, deployment or `terraform apply`.