### PR TITLE
Add current notification activation and rehearsal review views

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,7 @@ services:
       - ./sql/portfolio_risk_notification_retry_follow_up_schema.sql:/docker-entrypoint-initdb.d/20_portfolio_risk_notification_retry_follow_up_schema.sql:ro
       - ./sql/portfolio_risk_notification_retry_destination_follow_up_schema.sql:/docker-entrypoint-initdb.d/21_portfolio_risk_notification_retry_destination_follow_up_schema.sql:ro
       - ./sql/controlled_notification_receiver_rehearsal_schema.sql:/docker-entrypoint-initdb.d/22_controlled_notification_receiver_rehearsal_schema.sql:ro
+      - ./sql/controlled_notification_receiver_review_schema.sql:/docker-entrypoint-initdb.d/23_controlled_notification_receiver_review_schema.sql:ro
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U risk_user -d risk_platform"]
       interval: 5s

--- a/docs/controlled-notification-receiver-review-views.md
+++ b/docs/controlled-notification-receiver-review-views.md
@@ -1,0 +1,103 @@
+# Notification Activation and Controlled Receiver Review Views
+
+Primary arc42 block: `warehouse`.
+
+## Goal
+
+Turn retained activation checklists and controlled-receiver rehearsals into one
+current, reviewer-oriented state per notification destination:
+
+```text
+append-only activation checklists
+  + append-only controlled receiver rehearsals
+  -> deterministic latest evidence per destination
+  -> explicit review status
+  -> ready and review-required queues
+```
+
+These are query contracts, not authority to enable notification delivery.
+
+## Current-version selection
+
+The latest checklist for a destination is selected by:
+
+```text
+reviewed_at DESC
+checklist_id DESC
+```
+
+The latest rehearsal is selected independently by:
+
+```text
+recorded_at DESC
+record_id DESC
+```
+
+Historical rows remain immutable. A newer checklist can therefore supersede a
+successful rehearsal without deleting either item. The destination remains under
+review until the newer checklist has its own completed rehearsal.
+
+## Review states
+
+The current review view exposes exactly one of:
+
+```text
+checklist_incomplete
+checklist_not_yet_active
+checklist_expired
+rehearsal_missing
+rehearsal_evidence_conflict
+rehearsal_superseded
+rehearsal_rejected
+rehearsal_failed
+ready
+review_required
+```
+
+Precedence is fail closed. Incomplete or time-invalid checklist evidence outranks
+rehearsal evidence. A rehearsal whose stored destination or authority identity no
+longer reconciles is classified as an evidence conflict. A valid rehearsal against
+an older checklist is classified as superseded rather than ready.
+
+`incomplete_controls_json` lists every required checklist control that is not true.
+The review view also retains checklist and rehearsal identities, timing, host and
+event allow-lists, request counts, failure codes and receiver model metadata.
+
+## Serving views
+
+```text
+risk_platform.latest_notification_activation_checklists
+risk_platform.latest_controlled_notification_receiver_rehearsals
+risk_platform.current_notification_activation_rehearsal_review
+risk_platform.current_notification_activation_review_failures
+risk_platform.current_notification_activation_ready
+```
+
+`current_notification_activation_ready` contains only current active checklists
+with a completed, internally consistent rehearsal against the exact same checklist,
+destination fingerprint and authority identity.
+
+## PostgreSQL evidence
+
+The transaction fixture covers eight reviewer states:
+
+- ready;
+- incomplete checklist;
+- not-yet-active checklist;
+- expired checklist;
+- missing rehearsal;
+- rejected rehearsal;
+- failed rehearsal; and
+- a newer checklist superseding an older completed rehearsal.
+
+Reconciliation checks prove unique current grains, correct latest selection,
+incomplete-control expansion, status precedence, and exact ready/failure
+partitions.
+
+## Safety boundary
+
+The views are read only and expose no endpoint URL or path, endpoint value,
+credential, environment value, payload body, response body or PostgreSQL DSN.
+Ordinary validation performs no DNS lookup, socket open, external request,
+delivery-attempt write, outbox mutation, acknowledgement, cloud schedule
+activation, deployment or `terraform apply`.

--- a/sql/controlled_notification_receiver_review_consistency_checks.sql
+++ b/sql/controlled_notification_receiver_review_consistency_checks.sql
@@ -1,0 +1,297 @@
+-- Reconciliation for current activation and controlled receiver review views.
+
+WITH counts AS (
+    SELECT
+        (SELECT COUNT(DISTINCT destination_id)
+         FROM risk_platform.notification_activation_checklists)
+            AS destination_count,
+        (SELECT COUNT(*)
+         FROM risk_platform.latest_notification_activation_checklists)
+            AS latest_checklist_rows,
+        (SELECT COUNT(DISTINCT destination_id)
+         FROM risk_platform.controlled_notification_receiver_rehearsals)
+            AS rehearsal_destination_count,
+        (SELECT COUNT(*)
+         FROM risk_platform.latest_controlled_notification_receiver_rehearsals)
+            AS latest_rehearsal_rows,
+        (SELECT COUNT(*)
+         FROM risk_platform.current_notification_activation_rehearsal_review)
+            AS review_rows,
+        (SELECT COUNT(*)
+         FROM risk_platform.current_notification_activation_rehearsal_review
+         WHERE review_required)
+            AS expected_failure_rows,
+        (SELECT COUNT(*)
+         FROM risk_platform.current_notification_activation_review_failures)
+            AS failure_rows,
+        (SELECT COUNT(*)
+         FROM risk_platform.current_notification_activation_rehearsal_review
+         WHERE operational_activation_ready)
+            AS expected_ready_rows,
+        (SELECT COUNT(*)
+         FROM risk_platform.current_notification_activation_ready)
+            AS ready_rows
+),
+integrity AS (
+    SELECT
+        (
+            SELECT COUNT(*)
+            FROM (
+                SELECT destination_id
+                FROM risk_platform.latest_notification_activation_checklists
+                GROUP BY destination_id
+                HAVING COUNT(*) > 1
+            ) duplicated
+        ) AS duplicate_latest_checklists,
+        (
+            SELECT COUNT(*)
+            FROM risk_platform.latest_notification_activation_checklists latest
+            WHERE latest.current_version_rank <> 1
+               OR EXISTS (
+                   SELECT 1
+                   FROM risk_platform.notification_activation_checklists candidate
+                   WHERE candidate.destination_id = latest.destination_id
+                     AND (candidate.reviewed_at, candidate.checklist_id)
+                         > (latest.reviewed_at, latest.checklist_id)
+               )
+        ) AS stale_latest_checklists,
+        (
+            SELECT COUNT(*)
+            FROM (
+                SELECT destination_id
+                FROM risk_platform.latest_controlled_notification_receiver_rehearsals
+                GROUP BY destination_id
+                HAVING COUNT(*) > 1
+            ) duplicated
+        ) AS duplicate_latest_rehearsals,
+        (
+            SELECT COUNT(*)
+            FROM risk_platform.latest_controlled_notification_receiver_rehearsals
+                latest
+            WHERE latest.current_version_rank <> 1
+               OR EXISTS (
+                   SELECT 1
+                   FROM risk_platform.controlled_notification_receiver_rehearsals
+                       candidate
+                   WHERE candidate.destination_id = latest.destination_id
+                     AND (candidate.recorded_at, candidate.record_id)
+                         > (latest.recorded_at, latest.record_id)
+               )
+        ) AS stale_latest_rehearsals,
+        (
+            SELECT COUNT(*)
+            FROM (
+                SELECT destination_id
+                FROM risk_platform.current_notification_activation_rehearsal_review
+                GROUP BY destination_id
+                HAVING COUNT(*) > 1
+            ) duplicated
+        ) AS duplicate_review_destinations,
+        (
+            SELECT COUNT(*)
+            FROM risk_platform.current_notification_activation_rehearsal_review
+                review
+            WHERE jsonb_array_length(review.incomplete_controls_json) <> (
+                SELECT COUNT(*)
+                FROM jsonb_each(review.controls_json) control
+                WHERE control.value <> 'true'::jsonb
+            )
+        ) AS incomplete_control_mismatches,
+        (
+            SELECT COUNT(*)
+            FROM risk_platform.current_notification_activation_rehearsal_review
+                review
+            WHERE review.review_status <> CASE
+                WHEN NOT review.checklist_activation_ready
+                    THEN 'checklist_incomplete'
+                WHEN CURRENT_TIMESTAMP < review.reviewed_at
+                    THEN 'checklist_not_yet_active'
+                WHEN CURRENT_TIMESTAMP >= review.review_expires_at
+                    THEN 'checklist_expired'
+                WHEN review.rehearsal_record_id IS NULL
+                    THEN 'rehearsal_missing'
+                WHEN NOT review.rehearsal_reference_consistent
+                    THEN 'rehearsal_evidence_conflict'
+                WHEN NOT review.rehearsal_matches_current_checklist
+                    THEN 'rehearsal_superseded'
+                WHEN review.rehearsal_terminal_status
+                    = 'rejected_before_request'
+                    THEN 'rehearsal_rejected'
+                WHEN review.rehearsal_terminal_status
+                    = 'failed_during_rehearsal'
+                    THEN 'rehearsal_failed'
+                WHEN review.rehearsal_terminal_status = 'completed'
+                    THEN 'ready'
+                ELSE 'review_required'
+            END
+        ) AS review_status_mismatches,
+        (
+            SELECT COUNT(*)
+            FROM risk_platform.current_notification_activation_rehearsal_review
+                review
+            WHERE review.review_required = (review.review_status = 'ready')
+               OR review.operational_activation_ready
+                    <> (review.review_status = 'ready')
+        ) AS review_flag_mismatches,
+        (
+            SELECT COUNT(*)
+            FROM risk_platform.current_notification_activation_ready ready
+            WHERE ready.review_status <> 'ready'
+               OR ready.review_required
+               OR NOT ready.operational_activation_ready
+               OR NOT ready.checklist_activation_ready
+               OR ready.rehearsal_terminal_status <> 'completed'
+               OR NOT ready.rehearsal_reference_consistent
+               OR NOT ready.rehearsal_matches_current_checklist
+               OR CURRENT_TIMESTAMP < ready.reviewed_at
+               OR CURRENT_TIMESTAMP >= ready.review_expires_at
+        ) AS invalid_ready_rows,
+        (
+            SELECT COUNT(*)
+            FROM risk_platform.current_notification_activation_review_failures
+                failure
+            WHERE NOT failure.review_required
+               OR failure.operational_activation_ready
+               OR failure.review_status = 'ready'
+        ) AS invalid_failure_rows
+)
+SELECT
+    'notification_activation_latest_checklist_covers_destinations' AS check_name,
+    destination_count::TEXT AS expected,
+    latest_checklist_rows::TEXT AS actual,
+    CASE
+        WHEN destination_count = latest_checklist_rows THEN 'pass'
+        ELSE 'fail'
+    END AS status
+FROM counts
+
+UNION ALL
+
+SELECT
+    'notification_activation_latest_checklist_grain_unique',
+    '0',
+    duplicate_latest_checklists::TEXT,
+    CASE WHEN duplicate_latest_checklists = 0 THEN 'pass' ELSE 'fail' END
+FROM integrity
+
+UNION ALL
+
+SELECT
+    'notification_activation_latest_checklist_selection_current',
+    '0',
+    stale_latest_checklists::TEXT,
+    CASE WHEN stale_latest_checklists = 0 THEN 'pass' ELSE 'fail' END
+FROM integrity
+
+UNION ALL
+
+SELECT
+    'controlled_receiver_latest_rehearsal_covers_destinations',
+    rehearsal_destination_count::TEXT,
+    latest_rehearsal_rows::TEXT,
+    CASE
+        WHEN rehearsal_destination_count = latest_rehearsal_rows THEN 'pass'
+        ELSE 'fail'
+    END
+FROM counts
+
+UNION ALL
+
+SELECT
+    'controlled_receiver_latest_rehearsal_grain_unique',
+    '0',
+    duplicate_latest_rehearsals::TEXT,
+    CASE WHEN duplicate_latest_rehearsals = 0 THEN 'pass' ELSE 'fail' END
+FROM integrity
+
+UNION ALL
+
+SELECT
+    'controlled_receiver_latest_rehearsal_selection_current',
+    '0',
+    stale_latest_rehearsals::TEXT,
+    CASE WHEN stale_latest_rehearsals = 0 THEN 'pass' ELSE 'fail' END
+FROM integrity
+
+UNION ALL
+
+SELECT
+    'notification_activation_review_covers_destinations',
+    destination_count::TEXT,
+    review_rows::TEXT,
+    CASE WHEN destination_count = review_rows THEN 'pass' ELSE 'fail' END
+FROM counts
+
+UNION ALL
+
+SELECT
+    'notification_activation_review_grain_unique',
+    '0',
+    duplicate_review_destinations::TEXT,
+    CASE WHEN duplicate_review_destinations = 0 THEN 'pass' ELSE 'fail' END
+FROM integrity
+
+UNION ALL
+
+SELECT
+    'notification_activation_incomplete_controls_reconcile',
+    '0',
+    incomplete_control_mismatches::TEXT,
+    CASE WHEN incomplete_control_mismatches = 0 THEN 'pass' ELSE 'fail' END
+FROM integrity
+
+UNION ALL
+
+SELECT
+    'notification_activation_review_status_reconciles',
+    '0',
+    review_status_mismatches::TEXT,
+    CASE WHEN review_status_mismatches = 0 THEN 'pass' ELSE 'fail' END
+FROM integrity
+
+UNION ALL
+
+SELECT
+    'notification_activation_review_flags_reconcile',
+    '0',
+    review_flag_mismatches::TEXT,
+    CASE WHEN review_flag_mismatches = 0 THEN 'pass' ELSE 'fail' END
+FROM integrity
+
+UNION ALL
+
+SELECT
+    'notification_activation_failure_partition_matches',
+    expected_failure_rows::TEXT,
+    failure_rows::TEXT,
+    CASE WHEN expected_failure_rows = failure_rows THEN 'pass' ELSE 'fail' END
+FROM counts
+
+UNION ALL
+
+SELECT
+    'notification_activation_failure_rows_valid',
+    '0',
+    invalid_failure_rows::TEXT,
+    CASE WHEN invalid_failure_rows = 0 THEN 'pass' ELSE 'fail' END
+FROM integrity
+
+UNION ALL
+
+SELECT
+    'notification_activation_ready_partition_matches',
+    expected_ready_rows::TEXT,
+    ready_rows::TEXT,
+    CASE WHEN expected_ready_rows = ready_rows THEN 'pass' ELSE 'fail' END
+FROM counts
+
+UNION ALL
+
+SELECT
+    'notification_activation_ready_rows_valid',
+    '0',
+    invalid_ready_rows::TEXT,
+    CASE WHEN invalid_ready_rows = 0 THEN 'pass' ELSE 'fail' END
+FROM integrity
+
+ORDER BY check_name;

--- a/sql/controlled_notification_receiver_review_schema.sql
+++ b/sql/controlled_notification_receiver_review_schema.sql
@@ -1,0 +1,145 @@
+-- Current activation-checklist and controlled-receiver rehearsal review views.
+-- Apply after controlled_notification_receiver_rehearsal_schema.sql.
+
+CREATE OR REPLACE VIEW
+risk_platform.latest_notification_activation_checklists AS
+SELECT ranked.*
+FROM (
+    SELECT
+        checklist.*,
+        ROW_NUMBER() OVER (
+            PARTITION BY checklist.destination_id
+            ORDER BY checklist.reviewed_at DESC, checklist.checklist_id DESC
+        ) AS current_version_rank
+    FROM risk_platform.notification_activation_checklists checklist
+) ranked
+WHERE ranked.current_version_rank = 1;
+
+CREATE OR REPLACE VIEW
+risk_platform.latest_controlled_notification_receiver_rehearsals AS
+SELECT ranked.*
+FROM (
+    SELECT
+        rehearsal.*,
+        ROW_NUMBER() OVER (
+            PARTITION BY rehearsal.destination_id
+            ORDER BY rehearsal.recorded_at DESC, rehearsal.record_id DESC
+        ) AS current_version_rank
+    FROM risk_platform.controlled_notification_receiver_rehearsals rehearsal
+) ranked
+WHERE ranked.current_version_rank = 1;
+
+CREATE OR REPLACE VIEW
+risk_platform.current_notification_activation_rehearsal_review AS
+WITH evidence AS (
+    SELECT
+        checklist.destination_id,
+        checklist.destination_fingerprint,
+        checklist.authority_id,
+        checklist.checklist_id,
+        checklist.reviewed_at,
+        checklist.review_expires_at,
+        checklist.reviewed_by_json,
+        checklist.controls_json,
+        checklist.activation_ready AS checklist_activation_ready,
+        COALESCE(incomplete.incomplete_controls_json, '[]'::jsonb)
+            AS incomplete_controls_json,
+        rehearsal.record_id AS rehearsal_record_id,
+        rehearsal.request_id AS rehearsal_request_id,
+        rehearsal.rehearsal_id,
+        rehearsal.terminal_status AS rehearsal_terminal_status,
+        rehearsal.failure_code AS rehearsal_failure_code,
+        rehearsal.checklist_id AS rehearsal_checklist_id,
+        rehearsal.destination_fingerprint AS rehearsal_destination_fingerprint,
+        rehearsal.authority_id AS rehearsal_authority_id,
+        rehearsal.receiver_model_version,
+        rehearsal.response_status,
+        rehearsal.started_at AS rehearsal_started_at,
+        rehearsal.finished_at AS rehearsal_finished_at,
+        rehearsal.recorded_at AS rehearsal_recorded_at,
+        rehearsal.attempted_request_count,
+        rehearsal.request_count,
+        rehearsal.unique_idempotency_keys,
+        rehearsal.same_content_duplicate_count,
+        rehearsal.allowed_hosts_json,
+        rehearsal.allowed_event_types_json,
+        referenced.checklist_id IS NOT NULL
+            AND referenced.destination_id = rehearsal.destination_id
+            AND referenced.destination_fingerprint
+                = rehearsal.destination_fingerprint
+            AND referenced.authority_id = rehearsal.authority_id
+            AS rehearsal_reference_consistent,
+        rehearsal.record_id IS NOT NULL
+            AND rehearsal.checklist_id = checklist.checklist_id
+            AND rehearsal.destination_fingerprint
+                = checklist.destination_fingerprint
+            AND rehearsal.authority_id = checklist.authority_id
+            AS rehearsal_matches_current_checklist
+    FROM risk_platform.latest_notification_activation_checklists checklist
+    LEFT JOIN LATERAL (
+        SELECT jsonb_agg(control.key ORDER BY control.key)
+            AS incomplete_controls_json
+        FROM jsonb_each(checklist.controls_json) AS control(key, value)
+        WHERE control.value <> 'true'::jsonb
+    ) incomplete ON TRUE
+    LEFT JOIN risk_platform.latest_controlled_notification_receiver_rehearsals
+        rehearsal
+      ON rehearsal.destination_id = checklist.destination_id
+    LEFT JOIN risk_platform.notification_activation_checklists referenced
+      ON referenced.checklist_id = rehearsal.checklist_id
+),
+classified AS (
+    SELECT
+        evidence.*,
+        CASE
+            WHEN NOT evidence.checklist_activation_ready
+                THEN 'checklist_incomplete'
+            WHEN CURRENT_TIMESTAMP < evidence.reviewed_at
+                THEN 'checklist_not_yet_active'
+            WHEN CURRENT_TIMESTAMP >= evidence.review_expires_at
+                THEN 'checklist_expired'
+            WHEN evidence.rehearsal_record_id IS NULL
+                THEN 'rehearsal_missing'
+            WHEN NOT evidence.rehearsal_reference_consistent
+                THEN 'rehearsal_evidence_conflict'
+            WHEN NOT evidence.rehearsal_matches_current_checklist
+                THEN 'rehearsal_superseded'
+            WHEN evidence.rehearsal_terminal_status = 'rejected_before_request'
+                THEN 'rehearsal_rejected'
+            WHEN evidence.rehearsal_terminal_status = 'failed_during_rehearsal'
+                THEN 'rehearsal_failed'
+            WHEN evidence.rehearsal_terminal_status = 'completed'
+                THEN 'ready'
+            ELSE 'review_required'
+        END AS review_status
+    FROM evidence
+)
+SELECT
+    classified.*,
+    classified.review_status <> 'ready' AS review_required,
+    classified.review_status = 'ready' AS operational_activation_ready,
+    CASE classified.review_status
+        WHEN 'rehearsal_evidence_conflict' THEN 9
+        WHEN 'checklist_incomplete' THEN 8
+        WHEN 'checklist_expired' THEN 7
+        WHEN 'checklist_not_yet_active' THEN 6
+        WHEN 'rehearsal_superseded' THEN 5
+        WHEN 'rehearsal_failed' THEN 4
+        WHEN 'rehearsal_rejected' THEN 3
+        WHEN 'rehearsal_missing' THEN 2
+        WHEN 'review_required' THEN 1
+        ELSE 0
+    END AS review_priority
+FROM classified;
+
+CREATE OR REPLACE VIEW
+risk_platform.current_notification_activation_review_failures AS
+SELECT *
+FROM risk_platform.current_notification_activation_rehearsal_review
+WHERE review_required;
+
+CREATE OR REPLACE VIEW
+risk_platform.current_notification_activation_ready AS
+SELECT *
+FROM risk_platform.current_notification_activation_rehearsal_review
+WHERE operational_activation_ready;

--- a/src/warehouse/controlled_receiver_rehearsal_postgres_contract_check.py
+++ b/src/warehouse/controlled_receiver_rehearsal_postgres_contract_check.py
@@ -22,6 +22,9 @@ from src.warehouse.controlled_receiver_rehearsal_contract import (
 from src.warehouse.controlled_receiver_rehearsal_recorder import (
     record_controlled_receiver_rehearsal,
 )
+from src.warehouse.controlled_receiver_review_postgres_contract_check import (
+    run_contract_check as run_review_contract_check,
+)
 from src.warehouse.postgres_loader import DEFAULT_POSTGRES_DSN
 
 CHECK_PATH = Path(
@@ -239,6 +242,7 @@ def run_contract_check(dsn: str) -> dict[str, Any]:
         names = ", ".join(str(check[0]) for check in failures)
         raise AssertionError("controlled receiver reconciliation failed: " + names)
 
+    review_summary = run_review_contract_check(dsn)
     return {
         "model_version": "portfolio-risk-controlled-receiver-contract-v1",
         "terminal_records": len(created),
@@ -251,6 +255,7 @@ def run_contract_check(dsn: str) -> dict[str, Any]:
         "update_rejected": update_rejected,
         "delete_rejected": delete_rejected,
         "consistency_checks": len(checks),
+        "activation_review": review_summary,
         "external_request_performed": False,
         "payload_bodies_recorded": False,
         "response_bodies_recorded": False,
@@ -260,8 +265,8 @@ def run_contract_check(dsn: str) -> dict[str, Any]:
 def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         description=(
-            "Exercise append-only controlled receiver rehearsal history "
-            "against PostgreSQL 16."
+            "Exercise append-only controlled receiver rehearsal history and "
+            "current review views against PostgreSQL 16."
         )
     )
     parser.add_argument(

--- a/src/warehouse/controlled_receiver_review_postgres_contract_check.py
+++ b/src/warehouse/controlled_receiver_review_postgres_contract_check.py
@@ -367,7 +367,8 @@ def _assert_review_states(dsn: str) -> tuple[dict[str, str], int]:
                 WHERE destination_id LIKE 'review-%'
                 """
             )
-            if cursor.fetchone()[0] != 7:
+            failure_row = cursor.fetchone()
+            if failure_row is None or failure_row[0] != 7:
                 raise AssertionError("activation review failure partition changed")
             cursor.execute(
                 """
@@ -376,7 +377,8 @@ def _assert_review_states(dsn: str) -> tuple[dict[str, str], int]:
                 WHERE destination_id LIKE 'review-%'
                 """
             )
-            if cursor.fetchone()[0] != 1:
+            ready_row = cursor.fetchone()
+            if ready_row is None or ready_row[0] != 1:
                 raise AssertionError("activation-ready partition changed")
             cursor.execute(CHECK_PATH.read_text(encoding="utf-8"))
             checks = list(cursor.fetchall())

--- a/src/warehouse/controlled_receiver_review_postgres_contract_check.py
+++ b/src/warehouse/controlled_receiver_review_postgres_contract_check.py
@@ -1,0 +1,433 @@
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+from src.common.exceptions import ValidationError
+from src.orchestration.controlled_notification_receiver import (
+    ControlledNotificationReceiver,
+)
+from src.orchestration.notification_activation_checklist import (
+    CONTROL_NAMES,
+    build_notification_activation_checklist,
+    canonical_activation_checklist_bytes,
+)
+from src.warehouse.controlled_receiver_rehearsal_contract import (
+    build_controlled_receiver_rehearsal_record,
+)
+from src.warehouse.controlled_receiver_rehearsal_recorder import (
+    record_controlled_receiver_rehearsal,
+)
+from src.warehouse.postgres_loader import DEFAULT_POSTGRES_DSN
+
+CHECK_PATH = Path(
+    "sql/controlled_notification_receiver_review_consistency_checks.sql"
+)
+
+
+def _controls(**overrides: bool) -> dict[str, bool]:
+    values = {name: True for name in CONTROL_NAMES}
+    values.update(overrides)
+    return values
+
+
+def _checklist(
+    *,
+    destination_id: str,
+    reviewed_at: datetime,
+    review_expires_at: datetime,
+    controls: dict[str, bool] | None = None,
+    version: str = "v1",
+) -> dict[str, Any]:
+    return build_notification_activation_checklist(
+        destination_id=destination_id,
+        destination_fingerprint=f"{destination_id}-fingerprint-{version}",
+        authority_id=f"{destination_id}-authority-{version}",
+        reviewed_by=["activation-reviewer", "receiver-owner"],
+        reviewed_at=reviewed_at,
+        review_expires_at=review_expires_at,
+        controls=controls or _controls(),
+    )
+
+
+def _record_checklist(cursor: Any, checklist: dict[str, Any], jsonb: Any) -> None:
+    digest = hashlib.sha256(
+        canonical_activation_checklist_bytes(checklist)
+    ).hexdigest()
+    cursor.execute(
+        """
+        INSERT INTO risk_platform.notification_activation_checklists (
+            checklist_id,
+            model_version,
+            destination_id,
+            destination_fingerprint,
+            authority_id,
+            reviewed_at,
+            review_expires_at,
+            reviewed_by_json,
+            controls_json,
+            activation_ready,
+            checklist_json,
+            document_sha256
+        )
+        VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+        ON CONFLICT DO NOTHING
+        """,
+        (
+            checklist["checklist_id"],
+            checklist["model_version"],
+            checklist["destination_id"],
+            checklist["destination_fingerprint"],
+            checklist["authority_id"],
+            checklist["reviewed_at"],
+            checklist["review_expires_at"],
+            jsonb(checklist["reviewed_by"]),
+            jsonb(checklist["controls"]),
+            checklist["activation_ready"],
+            jsonb(checklist),
+            digest,
+        ),
+    )
+
+
+def _payload(event_id: str) -> bytes:
+    document = {
+        "event_id": event_id,
+        "event_type": "breach_opened",
+        "metric_name": "portfolio_volatility_annualized",
+        "payload": {"severity": "critical"},
+        "policy_id": "us-tech-standard",
+        "portfolio_id": "us-tech-equal",
+        "status": "critical",
+        "subject_key": "us-tech-equal",
+        "ts_event": "2026-08-28T09:00:00+00:00",
+    }
+    return json.dumps(
+        document,
+        sort_keys=True,
+        separators=(",", ":"),
+        allow_nan=False,
+    ).encode("utf-8")
+
+
+def _headers(event_id: str) -> dict[str, str]:
+    return {
+        "Content-Type": "application/json",
+        "Idempotency-Key": event_id,
+        "User-Agent": "financial-risk-data-platform/1",
+    }
+
+
+def _clock(*values: datetime) -> Any:
+    iterator = iter(values)
+    return lambda: next(iterator)
+
+
+def _completed_record(
+    *,
+    checklist: dict[str, Any],
+    request_id: str,
+    started_at: datetime,
+) -> dict[str, Any]:
+    receiver = ControlledNotificationReceiver(
+        activation_checklist=checklist,
+        allowed_hosts=["receiver.test"],
+        allowed_event_types=["breach_opened"],
+        clock=_clock(started_at + timedelta(seconds=1)),
+    )
+    event_id = f"{request_id.casefold()}-event"
+    receiver(
+        "https://receiver.test/controlled",
+        _payload(event_id),
+        _headers(event_id),
+        5.0,
+    )
+    return build_controlled_receiver_rehearsal_record(
+        request_id=request_id,
+        terminal_status="completed",
+        failure_code=None,
+        activation_checklist=checklist,
+        allowed_hosts=["receiver.test"],
+        allowed_event_types=["breach_opened"],
+        response_status=204,
+        started_at=started_at,
+        finished_at=started_at + timedelta(seconds=2),
+        recorded_at=started_at + timedelta(seconds=3),
+        attempted_request_count=1,
+        receiver_summary=receiver.summary(),
+    )
+
+
+def _rejected_record(
+    *,
+    checklist: dict[str, Any],
+    request_id: str,
+    started_at: datetime,
+) -> dict[str, Any]:
+    return build_controlled_receiver_rehearsal_record(
+        request_id=request_id,
+        terminal_status="rejected_before_request",
+        failure_code="validation_error",
+        activation_checklist=checklist,
+        allowed_hosts=["receiver.test"],
+        allowed_event_types=["breach_opened"],
+        response_status=204,
+        started_at=started_at,
+        finished_at=started_at,
+        recorded_at=started_at + timedelta(seconds=1),
+        attempted_request_count=0,
+        receiver_summary=None,
+    )
+
+
+def _failed_record(
+    *,
+    checklist: dict[str, Any],
+    request_id: str,
+    started_at: datetime,
+) -> dict[str, Any]:
+    receiver = ControlledNotificationReceiver(
+        activation_checklist=checklist,
+        allowed_hosts=["receiver.test"],
+        allowed_event_types=["breach_opened"],
+        clock=_clock(started_at + timedelta(seconds=1)),
+    )
+    event_id = f"{request_id.casefold()}-event"
+    endpoint = "https://receiver.test/controlled"
+    headers = _headers(event_id)
+    receiver(endpoint, _payload(event_id), headers, 5.0)
+    changed = json.loads(_payload(event_id))
+    changed["payload"]["severity"] = "warning"
+    changed_payload = json.dumps(
+        changed,
+        sort_keys=True,
+        separators=(",", ":"),
+        allow_nan=False,
+    ).encode("utf-8")
+    try:
+        receiver(endpoint, changed_payload, headers, 5.0)
+    except ValidationError:
+        pass
+    else:  # pragma: no cover - receiver must reject conflicting content.
+        raise AssertionError("controlled receiver accepted conflicting content")
+    return build_controlled_receiver_rehearsal_record(
+        request_id=request_id,
+        terminal_status="failed_during_rehearsal",
+        failure_code="validation_error",
+        activation_checklist=checklist,
+        allowed_hosts=["receiver.test"],
+        allowed_event_types=["breach_opened"],
+        response_status=204,
+        started_at=started_at,
+        finished_at=started_at + timedelta(seconds=3),
+        recorded_at=started_at + timedelta(seconds=4),
+        attempted_request_count=2,
+        receiver_summary=receiver.summary(),
+    )
+
+
+def _insert_fixtures(dsn: str, now: datetime) -> None:
+    try:
+        import psycopg
+        from psycopg.types.json import Jsonb
+    except ImportError as exc:  # pragma: no cover - required in CI.
+        raise RuntimeError("Controlled receiver review contract requires psycopg") from exc
+
+    active_start = now - timedelta(hours=2)
+    active_end = now + timedelta(hours=2)
+    ready = _checklist(
+        destination_id="review-ready",
+        reviewed_at=active_start,
+        review_expires_at=active_end,
+    )
+    rejected = _checklist(
+        destination_id="review-rejected",
+        reviewed_at=active_start,
+        review_expires_at=active_end,
+    )
+    failed = _checklist(
+        destination_id="review-failed",
+        reviewed_at=active_start,
+        review_expires_at=active_end,
+    )
+    old_superseded = _checklist(
+        destination_id="review-superseded",
+        reviewed_at=active_start,
+        review_expires_at=active_end,
+        version="old",
+    )
+    for record in (
+        _completed_record(
+            checklist=ready,
+            request_id="REVIEW-READY",
+            started_at=now - timedelta(minutes=30),
+        ),
+        _rejected_record(
+            checklist=rejected,
+            request_id="REVIEW-REJECTED",
+            started_at=now - timedelta(minutes=25),
+        ),
+        _failed_record(
+            checklist=failed,
+            request_id="REVIEW-FAILED",
+            started_at=now - timedelta(minutes=20),
+        ),
+        _completed_record(
+            checklist=old_superseded,
+            request_id="REVIEW-SUPERSEDED-OLD",
+            started_at=now - timedelta(minutes=15),
+        ),
+    ):
+        record_controlled_receiver_rehearsal(dsn=dsn, record=record)
+
+    checklists = (
+        _checklist(
+            destination_id="review-incomplete",
+            reviewed_at=active_start,
+            review_expires_at=active_end,
+            controls=_controls(rollback_tested=False),
+        ),
+        _checklist(
+            destination_id="review-expired",
+            reviewed_at=now - timedelta(days=2),
+            review_expires_at=now - timedelta(days=1),
+        ),
+        _checklist(
+            destination_id="review-missing",
+            reviewed_at=active_start,
+            review_expires_at=active_end,
+        ),
+        _checklist(
+            destination_id="review-not-yet",
+            reviewed_at=now + timedelta(hours=1),
+            review_expires_at=now + timedelta(hours=2),
+        ),
+        _checklist(
+            destination_id="review-superseded",
+            reviewed_at=now - timedelta(minutes=5),
+            review_expires_at=active_end,
+            version="current",
+        ),
+    )
+    with psycopg.connect(dsn) as connection:
+        with connection.cursor() as cursor:
+            for value in checklists:
+                _record_checklist(cursor, value, Jsonb)
+        connection.commit()
+
+
+def _assert_review_states(dsn: str) -> tuple[dict[str, str], int]:
+    try:
+        import psycopg
+    except ImportError as exc:  # pragma: no cover - required in CI.
+        raise RuntimeError("Controlled receiver review contract requires psycopg") from exc
+    with psycopg.connect(dsn) as connection:
+        with connection.cursor() as cursor:
+            cursor.execute(
+                """
+                SELECT destination_id, review_status
+                FROM risk_platform.current_notification_activation_rehearsal_review
+                WHERE destination_id LIKE 'review-%'
+                ORDER BY destination_id
+                """
+            )
+            actual = {str(destination): str(status) for destination, status in cursor}
+            expected = {
+                "review-expired": "checklist_expired",
+                "review-failed": "rehearsal_failed",
+                "review-incomplete": "checklist_incomplete",
+                "review-missing": "rehearsal_missing",
+                "review-not-yet": "checklist_not_yet_active",
+                "review-ready": "ready",
+                "review-rejected": "rehearsal_rejected",
+                "review-superseded": "rehearsal_superseded",
+            }
+            if actual != expected:
+                raise AssertionError(f"activation review states changed: {actual!r}")
+            cursor.execute(
+                """
+                SELECT incomplete_controls_json
+                FROM risk_platform.current_notification_activation_rehearsal_review
+                WHERE destination_id = 'review-incomplete'
+                """
+            )
+            row = cursor.fetchone()
+            if row is None or row[0] != ["rollback_tested"]:
+                raise AssertionError(f"incomplete controls changed: {row!r}")
+            cursor.execute(
+                """
+                SELECT COUNT(*)
+                FROM risk_platform.current_notification_activation_review_failures
+                WHERE destination_id LIKE 'review-%'
+                """
+            )
+            if cursor.fetchone()[0] != 7:
+                raise AssertionError("activation review failure partition changed")
+            cursor.execute(
+                """
+                SELECT COUNT(*)
+                FROM risk_platform.current_notification_activation_ready
+                WHERE destination_id LIKE 'review-%'
+                """
+            )
+            if cursor.fetchone()[0] != 1:
+                raise AssertionError("activation-ready partition changed")
+            cursor.execute(CHECK_PATH.read_text(encoding="utf-8"))
+            checks = list(cursor.fetchall())
+    failures = [check for check in checks if check[3] != "pass"]
+    if failures:
+        names = ", ".join(str(check[0]) for check in failures)
+        raise AssertionError("controlled receiver review reconciliation failed: " + names)
+    return actual, len(checks)
+
+
+def run_contract_check(dsn: str) -> dict[str, Any]:
+    now = datetime.now(timezone.utc)
+    _insert_fixtures(dsn, now)
+    states, check_count = _assert_review_states(dsn)
+    return {
+        "model_version": "portfolio-risk-controlled-receiver-review-v1",
+        "fixture_destinations": len(states),
+        "review_states": states,
+        "ready_rows": 1,
+        "review_failure_rows": 7,
+        "consistency_checks": check_count,
+        "external_request_performed": False,
+        "payload_bodies_recorded": False,
+        "response_bodies_recorded": False,
+    }
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Exercise current notification activation and controlled receiver "
+            "review views against PostgreSQL 16."
+        )
+    )
+    parser.add_argument(
+        "--dsn",
+        default=os.environ.get("WAREHOUSE_POSTGRES_DSN", DEFAULT_POSTGRES_DSN),
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    try:
+        summary = run_contract_check(args.dsn)
+    except Exception as exc:
+        print(f"Controlled receiver review contract failed: {exc}", file=sys.stderr)
+        return 1
+    print(json.dumps(summary, sort_keys=True, allow_nan=False))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/test_controlled_receiver_review_architecture_contract.py
+++ b/tests/unit/test_controlled_receiver_review_architecture_contract.py
@@ -1,0 +1,97 @@
+from pathlib import Path
+
+
+def test_controlled_receiver_review_views_are_current_read_only_and_reconciled() -> None:
+    schema = Path(
+        "sql/controlled_notification_receiver_review_schema.sql"
+    ).read_text(encoding="utf-8")
+    checks = Path(
+        "sql/controlled_notification_receiver_review_consistency_checks.sql"
+    ).read_text(encoding="utf-8")
+    fixture = Path(
+        "src/warehouse/controlled_receiver_review_postgres_contract_check.py"
+    ).read_text(encoding="utf-8")
+    compose = Path("docker-compose.yml").read_text(encoding="utf-8")
+    makefile = Path("Makefile").read_text(encoding="utf-8")
+    docs = Path(
+        "docs/controlled-notification-receiver-review-views.md"
+    ).read_text(encoding="utf-8")
+    normalized_docs = " ".join(docs.split()).casefold()
+
+    for view in (
+        "latest_notification_activation_checklists",
+        "latest_controlled_notification_receiver_rehearsals",
+        "current_notification_activation_rehearsal_review",
+        "current_notification_activation_review_failures",
+        "current_notification_activation_ready",
+    ):
+        assert f"risk_platform.{view}" in schema
+
+    for status in (
+        "checklist_incomplete",
+        "checklist_not_yet_active",
+        "checklist_expired",
+        "rehearsal_missing",
+        "rehearsal_evidence_conflict",
+        "rehearsal_superseded",
+        "rehearsal_rejected",
+        "rehearsal_failed",
+        "ready",
+    ):
+        assert status in schema
+        assert status in fixture
+        assert status in docs
+
+    for required in (
+        "reviewed_at DESC, checklist.checklist_id DESC",
+        "recorded_at DESC, rehearsal.record_id DESC",
+        "incomplete_controls_json",
+        "rehearsal_reference_consistent",
+        "rehearsal_matches_current_checklist",
+        "operational_activation_ready",
+    ):
+        assert required in schema
+
+    for required in (
+        "notification_activation_latest_checklist_selection_current",
+        "controlled_receiver_latest_rehearsal_selection_current",
+        "notification_activation_incomplete_controls_reconcile",
+        "notification_activation_review_status_reconciles",
+        "notification_activation_failure_partition_matches",
+        "notification_activation_ready_partition_matches",
+    ):
+        assert required in checks
+
+    for required in (
+        "review-ready",
+        "review-incomplete",
+        "review-not-yet",
+        "review-expired",
+        "review-missing",
+        "review-rejected",
+        "review-failed",
+        "review-superseded",
+        "review_failure_rows",
+        "external_request_performed",
+    ):
+        assert required in fixture
+
+    assert "23_controlled_notification_receiver_review_schema.sql:ro" in compose
+    assert "controlled_receiver_review_postgres_contract_check" in makefile
+
+    for required in (
+        "primary arc42 block: `warehouse`",
+        "one current, reviewer-oriented state per notification destination",
+        "historical rows remain immutable",
+        "newer checklist can therefore supersede a successful rehearsal",
+        "ordinary validation performs no dns lookup",
+        "terraform apply",
+    ):
+        assert required in normalized_docs
+
+    for forbidden in (
+        "urllib.request",
+        "requests.post(",
+        "httpx.",
+    ):
+        assert forbidden not in fixture.casefold()

--- a/tests/unit/test_controlled_receiver_review_architecture_contract.py
+++ b/tests/unit/test_controlled_receiver_review_architecture_contract.py
@@ -11,8 +11,10 @@ def test_controlled_receiver_review_views_are_current_read_only_and_reconciled()
     fixture = Path(
         "src/warehouse/controlled_receiver_review_postgres_contract_check.py"
     ).read_text(encoding="utf-8")
+    parent_fixture = Path(
+        "src/warehouse/controlled_receiver_rehearsal_postgres_contract_check.py"
+    ).read_text(encoding="utf-8")
     compose = Path("docker-compose.yml").read_text(encoding="utf-8")
-    makefile = Path("Makefile").read_text(encoding="utf-8")
     docs = Path(
         "docs/controlled-notification-receiver-review-views.md"
     ).read_text(encoding="utf-8")
@@ -77,7 +79,8 @@ def test_controlled_receiver_review_views_are_current_read_only_and_reconciled()
         assert required in fixture
 
     assert "23_controlled_notification_receiver_review_schema.sql:ro" in compose
-    assert "controlled_receiver_review_postgres_contract_check" in makefile
+    assert "run_review_contract_check" in parent_fixture
+    assert '"activation_review": review_summary' in parent_fixture
 
     for required in (
         "primary arc42 block: `warehouse`",

--- a/tests/unit/test_controlled_receiver_review_architecture_contract.py
+++ b/tests/unit/test_controlled_receiver_review_architecture_contract.py
@@ -41,8 +41,20 @@ def test_controlled_receiver_review_views_are_current_read_only_and_reconciled()
         "ready",
     ):
         assert status in schema
-        assert status in fixture
+        assert status in checks
         assert status in docs
+
+    for exercised_status in (
+        "checklist_incomplete",
+        "checklist_not_yet_active",
+        "checklist_expired",
+        "rehearsal_missing",
+        "rehearsal_superseded",
+        "rehearsal_rejected",
+        "rehearsal_failed",
+        "ready",
+    ):
+        assert exercised_status in fixture
 
     for required in (
         "reviewed_at DESC, checklist.checklist_id DESC",

--- a/tests/unit/test_docker_compose_contract.py
+++ b/tests/unit/test_docker_compose_contract.py
@@ -48,6 +48,7 @@ def test_local_database_seed_mounts_are_read_only_and_ordered() -> None:
         "./sql/portfolio_risk_notification_retry_follow_up_schema.sql:/docker-entrypoint-initdb.d/20_portfolio_risk_notification_retry_follow_up_schema.sql:ro",
         "./sql/portfolio_risk_notification_retry_destination_follow_up_schema.sql:/docker-entrypoint-initdb.d/21_portfolio_risk_notification_retry_destination_follow_up_schema.sql:ro",
         "./sql/controlled_notification_receiver_rehearsal_schema.sql:/docker-entrypoint-initdb.d/22_controlled_notification_receiver_rehearsal_schema.sql:ro",
+        "./sql/controlled_notification_receiver_review_schema.sql:/docker-entrypoint-initdb.d/23_controlled_notification_receiver_review_schema.sql:ro",
     ]
     assert services["mongo"]["volumes"] == [
         "./mongo/init:/docker-entrypoint-initdb.d:ro"


### PR DESCRIPTION
## Goal

Complete **P4d4d — activation-readiness and controlled-receiver review views**.

```text
append-only activation checklists
  + append-only controlled receiver rehearsals
  -> deterministic latest evidence per destination
  -> explicit review status
  -> ready and review-required queues
```

## Query contract

Adds:

- `latest_notification_activation_checklists`;
- `latest_controlled_notification_receiver_rehearsals`;
- `current_notification_activation_rehearsal_review`;
- `current_notification_activation_review_failures`; and
- `current_notification_activation_ready`.

Current checklist selection uses `reviewed_at DESC, checklist_id DESC`; rehearsal selection uses `recorded_at DESC, record_id DESC`. Historical rows remain immutable.

## Review states

The review view classifies each destination as one of:

- `checklist_incomplete`;
- `checklist_not_yet_active`;
- `checklist_expired`;
- `rehearsal_missing`;
- `rehearsal_evidence_conflict`;
- `rehearsal_superseded`;
- `rehearsal_rejected`;
- `rehearsal_failed`;
- `ready`; or
- `review_required`.

The precedence is fail closed. A newer checklist supersedes an older successful rehearsal until the new checklist receives its own completed rehearsal.

## PostgreSQL evidence

The existing controlled-receiver PostgreSQL contract now invokes an eight-destination review fixture covering ready, incomplete, not-yet-active, expired, missing, rejected, failed and superseded states. Fifteen reconciliation checks verify latest selection, unique grains, incomplete controls, status precedence, flags, and exact ready/failure partitions.

## Scope

Eight intended files, 1,087 additions and two deletions. The connector produced nine working commits; squash merge will retain one coherent warehouse/query increment. The branch is zero commits behind `main`.

## Safety boundary

The views are read only and expose no endpoint URL or path, endpoint value, credential, environment value, payload body, response body or PostgreSQL DSN. Ordinary validation performs no DNS lookup, socket open, external request, delivery-attempt write, outbox mutation, acknowledgement, scheduling, deployment or `terraform apply`.

Fresh exact-head CI is required before squash merge.