### PR TITLE
Add deterministic notification destination transition plans

### DIFF
--- a/docs/notification-destination-transition-plan.md
+++ b/docs/notification-destination-transition-plan.md
@@ -1,0 +1,90 @@
+# Notification Destination Transition Plan
+
+Primary arc42 block: `orchestration`.
+
+## Goal
+
+Create deterministic, delivery-free evidence for a notification destination
+rotation, disablement, or rollback:
+
+```text
+current reviewed destination
+  + target reviewed or disabled destination
+  + declared transition operation
+  -> exact metadata comparison
+  -> deterministic transition plan
+  -> target authority requirement
+  -> no endpoint resolution or delivery
+```
+
+The model is
+`portfolio-risk-notification-destination-transition-plan-v1`.
+
+## Operations
+
+### Rotate
+
+A rotation requires:
+
+- active current and target destination reviews at `planned_at`;
+- unchanged owner, purpose, recipient scope, classification, channel, and event
+  allow-list;
+- a changed endpoint environment-variable identity; and
+- different deterministic destination fingerprints.
+
+The plan explicitly states that current authority cannot authorise the target.
+A target authority must match the target fingerprint, endpoint environment
+identity, destination ID, and exact planning timestamp.
+
+### Disable
+
+Disablement requires an active current destination and a disabled target using
+the same endpoint environment-variable identity. The target contains no review
+evidence and must not receive execution authority.
+
+### Rollback
+
+Rollback requires a disabled current destination, a newly reviewed active
+target using the prior endpoint environment-variable identity, and an exact
+`prior_plan_id`. A previous authority is not reusable: the fresh rollback
+review changes the target fingerprint, so a new target authority is required.
+
+## Scope control
+
+The transition contract rejects changes to:
+
+- destination ownership;
+- purpose or recipient scope;
+- data classification;
+- channel; and
+- lifecycle event allow-list.
+
+Those changes require a separate destination-governance increment rather than
+being hidden inside an endpoint rotation.
+
+## Deterministic identity
+
+The plan ID binds:
+
+```text
+operation
+planned_at
+destination ID
+current and target fingerprints
+current and target endpoint environment-variable identities
+current and target activation evidence
+prior plan identity when rolling back
+authority requirement
+```
+
+Any changed review, endpoint identity, operation, time, or predecessor plan
+produces a different plan ID.
+
+## Safety boundary
+
+The plan stores environment-variable names but never endpoint values or URLs.
+It has no `--execute` option and performs no DNS lookup, socket operation,
+external request, delivery-attempt write, outbox mutation, acknowledgement,
+cloud scheduling, infrastructure deployment, or `terraform apply`.
+
+Committed notification destination activation and delivery remain disabled.

--- a/src/orchestration/notification_destination_transition_plan.py
+++ b/src/orchestration/notification_destination_transition_plan.py
@@ -1,0 +1,510 @@
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import sys
+from collections.abc import Mapping, Sequence
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from src.common.exceptions import StorageError, ValidationError
+from src.orchestration.portfolio_risk_notification_destination_authority import (
+    MODEL_VERSION as DESTINATION_AUTHORITY_MODEL_VERSION,
+)
+from src.orchestration.portfolio_risk_notification_destination_contract import (
+    NotificationDestination,
+    evaluate_destination_activation,
+    load_notification_destinations,
+)
+
+MODEL_VERSION = "portfolio-risk-notification-destination-transition-plan-v1"
+OPERATIONS = frozenset({"disable", "rollback", "rotate"})
+SAFE_TEXT = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,511}$")
+ENVIRONMENT_NAME = re.compile(r"^[A-Z][A-Z0-9_]{2,127}$")
+SIDE_EFFECT_FLAGS = (
+    "acknowledgement_mutated",
+    "delivery_attempt_written",
+    "endpoint_value_recorded",
+    "external_request_performed",
+    "infrastructure_deployed",
+    "outbox_mutated",
+)
+
+
+def _exact_mapping(value: Any, label: str, keys: set[str]) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        raise ValidationError(f"{label} must be a mapping")
+    actual = set(value)
+    if actual != keys:
+        raise ValidationError(
+            f"{label} fields are invalid; "
+            f"missing={sorted(keys - actual)}, unknown={sorted(actual - keys)}"
+        )
+    return value
+
+
+def _safe_text(value: Any, label: str, *, optional: bool = False) -> str | None:
+    if value is None and optional:
+        return None
+    if not isinstance(value, str) or not SAFE_TEXT.fullmatch(value):
+        raise ValidationError(f"{label} must be one safe text segment")
+    return value
+
+
+def _aware_utc(value: Any, label: str) -> datetime:
+    if isinstance(value, datetime):
+        parsed = value
+    elif isinstance(value, str):
+        try:
+            parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        except ValueError:
+            raise ValidationError(f"{label} must be ISO-8601") from None
+    else:
+        raise ValidationError(f"{label} must be timezone-aware")
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise ValidationError(f"{label} must be timezone-aware")
+    return parsed.astimezone(timezone.utc)
+
+
+def _reviewers(value: Any) -> list[str]:
+    if not isinstance(value, list):
+        raise ValidationError("transition side reviewed_by must be an array")
+    parsed = [_safe_text(item, "reviewed_by item") for item in value]
+    result = [item for item in parsed if item is not None]
+    if result != sorted(set(result)):
+        raise ValidationError("transition side reviewed_by must be canonical")
+    return result
+
+
+def _metadata(destination: NotificationDestination) -> dict[str, Any]:
+    return {
+        "allowed_event_types": list(destination.allowed_event_types),
+        "channel": destination.channel,
+        "data_classification": destination.data_classification,
+        "owner": {
+            "contact": destination.owner.contact,
+            "team": destination.owner.team,
+        },
+        "purpose": destination.purpose,
+        "recipient_scope": destination.recipient_scope,
+    }
+
+
+def _side(
+    destination: NotificationDestination,
+    evidence: Mapping[str, Any],
+) -> dict[str, Any]:
+    activation = evidence["activation"]
+    return {
+        "activation_status": activation["status"],
+        "change_request_id": activation["change_request_id"],
+        "endpoint_environment_variable": destination.endpoint_env,
+        "fingerprint": destination.fingerprint,
+        "review_expires_at": activation["review_expires_at"],
+        "reviewed_at": activation["reviewed_at"],
+        "reviewed_by": list(destination.activation.reviewed_by),
+    }
+
+
+def canonical_transition_plan_bytes(plan: Mapping[str, Any]) -> bytes:
+    try:
+        return json.dumps(
+            plan,
+            sort_keys=True,
+            separators=(",", ":"),
+            allow_nan=False,
+        ).encode("utf-8")
+    except (TypeError, ValueError):
+        raise ValidationError("destination transition plan is not canonical JSON") from None
+
+
+def _plan_id(identity: Mapping[str, Any]) -> str:
+    digest = hashlib.sha256(canonical_transition_plan_bytes(identity)).hexdigest()[:24]
+    return f"{MODEL_VERSION}-plan-{digest}"
+
+
+def _validate_transition_semantics(
+    *,
+    operation: str,
+    current: Mapping[str, Any],
+    target: Mapping[str, Any],
+    prior_plan_id: str | None,
+) -> None:
+    current_status = current["activation_status"]
+    target_status = target["activation_status"]
+    endpoint_changed = (
+        current["endpoint_environment_variable"]
+        != target["endpoint_environment_variable"]
+    )
+    if current["fingerprint"] == target["fingerprint"]:
+        raise ValidationError("transition fingerprints must differ")
+
+    if operation == "rotate":
+        if current_status != "active" or target_status != "active":
+            raise ValidationError("rotate requires active current and target destinations")
+        if not endpoint_changed:
+            raise ValidationError("rotate requires a new endpoint environment identity")
+        if prior_plan_id is not None:
+            raise ValidationError("rotate must not reference a prior plan")
+    elif operation == "disable":
+        if current_status != "active" or target_status != "disabled":
+            raise ValidationError("disable requires active current and disabled target")
+        if endpoint_changed:
+            raise ValidationError("disable must retain the endpoint environment identity")
+        if prior_plan_id is not None:
+            raise ValidationError("disable must not reference a prior plan")
+    else:
+        if current_status != "disabled" or target_status != "active":
+            raise ValidationError("rollback requires disabled current and active target")
+        if not endpoint_changed:
+            raise ValidationError("rollback requires the prior endpoint environment identity")
+        if prior_plan_id is None:
+            raise ValidationError("rollback requires prior_plan_id")
+
+
+def build_notification_destination_transition_plan(
+    *,
+    operation: str,
+    current_config_path: Path,
+    target_config_path: Path,
+    destination_id: str,
+    planned_at: datetime | str,
+    prior_plan_id: str | None = None,
+) -> dict[str, Any]:
+    if operation not in OPERATIONS:
+        raise ValidationError("notification destination transition operation is invalid")
+    selected_destination_id = _safe_text(destination_id, "destination_id")
+    selected_prior_plan_id = _safe_text(
+        prior_plan_id,
+        "prior_plan_id",
+        optional=True,
+    )
+    assert selected_destination_id is not None
+    as_of = _aware_utc(planned_at, "planned_at")
+
+    current_destinations = load_notification_destinations(current_config_path)
+    target_destinations = load_notification_destinations(target_config_path)
+    current_destination = current_destinations.get(selected_destination_id)
+    target_destination = target_destinations.get(selected_destination_id)
+    if current_destination is None or target_destination is None:
+        raise ValidationError("transition destination must exist in both configurations")
+    if _metadata(current_destination) != _metadata(target_destination):
+        raise ValidationError(
+            "transition may change only endpoint identity and activation evidence"
+        )
+
+    current_evidence = evaluate_destination_activation(
+        current_destination,
+        evaluated_at=as_of,
+    )
+    target_evidence = evaluate_destination_activation(
+        target_destination,
+        evaluated_at=as_of,
+    )
+    current = _side(current_destination, current_evidence)
+    target = _side(target_destination, target_evidence)
+    _validate_transition_semantics(
+        operation=operation,
+        current=current,
+        target=target,
+        prior_plan_id=selected_prior_plan_id,
+    )
+
+    identity = {
+        "current": current,
+        "current_authority_accepted_by_target": False,
+        "destination_id": selected_destination_id,
+        "endpoint_environment_changed": (
+            current["endpoint_environment_variable"]
+            != target["endpoint_environment_variable"]
+        ),
+        "metadata_unchanged": True,
+        "model_version": MODEL_VERSION,
+        "operation": operation,
+        "planned_at": as_of.isoformat(),
+        "prior_plan_id": selected_prior_plan_id,
+        "target": target,
+        "target_authority_required": operation != "disable",
+    }
+    return {
+        "plan_id": _plan_id(identity),
+        **identity,
+        "acknowledgement_mutated": False,
+        "delivery_attempt_written": False,
+        "endpoint_value_recorded": False,
+        "external_request_performed": False,
+        "infrastructure_deployed": False,
+        "outbox_mutated": False,
+    }
+
+
+def _canonical_side(value: Any, label: str, *, planned_at: datetime) -> dict[str, Any]:
+    side = _exact_mapping(
+        value,
+        label,
+        {
+            "activation_status",
+            "change_request_id",
+            "endpoint_environment_variable",
+            "fingerprint",
+            "review_expires_at",
+            "reviewed_at",
+            "reviewed_by",
+        },
+    )
+    status = side["activation_status"]
+    if status not in {"active", "disabled"}:
+        raise ValidationError(f"{label}.activation_status is invalid")
+    fingerprint = _safe_text(side["fingerprint"], f"{label}.fingerprint")
+    endpoint = side["endpoint_environment_variable"]
+    if not isinstance(endpoint, str) or not ENVIRONMENT_NAME.fullmatch(endpoint):
+        raise ValidationError(f"{label}.endpoint environment is invalid")
+    change_request_id = _safe_text(
+        side["change_request_id"],
+        f"{label}.change_request_id",
+        optional=True,
+    )
+    reviewed_by = _reviewers(side["reviewed_by"])
+    reviewed_at_value = side["reviewed_at"]
+    expires_at_value = side["review_expires_at"]
+    if status == "active":
+        if change_request_id is None or not reviewed_by:
+            raise ValidationError(f"{label} active review evidence is incomplete")
+        reviewed_at = _aware_utc(reviewed_at_value, f"{label}.reviewed_at")
+        expires_at = _aware_utc(expires_at_value, f"{label}.review_expires_at")
+        if not reviewed_at <= planned_at < expires_at:
+            raise ValidationError(f"{label} is outside its active review window")
+        reviewed_at_output: str | None = reviewed_at.isoformat()
+        expires_at_output: str | None = expires_at.isoformat()
+    else:
+        if (
+            change_request_id is not None
+            or reviewed_by
+            or reviewed_at_value is not None
+            or expires_at_value is not None
+        ):
+            raise ValidationError(f"{label} disabled evidence must be empty")
+        reviewed_at_output = None
+        expires_at_output = None
+    assert fingerprint is not None
+    return {
+        "activation_status": status,
+        "change_request_id": change_request_id,
+        "endpoint_environment_variable": endpoint,
+        "fingerprint": fingerprint,
+        "review_expires_at": expires_at_output,
+        "reviewed_at": reviewed_at_output,
+        "reviewed_by": reviewed_by,
+    }
+
+
+def validate_notification_destination_transition_plan(
+    plan: Mapping[str, Any],
+) -> dict[str, Any]:
+    exact = _exact_mapping(
+        plan,
+        "destination transition plan",
+        {
+            "acknowledgement_mutated",
+            "current",
+            "current_authority_accepted_by_target",
+            "delivery_attempt_written",
+            "destination_id",
+            "endpoint_environment_changed",
+            "endpoint_value_recorded",
+            "external_request_performed",
+            "infrastructure_deployed",
+            "metadata_unchanged",
+            "model_version",
+            "operation",
+            "outbox_mutated",
+            "plan_id",
+            "planned_at",
+            "prior_plan_id",
+            "target",
+            "target_authority_required",
+        },
+    )
+    if exact["model_version"] != MODEL_VERSION:
+        raise ValidationError("destination transition plan model_version is unsupported")
+    operation = exact["operation"]
+    if operation not in OPERATIONS:
+        raise ValidationError("destination transition plan operation is invalid")
+    planned_at = _aware_utc(exact["planned_at"], "planned_at")
+    destination_id = _safe_text(exact["destination_id"], "destination_id")
+    prior_plan_id = _safe_text(
+        exact["prior_plan_id"],
+        "prior_plan_id",
+        optional=True,
+    )
+    current = _canonical_side(exact["current"], "current", planned_at=planned_at)
+    target = _canonical_side(exact["target"], "target", planned_at=planned_at)
+    _validate_transition_semantics(
+        operation=operation,
+        current=current,
+        target=target,
+        prior_plan_id=prior_plan_id,
+    )
+    if exact["metadata_unchanged"] is not True:
+        raise ValidationError("destination transition metadata changed")
+    expected_endpoint_changed = (
+        current["endpoint_environment_variable"]
+        != target["endpoint_environment_variable"]
+    )
+    if exact["endpoint_environment_changed"] is not expected_endpoint_changed:
+        raise ValidationError("endpoint environment change evidence is inconsistent")
+    if exact["target_authority_required"] is not (operation != "disable"):
+        raise ValidationError("target authority requirement is inconsistent")
+    if exact["current_authority_accepted_by_target"] is not False:
+        raise ValidationError("current authority must not authorise the target")
+    if any(exact[flag] is not False for flag in SIDE_EFFECT_FLAGS):
+        raise ValidationError("destination transition side-effect evidence is invalid")
+    assert destination_id is not None
+    identity = {
+        "current": current,
+        "current_authority_accepted_by_target": False,
+        "destination_id": destination_id,
+        "endpoint_environment_changed": expected_endpoint_changed,
+        "metadata_unchanged": True,
+        "model_version": MODEL_VERSION,
+        "operation": operation,
+        "planned_at": planned_at.isoformat(),
+        "prior_plan_id": prior_plan_id,
+        "target": target,
+        "target_authority_required": operation != "disable",
+    }
+    expected_plan_id = _plan_id(identity)
+    if exact["plan_id"] != expected_plan_id:
+        raise ValidationError("destination transition plan identity is invalid")
+    return {
+        "plan_id": expected_plan_id,
+        **identity,
+        **{flag: False for flag in SIDE_EFFECT_FLAGS},
+    }
+
+
+def validate_target_destination_authority(
+    *,
+    plan: Mapping[str, Any],
+    authority: Mapping[str, Any],
+) -> dict[str, Any]:
+    validated_plan = validate_notification_destination_transition_plan(plan)
+    if validated_plan["target_authority_required"] is not True:
+        raise ValidationError("disabled transition must not receive target authority")
+    exact = _exact_mapping(
+        authority,
+        "target destination authority",
+        {
+            "acknowledgement_mutated",
+            "activation",
+            "active",
+            "allowed_event_types",
+            "authority_id",
+            "channel",
+            "delivery_attempt_written",
+            "destination_fingerprint",
+            "destination_id",
+            "endpoint_environment_variable",
+            "endpoint_value_recorded",
+            "evaluated_at",
+            "evaluated_event_types",
+            "external_request_performed",
+            "model_version",
+            "outbox_mutated",
+        },
+    )
+    if exact["model_version"] != DESTINATION_AUTHORITY_MODEL_VERSION:
+        raise ValidationError("target destination authority model_version is unsupported")
+    if exact["active"] is not True:
+        raise ValidationError("target destination authority must be active")
+    target = validated_plan["target"]
+    comparisons = {
+        "destination_id": validated_plan["destination_id"],
+        "destination_fingerprint": target["fingerprint"],
+        "endpoint_environment_variable": target["endpoint_environment_variable"],
+        "evaluated_at": validated_plan["planned_at"],
+    }
+    for field, expected in comparisons.items():
+        if exact[field] != expected:
+            raise ValidationError(f"target destination authority {field} does not match")
+    activation = exact["activation"]
+    if not isinstance(activation, Mapping) or activation.get("status") != "active":
+        raise ValidationError("target destination authority activation is not active")
+    if any(
+        exact[flag] is not False
+        for flag in (
+            "acknowledgement_mutated",
+            "delivery_attempt_written",
+            "endpoint_value_recorded",
+            "external_request_performed",
+            "outbox_mutated",
+        )
+    ):
+        raise ValidationError("target destination authority side effects are invalid")
+    return dict(exact)
+
+
+def _write_summary(path: Path, summary: Mapping[str, Any]) -> None:
+    if path.is_symlink():
+        raise StorageError("destination transition summary must not be a symbolic link")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_suffix(path.suffix + ".tmp")
+    try:
+        temporary.write_text(
+            json.dumps(summary, indent=2, sort_keys=True, allow_nan=False) + "\n",
+            encoding="utf-8",
+        )
+        temporary.replace(path)
+    except (OSError, TypeError, ValueError):
+        temporary.unlink(missing_ok=True)
+        raise StorageError("unable to write destination transition summary") from None
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Build a delivery-free notification destination rotation, disablement, "
+            "or rollback plan."
+        )
+    )
+    parser.add_argument("--operation", choices=sorted(OPERATIONS), required=True)
+    parser.add_argument("--current-config", type=Path, required=True)
+    parser.add_argument("--target-config", type=Path, required=True)
+    parser.add_argument("--destination-id", required=True)
+    parser.add_argument("--planned-at", required=True)
+    parser.add_argument("--prior-plan-id")
+    parser.add_argument("--summary-json", type=Path)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    try:
+        plan = build_notification_destination_transition_plan(
+            operation=args.operation,
+            current_config_path=args.current_config,
+            target_config_path=args.target_config,
+            destination_id=args.destination_id,
+            planned_at=args.planned_at,
+            prior_plan_id=args.prior_plan_id,
+        )
+        if args.summary_json is not None:
+            _write_summary(args.summary_json, plan)
+    except (StorageError, ValidationError) as exc:
+        print(f"Notification destination transition rejected: {exc}", file=sys.stderr)
+        return 1
+    except Exception:
+        print(
+            "Notification destination transition failed: unexpected local failure",
+            file=sys.stderr,
+        )
+        return 1
+    print(json.dumps(plan, sort_keys=True, allow_nan=False))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/orchestration/notification_destination_transition_plan.py
+++ b/src/orchestration/notification_destination_transition_plan.py
@@ -159,10 +159,10 @@ def _validate_transition_semantics(
     else:
         if current_status != "disabled" or target_status != "active":
             raise ValidationError("rollback requires disabled current and active target")
-        if not endpoint_changed:
-            raise ValidationError("rollback requires the prior endpoint environment identity")
         if prior_plan_id is None:
             raise ValidationError("rollback requires prior_plan_id")
+        if not endpoint_changed:
+            raise ValidationError("rollback requires the prior endpoint environment identity")
 
 
 def build_notification_destination_transition_plan(

--- a/tests/unit/test_notification_destination_transition_architecture_contract.py
+++ b/tests/unit/test_notification_destination_transition_architecture_contract.py
@@ -1,0 +1,44 @@
+from pathlib import Path
+
+
+def test_destination_transition_plan_is_delivery_free_and_authority_bound() -> None:
+    source = Path(
+        "src/orchestration/notification_destination_transition_plan.py"
+    ).read_text(encoding="utf-8")
+    docs = Path(
+        "docs/notification-destination-transition-plan.md"
+    ).read_text(encoding="utf-8")
+    normalized_docs = " ".join(docs.split()).casefold()
+
+    for operation in ("rotate", "disable", "rollback"):
+        assert f'"{operation}"' in source
+        assert operation in normalized_docs
+
+    for required in (
+        "current_authority_accepted_by_target",
+        "target_authority_required",
+        "validate_target_destination_authority",
+        "transition may change only endpoint identity and activation evidence",
+        "rollback requires prior_plan_id",
+        "endpoint_value_recorded",
+        "external_request_performed",
+    ):
+        assert required in source
+
+    for required in (
+        "primary arc42 block: `orchestration`",
+        "current authority cannot authorise the target",
+        "fresh rollback review changes the target fingerprint",
+        "has no `--execute` option",
+        "performs no dns lookup",
+        "terraform apply",
+    ):
+        assert required in normalized_docs
+
+    for forbidden in (
+        "requests.post(",
+        "urllib.request",
+        "httpx.",
+        "socket.",
+    ):
+        assert forbidden not in source.casefold()

--- a/tests/unit/test_notification_destination_transition_plan.py
+++ b/tests/unit/test_notification_destination_transition_plan.py
@@ -1,0 +1,364 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+from src.common.exceptions import StorageError, ValidationError
+from src.orchestration.notification_destination_transition_plan import (
+    MODEL_VERSION,
+    _build_parser,
+    _write_summary,
+    build_notification_destination_transition_plan,
+    validate_notification_destination_transition_plan,
+    validate_target_destination_authority,
+)
+from src.orchestration.portfolio_risk_notification_destination_authority import (
+    resolve_notification_destination_authority,
+)
+
+PLANNED_AT = datetime(2026, 6, 15, 12, tzinfo=timezone.utc)
+DESTINATION_ID = "risk-operations-webhook"
+OLD_ENDPOINT = "RISK_NOTIFICATION_WEBHOOK_URL"
+NEW_ENDPOINT = "RISK_NOTIFICATION_WEBHOOK_URL_V2"
+
+
+def _activation(
+    *,
+    enabled: bool,
+    change_request_id: str = "CHG-2026-001",
+    reviewed_at: str = "2026-01-01T00:00:00Z",
+) -> dict[str, Any]:
+    if not enabled:
+        return {
+            "enabled": False,
+            "change_request_id": None,
+            "reviewed_by": [],
+            "reviewed_at": None,
+            "review_expires_at": None,
+        }
+    return {
+        "enabled": True,
+        "change_request_id": change_request_id,
+        "reviewed_by": ["risk-control-reviewer"],
+        "reviewed_at": reviewed_at,
+        "review_expires_at": "2026-12-31T00:00:00Z",
+    }
+
+
+def _payload(
+    *,
+    endpoint_env: str,
+    enabled: bool,
+    change_request_id: str = "CHG-2026-001",
+    reviewed_at: str = "2026-01-01T00:00:00Z",
+) -> dict[str, Any]:
+    return {
+        "model_version": "portfolio-risk-notification-destination-v1",
+        "destinations": {
+            DESTINATION_ID: {
+                "channel": "webhook",
+                "endpoint_env": endpoint_env,
+                "owner": {
+                    "team": "risk-operations",
+                    "contact": "risk-operations-oncall",
+                },
+                "purpose": "portfolio-risk-breach-lifecycle",
+                "recipient_scope": "risk-operations",
+                "data_classification": "internal",
+                "allowed_event_types": [
+                    "breach_escalated",
+                    "breach_opened",
+                    "breach_resolved",
+                ],
+                "activation": _activation(
+                    enabled=enabled,
+                    change_request_id=change_request_id,
+                    reviewed_at=reviewed_at,
+                ),
+            }
+        },
+    }
+
+
+def _write(tmp_path: Path, name: str, payload: dict[str, Any]) -> Path:
+    path = tmp_path / name
+    path.write_text(yaml.safe_dump(payload, sort_keys=False), encoding="utf-8")
+    return path
+
+
+def _rotation_paths(tmp_path: Path) -> tuple[Path, Path]:
+    current = _write(
+        tmp_path,
+        "current.yaml",
+        _payload(endpoint_env=OLD_ENDPOINT, enabled=True),
+    )
+    target = _write(
+        tmp_path,
+        "rotated.yaml",
+        _payload(
+            endpoint_env=NEW_ENDPOINT,
+            enabled=True,
+            change_request_id="CHG-ROTATE-001",
+            reviewed_at="2026-05-01T00:00:00Z",
+        ),
+    )
+    return current, target
+
+
+def test_rotation_plan_is_deterministic_secret_free_and_authority_bound(
+    tmp_path: Path,
+) -> None:
+    current, target = _rotation_paths(tmp_path)
+    kwargs = {
+        "operation": "rotate",
+        "current_config_path": current,
+        "target_config_path": target,
+        "destination_id": DESTINATION_ID,
+        "planned_at": PLANNED_AT,
+    }
+
+    first = build_notification_destination_transition_plan(**kwargs)
+    second = build_notification_destination_transition_plan(**kwargs)
+
+    assert first == second
+    assert first["model_version"] == MODEL_VERSION
+    assert first["operation"] == "rotate"
+    assert first["endpoint_environment_changed"] is True
+    assert first["target_authority_required"] is True
+    assert first["current_authority_accepted_by_target"] is False
+    assert first["current"]["endpoint_environment_variable"] == OLD_ENDPOINT
+    assert first["target"]["endpoint_environment_variable"] == NEW_ENDPOINT
+    assert validate_notification_destination_transition_plan(first) == first
+
+    target_authority = resolve_notification_destination_authority(
+        destination_config_path=target,
+        destination_id=DESTINATION_ID,
+        delivery_endpoint_env=NEW_ENDPOINT,
+        evaluated_at=PLANNED_AT,
+        event_types=["breach_opened"],
+    )
+    assert validate_target_destination_authority(
+        plan=first,
+        authority=target_authority,
+    ) == target_authority
+
+    rendered = json.dumps(first, sort_keys=True)
+    assert "https://" not in rendered
+    assert first["external_request_performed"] is False
+    assert first["delivery_attempt_written"] is False
+    assert first["endpoint_value_recorded"] is False
+
+
+def test_old_authority_cannot_authorise_rotated_destination(tmp_path: Path) -> None:
+    current, target = _rotation_paths(tmp_path)
+    plan = build_notification_destination_transition_plan(
+        operation="rotate",
+        current_config_path=current,
+        target_config_path=target,
+        destination_id=DESTINATION_ID,
+        planned_at=PLANNED_AT,
+    )
+    old_authority = resolve_notification_destination_authority(
+        destination_config_path=current,
+        destination_id=DESTINATION_ID,
+        delivery_endpoint_env=OLD_ENDPOINT,
+        evaluated_at=PLANNED_AT,
+        event_types=["breach_opened"],
+    )
+
+    with pytest.raises(ValidationError, match="does not match"):
+        validate_target_destination_authority(
+            plan=plan,
+            authority=old_authority,
+        )
+
+
+def test_disable_and_rollback_plans_form_a_bounded_chain(tmp_path: Path) -> None:
+    baseline, rotated = _rotation_paths(tmp_path)
+    disabled = _write(
+        tmp_path,
+        "disabled.yaml",
+        _payload(endpoint_env=NEW_ENDPOINT, enabled=False),
+    )
+    rollback = _write(
+        tmp_path,
+        "rollback.yaml",
+        _payload(
+            endpoint_env=OLD_ENDPOINT,
+            enabled=True,
+            change_request_id="CHG-ROLLBACK-001",
+            reviewed_at="2026-06-01T00:00:00Z",
+        ),
+    )
+    rotate_plan = build_notification_destination_transition_plan(
+        operation="rotate",
+        current_config_path=baseline,
+        target_config_path=rotated,
+        destination_id=DESTINATION_ID,
+        planned_at=PLANNED_AT,
+    )
+    disable_plan = build_notification_destination_transition_plan(
+        operation="disable",
+        current_config_path=rotated,
+        target_config_path=disabled,
+        destination_id=DESTINATION_ID,
+        planned_at=PLANNED_AT,
+    )
+    rollback_plan = build_notification_destination_transition_plan(
+        operation="rollback",
+        current_config_path=disabled,
+        target_config_path=rollback,
+        destination_id=DESTINATION_ID,
+        planned_at=PLANNED_AT,
+        prior_plan_id=disable_plan["plan_id"],
+    )
+
+    assert disable_plan["target_authority_required"] is False
+    assert disable_plan["endpoint_environment_changed"] is False
+    assert rollback_plan["prior_plan_id"] == disable_plan["plan_id"]
+    assert rollback_plan["target_authority_required"] is True
+    assert rollback_plan["target"]["endpoint_environment_variable"] == OLD_ENDPOINT
+    assert rotate_plan["target"]["fingerprint"] == disable_plan["current"]["fingerprint"]
+    assert disable_plan["target"]["fingerprint"] == rollback_plan["current"]["fingerprint"]
+
+    with pytest.raises(ValidationError, match="must not receive target authority"):
+        validate_target_destination_authority(
+            plan=disable_plan,
+            authority={},
+        )
+
+    original_authority = resolve_notification_destination_authority(
+        destination_config_path=baseline,
+        destination_id=DESTINATION_ID,
+        delivery_endpoint_env=OLD_ENDPOINT,
+        evaluated_at=PLANNED_AT,
+    )
+    with pytest.raises(ValidationError, match="fingerprint"):
+        validate_target_destination_authority(
+            plan=rollback_plan,
+            authority=original_authority,
+        )
+
+    rollback_authority = resolve_notification_destination_authority(
+        destination_config_path=rollback,
+        destination_id=DESTINATION_ID,
+        delivery_endpoint_env=OLD_ENDPOINT,
+        evaluated_at=PLANNED_AT,
+    )
+    validate_target_destination_authority(
+        plan=rollback_plan,
+        authority=rollback_authority,
+    )
+
+
+def test_transition_rejects_scope_creep_and_invalid_state_changes(
+    tmp_path: Path,
+) -> None:
+    current, target = _rotation_paths(tmp_path)
+    changed_owner = _payload(
+        endpoint_env=NEW_ENDPOINT,
+        enabled=True,
+        change_request_id="CHG-ROTATE-001",
+        reviewed_at="2026-05-01T00:00:00Z",
+    )
+    changed_owner["destinations"][DESTINATION_ID]["owner"]["team"] = "another-team"
+    changed_owner_path = _write(tmp_path, "changed-owner.yaml", changed_owner)
+    with pytest.raises(ValidationError, match="only endpoint identity"):
+        build_notification_destination_transition_plan(
+            operation="rotate",
+            current_config_path=current,
+            target_config_path=changed_owner_path,
+            destination_id=DESTINATION_ID,
+            planned_at=PLANNED_AT,
+        )
+
+    same_endpoint = _write(
+        tmp_path,
+        "same-endpoint.yaml",
+        _payload(
+            endpoint_env=OLD_ENDPOINT,
+            enabled=True,
+            change_request_id="CHG-ROTATE-002",
+            reviewed_at="2026-05-01T00:00:00Z",
+        ),
+    )
+    with pytest.raises(ValidationError, match="new endpoint"):
+        build_notification_destination_transition_plan(
+            operation="rotate",
+            current_config_path=current,
+            target_config_path=same_endpoint,
+            destination_id=DESTINATION_ID,
+            planned_at=PLANNED_AT,
+        )
+
+    disabled_new_endpoint = _write(
+        tmp_path,
+        "disabled-new-endpoint.yaml",
+        _payload(endpoint_env=NEW_ENDPOINT, enabled=False),
+    )
+    with pytest.raises(ValidationError, match="retain the endpoint"):
+        build_notification_destination_transition_plan(
+            operation="disable",
+            current_config_path=current,
+            target_config_path=disabled_new_endpoint,
+            destination_id=DESTINATION_ID,
+            planned_at=PLANNED_AT,
+        )
+
+    with pytest.raises(ValidationError, match="prior_plan_id"):
+        build_notification_destination_transition_plan(
+            operation="rollback",
+            current_config_path=disabled_new_endpoint,
+            target_config_path=target,
+            destination_id=DESTINATION_ID,
+            planned_at=PLANNED_AT,
+        )
+
+
+def test_plan_validation_rejects_tampering(tmp_path: Path) -> None:
+    current, target = _rotation_paths(tmp_path)
+    plan = build_notification_destination_transition_plan(
+        operation="rotate",
+        current_config_path=current,
+        target_config_path=target,
+        destination_id=DESTINATION_ID,
+        planned_at=PLANNED_AT,
+    )
+    plan["target"]["fingerprint"] = "tampered-fingerprint"
+
+    with pytest.raises(ValidationError, match="identity"):
+        validate_notification_destination_transition_plan(plan)
+
+
+def test_cli_has_no_execute_switch_and_summary_rejects_symlink(
+    tmp_path: Path,
+) -> None:
+    parser = _build_parser()
+    with pytest.raises(SystemExit):
+        parser.parse_args(
+            [
+                "--operation",
+                "rotate",
+                "--current-config",
+                "current.yaml",
+                "--target-config",
+                "target.yaml",
+                "--destination-id",
+                DESTINATION_ID,
+                "--planned-at",
+                PLANNED_AT.isoformat(),
+                "--execute",
+            ]
+        )
+
+    target = tmp_path / "target.json"
+    target.write_text("{}", encoding="utf-8")
+    link = tmp_path / "summary.json"
+    link.symlink_to(target)
+    with pytest.raises(StorageError, match="symbolic link"):
+        _write_summary(link, {"safe": True})


### PR DESCRIPTION
## Goal

Complete the planning half of **P4d4e — rotation, disablement, and rollback rehearsal**.

```text
current reviewed destination
  + target reviewed or disabled destination
  + declared operation
  -> strict governance-metadata comparison
  -> deterministic transition plan
  -> exact target-authority requirement
```

## Contract

Adds `portfolio-risk-notification-destination-transition-plan-v1` with three bounded operations:

- `rotate`: active current and target reviews, changed endpoint environment-variable identity;
- `disable`: active current to disabled target, retaining the endpoint environment identity; and
- `rollback`: disabled current to freshly reviewed prior endpoint identity, bound to `prior_plan_id`.

The plan rejects hidden changes to ownership, purpose, recipient scope, classification, channel, and event allow-list.

## Authority boundary

The target-authority validator requires the exact target destination ID, target fingerprint, endpoint environment-variable identity, and planning timestamp. An old authority cannot authorise a rotated or freshly reviewed rollback target. Disablement must not receive target authority.

The first CI run exposed a failure-ordering issue: rollback endpoint continuity was checked before the mandatory predecessor-plan identity. The production contract now fails first on a missing `prior_plan_id`, preserving a clearer fail-closed chain boundary.

## Scope

Four intended files, 1,008 additions. The branch is zero commits behind `main`; squash merge retains one coherent orchestration increment.

## Exact-head validation

GitHub Actions run **376** (`33487587079`) passed on final head `331548cbf167c4d4f13b97f0aec12652f04fac1d`:

- Security guardrails passed.
- Ruff passed.
- mypy passed across **130 source files**.
- **858 tests passed** in quality and **858 passed again** in readiness.
- Dependency integrity and standard replay passed.
- PostgreSQL 16 contract passed.
- Kubernetes rendering and Terraform format/init/validate passed without apply.

There are no review submissions or unresolved review threads.

## Safety

The plan retains environment-variable names but no endpoint values or URLs. It has no `--execute` option and performs no DNS lookup, socket operation, external request, attempt write, outbox mutation, acknowledgement, deployment, or `terraform apply`.

Validated and ready for squash merge.