### PR TITLE
Add no-network destination rotation and rollback rehearsal

### DIFF
--- a/docs/notification-destination-transition-rehearsal.md
+++ b/docs/notification-destination-transition-rehearsal.md
@@ -1,0 +1,98 @@
+# Notification Destination Transition Rehearsal
+
+Primary arc42 block: `orchestration`.
+
+## Goal
+
+Exercise a complete destination rotation, disablement, and rollback chain using
+the existing controlled in-memory receiver:
+
+```text
+three exact transition plans
+  + current and target destination authorities
+  + activation-ready receiver checklists
+  + bounded canonical request packages
+  -> rotate receiver rehearsal
+  -> zero-request disablement stage
+  -> rollback receiver rehearsal
+  -> deterministic no-network evidence
+```
+
+The model is
+`portfolio-risk-notification-destination-transition-rehearsal-v1`.
+
+## Chain validation
+
+The rehearsal requires:
+
+- operations ordered as `rotate`, `disable`, `rollback`;
+- one destination ID across all plans;
+- non-decreasing plan timestamps;
+- the rotation target to equal the disablement current state;
+- the disablement target to equal the rollback current state;
+- the rollback plan to reference the exact disablement plan; and
+- rollback to restore the original endpoint environment-variable identity.
+
+The baseline authority is validated against the rotation current state. The
+rotated authority is validated against the disablement current state. Both are
+then deliberately tested against later targets and must fail. A stale authority
+therefore cannot authorise either the rotated destination or the freshly
+reviewed rollback destination.
+
+## Active stages
+
+Rotation and rollback each require:
+
+- exact target destination authority;
+- an activation-ready checklist matching destination, fingerprint, and
+  authority ID;
+- between one and fifty canonical requests;
+- an explicit controlled HTTPS host allow-list; and
+- receiver-side stable `Idempotency-Key` behaviour.
+
+The receiver accepts a same-key, same-payload duplicate and rejects changed
+content under the same key. Request bodies are not retained; receipts contain
+only host, event identity, event type, payload SHA-256, time, status, and
+same-content duplicate classification.
+
+## Disablement stage
+
+The disablement target is explicitly authority-free and request-free:
+
+```text
+target_authority_required = false
+authority_id = null
+request_count = 0
+receiver_summary = null
+```
+
+This prevents a disablement rehearsal from being presented as a delivery
+attempt.
+
+## Deterministic evidence
+
+The rehearsal ID binds:
+
+```text
+all three plan IDs
+baseline, rotated, and rollback authority evidence
+rotation and rollback checklist IDs
+ordered credential-free receiver receipts
+start and finish timestamps
+stale-authority rejection results
+```
+
+Exact evidence produces the same rehearsal ID. Changed plan continuity,
+authority, checklist, request ordering, payload hash, host, or timestamp changes
+the result or fails closed.
+
+## Safety boundary
+
+The rehearsal uses `ControlledNotificationReceiver`, which opens no socket and
+performs no DNS lookup or external request. The summary omits endpoint URLs and
+paths, endpoint values, payload bodies, response bodies, credentials,
+environment values, and PostgreSQL DSNs.
+
+It performs no delivery-attempt write, outbox mutation, acknowledgement, cloud
+scheduling, infrastructure deployment, or `terraform apply`. Committed
+destination activation and notification delivery remain disabled.

--- a/src/orchestration/notification_destination_transition_rehearsal.py
+++ b/src/orchestration/notification_destination_transition_rehearsal.py
@@ -1,0 +1,474 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from collections.abc import Callable, Mapping, Sequence
+from datetime import datetime, timezone
+from typing import Any
+
+from src.common.exceptions import ValidationError
+from src.orchestration.controlled_notification_receiver import (
+    ControlledNotificationReceiver,
+)
+from src.orchestration.notification_activation_checklist import (
+    validate_notification_activation_checklist,
+)
+from src.orchestration.notification_destination_transition_plan import (
+    validate_notification_destination_transition_plan,
+    validate_target_destination_authority,
+)
+from src.orchestration.portfolio_risk_notification_destination_authority import (
+    MODEL_VERSION as DESTINATION_AUTHORITY_MODEL_VERSION,
+)
+
+MODEL_VERSION = "portfolio-risk-notification-destination-transition-rehearsal-v1"
+SAFE_TEXT = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,511}$")
+MAX_STAGE_REQUESTS = 50
+Clock = Callable[[], datetime]
+
+
+def _exact_mapping(value: Any, label: str, keys: set[str]) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        raise ValidationError(f"{label} must be a mapping")
+    actual = set(value)
+    if actual != keys:
+        raise ValidationError(
+            f"{label} fields are invalid; "
+            f"missing={sorted(keys - actual)}, unknown={sorted(actual - keys)}"
+        )
+    return value
+
+
+def _safe_text(value: Any, label: str) -> str:
+    if not isinstance(value, str) or not SAFE_TEXT.fullmatch(value):
+        raise ValidationError(f"{label} must be one safe text segment")
+    return value
+
+
+def _aware_utc(value: Any, label: str) -> datetime:
+    if isinstance(value, datetime):
+        parsed = value
+    elif isinstance(value, str):
+        try:
+            parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        except ValueError:
+            raise ValidationError(f"{label} must be ISO-8601") from None
+    else:
+        raise ValidationError(f"{label} must be timezone-aware")
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise ValidationError(f"{label} must be timezone-aware")
+    return parsed.astimezone(timezone.utc)
+
+
+def _authority_fields(value: Any, label: str) -> Mapping[str, Any]:
+    authority = _exact_mapping(
+        value,
+        label,
+        {
+            "acknowledgement_mutated",
+            "activation",
+            "active",
+            "allowed_event_types",
+            "authority_id",
+            "channel",
+            "delivery_attempt_written",
+            "destination_fingerprint",
+            "destination_id",
+            "endpoint_environment_variable",
+            "endpoint_value_recorded",
+            "evaluated_at",
+            "evaluated_event_types",
+            "external_request_performed",
+            "model_version",
+            "outbox_mutated",
+        },
+    )
+    if authority["model_version"] != DESTINATION_AUTHORITY_MODEL_VERSION:
+        raise ValidationError(f"{label} model_version is unsupported")
+    if authority["channel"] != "webhook" or authority["active"] is not True:
+        raise ValidationError(f"{label} must be active webhook authority")
+    if any(
+        authority[flag] is not False
+        for flag in (
+            "acknowledgement_mutated",
+            "delivery_attempt_written",
+            "endpoint_value_recorded",
+            "external_request_performed",
+            "outbox_mutated",
+        )
+    ):
+        raise ValidationError(f"{label} side-effect evidence is invalid")
+    return authority
+
+
+def _validate_current_authority(
+    *,
+    plan: Mapping[str, Any],
+    authority: Mapping[str, Any],
+    label: str,
+) -> dict[str, Any]:
+    validated_plan = validate_notification_destination_transition_plan(plan)
+    current = validated_plan["current"]
+    exact = _authority_fields(authority, label)
+    expected = {
+        "destination_id": validated_plan["destination_id"],
+        "destination_fingerprint": current["fingerprint"],
+        "endpoint_environment_variable": current["endpoint_environment_variable"],
+        "evaluated_at": validated_plan["planned_at"],
+    }
+    for field, expected_value in expected.items():
+        if exact[field] != expected_value:
+            raise ValidationError(f"{label} {field} does not match current plan evidence")
+    activation = exact["activation"]
+    if not isinstance(activation, Mapping) or activation.get("status") != "active":
+        raise ValidationError(f"{label} activation is not active")
+    return dict(exact)
+
+
+def _validate_checklist(
+    *,
+    checklist: Mapping[str, Any],
+    authority: Mapping[str, Any],
+    label: str,
+) -> dict[str, Any]:
+    validated = validate_notification_activation_checklist(checklist)
+    if validated["activation_ready"] is not True:
+        raise ValidationError(f"{label} must be activation-ready")
+    expected = {
+        "destination_id": authority["destination_id"],
+        "destination_fingerprint": authority["destination_fingerprint"],
+        "authority_id": authority["authority_id"],
+    }
+    for field, expected_value in expected.items():
+        if validated[field] != expected_value:
+            raise ValidationError(f"{label} {field} does not match authority")
+    return validated
+
+
+def _request_bytes(value: Any, label: str) -> tuple[str, bytes]:
+    request = _exact_mapping(value, label, {"endpoint", "payload"})
+    endpoint = request["endpoint"]
+    if not isinstance(endpoint, str) or not endpoint:
+        raise ValidationError(f"{label}.endpoint must be non-empty text")
+    payload = request["payload"]
+    if not isinstance(payload, Mapping):
+        raise ValidationError(f"{label}.payload must be a mapping")
+    try:
+        payload_bytes = json.dumps(
+            dict(payload),
+            sort_keys=True,
+            separators=(",", ":"),
+            allow_nan=False,
+        ).encode("utf-8")
+    except (TypeError, ValueError):
+        raise ValidationError(f"{label}.payload is not canonical JSON") from None
+    return endpoint, payload_bytes
+
+
+def _event_identity(payload_bytes: bytes, label: str) -> tuple[str, str]:
+    try:
+        payload = json.loads(payload_bytes.decode("utf-8"))
+    except (UnicodeError, ValueError):  # pragma: no cover - encoded above.
+        raise ValidationError(f"{label}.payload is invalid JSON") from None
+    if not isinstance(payload, Mapping):
+        raise ValidationError(f"{label}.payload must be an object")
+    return (
+        _safe_text(payload.get("event_id"), f"{label}.payload.event_id"),
+        _safe_text(payload.get("event_type"), f"{label}.payload.event_type"),
+    )
+
+
+def _run_receiver_stage(
+    *,
+    operation: str,
+    plan: Mapping[str, Any],
+    authority: Mapping[str, Any],
+    checklist: Mapping[str, Any],
+    allowed_hosts: Sequence[str],
+    requests: Sequence[Mapping[str, Any]],
+    response_status: int,
+    clock: Clock,
+) -> dict[str, Any]:
+    if isinstance(requests, (str, bytes)) or not 1 <= len(requests) <= MAX_STAGE_REQUESTS:
+        raise ValidationError(
+            f"{operation} requests must contain between 1 and {MAX_STAGE_REQUESTS} items"
+        )
+    validated_plan = validate_notification_destination_transition_plan(plan)
+    validated_authority = validate_target_destination_authority(
+        plan=validated_plan,
+        authority=authority,
+    )
+    validated_checklist = _validate_checklist(
+        checklist=checklist,
+        authority=validated_authority,
+        label=f"{operation} checklist",
+    )
+    receiver = ControlledNotificationReceiver(
+        activation_checklist=validated_checklist,
+        allowed_hosts=allowed_hosts,
+        allowed_event_types=validated_authority["allowed_event_types"],
+        response_status=response_status,
+        max_requests=len(requests),
+        clock=clock,
+    )
+    requested_event_ids: list[str] = []
+    requested_event_types: list[str] = []
+    for index, request in enumerate(requests, start=1):
+        label = f"{operation} request {index}"
+        endpoint, payload_bytes = _request_bytes(request, label)
+        event_id, event_type = _event_identity(payload_bytes, label)
+        receiver(
+            endpoint,
+            payload_bytes,
+            {
+                "Content-Type": "application/json",
+                "Idempotency-Key": event_id,
+                "User-Agent": "financial-risk-data-platform/1",
+            },
+            5.0,
+        )
+        requested_event_ids.append(event_id)
+        requested_event_types.append(event_type)
+
+    summary = receiver.summary()
+    if summary["destination_id"] != validated_plan["destination_id"]:
+        raise ValidationError(f"{operation} receiver destination identity changed")
+    if summary["destination_fingerprint"] != validated_authority[
+        "destination_fingerprint"
+    ]:
+        raise ValidationError(f"{operation} receiver destination fingerprint changed")
+    if summary["authority_id"] != validated_authority["authority_id"]:
+        raise ValidationError(f"{operation} receiver authority identity changed")
+    if summary["activation_checklist_id"] != validated_checklist["checklist_id"]:
+        raise ValidationError(f"{operation} receiver checklist identity changed")
+    if summary["request_count"] != len(requests):
+        raise ValidationError(f"{operation} receiver request count changed")
+
+    receipts = summary["receipts"]
+    first_received_at = receipts[0]["received_at"]
+    last_received_at = receipts[-1]["received_at"]
+    return {
+        "operation": operation,
+        "plan_id": validated_plan["plan_id"],
+        "authority_id": validated_authority["authority_id"],
+        "checklist_id": validated_checklist["checklist_id"],
+        "destination_fingerprint": validated_authority["destination_fingerprint"],
+        "endpoint_environment_variable": validated_authority[
+            "endpoint_environment_variable"
+        ],
+        "requested_event_ids": requested_event_ids,
+        "requested_event_types": requested_event_types,
+        "request_count": len(requests),
+        "first_received_at": first_received_at,
+        "last_received_at": last_received_at,
+        "receiver_summary": summary,
+    }
+
+
+def _assert_stale_authority_rejected(
+    *,
+    plan: Mapping[str, Any],
+    authority: Mapping[str, Any],
+    label: str,
+) -> None:
+    try:
+        validate_target_destination_authority(plan=plan, authority=authority)
+    except ValidationError:
+        return
+    raise ValidationError(f"{label} unexpectedly authorised a later transition target")
+
+
+def _chain(
+    *,
+    rotate_plan: Mapping[str, Any],
+    disable_plan: Mapping[str, Any],
+    rollback_plan: Mapping[str, Any],
+) -> tuple[dict[str, Any], dict[str, Any], dict[str, Any]]:
+    rotate = validate_notification_destination_transition_plan(rotate_plan)
+    disable = validate_notification_destination_transition_plan(disable_plan)
+    rollback = validate_notification_destination_transition_plan(rollback_plan)
+    if [rotate["operation"], disable["operation"], rollback["operation"]] != [
+        "rotate",
+        "disable",
+        "rollback",
+    ]:
+        raise ValidationError("transition rehearsal operations are not canonical")
+    destination_ids = {
+        rotate["destination_id"],
+        disable["destination_id"],
+        rollback["destination_id"],
+    }
+    if len(destination_ids) != 1:
+        raise ValidationError("transition rehearsal destination identities differ")
+    plan_times = [
+        _aware_utc(rotate["planned_at"], "rotate planned_at"),
+        _aware_utc(disable["planned_at"], "disable planned_at"),
+        _aware_utc(rollback["planned_at"], "rollback planned_at"),
+    ]
+    if plan_times != sorted(plan_times):
+        raise ValidationError("transition rehearsal plan times are not ordered")
+    if rotate["target"] != disable["current"]:
+        raise ValidationError("rotation target does not equal disablement current state")
+    if disable["target"] != rollback["current"]:
+        raise ValidationError("disablement target does not equal rollback current state")
+    if rollback["prior_plan_id"] != disable["plan_id"]:
+        raise ValidationError("rollback does not reference the exact disablement plan")
+    if rollback["target"]["endpoint_environment_variable"] != rotate["current"][
+        "endpoint_environment_variable"
+    ]:
+        raise ValidationError("rollback does not restore the prior endpoint identity")
+    return rotate, disable, rollback
+
+
+def canonical_transition_rehearsal_bytes(summary: Mapping[str, Any]) -> bytes:
+    try:
+        return json.dumps(
+            summary,
+            sort_keys=True,
+            separators=(",", ":"),
+            allow_nan=False,
+        ).encode("utf-8")
+    except (TypeError, ValueError):
+        raise ValidationError("transition rehearsal is not canonical JSON") from None
+
+
+def _rehearsal_id(identity: Mapping[str, Any]) -> str:
+    digest = hashlib.sha256(canonical_transition_rehearsal_bytes(identity)).hexdigest()[:24]
+    return f"{MODEL_VERSION}-rehearsal-{digest}"
+
+
+def rehearse_notification_destination_transition(
+    *,
+    rotate_plan: Mapping[str, Any],
+    disable_plan: Mapping[str, Any],
+    rollback_plan: Mapping[str, Any],
+    baseline_authority: Mapping[str, Any],
+    rotate_authority: Mapping[str, Any],
+    rollback_authority: Mapping[str, Any],
+    rotate_checklist: Mapping[str, Any],
+    rollback_checklist: Mapping[str, Any],
+    rotate_allowed_hosts: Sequence[str],
+    rollback_allowed_hosts: Sequence[str],
+    rotate_requests: Sequence[Mapping[str, Any]],
+    rollback_requests: Sequence[Mapping[str, Any]],
+    started_at: datetime | str,
+    response_status: int = 204,
+    clock: Clock | None = None,
+) -> dict[str, Any]:
+    """Rehearse rotate, disable, and rollback without resolving an endpoint."""
+
+    rotate, disable, rollback = _chain(
+        rotate_plan=rotate_plan,
+        disable_plan=disable_plan,
+        rollback_plan=rollback_plan,
+    )
+    started = _aware_utc(started_at, "started_at")
+    if any(
+        _aware_utc(plan["planned_at"], "planned_at") > started
+        for plan in (rotate, disable, rollback)
+    ):
+        raise ValidationError("transition rehearsal starts before a plan was produced")
+    baseline = _validate_current_authority(
+        plan=rotate,
+        authority=baseline_authority,
+        label="baseline authority",
+    )
+    rotated = _validate_current_authority(
+        plan=disable,
+        authority=rotate_authority,
+        label="rotated authority",
+    )
+    _assert_stale_authority_rejected(
+        plan=rotate,
+        authority=baseline,
+        label="baseline authority",
+    )
+    _assert_stale_authority_rejected(
+        plan=rollback,
+        authority=rotated,
+        label="rotated authority",
+    )
+
+    selected_clock = clock or (lambda: datetime.now(timezone.utc))
+    rotate_stage = _run_receiver_stage(
+        operation="rotate",
+        plan=rotate,
+        authority=rotate_authority,
+        checklist=rotate_checklist,
+        allowed_hosts=rotate_allowed_hosts,
+        requests=rotate_requests,
+        response_status=response_status,
+        clock=selected_clock,
+    )
+    rotate_last = _aware_utc(rotate_stage["last_received_at"], "rotate received_at")
+    if rotate_last < started:
+        raise ValidationError("rotation receipt precedes rehearsal start")
+
+    disable_stage = {
+        "operation": "disable",
+        "plan_id": disable["plan_id"],
+        "authority_id": None,
+        "checklist_id": None,
+        "destination_fingerprint": disable["target"]["fingerprint"],
+        "endpoint_environment_variable": disable["target"][
+            "endpoint_environment_variable"
+        ],
+        "requested_event_ids": [],
+        "requested_event_types": [],
+        "request_count": 0,
+        "receiver_summary": None,
+        "target_authority_required": False,
+    }
+
+    rollback_stage = _run_receiver_stage(
+        operation="rollback",
+        plan=rollback,
+        authority=rollback_authority,
+        checklist=rollback_checklist,
+        allowed_hosts=rollback_allowed_hosts,
+        requests=rollback_requests,
+        response_status=response_status,
+        clock=selected_clock,
+    )
+    rollback_first = _aware_utc(
+        rollback_stage["first_received_at"],
+        "rollback received_at",
+    )
+    rollback_last = _aware_utc(
+        rollback_stage["last_received_at"],
+        "rollback received_at",
+    )
+    if rollback_first < rotate_last:
+        raise ValidationError("rollback receipts precede rotation completion")
+
+    identity = {
+        "baseline_authority_id": baseline["authority_id"],
+        "destination_id": rotate["destination_id"],
+        "disable_plan_id": disable["plan_id"],
+        "finished_at": rollback_last.isoformat(),
+        "model_version": MODEL_VERSION,
+        "rollback_plan_id": rollback["plan_id"],
+        "rotate_plan_id": rotate["plan_id"],
+        "stages": [rotate_stage, disable_stage, rollback_stage],
+        "stale_authority_rejections": {
+            "baseline_for_rotation_target": True,
+            "rotated_for_rollback_target": True,
+        },
+        "started_at": started.isoformat(),
+    }
+    return {
+        "rehearsal_id": _rehearsal_id(identity),
+        **identity,
+        "acknowledgement_mutated": False,
+        "delivery_attempt_written": False,
+        "dns_lookup_performed": False,
+        "endpoint_paths_recorded": False,
+        "endpoint_values_recorded": False,
+        "external_request_performed": False,
+        "infrastructure_deployed": False,
+        "outbox_mutated": False,
+        "payload_bodies_recorded": False,
+        "response_bodies_recorded": False,
+        "socket_opened": False,
+    }

--- a/tests/unit/test_notification_destination_transition_rehearsal.py
+++ b/tests/unit/test_notification_destination_transition_rehearsal.py
@@ -1,0 +1,448 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+from src.common.exceptions import ValidationError
+from src.orchestration.notification_activation_checklist import (
+    CONTROL_NAMES,
+    build_notification_activation_checklist,
+)
+from src.orchestration.notification_destination_transition_plan import (
+    build_notification_destination_transition_plan,
+)
+from src.orchestration.notification_destination_transition_rehearsal import (
+    MODEL_VERSION,
+    rehearse_notification_destination_transition,
+)
+from src.orchestration.portfolio_risk_notification_destination_authority import (
+    resolve_notification_destination_authority,
+)
+
+DESTINATION_ID = "risk-operations-webhook"
+OLD_ENDPOINT_ENV = "RISK_NOTIFICATION_WEBHOOK_URL"
+NEW_ENDPOINT_ENV = "RISK_NOTIFICATION_WEBHOOK_URL_V2"
+PLANNED_AT = datetime(2026, 6, 15, 12, tzinfo=timezone.utc)
+STARTED_AT = PLANNED_AT + timedelta(minutes=1)
+
+
+def _activation(
+    *,
+    enabled: bool,
+    change_request_id: str,
+    reviewed_at: str,
+) -> dict[str, Any]:
+    if not enabled:
+        return {
+            "enabled": False,
+            "change_request_id": None,
+            "reviewed_by": [],
+            "reviewed_at": None,
+            "review_expires_at": None,
+        }
+    return {
+        "enabled": True,
+        "change_request_id": change_request_id,
+        "reviewed_by": ["risk-control-reviewer"],
+        "reviewed_at": reviewed_at,
+        "review_expires_at": "2026-12-31T00:00:00Z",
+    }
+
+
+def _payload(
+    *,
+    endpoint_env: str,
+    enabled: bool,
+    change_request_id: str,
+    reviewed_at: str,
+) -> dict[str, Any]:
+    return {
+        "model_version": "portfolio-risk-notification-destination-v1",
+        "destinations": {
+            DESTINATION_ID: {
+                "channel": "webhook",
+                "endpoint_env": endpoint_env,
+                "owner": {
+                    "team": "risk-operations",
+                    "contact": "risk-operations-oncall",
+                },
+                "purpose": "portfolio-risk-breach-lifecycle",
+                "recipient_scope": "risk-operations",
+                "data_classification": "internal",
+                "allowed_event_types": [
+                    "breach_escalated",
+                    "breach_opened",
+                    "breach_resolved",
+                ],
+                "activation": _activation(
+                    enabled=enabled,
+                    change_request_id=change_request_id,
+                    reviewed_at=reviewed_at,
+                ),
+            }
+        },
+    }
+
+
+def _write(tmp_path: Path, name: str, payload: dict[str, Any]) -> Path:
+    path = tmp_path / name
+    path.write_text(yaml.safe_dump(payload, sort_keys=False), encoding="utf-8")
+    return path
+
+
+def _evidence(tmp_path: Path, *, wrong_rollback_parent: bool = False) -> dict[str, Any]:
+    baseline = _write(
+        tmp_path,
+        "baseline.yaml",
+        _payload(
+            endpoint_env=OLD_ENDPOINT_ENV,
+            enabled=True,
+            change_request_id="CHG-BASELINE",
+            reviewed_at="2026-01-01T00:00:00Z",
+        ),
+    )
+    rotated = _write(
+        tmp_path,
+        "rotated.yaml",
+        _payload(
+            endpoint_env=NEW_ENDPOINT_ENV,
+            enabled=True,
+            change_request_id="CHG-ROTATE",
+            reviewed_at="2026-05-01T00:00:00Z",
+        ),
+    )
+    disabled = _write(
+        tmp_path,
+        "disabled.yaml",
+        _payload(
+            endpoint_env=NEW_ENDPOINT_ENV,
+            enabled=False,
+            change_request_id="unused",
+            reviewed_at="2026-05-01T00:00:00Z",
+        ),
+    )
+    rollback = _write(
+        tmp_path,
+        "rollback.yaml",
+        _payload(
+            endpoint_env=OLD_ENDPOINT_ENV,
+            enabled=True,
+            change_request_id="CHG-ROLLBACK",
+            reviewed_at="2026-06-01T00:00:00Z",
+        ),
+    )
+
+    rotate_plan = build_notification_destination_transition_plan(
+        operation="rotate",
+        current_config_path=baseline,
+        target_config_path=rotated,
+        destination_id=DESTINATION_ID,
+        planned_at=PLANNED_AT,
+    )
+    disable_plan = build_notification_destination_transition_plan(
+        operation="disable",
+        current_config_path=rotated,
+        target_config_path=disabled,
+        destination_id=DESTINATION_ID,
+        planned_at=PLANNED_AT,
+    )
+    rollback_plan = build_notification_destination_transition_plan(
+        operation="rollback",
+        current_config_path=disabled,
+        target_config_path=rollback,
+        destination_id=DESTINATION_ID,
+        planned_at=PLANNED_AT,
+        prior_plan_id=(
+            rotate_plan["plan_id"]
+            if wrong_rollback_parent
+            else disable_plan["plan_id"]
+        ),
+    )
+
+    baseline_authority = resolve_notification_destination_authority(
+        destination_config_path=baseline,
+        destination_id=DESTINATION_ID,
+        delivery_endpoint_env=OLD_ENDPOINT_ENV,
+        evaluated_at=PLANNED_AT,
+        event_types=["breach_opened"],
+    )
+    rotate_authority = resolve_notification_destination_authority(
+        destination_config_path=rotated,
+        destination_id=DESTINATION_ID,
+        delivery_endpoint_env=NEW_ENDPOINT_ENV,
+        evaluated_at=PLANNED_AT,
+        event_types=["breach_opened"],
+    )
+    rollback_authority = resolve_notification_destination_authority(
+        destination_config_path=rollback,
+        destination_id=DESTINATION_ID,
+        delivery_endpoint_env=OLD_ENDPOINT_ENV,
+        evaluated_at=PLANNED_AT,
+        event_types=["breach_opened"],
+    )
+
+    controls = {name: True for name in CONTROL_NAMES}
+    rotate_checklist = build_notification_activation_checklist(
+        destination_id=DESTINATION_ID,
+        destination_fingerprint=rotate_authority["destination_fingerprint"],
+        authority_id=rotate_authority["authority_id"],
+        reviewed_by=["receiver-owner", "risk-control-reviewer"],
+        reviewed_at=PLANNED_AT - timedelta(days=1),
+        review_expires_at=PLANNED_AT + timedelta(days=30),
+        controls=controls,
+    )
+    rollback_checklist = build_notification_activation_checklist(
+        destination_id=DESTINATION_ID,
+        destination_fingerprint=rollback_authority["destination_fingerprint"],
+        authority_id=rollback_authority["authority_id"],
+        reviewed_by=["receiver-owner", "risk-control-reviewer"],
+        reviewed_at=PLANNED_AT - timedelta(hours=1),
+        review_expires_at=PLANNED_AT + timedelta(days=30),
+        controls=controls,
+    )
+    return {
+        "rotate_plan": rotate_plan,
+        "disable_plan": disable_plan,
+        "rollback_plan": rollback_plan,
+        "baseline_authority": baseline_authority,
+        "rotate_authority": rotate_authority,
+        "rollback_authority": rollback_authority,
+        "rotate_checklist": rotate_checklist,
+        "rollback_checklist": rollback_checklist,
+    }
+
+
+def _request(
+    *,
+    endpoint: str,
+    event_id: str,
+    severity: str = "critical",
+) -> dict[str, Any]:
+    return {
+        "endpoint": endpoint,
+        "payload": {
+            "event_id": event_id,
+            "event_type": "breach_opened",
+            "payload": {"severity": severity},
+            "policy_id": "us-tech-standard",
+            "portfolio_id": "us-tech-equal",
+        },
+    }
+
+
+def _clock(*values: datetime):
+    iterator = iter(values)
+    return lambda: next(iterator)
+
+
+def _run(tmp_path: Path) -> dict[str, Any]:
+    evidence = _evidence(tmp_path)
+    rotate_request = _request(
+        endpoint="https://receiver-v2.test/risk?mode=controlled",
+        event_id="rotation-event-1",
+    )
+    rollback_request = _request(
+        endpoint="https://receiver-v1.test/risk?mode=controlled",
+        event_id="rollback-event-1",
+    )
+    return rehearse_notification_destination_transition(
+        **evidence,
+        rotate_allowed_hosts=["receiver-v2.test"],
+        rollback_allowed_hosts=["receiver-v1.test"],
+        rotate_requests=[rotate_request, rotate_request],
+        rollback_requests=[rollback_request],
+        started_at=STARTED_AT,
+        clock=_clock(
+            STARTED_AT + timedelta(seconds=1),
+            STARTED_AT + timedelta(seconds=2),
+            STARTED_AT + timedelta(seconds=3),
+        ),
+    )
+
+
+def test_complete_transition_rehearsal_is_deterministic_and_no_network(
+    tmp_path: Path,
+) -> None:
+    first = _run(tmp_path / "first")
+    second = _run(tmp_path / "second")
+
+    assert first == second
+    assert first["model_version"] == MODEL_VERSION
+    assert [stage["operation"] for stage in first["stages"]] == [
+        "rotate",
+        "disable",
+        "rollback",
+    ]
+    assert [stage["request_count"] for stage in first["stages"]] == [2, 0, 1]
+    assert first["stages"][0]["receiver_summary"][
+        "same_content_duplicate_count"
+    ] == 1
+    assert first["stages"][1]["authority_id"] is None
+    assert first["stages"][1]["receiver_summary"] is None
+    assert first["stale_authority_rejections"] == {
+        "baseline_for_rotation_target": True,
+        "rotated_for_rollback_target": True,
+    }
+    for flag in (
+        "external_request_performed",
+        "socket_opened",
+        "dns_lookup_performed",
+        "delivery_attempt_written",
+        "outbox_mutated",
+        "acknowledgement_mutated",
+        "infrastructure_deployed",
+    ):
+        assert first[flag] is False
+
+    rendered = json.dumps(first, sort_keys=True)
+    assert "https://" not in rendered
+    assert "/risk" not in rendered
+    assert '"severity"' not in rendered
+    assert "postgresql://" not in rendered
+
+
+def test_rehearsal_rejects_broken_plan_chain(tmp_path: Path) -> None:
+    evidence = _evidence(tmp_path, wrong_rollback_parent=True)
+    request = _request(
+        endpoint="https://receiver-v2.test/risk",
+        event_id="event-1",
+    )
+    with pytest.raises(ValidationError, match="exact disablement plan"):
+        rehearse_notification_destination_transition(
+            **evidence,
+            rotate_allowed_hosts=["receiver-v2.test"],
+            rollback_allowed_hosts=["receiver-v1.test"],
+            rotate_requests=[request],
+            rollback_requests=[
+                _request(
+                    endpoint="https://receiver-v1.test/risk",
+                    event_id="event-2",
+                )
+            ],
+            started_at=STARTED_AT,
+            clock=_clock(
+                STARTED_AT + timedelta(seconds=1),
+                STARTED_AT + timedelta(seconds=2),
+            ),
+        )
+
+
+def test_rehearsal_rejects_wrong_current_authority(tmp_path: Path) -> None:
+    evidence = _evidence(tmp_path)
+    evidence["baseline_authority"] = evidence["rotate_authority"]
+    with pytest.raises(ValidationError, match="current plan evidence"):
+        rehearse_notification_destination_transition(
+            **evidence,
+            rotate_allowed_hosts=["receiver-v2.test"],
+            rollback_allowed_hosts=["receiver-v1.test"],
+            rotate_requests=[
+                _request(
+                    endpoint="https://receiver-v2.test/risk",
+                    event_id="event-1",
+                )
+            ],
+            rollback_requests=[
+                _request(
+                    endpoint="https://receiver-v1.test/risk",
+                    event_id="event-2",
+                )
+            ],
+            started_at=STARTED_AT,
+            clock=_clock(
+                STARTED_AT + timedelta(seconds=1),
+                STARTED_AT + timedelta(seconds=2),
+            ),
+        )
+
+
+def test_rehearsal_rejects_mismatched_checklist(tmp_path: Path) -> None:
+    evidence = _evidence(tmp_path)
+    evidence["rollback_checklist"] = evidence["rotate_checklist"]
+    with pytest.raises(ValidationError, match="does not match authority"):
+        rehearse_notification_destination_transition(
+            **evidence,
+            rotate_allowed_hosts=["receiver-v2.test"],
+            rollback_allowed_hosts=["receiver-v1.test"],
+            rotate_requests=[
+                _request(
+                    endpoint="https://receiver-v2.test/risk",
+                    event_id="event-1",
+                )
+            ],
+            rollback_requests=[
+                _request(
+                    endpoint="https://receiver-v1.test/risk",
+                    event_id="event-2",
+                )
+            ],
+            started_at=STARTED_AT,
+            clock=_clock(
+                STARTED_AT + timedelta(seconds=1),
+                STARTED_AT + timedelta(seconds=2),
+            ),
+        )
+
+
+def test_rehearsal_requires_requests_only_for_active_stages(tmp_path: Path) -> None:
+    evidence = _evidence(tmp_path)
+    with pytest.raises(ValidationError, match="between 1 and"):
+        rehearse_notification_destination_transition(
+            **evidence,
+            rotate_allowed_hosts=["receiver-v2.test"],
+            rollback_allowed_hosts=["receiver-v1.test"],
+            rotate_requests=[],
+            rollback_requests=[
+                _request(
+                    endpoint="https://receiver-v1.test/risk",
+                    event_id="event-2",
+                )
+            ],
+            started_at=STARTED_AT,
+            clock=_clock(STARTED_AT + timedelta(seconds=1)),
+        )
+
+
+def test_rehearsal_rejects_receipts_before_start_or_out_of_order(
+    tmp_path: Path,
+) -> None:
+    evidence = _evidence(tmp_path)
+    request_one = _request(
+        endpoint="https://receiver-v2.test/risk",
+        event_id="event-1",
+    )
+    request_two = _request(
+        endpoint="https://receiver-v1.test/risk",
+        event_id="event-2",
+    )
+    with pytest.raises(ValidationError, match="precedes rehearsal start"):
+        rehearse_notification_destination_transition(
+            **evidence,
+            rotate_allowed_hosts=["receiver-v2.test"],
+            rollback_allowed_hosts=["receiver-v1.test"],
+            rotate_requests=[request_one],
+            rollback_requests=[request_two],
+            started_at=STARTED_AT,
+            clock=_clock(
+                STARTED_AT - timedelta(seconds=1),
+                STARTED_AT + timedelta(seconds=1),
+            ),
+        )
+
+    with pytest.raises(ValidationError, match="precede rotation completion"):
+        rehearse_notification_destination_transition(
+            **evidence,
+            rotate_allowed_hosts=["receiver-v2.test"],
+            rollback_allowed_hosts=["receiver-v1.test"],
+            rotate_requests=[request_one],
+            rollback_requests=[request_two],
+            started_at=STARTED_AT,
+            clock=_clock(
+                STARTED_AT + timedelta(seconds=2),
+                STARTED_AT + timedelta(seconds=1),
+            ),
+        )

--- a/tests/unit/test_notification_destination_transition_rehearsal.py
+++ b/tests/unit/test_notification_destination_transition_rehearsal.py
@@ -90,12 +90,17 @@ def _payload(
 
 
 def _write(tmp_path: Path, name: str, payload: dict[str, Any]) -> Path:
+    tmp_path.mkdir(parents=True, exist_ok=True)
     path = tmp_path / name
     path.write_text(yaml.safe_dump(payload, sort_keys=False), encoding="utf-8")
     return path
 
 
-def _evidence(tmp_path: Path, *, wrong_rollback_parent: bool = False) -> dict[str, Any]:
+def _evidence(
+    tmp_path: Path,
+    *,
+    wrong_rollback_parent: bool = False,
+) -> dict[str, Any]:
     baseline = _write(
         tmp_path,
         "baseline.yaml",
@@ -265,6 +270,19 @@ def _run(tmp_path: Path) -> dict[str, Any]:
     )
 
 
+def _single_requests() -> tuple[dict[str, Any], dict[str, Any]]:
+    return (
+        _request(
+            endpoint="https://receiver-v2.test/risk",
+            event_id="event-1",
+        ),
+        _request(
+            endpoint="https://receiver-v1.test/risk",
+            event_id="event-2",
+        ),
+    )
+
+
 def test_complete_transition_rehearsal_is_deterministic_and_no_network(
     tmp_path: Path,
 ) -> None:
@@ -308,22 +326,14 @@ def test_complete_transition_rehearsal_is_deterministic_and_no_network(
 
 def test_rehearsal_rejects_broken_plan_chain(tmp_path: Path) -> None:
     evidence = _evidence(tmp_path, wrong_rollback_parent=True)
-    request = _request(
-        endpoint="https://receiver-v2.test/risk",
-        event_id="event-1",
-    )
+    rotate_request, rollback_request = _single_requests()
     with pytest.raises(ValidationError, match="exact disablement plan"):
         rehearse_notification_destination_transition(
             **evidence,
             rotate_allowed_hosts=["receiver-v2.test"],
             rollback_allowed_hosts=["receiver-v1.test"],
-            rotate_requests=[request],
-            rollback_requests=[
-                _request(
-                    endpoint="https://receiver-v1.test/risk",
-                    event_id="event-2",
-                )
-            ],
+            rotate_requests=[rotate_request],
+            rollback_requests=[rollback_request],
             started_at=STARTED_AT,
             clock=_clock(
                 STARTED_AT + timedelta(seconds=1),
@@ -335,23 +345,14 @@ def test_rehearsal_rejects_broken_plan_chain(tmp_path: Path) -> None:
 def test_rehearsal_rejects_wrong_current_authority(tmp_path: Path) -> None:
     evidence = _evidence(tmp_path)
     evidence["baseline_authority"] = evidence["rotate_authority"]
+    rotate_request, rollback_request = _single_requests()
     with pytest.raises(ValidationError, match="current plan evidence"):
         rehearse_notification_destination_transition(
             **evidence,
             rotate_allowed_hosts=["receiver-v2.test"],
             rollback_allowed_hosts=["receiver-v1.test"],
-            rotate_requests=[
-                _request(
-                    endpoint="https://receiver-v2.test/risk",
-                    event_id="event-1",
-                )
-            ],
-            rollback_requests=[
-                _request(
-                    endpoint="https://receiver-v1.test/risk",
-                    event_id="event-2",
-                )
-            ],
+            rotate_requests=[rotate_request],
+            rollback_requests=[rollback_request],
             started_at=STARTED_AT,
             clock=_clock(
                 STARTED_AT + timedelta(seconds=1),
@@ -363,23 +364,14 @@ def test_rehearsal_rejects_wrong_current_authority(tmp_path: Path) -> None:
 def test_rehearsal_rejects_mismatched_checklist(tmp_path: Path) -> None:
     evidence = _evidence(tmp_path)
     evidence["rollback_checklist"] = evidence["rotate_checklist"]
+    rotate_request, rollback_request = _single_requests()
     with pytest.raises(ValidationError, match="does not match authority"):
         rehearse_notification_destination_transition(
             **evidence,
             rotate_allowed_hosts=["receiver-v2.test"],
             rollback_allowed_hosts=["receiver-v1.test"],
-            rotate_requests=[
-                _request(
-                    endpoint="https://receiver-v2.test/risk",
-                    event_id="event-1",
-                )
-            ],
-            rollback_requests=[
-                _request(
-                    endpoint="https://receiver-v1.test/risk",
-                    event_id="event-2",
-                )
-            ],
+            rotate_requests=[rotate_request],
+            rollback_requests=[rollback_request],
             started_at=STARTED_AT,
             clock=_clock(
                 STARTED_AT + timedelta(seconds=1),
@@ -390,18 +382,14 @@ def test_rehearsal_rejects_mismatched_checklist(tmp_path: Path) -> None:
 
 def test_rehearsal_requires_requests_only_for_active_stages(tmp_path: Path) -> None:
     evidence = _evidence(tmp_path)
+    _, rollback_request = _single_requests()
     with pytest.raises(ValidationError, match="between 1 and"):
         rehearse_notification_destination_transition(
             **evidence,
             rotate_allowed_hosts=["receiver-v2.test"],
             rollback_allowed_hosts=["receiver-v1.test"],
             rotate_requests=[],
-            rollback_requests=[
-                _request(
-                    endpoint="https://receiver-v1.test/risk",
-                    event_id="event-2",
-                )
-            ],
+            rollback_requests=[rollback_request],
             started_at=STARTED_AT,
             clock=_clock(STARTED_AT + timedelta(seconds=1)),
         )
@@ -411,21 +399,14 @@ def test_rehearsal_rejects_receipts_before_start_or_out_of_order(
     tmp_path: Path,
 ) -> None:
     evidence = _evidence(tmp_path)
-    request_one = _request(
-        endpoint="https://receiver-v2.test/risk",
-        event_id="event-1",
-    )
-    request_two = _request(
-        endpoint="https://receiver-v1.test/risk",
-        event_id="event-2",
-    )
+    rotate_request, rollback_request = _single_requests()
     with pytest.raises(ValidationError, match="precedes rehearsal start"):
         rehearse_notification_destination_transition(
             **evidence,
             rotate_allowed_hosts=["receiver-v2.test"],
             rollback_allowed_hosts=["receiver-v1.test"],
-            rotate_requests=[request_one],
-            rollback_requests=[request_two],
+            rotate_requests=[rotate_request],
+            rollback_requests=[rollback_request],
             started_at=STARTED_AT,
             clock=_clock(
                 STARTED_AT - timedelta(seconds=1),
@@ -438,8 +419,8 @@ def test_rehearsal_rejects_receipts_before_start_or_out_of_order(
             **evidence,
             rotate_allowed_hosts=["receiver-v2.test"],
             rollback_allowed_hosts=["receiver-v1.test"],
-            rotate_requests=[request_one],
-            rollback_requests=[request_two],
+            rotate_requests=[rotate_request],
+            rollback_requests=[rollback_request],
             started_at=STARTED_AT,
             clock=_clock(
                 STARTED_AT + timedelta(seconds=2),

--- a/tests/unit/test_notification_destination_transition_rehearsal_architecture_contract.py
+++ b/tests/unit/test_notification_destination_transition_rehearsal_architecture_contract.py
@@ -1,0 +1,47 @@
+from pathlib import Path
+
+
+def test_transition_rehearsal_is_chained_no_network_and_secret_free() -> None:
+    source = Path(
+        "src/orchestration/notification_destination_transition_rehearsal.py"
+    ).read_text(encoding="utf-8")
+    docs = Path(
+        "docs/notification-destination-transition-rehearsal.md"
+    ).read_text(encoding="utf-8")
+    normalized_docs = " ".join(docs.split()).casefold()
+
+    for required in (
+        "validate_notification_destination_transition_plan",
+        "validate_target_destination_authority",
+        "ControlledNotificationReceiver",
+        "rotation target does not equal disablement current state",
+        "disablement target does not equal rollback current state",
+        "rollback does not reference the exact disablement plan",
+        "_assert_stale_authority_rejected",
+        '"request_count": 0',
+        '"receiver_summary": None',
+        '"target_authority_required": False',
+        '"external_request_performed": False',
+        '"socket_opened": False',
+        '"dns_lookup_performed": False',
+    ):
+        assert required in source
+
+    for required in (
+        "primary arc42 block: `orchestration`",
+        "complete destination rotation, disablement, and rollback chain",
+        "stale authority therefore cannot authorise",
+        "authority-free and request-free",
+        "opens no socket",
+        "performs no dns lookup",
+        "terraform apply",
+    ):
+        assert required in normalized_docs
+
+    for forbidden in (
+        "requests.post(",
+        "urllib.request",
+        "httpx.",
+        "socket.socket",
+    ):
+        assert forbidden not in source.casefold()


### PR DESCRIPTION
## Goal

Complete the executable rehearsal half of **P4d4e** without creating a delivery path.

```text
exact rotate, disable, and rollback plans
  + current and target authorities
  + activation-ready receiver checklists
  + bounded canonical requests
  -> in-memory rotation rehearsal
  -> zero-request disablement
  -> in-memory rollback rehearsal
```

## Controls

- Requires exact plan continuity and predecessor-plan identity.
- Validates baseline and rotated current authority against their plan states.
- Proves baseline authority cannot authorise the rotation target.
- Proves rotated authority cannot authorise the freshly reviewed rollback target.
- Requires exact target authority and checklist identity for rotation and rollback.
- Uses the existing `ControlledNotificationReceiver` for receiver-side idempotency.
- Keeps disablement authority-free and request-free.

The first run found a test-fixture defect: the deterministic comparison used nested temporary directories without creating them. The fixture now creates its bounded temporary directory before writing YAML. Product orchestration code, authority checks, and safety controls were unchanged.

## Scope

Four intended files, 1,048 additions. The branch is zero commits behind `main`; squash merge retains one coherent orchestration increment.

## Exact-head validation

GitHub Actions run **379** (`33488587214`) passed on final head `4ee9e928484417090ca14d43f5e5ce56a6cf4320`:

- Security guardrails passed.
- Ruff passed.
- mypy passed across **131 source files**.
- **865 tests passed** in quality and **865 passed again** in readiness.
- Dependency integrity and standard replay passed.
- PostgreSQL 16 contract passed.
- Kubernetes rendering and Terraform format/init/validate passed without apply.

There are no review submissions or unresolved review threads.

## Safety

No endpoint URL or path, endpoint value, payload body, response body, credential, environment value, or DSN is retained. Ordinary validation opened no socket, performed no DNS lookup or external request, wrote no delivery attempt, mutated no outbox or acknowledgement, deployed nothing, and did not run `terraform apply`.

Validated and ready for squash merge.