### PR TITLE
Persist destination transition rehearsal history and review state

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,6 +32,7 @@ services:
       - ./sql/portfolio_risk_notification_retry_destination_follow_up_schema.sql:/docker-entrypoint-initdb.d/21_portfolio_risk_notification_retry_destination_follow_up_schema.sql:ro
       - ./sql/controlled_notification_receiver_rehearsal_schema.sql:/docker-entrypoint-initdb.d/22_controlled_notification_receiver_rehearsal_schema.sql:ro
       - ./sql/controlled_notification_receiver_review_schema.sql:/docker-entrypoint-initdb.d/23_controlled_notification_receiver_review_schema.sql:ro
+      - ./sql/notification_destination_transition_rehearsal_schema.sql:/docker-entrypoint-initdb.d/24_notification_destination_transition_rehearsal_schema.sql:ro
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U risk_user -d risk_platform"]
       interval: 5s

--- a/docs/notification-destination-transition-rehearsal-history.md
+++ b/docs/notification-destination-transition-rehearsal-history.md
@@ -1,0 +1,123 @@
+# Append-Only Notification Destination Transition History
+
+Primary arc42 blocks: `orchestration` and `warehouse`.
+
+## Goal
+
+Retain completed rotation, disablement, and rollback rehearsal evidence and make
+its relationship to the current activation review queryable:
+
+```text
+canonical no-network transition rehearsal
+  + operator request identity
+  -> strict independent revalidation
+  -> append-only PostgreSQL history
+  -> deterministic latest transition per destination
+  -> current ready, missing, superseded, or activation-not-ready state
+```
+
+The retained record model is
+`portfolio-risk-notification-destination-transition-record-v1`.
+
+## Independent record validation
+
+The recorder does not trust a rehearsal JSON document merely because it was
+produced by the orchestration module. It independently checks:
+
+- exact top-level and stage fields;
+- the `rotate`, `disable`, `rollback` stage order;
+- all plan, authority, checklist, destination, and endpoint-environment
+  identities;
+- the authority-free and request-free disablement stage;
+- ordered request and receipt evidence;
+- canonical receiver rehearsal IDs;
+- same-key, same-payload duplicate arithmetic;
+- start, receipt, finish, and record timestamps;
+- the deterministic transition rehearsal ID; and
+- every no-network and no-mutation declaration.
+
+Only a completed three-stage rehearsal can be retained by this contract. Other
+failure semantics remain in their existing bounded source contracts rather than
+being reclassified during persistence.
+
+## Replay and conflict behaviour
+
+The operator `request_id` is the append-only idempotency boundary:
+
+```text
+same request ID + same canonical record
+  -> return the retained row
+
+same request ID + changed rehearsal or record time
+  -> reject
+```
+
+The rehearsal ID is also unique. Reusing it under a different operator request
+or changed canonical evidence fails closed. PostgreSQL triggers reject direct
+`UPDATE` and `DELETE` operations.
+
+## Current review contract
+
+`latest_notification_destination_transition_rehearsals` selects one retained
+transition per destination using:
+
+```text
+finished_at DESC
+record_id DESC
+```
+
+`current_notification_destination_transition_review` joins that evidence to the
+current activation-checklist and controlled-receiver review. It emits exactly
+one of:
+
+```text
+activation_not_ready
+transition_rehearsal_missing
+transition_rehearsal_superseded
+ready
+```
+
+A transition is ready only when the current activation review is itself ready
+and the transition rollback checklist, destination fingerprint, and authority
+ID exactly match the current activation evidence.
+
+A newer receiver checklist and successful controlled rehearsal can therefore
+supersede an older transition rehearsal without deleting either history. The
+operator must produce a new transition rehearsal for the newly reviewed
+configuration.
+
+The serving views are:
+
+```text
+risk_platform.latest_notification_destination_transition_rehearsals
+risk_platform.current_notification_destination_transition_review
+risk_platform.current_notification_destination_transition_review_failures
+risk_platform.current_notification_destination_transition_ready
+```
+
+## PostgreSQL evidence
+
+The PostgreSQL 16 contract:
+
+1. Builds an exact rotation, disablement, and rollback chain.
+2. Runs the existing in-memory controlled receiver for rotation and rollback.
+3. Persists a current rollback checklist and controlled-receiver rehearsal.
+4. Records the transition rehearsal and proves the current state is `ready`.
+5. Replays the exact operator request and proves convergence.
+6. Rejects changed evidence under the same request ID.
+7. Persists a newer independently reviewed receiver checklist and rehearsal.
+8. Proves the old transition becomes `transition_rehearsal_superseded`.
+9. Rejects direct update and delete attempts.
+10. Runs the complete transition reconciliation suite.
+
+## Safety boundary
+
+The history retains endpoint environment-variable names, approved host names,
+event identities, and payload SHA-256 values. It retains no endpoint value or
+full URL, endpoint path, payload body, response body, credential, environment
+value, or PostgreSQL DSN.
+
+Ordinary validation performs no DNS lookup, socket operation, external request,
+delivery-attempt write, outbox mutation, acknowledgement, cloud scheduling,
+infrastructure deployment, or `terraform apply`. Committed destination
+activation and notification delivery remain disabled.

--- a/sql/notification_destination_transition_rehearsal_consistency_checks.sql
+++ b/sql/notification_destination_transition_rehearsal_consistency_checks.sql
@@ -1,0 +1,323 @@
+-- Reconciliation for append-only destination transition rehearsal history.
+
+WITH counts AS (
+    SELECT
+        (SELECT COUNT(*)
+         FROM risk_platform.notification_destination_transition_rehearsals)
+            AS rehearsal_rows,
+        (SELECT COUNT(DISTINCT request_id)
+         FROM risk_platform.notification_destination_transition_rehearsals)
+            AS distinct_request_ids,
+        (SELECT COUNT(DISTINCT rehearsal_id)
+         FROM risk_platform.notification_destination_transition_rehearsals)
+            AS distinct_rehearsal_ids,
+        (SELECT COUNT(DISTINCT destination_id)
+         FROM risk_platform.notification_destination_transition_rehearsals)
+            AS expected_latest_rows,
+        (SELECT COUNT(*)
+         FROM risk_platform.latest_notification_destination_transition_rehearsals)
+            AS latest_rows,
+        (SELECT COUNT(*)
+         FROM risk_platform.current_notification_activation_rehearsal_review)
+            AS expected_review_rows,
+        (SELECT COUNT(*)
+         FROM risk_platform.current_notification_destination_transition_review)
+            AS review_rows,
+        (SELECT COUNT(*)
+         FROM risk_platform.current_notification_destination_transition_review
+         WHERE transition_review_required)
+            AS expected_failure_rows,
+        (SELECT COUNT(*)
+         FROM
+            risk_platform.current_notification_destination_transition_review_failures)
+            AS failure_rows,
+        (SELECT COUNT(*)
+         FROM risk_platform.current_notification_destination_transition_review
+         WHERE transition_ready)
+            AS expected_ready_rows,
+        (SELECT COUNT(*)
+         FROM risk_platform.current_notification_destination_transition_ready)
+            AS ready_rows
+),
+integrity AS (
+    SELECT
+        (
+            SELECT COUNT(*)
+            FROM risk_platform.notification_destination_transition_rehearsals
+            WHERE (rehearsal_json #>> '{stages,0,request_count}')::INTEGER
+                    <> rotate_request_count
+               OR (rehearsal_json #>> '{stages,2,request_count}')::INTEGER
+                    <> rollback_request_count
+               OR (
+                    (rehearsal_json #>>
+                        '{stages,0,receiver_summary,same_content_duplicate_count}'
+                    )::INTEGER
+                    +
+                    (rehearsal_json #>>
+                        '{stages,2,receiver_summary,same_content_duplicate_count}'
+                    )::INTEGER
+                  ) <> same_content_duplicate_count
+        ) AS invalid_request_counts,
+        (
+            SELECT COUNT(*)
+            FROM risk_platform.notification_destination_transition_rehearsals
+            WHERE rehearsal_json #>> '{stages,1,operation}' <> 'disable'
+               OR (rehearsal_json #> '{stages,1,authority_id}') <> 'null'::jsonb
+               OR (rehearsal_json #> '{stages,1,checklist_id}') <> 'null'::jsonb
+               OR (rehearsal_json #> '{stages,1,receiver_summary}')
+                    <> 'null'::jsonb
+               OR (rehearsal_json #>> '{stages,1,request_count}')::INTEGER <> 0
+               OR (rehearsal_json #> '{stages,1,requested_event_ids}')
+                    <> '[]'::jsonb
+               OR (rehearsal_json #> '{stages,1,requested_event_types}')
+                    <> '[]'::jsonb
+               OR (rehearsal_json #>> '{stages,1,target_authority_required}')
+                    ::BOOLEAN
+        ) AS invalid_disable_stages,
+        (
+            SELECT COUNT(*)
+            FROM risk_platform.notification_destination_transition_rehearsals
+            WHERE started_at > finished_at
+               OR finished_at > recorded_at
+               OR (rehearsal_json ->> 'started_at')::TIMESTAMPTZ <> started_at
+               OR (rehearsal_json ->> 'finished_at')::TIMESTAMPTZ <> finished_at
+        ) AS invalid_timestamps,
+        (
+            SELECT COUNT(*)
+            FROM risk_platform.notification_destination_transition_rehearsals
+            WHERE (rehearsal_json ->> 'external_request_performed')::BOOLEAN
+               OR (rehearsal_json ->> 'socket_opened')::BOOLEAN
+               OR (rehearsal_json ->> 'dns_lookup_performed')::BOOLEAN
+               OR (rehearsal_json ->> 'delivery_attempt_written')::BOOLEAN
+               OR (rehearsal_json ->> 'outbox_mutated')::BOOLEAN
+               OR (rehearsal_json ->> 'acknowledgement_mutated')::BOOLEAN
+               OR (rehearsal_json ->> 'endpoint_values_recorded')::BOOLEAN
+               OR (rehearsal_json ->> 'endpoint_paths_recorded')::BOOLEAN
+               OR (rehearsal_json ->> 'payload_bodies_recorded')::BOOLEAN
+               OR (rehearsal_json ->> 'response_bodies_recorded')::BOOLEAN
+               OR (rehearsal_json ->> 'infrastructure_deployed')::BOOLEAN
+        ) AS unsafe_rows,
+        (
+            SELECT COUNT(*)
+            FROM (
+                SELECT destination_id
+                FROM risk_platform.latest_notification_destination_transition_rehearsals
+                GROUP BY destination_id
+                HAVING COUNT(*) > 1
+            ) duplicated
+        ) AS duplicate_latest_destinations,
+        (
+            SELECT COUNT(*)
+            FROM risk_platform.latest_notification_destination_transition_rehearsals
+                latest
+            WHERE EXISTS (
+                SELECT 1
+                FROM risk_platform.notification_destination_transition_rehearsals
+                    candidate
+                WHERE candidate.destination_id = latest.destination_id
+                  AND (
+                      candidate.finished_at > latest.finished_at
+                      OR (
+                          candidate.finished_at = latest.finished_at
+                          AND candidate.record_id > latest.record_id
+                      )
+                  )
+            )
+        ) AS stale_latest_rows,
+        (
+            SELECT COUNT(*)
+            FROM (
+                SELECT destination_id
+                FROM risk_platform.current_notification_destination_transition_review
+                GROUP BY destination_id
+                HAVING COUNT(*) > 1
+            ) duplicated
+        ) AS duplicate_review_destinations,
+        (
+            SELECT COUNT(*)
+            FROM risk_platform.current_notification_destination_transition_review
+            WHERE transition_review_status <>
+                CASE
+                    WHEN NOT operational_activation_ready
+                        THEN 'activation_not_ready'
+                    WHEN transition_record_id IS NULL
+                        THEN 'transition_rehearsal_missing'
+                    WHEN NOT transition_matches_current_activation
+                        THEN 'transition_rehearsal_superseded'
+                    ELSE 'ready'
+                END
+        ) AS invalid_review_statuses,
+        (
+            SELECT COUNT(*)
+            FROM risk_platform.current_notification_destination_transition_review
+            WHERE transition_review_required
+                    <> (transition_review_status <> 'ready')
+               OR transition_ready <> (transition_review_status = 'ready')
+               OR transition_review_priority <>
+                    CASE transition_review_status
+                        WHEN 'activation_not_ready' THEN 3
+                        WHEN 'transition_rehearsal_superseded' THEN 2
+                        WHEN 'transition_rehearsal_missing' THEN 1
+                        ELSE 0
+                    END
+        ) AS invalid_review_flags,
+        (
+            SELECT COUNT(*)
+            FROM pg_trigger trigger
+            JOIN pg_class relation ON relation.oid = trigger.tgrelid
+            JOIN pg_namespace namespace ON namespace.oid = relation.relnamespace
+            WHERE namespace.nspname = 'risk_platform'
+              AND relation.relname =
+                    'notification_destination_transition_rehearsals'
+              AND trigger.tgenabled <> 'D'
+              AND NOT trigger.tgisinternal
+              AND trigger.tgname IN (
+                  'notification_destination_transition_rehearsals_reject_update',
+                  'notification_destination_transition_rehearsals_reject_delete'
+              )
+        ) AS append_only_trigger_count
+)
+SELECT
+    'notification_destination_transition_request_ids_unique' AS check_name,
+    rehearsal_rows::TEXT AS expected,
+    distinct_request_ids::TEXT AS actual,
+    CASE WHEN rehearsal_rows = distinct_request_ids THEN 'pass' ELSE 'fail' END
+        AS status
+FROM counts
+
+UNION ALL
+
+SELECT
+    'notification_destination_transition_rehearsal_ids_unique',
+    rehearsal_rows::TEXT,
+    distinct_rehearsal_ids::TEXT,
+    CASE WHEN rehearsal_rows = distinct_rehearsal_ids THEN 'pass' ELSE 'fail' END
+FROM counts
+
+UNION ALL
+
+SELECT
+    'notification_destination_transition_request_counts_reconcile',
+    '0',
+    invalid_request_counts::TEXT,
+    CASE WHEN invalid_request_counts = 0 THEN 'pass' ELSE 'fail' END
+FROM integrity
+
+UNION ALL
+
+SELECT
+    'notification_destination_transition_disable_stages_safe',
+    '0',
+    invalid_disable_stages::TEXT,
+    CASE WHEN invalid_disable_stages = 0 THEN 'pass' ELSE 'fail' END
+FROM integrity
+
+UNION ALL
+
+SELECT
+    'notification_destination_transition_timestamps_valid',
+    '0',
+    invalid_timestamps::TEXT,
+    CASE WHEN invalid_timestamps = 0 THEN 'pass' ELSE 'fail' END
+FROM integrity
+
+UNION ALL
+
+SELECT
+    'notification_destination_transition_side_effects_safe',
+    '0',
+    unsafe_rows::TEXT,
+    CASE WHEN unsafe_rows = 0 THEN 'pass' ELSE 'fail' END
+FROM integrity
+
+UNION ALL
+
+SELECT
+    'notification_destination_transition_latest_rows_match_destinations',
+    expected_latest_rows::TEXT,
+    latest_rows::TEXT,
+    CASE WHEN expected_latest_rows = latest_rows THEN 'pass' ELSE 'fail' END
+FROM counts
+
+UNION ALL
+
+SELECT
+    'notification_destination_transition_latest_grain_unique',
+    '0',
+    duplicate_latest_destinations::TEXT,
+    CASE WHEN duplicate_latest_destinations = 0 THEN 'pass' ELSE 'fail' END
+FROM integrity
+
+UNION ALL
+
+SELECT
+    'notification_destination_transition_latest_selection_current',
+    '0',
+    stale_latest_rows::TEXT,
+    CASE WHEN stale_latest_rows = 0 THEN 'pass' ELSE 'fail' END
+FROM integrity
+
+UNION ALL
+
+SELECT
+    'notification_destination_transition_review_covers_activation',
+    expected_review_rows::TEXT,
+    review_rows::TEXT,
+    CASE WHEN expected_review_rows = review_rows THEN 'pass' ELSE 'fail' END
+FROM counts
+
+UNION ALL
+
+SELECT
+    'notification_destination_transition_review_grain_unique',
+    '0',
+    duplicate_review_destinations::TEXT,
+    CASE WHEN duplicate_review_destinations = 0 THEN 'pass' ELSE 'fail' END
+FROM integrity
+
+UNION ALL
+
+SELECT
+    'notification_destination_transition_review_status_reconciles',
+    '0',
+    invalid_review_statuses::TEXT,
+    CASE WHEN invalid_review_statuses = 0 THEN 'pass' ELSE 'fail' END
+FROM integrity
+
+UNION ALL
+
+SELECT
+    'notification_destination_transition_review_flags_reconcile',
+    '0',
+    invalid_review_flags::TEXT,
+    CASE WHEN invalid_review_flags = 0 THEN 'pass' ELSE 'fail' END
+FROM integrity
+
+UNION ALL
+
+SELECT
+    'notification_destination_transition_failure_partition_matches',
+    expected_failure_rows::TEXT,
+    failure_rows::TEXT,
+    CASE WHEN expected_failure_rows = failure_rows THEN 'pass' ELSE 'fail' END
+FROM counts
+
+UNION ALL
+
+SELECT
+    'notification_destination_transition_ready_partition_matches',
+    expected_ready_rows::TEXT,
+    ready_rows::TEXT,
+    CASE WHEN expected_ready_rows = ready_rows THEN 'pass' ELSE 'fail' END
+FROM counts
+
+UNION ALL
+
+SELECT
+    'notification_destination_transition_append_only_triggers_enabled',
+    '2',
+    append_only_trigger_count::TEXT,
+    CASE WHEN append_only_trigger_count = 2 THEN 'pass' ELSE 'fail' END
+FROM integrity
+
+ORDER BY check_name;

--- a/sql/notification_destination_transition_rehearsal_schema.sql
+++ b/sql/notification_destination_transition_rehearsal_schema.sql
@@ -1,0 +1,212 @@
+-- Append-only notification destination transition rehearsals and current review views.
+-- Apply after controlled_notification_receiver_review_schema.sql.
+
+CREATE SCHEMA IF NOT EXISTS risk_platform;
+
+CREATE TABLE IF NOT EXISTS
+risk_platform.notification_destination_transition_rehearsals (
+    record_id TEXT PRIMARY KEY,
+    model_version TEXT NOT NULL CHECK (
+        model_version =
+            'portfolio-risk-notification-destination-transition-record-v1'
+    ),
+    request_id TEXT NOT NULL UNIQUE,
+    rehearsal_id TEXT NOT NULL UNIQUE,
+    destination_id TEXT NOT NULL,
+    rotate_plan_id TEXT NOT NULL,
+    disable_plan_id TEXT NOT NULL,
+    rollback_plan_id TEXT NOT NULL,
+    baseline_authority_id TEXT NOT NULL,
+    rotate_authority_id TEXT NOT NULL,
+    rollback_authority_id TEXT NOT NULL,
+    rotate_checklist_id TEXT NOT NULL,
+    rollback_checklist_id TEXT NOT NULL,
+    rotate_destination_fingerprint TEXT NOT NULL,
+    disable_destination_fingerprint TEXT NOT NULL,
+    rollback_destination_fingerprint TEXT NOT NULL,
+    rotate_endpoint_environment_variable TEXT NOT NULL,
+    disable_endpoint_environment_variable TEXT NOT NULL,
+    rollback_endpoint_environment_variable TEXT NOT NULL,
+    started_at TIMESTAMPTZ NOT NULL,
+    finished_at TIMESTAMPTZ NOT NULL,
+    recorded_at TIMESTAMPTZ NOT NULL,
+    rotate_request_count INTEGER NOT NULL CHECK (
+        rotate_request_count BETWEEN 1 AND 50
+    ),
+    rollback_request_count INTEGER NOT NULL CHECK (
+        rollback_request_count BETWEEN 1 AND 50
+    ),
+    same_content_duplicate_count INTEGER NOT NULL CHECK (
+        same_content_duplicate_count >= 0
+    ),
+    rehearsal_json JSONB NOT NULL CHECK (
+        jsonb_typeof(rehearsal_json) = 'object'
+    ),
+    record_json JSONB NOT NULL CHECK (
+        jsonb_typeof(record_json) = 'object'
+    ),
+    document_sha256 CHAR(64) NOT NULL,
+    CHECK (started_at <= finished_at),
+    CHECK (finished_at <= recorded_at),
+    CHECK (
+        rotate_request_count + rollback_request_count <= 100
+    ),
+    CHECK (
+        same_content_duplicate_count
+            <= rotate_request_count + rollback_request_count
+    ),
+    CHECK ((rehearsal_json ->> 'destination_id') = destination_id),
+    CHECK ((rehearsal_json ->> 'rotate_plan_id') = rotate_plan_id),
+    CHECK ((rehearsal_json ->> 'disable_plan_id') = disable_plan_id),
+    CHECK ((rehearsal_json ->> 'rollback_plan_id') = rollback_plan_id),
+    CHECK ((rehearsal_json ->> 'rehearsal_id') = rehearsal_id),
+    CHECK (
+        (rehearsal_json ->> 'external_request_performed')::BOOLEAN = FALSE
+    ),
+    CHECK ((rehearsal_json ->> 'socket_opened')::BOOLEAN = FALSE),
+    CHECK ((rehearsal_json ->> 'dns_lookup_performed')::BOOLEAN = FALSE),
+    CHECK (
+        (rehearsal_json ->> 'delivery_attempt_written')::BOOLEAN = FALSE
+    ),
+    CHECK ((rehearsal_json ->> 'outbox_mutated')::BOOLEAN = FALSE),
+    CHECK ((rehearsal_json ->> 'acknowledgement_mutated')::BOOLEAN = FALSE),
+    CHECK ((rehearsal_json ->> 'endpoint_values_recorded')::BOOLEAN = FALSE),
+    CHECK ((rehearsal_json ->> 'endpoint_paths_recorded')::BOOLEAN = FALSE),
+    CHECK ((rehearsal_json ->> 'payload_bodies_recorded')::BOOLEAN = FALSE),
+    CHECK ((rehearsal_json ->> 'response_bodies_recorded')::BOOLEAN = FALSE),
+    CHECK ((rehearsal_json ->> 'infrastructure_deployed')::BOOLEAN = FALSE)
+);
+
+CREATE INDEX IF NOT EXISTS
+idx_notification_destination_transition_rehearsals_current
+ON risk_platform.notification_destination_transition_rehearsals (
+    destination_id,
+    finished_at DESC,
+    record_id DESC
+);
+
+CREATE OR REPLACE FUNCTION
+risk_platform.reject_notification_destination_transition_rehearsal_mutation()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    RAISE EXCEPTION
+        'notification destination transition rehearsal history is append-only';
+END;
+$$;
+
+DROP TRIGGER IF EXISTS
+notification_destination_transition_rehearsals_reject_update
+ON risk_platform.notification_destination_transition_rehearsals;
+CREATE TRIGGER notification_destination_transition_rehearsals_reject_update
+BEFORE UPDATE ON risk_platform.notification_destination_transition_rehearsals
+FOR EACH ROW
+EXECUTE FUNCTION
+risk_platform.reject_notification_destination_transition_rehearsal_mutation();
+
+DROP TRIGGER IF EXISTS
+notification_destination_transition_rehearsals_reject_delete
+ON risk_platform.notification_destination_transition_rehearsals;
+CREATE TRIGGER notification_destination_transition_rehearsals_reject_delete
+BEFORE DELETE ON risk_platform.notification_destination_transition_rehearsals
+FOR EACH ROW
+EXECUTE FUNCTION
+risk_platform.reject_notification_destination_transition_rehearsal_mutation();
+
+CREATE OR REPLACE VIEW
+risk_platform.latest_notification_destination_transition_rehearsals AS
+SELECT ranked.*
+FROM (
+    SELECT
+        rehearsal.*,
+        ROW_NUMBER() OVER (
+            PARTITION BY rehearsal.destination_id
+            ORDER BY rehearsal.finished_at DESC, rehearsal.record_id DESC
+        ) AS current_version_rank
+    FROM risk_platform.notification_destination_transition_rehearsals rehearsal
+) ranked
+WHERE ranked.current_version_rank = 1;
+
+CREATE OR REPLACE VIEW
+risk_platform.current_notification_destination_transition_review AS
+WITH evidence AS (
+    SELECT
+        activation.destination_id,
+        activation.destination_fingerprint AS current_destination_fingerprint,
+        activation.authority_id AS current_authority_id,
+        activation.checklist_id AS current_checklist_id,
+        activation.review_status AS activation_review_status,
+        activation.operational_activation_ready,
+        transition.record_id AS transition_record_id,
+        transition.request_id AS transition_request_id,
+        transition.rehearsal_id AS transition_rehearsal_id,
+        transition.rotate_plan_id,
+        transition.disable_plan_id,
+        transition.rollback_plan_id,
+        transition.baseline_authority_id,
+        transition.rotate_authority_id,
+        transition.rollback_authority_id,
+        transition.rotate_checklist_id,
+        transition.rollback_checklist_id,
+        transition.rotate_destination_fingerprint,
+        transition.disable_destination_fingerprint,
+        transition.rollback_destination_fingerprint,
+        transition.rotate_endpoint_environment_variable,
+        transition.disable_endpoint_environment_variable,
+        transition.rollback_endpoint_environment_variable,
+        transition.started_at AS transition_started_at,
+        transition.finished_at AS transition_finished_at,
+        transition.recorded_at AS transition_recorded_at,
+        transition.rotate_request_count,
+        transition.rollback_request_count,
+        transition.same_content_duplicate_count,
+        transition.record_id IS NOT NULL
+            AND transition.rollback_checklist_id = activation.checklist_id
+            AND transition.rollback_destination_fingerprint
+                = activation.destination_fingerprint
+            AND transition.rollback_authority_id = activation.authority_id
+            AS transition_matches_current_activation
+    FROM risk_platform.current_notification_activation_rehearsal_review activation
+    LEFT JOIN
+        risk_platform.latest_notification_destination_transition_rehearsals
+        transition
+      ON transition.destination_id = activation.destination_id
+),
+classified AS (
+    SELECT
+        evidence.*,
+        CASE
+            WHEN NOT evidence.operational_activation_ready
+                THEN 'activation_not_ready'
+            WHEN evidence.transition_record_id IS NULL
+                THEN 'transition_rehearsal_missing'
+            WHEN NOT evidence.transition_matches_current_activation
+                THEN 'transition_rehearsal_superseded'
+            ELSE 'ready'
+        END AS transition_review_status
+    FROM evidence
+)
+SELECT
+    classified.*,
+    classified.transition_review_status <> 'ready' AS transition_review_required,
+    classified.transition_review_status = 'ready' AS transition_ready,
+    CASE classified.transition_review_status
+        WHEN 'activation_not_ready' THEN 3
+        WHEN 'transition_rehearsal_superseded' THEN 2
+        WHEN 'transition_rehearsal_missing' THEN 1
+        ELSE 0
+    END AS transition_review_priority
+FROM classified;
+
+CREATE OR REPLACE VIEW
+risk_platform.current_notification_destination_transition_review_failures AS
+SELECT *
+FROM risk_platform.current_notification_destination_transition_review
+WHERE transition_review_required;
+
+CREATE OR REPLACE VIEW
+risk_platform.current_notification_destination_transition_ready AS
+SELECT *
+FROM risk_platform.current_notification_destination_transition_review
+WHERE transition_ready;

--- a/src/warehouse/controlled_receiver_rehearsal_postgres_contract_check.py
+++ b/src/warehouse/controlled_receiver_rehearsal_postgres_contract_check.py
@@ -25,6 +25,9 @@ from src.warehouse.controlled_receiver_rehearsal_recorder import (
 from src.warehouse.controlled_receiver_review_postgres_contract_check import (
     run_contract_check as run_review_contract_check,
 )
+from src.warehouse.notification_destination_transition_rehearsal_postgres_contract_check import (
+    run_contract_check as run_transition_contract_check,
+)
 from src.warehouse.postgres_loader import DEFAULT_POSTGRES_DSN
 
 CHECK_PATH = Path(
@@ -243,6 +246,7 @@ def run_contract_check(dsn: str) -> dict[str, Any]:
         raise AssertionError("controlled receiver reconciliation failed: " + names)
 
     review_summary = run_review_contract_check(dsn)
+    transition_summary = run_transition_contract_check(dsn)
     return {
         "model_version": "portfolio-risk-controlled-receiver-contract-v1",
         "terminal_records": len(created),
@@ -256,6 +260,7 @@ def run_contract_check(dsn: str) -> dict[str, Any]:
         "delete_rejected": delete_rejected,
         "consistency_checks": len(checks),
         "activation_review": review_summary,
+        "destination_transition": transition_summary,
         "external_request_performed": False,
         "payload_bodies_recorded": False,
         "response_bodies_recorded": False,
@@ -265,8 +270,8 @@ def run_contract_check(dsn: str) -> dict[str, Any]:
 def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         description=(
-            "Exercise append-only controlled receiver rehearsal history and "
-            "current review views against PostgreSQL 16."
+            "Exercise append-only controlled receiver, activation review, and "
+            "destination transition history against PostgreSQL 16."
         )
     )
     parser.add_argument(

--- a/src/warehouse/notification_destination_transition_rehearsal_contract.py
+++ b/src/warehouse/notification_destination_transition_rehearsal_contract.py
@@ -1,0 +1,785 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from collections.abc import Mapping, Sequence
+from datetime import datetime, timezone
+from typing import Any
+
+from src.common.exceptions import ValidationError
+from src.orchestration.controlled_notification_receiver import (
+    MODEL_VERSION as RECEIVER_MODEL_VERSION,
+)
+from src.orchestration.notification_destination_transition_rehearsal import (
+    MODEL_VERSION as REHEARSAL_MODEL_VERSION,
+)
+
+MODEL_VERSION = "portfolio-risk-notification-destination-transition-record-v1"
+SAFE_TEXT = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,511}$")
+SAFE_EVENT_TYPE = re.compile(r"^[a-z][a-z0-9_]{0,63}$")
+ENVIRONMENT_NAME = re.compile(r"^[A-Z][A-Z0-9_]{2,127}$")
+SHA256_PATTERN = re.compile(r"^[0-9a-f]{64}$")
+MAX_STAGE_REQUESTS = 50
+MAX_TOTAL_REQUESTS = 100
+REHEARSAL_SIDE_EFFECT_FLAGS = (
+    "acknowledgement_mutated",
+    "delivery_attempt_written",
+    "dns_lookup_performed",
+    "endpoint_paths_recorded",
+    "endpoint_values_recorded",
+    "external_request_performed",
+    "infrastructure_deployed",
+    "outbox_mutated",
+    "payload_bodies_recorded",
+    "response_bodies_recorded",
+    "socket_opened",
+)
+RECEIVER_SIDE_EFFECT_FLAGS = (
+    "acknowledgement_mutated",
+    "delivery_attempt_written",
+    "dns_lookup_performed",
+    "endpoint_paths_recorded",
+    "external_request_performed",
+    "infrastructure_deployed",
+    "outbox_mutated",
+    "payload_bodies_recorded",
+    "response_bodies_recorded",
+    "socket_opened",
+)
+
+
+def _exact_mapping(value: Any, label: str, keys: set[str]) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        raise ValidationError(f"{label} must be a mapping")
+    actual = set(value)
+    if actual != keys:
+        raise ValidationError(
+            f"{label} fields are invalid; "
+            f"missing={sorted(keys - actual)}, unknown={sorted(actual - keys)}"
+        )
+    return value
+
+
+def _safe_text(value: Any, label: str, *, optional: bool = False) -> str | None:
+    if value is None and optional:
+        return None
+    if not isinstance(value, str) or not SAFE_TEXT.fullmatch(value):
+        raise ValidationError(f"{label} must be one safe text segment")
+    return value
+
+
+def _aware_utc(value: Any, label: str) -> datetime:
+    if isinstance(value, datetime):
+        parsed = value
+    elif isinstance(value, str):
+        try:
+            parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        except ValueError:
+            raise ValidationError(f"{label} must be ISO-8601") from None
+    else:
+        raise ValidationError(f"{label} must be timezone-aware")
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise ValidationError(f"{label} must be timezone-aware")
+    return parsed.astimezone(timezone.utc)
+
+
+def _bounded_integer(value: Any, label: str, *, maximum: int) -> int:
+    if type(value) is not int or not 0 <= value <= maximum:
+        raise ValidationError(
+            f"{label} must be an integer between 0 and {maximum}"
+        )
+    return value
+
+
+def _safe_text_list(
+    value: Any,
+    label: str,
+    *,
+    allow_duplicates: bool,
+    event_types: bool = False,
+) -> list[str]:
+    if not isinstance(value, list):
+        raise ValidationError(f"{label} must be an array")
+    result: list[str] = []
+    for item in value:
+        if event_types:
+            if not isinstance(item, str) or not SAFE_EVENT_TYPE.fullmatch(item):
+                raise ValidationError(f"{label} contains an invalid event type")
+            parsed = item
+        else:
+            parsed_value = _safe_text(item, f"{label} item")
+            assert parsed_value is not None
+            parsed = parsed_value
+        result.append(parsed)
+    if not allow_duplicates and len(result) != len(set(result)):
+        raise ValidationError(f"{label} must contain no duplicates")
+    return result
+
+
+def _canonical_bytes(value: Mapping[str, Any], label: str) -> bytes:
+    try:
+        return json.dumps(
+            value,
+            sort_keys=True,
+            separators=(",", ":"),
+            allow_nan=False,
+        ).encode("utf-8")
+    except (TypeError, ValueError):
+        raise ValidationError(f"{label} is not canonical JSON") from None
+
+
+def canonical_transition_rehearsal_record_bytes(
+    record: Mapping[str, Any],
+) -> bytes:
+    return _canonical_bytes(record, "destination transition rehearsal record")
+
+
+def _digest_id(prefix: str, identity: Mapping[str, Any]) -> str:
+    digest = hashlib.sha256(_canonical_bytes(identity, prefix)).hexdigest()[:24]
+    return f"{prefix}-{digest}"
+
+
+def _false_flags(
+    evidence: Mapping[str, Any],
+    flags: Sequence[str],
+    label: str,
+) -> None:
+    for flag in flags:
+        if evidence[flag] is not False:
+            raise ValidationError(f"{label} side-effect evidence is invalid")
+
+
+def _receipt(
+    value: Any,
+    *,
+    index: int,
+    allowed_hosts: set[str],
+    response_status: int,
+) -> dict[str, Any]:
+    receipt = _exact_mapping(
+        value,
+        f"receiver receipt {index}",
+        {
+            "endpoint_host",
+            "event_id",
+            "event_type",
+            "http_status",
+            "idempotency_key",
+            "payload_sha256",
+            "received_at",
+            "request_ordinal",
+            "same_content_duplicate",
+        },
+    )
+    host = receipt["endpoint_host"]
+    if not isinstance(host, str) or host not in allowed_hosts:
+        raise ValidationError("receiver receipt host is not in the approved host set")
+    event_id = _safe_text(receipt["event_id"], "receiver receipt event_id")
+    idempotency_key = _safe_text(
+        receipt["idempotency_key"],
+        "receiver receipt idempotency_key",
+    )
+    assert event_id is not None and idempotency_key is not None
+    if event_id != idempotency_key:
+        raise ValidationError("receiver receipt idempotency key differs from event_id")
+    event_type = receipt["event_type"]
+    if not isinstance(event_type, str) or not SAFE_EVENT_TYPE.fullmatch(event_type):
+        raise ValidationError("receiver receipt event_type is invalid")
+    if receipt["http_status"] != response_status:
+        raise ValidationError("receiver receipt HTTP status differs from receiver status")
+    payload_sha256 = receipt["payload_sha256"]
+    if not isinstance(payload_sha256, str) or not SHA256_PATTERN.fullmatch(
+        payload_sha256
+    ):
+        raise ValidationError("receiver receipt payload SHA-256 is invalid")
+    ordinal = receipt["request_ordinal"]
+    if ordinal != index:
+        raise ValidationError("receiver receipt ordinals are not contiguous")
+    duplicate = receipt["same_content_duplicate"]
+    if type(duplicate) is not bool:
+        raise ValidationError("receiver duplicate evidence must be boolean")
+    received_at = _aware_utc(receipt["received_at"], "receiver receipt received_at")
+    return {
+        "endpoint_host": host,
+        "event_id": event_id,
+        "event_type": event_type,
+        "http_status": response_status,
+        "idempotency_key": idempotency_key,
+        "payload_sha256": payload_sha256,
+        "received_at": received_at.isoformat(),
+        "request_ordinal": ordinal,
+        "same_content_duplicate": duplicate,
+    }
+
+
+def _receiver_summary(value: Any, label: str) -> dict[str, Any]:
+    summary = _exact_mapping(
+        value,
+        label,
+        {
+            "acknowledgement_mutated",
+            "activation_checklist_id",
+            "allowed_event_types",
+            "allowed_hosts",
+            "authority_id",
+            "delivery_attempt_written",
+            "destination_fingerprint",
+            "destination_id",
+            "dns_lookup_performed",
+            "endpoint_paths_recorded",
+            "external_request_performed",
+            "infrastructure_deployed",
+            "model_version",
+            "outbox_mutated",
+            "payload_bodies_recorded",
+            "rehearsal_id",
+            "receipts",
+            "request_count",
+            "response_bodies_recorded",
+            "response_status",
+            "same_content_duplicate_count",
+            "socket_opened",
+            "unique_idempotency_keys",
+        },
+    )
+    if summary["model_version"] != RECEIVER_MODEL_VERSION:
+        raise ValidationError(f"{label} model_version is unsupported")
+    checklist_id = _safe_text(
+        summary["activation_checklist_id"],
+        f"{label} checklist_id",
+    )
+    authority_id = _safe_text(summary["authority_id"], f"{label} authority_id")
+    destination_id = _safe_text(
+        summary["destination_id"],
+        f"{label} destination_id",
+    )
+    destination_fingerprint = _safe_text(
+        summary["destination_fingerprint"],
+        f"{label} destination_fingerprint",
+    )
+    assert checklist_id is not None
+    assert authority_id is not None
+    assert destination_id is not None
+    assert destination_fingerprint is not None
+
+    hosts = _safe_text_list(
+        summary["allowed_hosts"],
+        f"{label} allowed_hosts",
+        allow_duplicates=False,
+    )
+    if hosts != sorted(hosts):
+        raise ValidationError(f"{label} allowed_hosts must be sorted")
+    event_types = _safe_text_list(
+        summary["allowed_event_types"],
+        f"{label} allowed_event_types",
+        allow_duplicates=False,
+        event_types=True,
+    )
+    if event_types != sorted(event_types):
+        raise ValidationError(f"{label} allowed_event_types must be sorted")
+
+    response_status = summary["response_status"]
+    if type(response_status) is not int or not 200 <= response_status <= 299:
+        raise ValidationError(f"{label} response_status is invalid")
+    request_count = _bounded_integer(
+        summary["request_count"],
+        f"{label} request_count",
+        maximum=MAX_STAGE_REQUESTS,
+    )
+    if request_count < 1:
+        raise ValidationError(f"{label} must contain at least one request")
+    unique_keys = _bounded_integer(
+        summary["unique_idempotency_keys"],
+        f"{label} unique_idempotency_keys",
+        maximum=MAX_STAGE_REQUESTS,
+    )
+    duplicate_count = _bounded_integer(
+        summary["same_content_duplicate_count"],
+        f"{label} same_content_duplicate_count",
+        maximum=MAX_STAGE_REQUESTS,
+    )
+    if unique_keys + duplicate_count != request_count:
+        raise ValidationError(f"{label} idempotency counts do not reconcile")
+
+    receipts_value = summary["receipts"]
+    if not isinstance(receipts_value, list) or len(receipts_value) != request_count:
+        raise ValidationError(f"{label} receipt count does not match request_count")
+    receipts = [
+        _receipt(
+            receipt,
+            index=index,
+            allowed_hosts=set(hosts),
+            response_status=response_status,
+        )
+        for index, receipt in enumerate(receipts_value, start=1)
+    ]
+    received_times = [
+        _aware_utc(receipt["received_at"], "receiver receipt received_at")
+        for receipt in receipts
+    ]
+    if received_times != sorted(received_times):
+        raise ValidationError(f"{label} receipt timestamps are not ordered")
+    if sum(bool(receipt["same_content_duplicate"]) for receipt in receipts) != (
+        duplicate_count
+    ):
+        raise ValidationError(f"{label} duplicate count differs from receipts")
+    seen: dict[str, str] = {}
+    for receipt in receipts:
+        event_id = str(receipt["event_id"])
+        payload_sha256 = str(receipt["payload_sha256"])
+        previous = seen.get(event_id)
+        if receipt["same_content_duplicate"]:
+            if previous != payload_sha256:
+                raise ValidationError(
+                    f"{label} duplicate receipt does not reuse identical content"
+                )
+        elif previous is not None:
+            raise ValidationError(
+                f"{label} repeated event evidence is not marked duplicate"
+            )
+        seen.setdefault(event_id, payload_sha256)
+    if len(seen) != unique_keys:
+        raise ValidationError(f"{label} unique idempotency count differs from receipts")
+
+    _false_flags(summary, RECEIVER_SIDE_EFFECT_FLAGS, label)
+    identity = {
+        "activation_checklist_id": checklist_id,
+        "allowed_event_types": event_types,
+        "allowed_hosts": hosts,
+        "authority_id": authority_id,
+        "destination_fingerprint": destination_fingerprint,
+        "destination_id": destination_id,
+        "model_version": RECEIVER_MODEL_VERSION,
+        "receipts": receipts,
+        "response_status": response_status,
+    }
+    expected_rehearsal_id = _digest_id(
+        f"{RECEIVER_MODEL_VERSION}-rehearsal",
+        identity,
+    )
+    if summary["rehearsal_id"] != expected_rehearsal_id:
+        raise ValidationError(f"{label} rehearsal identity is invalid")
+    return {
+        "rehearsal_id": expected_rehearsal_id,
+        **identity,
+        "request_count": request_count,
+        "same_content_duplicate_count": duplicate_count,
+        "unique_idempotency_keys": unique_keys,
+        **{flag: False for flag in RECEIVER_SIDE_EFFECT_FLAGS},
+    }
+
+
+def _active_stage(value: Any, operation: str) -> dict[str, Any]:
+    stage = _exact_mapping(
+        value,
+        f"{operation} stage",
+        {
+            "authority_id",
+            "checklist_id",
+            "destination_fingerprint",
+            "endpoint_environment_variable",
+            "first_received_at",
+            "last_received_at",
+            "operation",
+            "plan_id",
+            "receiver_summary",
+            "request_count",
+            "requested_event_ids",
+            "requested_event_types",
+        },
+    )
+    if stage["operation"] != operation:
+        raise ValidationError(f"{operation} stage operation is invalid")
+    plan_id = _safe_text(stage["plan_id"], f"{operation} plan_id")
+    authority_id = _safe_text(stage["authority_id"], f"{operation} authority_id")
+    checklist_id = _safe_text(stage["checklist_id"], f"{operation} checklist_id")
+    fingerprint = _safe_text(
+        stage["destination_fingerprint"],
+        f"{operation} destination_fingerprint",
+    )
+    endpoint_environment = stage["endpoint_environment_variable"]
+    if not isinstance(endpoint_environment, str) or not ENVIRONMENT_NAME.fullmatch(
+        endpoint_environment
+    ):
+        raise ValidationError(f"{operation} endpoint environment is invalid")
+    assert plan_id is not None
+    assert authority_id is not None
+    assert checklist_id is not None
+    assert fingerprint is not None
+
+    request_count = _bounded_integer(
+        stage["request_count"],
+        f"{operation} request_count",
+        maximum=MAX_STAGE_REQUESTS,
+    )
+    if request_count < 1:
+        raise ValidationError(f"{operation} stage requires at least one request")
+    event_ids = _safe_text_list(
+        stage["requested_event_ids"],
+        f"{operation} requested_event_ids",
+        allow_duplicates=True,
+    )
+    event_types = _safe_text_list(
+        stage["requested_event_types"],
+        f"{operation} requested_event_types",
+        allow_duplicates=True,
+        event_types=True,
+    )
+    if len(event_ids) != request_count or len(event_types) != request_count:
+        raise ValidationError(f"{operation} stage request evidence count differs")
+
+    receiver = _receiver_summary(
+        stage["receiver_summary"],
+        f"{operation} receiver summary",
+    )
+    comparisons = {
+        "authority_id": authority_id,
+        "activation_checklist_id": checklist_id,
+        "destination_fingerprint": fingerprint,
+        "request_count": request_count,
+    }
+    for field, expected in comparisons.items():
+        if receiver[field] != expected:
+            raise ValidationError(
+                f"{operation} receiver {field} differs from stage evidence"
+            )
+    receipt_event_ids = [str(receipt["event_id"]) for receipt in receiver["receipts"]]
+    receipt_event_types = [
+        str(receipt["event_type"]) for receipt in receiver["receipts"]
+    ]
+    if receipt_event_ids != event_ids or receipt_event_types != event_types:
+        raise ValidationError(f"{operation} receiver receipts differ from selected events")
+    first_received_at = _aware_utc(
+        stage["first_received_at"],
+        f"{operation} first_received_at",
+    )
+    last_received_at = _aware_utc(
+        stage["last_received_at"],
+        f"{operation} last_received_at",
+    )
+    if first_received_at > last_received_at:
+        raise ValidationError(f"{operation} stage receipt times are reversed")
+    if first_received_at.isoformat() != receiver["receipts"][0]["received_at"]:
+        raise ValidationError(f"{operation} first receipt timestamp differs")
+    if last_received_at.isoformat() != receiver["receipts"][-1]["received_at"]:
+        raise ValidationError(f"{operation} last receipt timestamp differs")
+    return {
+        "operation": operation,
+        "plan_id": plan_id,
+        "authority_id": authority_id,
+        "checklist_id": checklist_id,
+        "destination_fingerprint": fingerprint,
+        "endpoint_environment_variable": endpoint_environment,
+        "requested_event_ids": event_ids,
+        "requested_event_types": event_types,
+        "request_count": request_count,
+        "first_received_at": first_received_at.isoformat(),
+        "last_received_at": last_received_at.isoformat(),
+        "receiver_summary": receiver,
+    }
+
+
+def _disable_stage(value: Any) -> dict[str, Any]:
+    stage = _exact_mapping(
+        value,
+        "disable stage",
+        {
+            "authority_id",
+            "checklist_id",
+            "destination_fingerprint",
+            "endpoint_environment_variable",
+            "operation",
+            "plan_id",
+            "receiver_summary",
+            "request_count",
+            "requested_event_ids",
+            "requested_event_types",
+            "target_authority_required",
+        },
+    )
+    if stage["operation"] != "disable":
+        raise ValidationError("disable stage operation is invalid")
+    plan_id = _safe_text(stage["plan_id"], "disable plan_id")
+    fingerprint = _safe_text(
+        stage["destination_fingerprint"],
+        "disable destination_fingerprint",
+    )
+    assert plan_id is not None and fingerprint is not None
+    endpoint_environment = stage["endpoint_environment_variable"]
+    if not isinstance(endpoint_environment, str) or not ENVIRONMENT_NAME.fullmatch(
+        endpoint_environment
+    ):
+        raise ValidationError("disable endpoint environment is invalid")
+    if (
+        stage["authority_id"] is not None
+        or stage["checklist_id"] is not None
+        or stage["receiver_summary"] is not None
+        or stage["request_count"] != 0
+        or stage["requested_event_ids"] != []
+        or stage["requested_event_types"] != []
+        or stage["target_authority_required"] is not False
+    ):
+        raise ValidationError("disable stage must be authority-free and request-free")
+    return {
+        "operation": "disable",
+        "plan_id": plan_id,
+        "authority_id": None,
+        "checklist_id": None,
+        "destination_fingerprint": fingerprint,
+        "endpoint_environment_variable": endpoint_environment,
+        "requested_event_ids": [],
+        "requested_event_types": [],
+        "request_count": 0,
+        "receiver_summary": None,
+        "target_authority_required": False,
+    }
+
+
+def validate_notification_destination_transition_rehearsal(
+    summary: Mapping[str, Any],
+) -> dict[str, Any]:
+    exact = _exact_mapping(
+        summary,
+        "destination transition rehearsal",
+        {
+            "acknowledgement_mutated",
+            "baseline_authority_id",
+            "delivery_attempt_written",
+            "destination_id",
+            "disable_plan_id",
+            "dns_lookup_performed",
+            "endpoint_paths_recorded",
+            "endpoint_values_recorded",
+            "external_request_performed",
+            "finished_at",
+            "infrastructure_deployed",
+            "model_version",
+            "outbox_mutated",
+            "payload_bodies_recorded",
+            "rehearsal_id",
+            "response_bodies_recorded",
+            "rollback_plan_id",
+            "rotate_plan_id",
+            "socket_opened",
+            "stages",
+            "stale_authority_rejections",
+            "started_at",
+        },
+    )
+    if exact["model_version"] != REHEARSAL_MODEL_VERSION:
+        raise ValidationError("destination transition rehearsal model_version is unsupported")
+    destination_id = _safe_text(exact["destination_id"], "destination_id")
+    baseline_authority_id = _safe_text(
+        exact["baseline_authority_id"],
+        "baseline_authority_id",
+    )
+    rotate_plan_id = _safe_text(exact["rotate_plan_id"], "rotate_plan_id")
+    disable_plan_id = _safe_text(exact["disable_plan_id"], "disable_plan_id")
+    rollback_plan_id = _safe_text(exact["rollback_plan_id"], "rollback_plan_id")
+    assert destination_id is not None
+    assert baseline_authority_id is not None
+    assert rotate_plan_id is not None
+    assert disable_plan_id is not None
+    assert rollback_plan_id is not None
+
+    stages_value = exact["stages"]
+    if not isinstance(stages_value, list) or len(stages_value) != 3:
+        raise ValidationError("destination transition rehearsal must have three stages")
+    rotate_stage = _active_stage(stages_value[0], "rotate")
+    disable_stage = _disable_stage(stages_value[1])
+    rollback_stage = _active_stage(stages_value[2], "rollback")
+    if rotate_stage["plan_id"] != rotate_plan_id:
+        raise ValidationError("rotate stage plan identity differs")
+    if disable_stage["plan_id"] != disable_plan_id:
+        raise ValidationError("disable stage plan identity differs")
+    if rollback_stage["plan_id"] != rollback_plan_id:
+        raise ValidationError("rollback stage plan identity differs")
+    for stage in (rotate_stage, rollback_stage):
+        if stage["receiver_summary"]["destination_id"] != destination_id:
+            raise ValidationError("receiver stage destination identity differs")
+
+    stale = _exact_mapping(
+        exact["stale_authority_rejections"],
+        "stale_authority_rejections",
+        {
+            "baseline_for_rotation_target",
+            "rotated_for_rollback_target",
+        },
+    )
+    if any(stale[key] is not True for key in stale):
+        raise ValidationError("stale authority rejection evidence is incomplete")
+
+    started_at = _aware_utc(exact["started_at"], "started_at")
+    finished_at = _aware_utc(exact["finished_at"], "finished_at")
+    rotate_first = _aware_utc(
+        rotate_stage["first_received_at"],
+        "rotate first_received_at",
+    )
+    rotate_last = _aware_utc(
+        rotate_stage["last_received_at"],
+        "rotate last_received_at",
+    )
+    rollback_first = _aware_utc(
+        rollback_stage["first_received_at"],
+        "rollback first_received_at",
+    )
+    rollback_last = _aware_utc(
+        rollback_stage["last_received_at"],
+        "rollback last_received_at",
+    )
+    if not started_at <= rotate_first <= rotate_last <= rollback_first <= rollback_last:
+        raise ValidationError("destination transition rehearsal timestamps are not ordered")
+    if finished_at != rollback_last:
+        raise ValidationError("destination transition rehearsal finished_at differs")
+    total_requests = rotate_stage["request_count"] + rollback_stage["request_count"]
+    if total_requests > MAX_TOTAL_REQUESTS:
+        raise ValidationError("destination transition rehearsal request bound exceeded")
+
+    _false_flags(exact, REHEARSAL_SIDE_EFFECT_FLAGS, "transition rehearsal")
+    canonical_stages = [rotate_stage, disable_stage, rollback_stage]
+    identity = {
+        "baseline_authority_id": baseline_authority_id,
+        "destination_id": destination_id,
+        "disable_plan_id": disable_plan_id,
+        "finished_at": finished_at.isoformat(),
+        "model_version": REHEARSAL_MODEL_VERSION,
+        "rollback_plan_id": rollback_plan_id,
+        "rotate_plan_id": rotate_plan_id,
+        "stages": canonical_stages,
+        "stale_authority_rejections": {
+            "baseline_for_rotation_target": True,
+            "rotated_for_rollback_target": True,
+        },
+        "started_at": started_at.isoformat(),
+    }
+    expected_rehearsal_id = _digest_id(
+        f"{REHEARSAL_MODEL_VERSION}-rehearsal",
+        identity,
+    )
+    if exact["rehearsal_id"] != expected_rehearsal_id:
+        raise ValidationError("destination transition rehearsal identity is invalid")
+    return {
+        "rehearsal_id": expected_rehearsal_id,
+        **identity,
+        **{flag: False for flag in REHEARSAL_SIDE_EFFECT_FLAGS},
+    }
+
+
+def _record_identity(
+    *,
+    request_id: str,
+    recorded_at: datetime,
+    rehearsal: Mapping[str, Any],
+) -> dict[str, Any]:
+    stages = rehearsal["stages"]
+    rotate = stages[0]
+    disable = stages[1]
+    rollback = stages[2]
+    duplicate_count = (
+        rotate["receiver_summary"]["same_content_duplicate_count"]
+        + rollback["receiver_summary"]["same_content_duplicate_count"]
+    )
+    return {
+        "baseline_authority_id": rehearsal["baseline_authority_id"],
+        "destination_id": rehearsal["destination_id"],
+        "disable_destination_fingerprint": disable["destination_fingerprint"],
+        "disable_endpoint_environment_variable": disable[
+            "endpoint_environment_variable"
+        ],
+        "disable_plan_id": rehearsal["disable_plan_id"],
+        "finished_at": rehearsal["finished_at"],
+        "model_version": MODEL_VERSION,
+        "recorded_at": recorded_at.isoformat(),
+        "rehearsal_id": rehearsal["rehearsal_id"],
+        "rehearsal_summary": dict(rehearsal),
+        "request_id": request_id,
+        "rollback_authority_id": rollback["authority_id"],
+        "rollback_checklist_id": rollback["checklist_id"],
+        "rollback_destination_fingerprint": rollback["destination_fingerprint"],
+        "rollback_endpoint_environment_variable": rollback[
+            "endpoint_environment_variable"
+        ],
+        "rollback_plan_id": rehearsal["rollback_plan_id"],
+        "rollback_request_count": rollback["request_count"],
+        "rotate_authority_id": rotate["authority_id"],
+        "rotate_checklist_id": rotate["checklist_id"],
+        "rotate_destination_fingerprint": rotate["destination_fingerprint"],
+        "rotate_endpoint_environment_variable": rotate[
+            "endpoint_environment_variable"
+        ],
+        "rotate_plan_id": rehearsal["rotate_plan_id"],
+        "rotate_request_count": rotate["request_count"],
+        "same_content_duplicate_count": duplicate_count,
+        "started_at": rehearsal["started_at"],
+    }
+
+
+def build_notification_destination_transition_rehearsal_record(
+    *,
+    request_id: str,
+    recorded_at: datetime | str,
+    rehearsal: Mapping[str, Any],
+) -> dict[str, Any]:
+    selected_request_id = _safe_text(request_id, "request_id")
+    assert selected_request_id is not None
+    recorded = _aware_utc(recorded_at, "recorded_at")
+    validated_rehearsal = validate_notification_destination_transition_rehearsal(
+        rehearsal
+    )
+    finished = _aware_utc(validated_rehearsal["finished_at"], "finished_at")
+    if recorded < finished:
+        raise ValidationError("recorded_at must not precede rehearsal completion")
+    identity = _record_identity(
+        request_id=selected_request_id,
+        recorded_at=recorded,
+        rehearsal=validated_rehearsal,
+    )
+    return {
+        "record_id": _digest_id(f"{MODEL_VERSION}-record", identity),
+        **identity,
+    }
+
+
+def validate_notification_destination_transition_rehearsal_record(
+    record: Mapping[str, Any],
+) -> dict[str, Any]:
+    expected = {
+        "baseline_authority_id",
+        "destination_id",
+        "disable_destination_fingerprint",
+        "disable_endpoint_environment_variable",
+        "disable_plan_id",
+        "finished_at",
+        "model_version",
+        "record_id",
+        "recorded_at",
+        "rehearsal_id",
+        "rehearsal_summary",
+        "request_id",
+        "rollback_authority_id",
+        "rollback_checklist_id",
+        "rollback_destination_fingerprint",
+        "rollback_endpoint_environment_variable",
+        "rollback_plan_id",
+        "rollback_request_count",
+        "rotate_authority_id",
+        "rotate_checklist_id",
+        "rotate_destination_fingerprint",
+        "rotate_endpoint_environment_variable",
+        "rotate_plan_id",
+        "rotate_request_count",
+        "same_content_duplicate_count",
+        "started_at",
+    }
+    exact = _exact_mapping(record, "transition rehearsal record", expected)
+    if exact["model_version"] != MODEL_VERSION:
+        raise ValidationError("transition rehearsal record model_version is unsupported")
+    rebuilt = build_notification_destination_transition_rehearsal_record(
+        request_id=exact["request_id"],
+        recorded_at=exact["recorded_at"],
+        rehearsal=exact["rehearsal_summary"],
+    )
+    if dict(exact) != rebuilt:
+        raise ValidationError("transition rehearsal record is not canonical")
+    return rebuilt

--- a/src/warehouse/notification_destination_transition_rehearsal_postgres_contract_check.py
+++ b/src/warehouse/notification_destination_transition_rehearsal_postgres_contract_check.py
@@ -1,0 +1,537 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import tempfile
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from src.common.exceptions import ValidationError
+from src.orchestration.controlled_notification_receiver import (
+    ControlledNotificationReceiver,
+)
+from src.orchestration.notification_activation_checklist import (
+    CONTROL_NAMES,
+    build_notification_activation_checklist,
+)
+from src.orchestration.notification_destination_transition_plan import (
+    build_notification_destination_transition_plan,
+)
+from src.orchestration.notification_destination_transition_rehearsal import (
+    rehearse_notification_destination_transition,
+)
+from src.orchestration.portfolio_risk_notification_destination_authority import (
+    resolve_notification_destination_authority,
+)
+from src.warehouse.controlled_receiver_rehearsal_contract import (
+    build_controlled_receiver_rehearsal_record,
+)
+from src.warehouse.controlled_receiver_rehearsal_recorder import (
+    record_controlled_receiver_rehearsal,
+)
+from src.warehouse.notification_destination_transition_rehearsal_contract import (
+    build_notification_destination_transition_rehearsal_record,
+)
+from src.warehouse.notification_destination_transition_rehearsal_recorder import (
+    record_notification_destination_transition_rehearsal,
+)
+from src.warehouse.postgres_loader import DEFAULT_POSTGRES_DSN
+
+CHECK_PATH = Path(
+    "sql/notification_destination_transition_rehearsal_consistency_checks.sql"
+)
+DESTINATION_ID = "risk-operations-webhook"
+OLD_ENDPOINT_ENV = "RISK_NOTIFICATION_WEBHOOK_URL"
+NEW_ENDPOINT_ENV = "RISK_NOTIFICATION_WEBHOOK_URL_V2"
+
+
+def _iso(value: datetime) -> str:
+    return value.astimezone(timezone.utc).isoformat()
+
+
+def _activation(
+    *,
+    enabled: bool,
+    change_request_id: str,
+    reviewed_at: datetime,
+    expires_at: datetime,
+) -> dict[str, Any]:
+    if not enabled:
+        return {
+            "enabled": False,
+            "change_request_id": None,
+            "reviewed_by": [],
+            "reviewed_at": None,
+            "review_expires_at": None,
+        }
+    return {
+        "enabled": True,
+        "change_request_id": change_request_id,
+        "reviewed_by": ["transition-contract-reviewer"],
+        "reviewed_at": _iso(reviewed_at),
+        "review_expires_at": _iso(expires_at),
+    }
+
+
+def _destination_config(
+    *,
+    endpoint_env: str,
+    enabled: bool,
+    change_request_id: str,
+    reviewed_at: datetime,
+    expires_at: datetime,
+) -> dict[str, Any]:
+    return {
+        "model_version": "portfolio-risk-notification-destination-v1",
+        "destinations": {
+            DESTINATION_ID: {
+                "channel": "webhook",
+                "endpoint_env": endpoint_env,
+                "owner": {
+                    "team": "risk-operations",
+                    "contact": "risk-operations-oncall",
+                },
+                "purpose": "portfolio-risk-breach-lifecycle",
+                "recipient_scope": "risk-operations",
+                "data_classification": "internal",
+                "allowed_event_types": [
+                    "breach_escalated",
+                    "breach_opened",
+                    "breach_resolved",
+                ],
+                "activation": _activation(
+                    enabled=enabled,
+                    change_request_id=change_request_id,
+                    reviewed_at=reviewed_at,
+                    expires_at=expires_at,
+                ),
+            }
+        },
+    }
+
+
+def _write_config(root: Path, name: str, value: dict[str, Any]) -> Path:
+    path = root / name
+    path.write_text(yaml.safe_dump(value, sort_keys=False), encoding="utf-8")
+    return path
+
+
+def _clock(*values: datetime):
+    iterator = iter(values)
+    return lambda: next(iterator)
+
+
+def _payload_bytes(event_id: str) -> bytes:
+    return json.dumps(
+        {
+            "event_id": event_id,
+            "event_type": "breach_opened",
+            "payload": {"severity": "critical"},
+            "policy_id": "us-tech-standard",
+            "portfolio_id": "us-tech-equal",
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+        allow_nan=False,
+    ).encode("utf-8")
+
+
+def _request(endpoint: str, event_id: str) -> dict[str, Any]:
+    return {
+        "endpoint": endpoint,
+        "payload": json.loads(_payload_bytes(event_id).decode("utf-8")),
+    }
+
+
+def _checklist(
+    *,
+    destination_id: str,
+    fingerprint: str,
+    authority_id: str,
+    reviewed_at: datetime,
+    expires_at: datetime,
+) -> dict[str, Any]:
+    return build_notification_activation_checklist(
+        destination_id=destination_id,
+        destination_fingerprint=fingerprint,
+        authority_id=authority_id,
+        reviewed_by=["receiver-owner", "transition-contract-reviewer"],
+        reviewed_at=reviewed_at,
+        review_expires_at=expires_at,
+        controls={name: True for name in CONTROL_NAMES},
+    )
+
+
+def _controlled_receiver_record(
+    *,
+    checklist: dict[str, Any],
+    request_id: str,
+    event_id: str,
+    host: str,
+    started_at: datetime,
+) -> dict[str, Any]:
+    received_at = started_at + timedelta(seconds=1)
+    receiver = ControlledNotificationReceiver(
+        activation_checklist=checklist,
+        allowed_hosts=[host],
+        allowed_event_types=["breach_opened"],
+        clock=_clock(received_at),
+    )
+    receiver(
+        f"https://{host}/controlled",
+        _payload_bytes(event_id),
+        {
+            "Content-Type": "application/json",
+            "Idempotency-Key": event_id,
+            "User-Agent": "financial-risk-data-platform/1",
+        },
+        5.0,
+    )
+    return build_controlled_receiver_rehearsal_record(
+        request_id=request_id,
+        terminal_status="completed",
+        failure_code=None,
+        activation_checklist=checklist,
+        allowed_hosts=[host],
+        allowed_event_types=["breach_opened"],
+        response_status=204,
+        started_at=started_at,
+        finished_at=started_at + timedelta(seconds=2),
+        recorded_at=started_at + timedelta(seconds=3),
+        attempted_request_count=1,
+        receiver_summary=receiver.summary(),
+    )
+
+
+def _transition_evidence(now: datetime) -> tuple[dict[str, Any], dict[str, Any]]:
+    planned_at = now - timedelta(hours=4)
+    started_at = now - timedelta(hours=3)
+    expires_at = now + timedelta(days=30)
+    with tempfile.TemporaryDirectory(prefix="transition-contract-") as directory:
+        root = Path(directory)
+        baseline_path = _write_config(
+            root,
+            "baseline.yaml",
+            _destination_config(
+                endpoint_env=OLD_ENDPOINT_ENV,
+                enabled=True,
+                change_request_id="CHG-CONTRACT-BASELINE",
+                reviewed_at=planned_at - timedelta(days=30),
+                expires_at=expires_at,
+            ),
+        )
+        rotated_path = _write_config(
+            root,
+            "rotated.yaml",
+            _destination_config(
+                endpoint_env=NEW_ENDPOINT_ENV,
+                enabled=True,
+                change_request_id="CHG-CONTRACT-ROTATE",
+                reviewed_at=planned_at - timedelta(days=10),
+                expires_at=expires_at,
+            ),
+        )
+        disabled_path = _write_config(
+            root,
+            "disabled.yaml",
+            _destination_config(
+                endpoint_env=NEW_ENDPOINT_ENV,
+                enabled=False,
+                change_request_id="unused",
+                reviewed_at=planned_at,
+                expires_at=expires_at,
+            ),
+        )
+        rollback_path = _write_config(
+            root,
+            "rollback.yaml",
+            _destination_config(
+                endpoint_env=OLD_ENDPOINT_ENV,
+                enabled=True,
+                change_request_id="CHG-CONTRACT-ROLLBACK",
+                reviewed_at=planned_at - timedelta(days=1),
+                expires_at=expires_at,
+            ),
+        )
+        rotate_plan = build_notification_destination_transition_plan(
+            operation="rotate",
+            current_config_path=baseline_path,
+            target_config_path=rotated_path,
+            destination_id=DESTINATION_ID,
+            planned_at=planned_at,
+        )
+        disable_plan = build_notification_destination_transition_plan(
+            operation="disable",
+            current_config_path=rotated_path,
+            target_config_path=disabled_path,
+            destination_id=DESTINATION_ID,
+            planned_at=planned_at,
+        )
+        rollback_plan = build_notification_destination_transition_plan(
+            operation="rollback",
+            current_config_path=disabled_path,
+            target_config_path=rollback_path,
+            destination_id=DESTINATION_ID,
+            planned_at=planned_at,
+            prior_plan_id=disable_plan["plan_id"],
+        )
+        baseline_authority = resolve_notification_destination_authority(
+            destination_config_path=baseline_path,
+            destination_id=DESTINATION_ID,
+            delivery_endpoint_env=OLD_ENDPOINT_ENV,
+            evaluated_at=planned_at,
+            event_types=["breach_opened"],
+        )
+        rotate_authority = resolve_notification_destination_authority(
+            destination_config_path=rotated_path,
+            destination_id=DESTINATION_ID,
+            delivery_endpoint_env=NEW_ENDPOINT_ENV,
+            evaluated_at=planned_at,
+            event_types=["breach_opened"],
+        )
+        rollback_authority = resolve_notification_destination_authority(
+            destination_config_path=rollback_path,
+            destination_id=DESTINATION_ID,
+            delivery_endpoint_env=OLD_ENDPOINT_ENV,
+            evaluated_at=planned_at,
+            event_types=["breach_opened"],
+        )
+
+    rotate_checklist = _checklist(
+        destination_id=DESTINATION_ID,
+        fingerprint=rotate_authority["destination_fingerprint"],
+        authority_id=rotate_authority["authority_id"],
+        reviewed_at=planned_at - timedelta(hours=2),
+        expires_at=expires_at,
+    )
+    rollback_checklist = _checklist(
+        destination_id=DESTINATION_ID,
+        fingerprint=rollback_authority["destination_fingerprint"],
+        authority_id=rollback_authority["authority_id"],
+        reviewed_at=planned_at - timedelta(hours=1),
+        expires_at=expires_at,
+    )
+    rotate_request = _request(
+        "https://receiver-v2.test/controlled",
+        "transition-contract-rotate",
+    )
+    rollback_request = _request(
+        "https://receiver-v1.test/controlled",
+        "transition-contract-rollback",
+    )
+    rehearsal = rehearse_notification_destination_transition(
+        rotate_plan=rotate_plan,
+        disable_plan=disable_plan,
+        rollback_plan=rollback_plan,
+        baseline_authority=baseline_authority,
+        rotate_authority=rotate_authority,
+        rollback_authority=rollback_authority,
+        rotate_checklist=rotate_checklist,
+        rollback_checklist=rollback_checklist,
+        rotate_allowed_hosts=["receiver-v2.test"],
+        rollback_allowed_hosts=["receiver-v1.test"],
+        rotate_requests=[rotate_request, rotate_request],
+        rollback_requests=[rollback_request],
+        started_at=started_at,
+        clock=_clock(
+            started_at + timedelta(seconds=1),
+            started_at + timedelta(seconds=2),
+            started_at + timedelta(seconds=3),
+        ),
+    )
+    return rehearsal, rollback_checklist
+
+
+def _mutation_rejected(dsn: str, statement: str) -> bool:
+    try:
+        import psycopg
+    except ImportError as exc:  # pragma: no cover - required in CI.
+        raise RuntimeError("Transition rehearsal contract requires psycopg") from exc
+    try:
+        with psycopg.connect(dsn) as connection:
+            with connection.cursor() as cursor:
+                cursor.execute(statement)
+            connection.commit()
+    except Exception as exc:
+        if "append-only" not in str(exc):
+            raise
+        return True
+    return False
+
+
+def _review_status(dsn: str) -> str:
+    try:
+        import psycopg
+    except ImportError as exc:  # pragma: no cover - required in CI.
+        raise RuntimeError("Transition rehearsal contract requires psycopg") from exc
+    with psycopg.connect(dsn) as connection:
+        with connection.cursor() as cursor:
+            cursor.execute(
+                """
+                SELECT transition_review_status
+                FROM risk_platform.current_notification_destination_transition_review
+                WHERE destination_id = %s
+                """,
+                (DESTINATION_ID,),
+            )
+            row = cursor.fetchone()
+    if row is None:
+        raise AssertionError("transition review row was not produced")
+    return str(row[0])
+
+
+def run_contract_check(dsn: str) -> dict[str, Any]:
+    now = datetime.now(timezone.utc).replace(microsecond=0)
+    rehearsal, rollback_checklist = _transition_evidence(now)
+    transition_record = build_notification_destination_transition_rehearsal_record(
+        request_id="TRANSITION-CONTRACT-001",
+        recorded_at=now - timedelta(hours=2, minutes=59, seconds=56),
+        rehearsal=rehearsal,
+    )
+
+    rollback_receiver_record = _controlled_receiver_record(
+        checklist=rollback_checklist,
+        request_id="TRANSITION-CONTRACT-CURRENT-RECEIVER",
+        event_id="transition-current-receiver",
+        host="receiver-v1.test",
+        started_at=now - timedelta(hours=2),
+    )
+    record_controlled_receiver_rehearsal(
+        dsn=dsn,
+        record=rollback_receiver_record,
+    )
+    created = record_notification_destination_transition_rehearsal(
+        dsn=dsn,
+        record=transition_record,
+    )
+    if created["created"] is not True:
+        raise AssertionError("transition rehearsal was not created")
+    replay = record_notification_destination_transition_rehearsal(
+        dsn=dsn,
+        record=transition_record,
+    )
+    if replay["created"] is not False:
+        raise AssertionError("exact transition rehearsal retry did not converge")
+    if _review_status(dsn) != "ready":
+        raise AssertionError("current transition rehearsal was not ready")
+
+    conflicting = build_notification_destination_transition_rehearsal_record(
+        request_id=transition_record["request_id"],
+        recorded_at=(
+            datetime.fromisoformat(transition_record["recorded_at"])
+            + timedelta(seconds=1)
+        ),
+        rehearsal=rehearsal,
+    )
+    try:
+        record_notification_destination_transition_rehearsal(
+            dsn=dsn,
+            record=conflicting,
+        )
+    except ValidationError:
+        conflict_rejected = True
+    else:
+        conflict_rejected = False
+    if not conflict_rejected:
+        raise AssertionError("conflicting transition request identity was accepted")
+
+    replacement_checklist = _checklist(
+        destination_id=DESTINATION_ID,
+        fingerprint="post-transition-destination-fingerprint",
+        authority_id="post-transition-destination-authority",
+        reviewed_at=now - timedelta(minutes=30),
+        expires_at=now + timedelta(days=30),
+    )
+    replacement_receiver_record = _controlled_receiver_record(
+        checklist=replacement_checklist,
+        request_id="TRANSITION-CONTRACT-REPLACEMENT-RECEIVER",
+        event_id="transition-replacement-receiver",
+        host="receiver-v3.test",
+        started_at=now - timedelta(minutes=20),
+    )
+    record_controlled_receiver_rehearsal(
+        dsn=dsn,
+        record=replacement_receiver_record,
+    )
+    if _review_status(dsn) != "transition_rehearsal_superseded":
+        raise AssertionError("new receiver review did not supersede transition evidence")
+
+    update_rejected = _mutation_rejected(
+        dsn,
+        """
+        UPDATE risk_platform.notification_destination_transition_rehearsals
+        SET rotate_request_count = rotate_request_count + 1
+        WHERE request_id = 'TRANSITION-CONTRACT-001'
+        """,
+    )
+    delete_rejected = _mutation_rejected(
+        dsn,
+        """
+        DELETE FROM risk_platform.notification_destination_transition_rehearsals
+        WHERE request_id = 'TRANSITION-CONTRACT-001'
+        """,
+    )
+    if not update_rejected or not delete_rejected:
+        raise AssertionError("append-only transition mutation was accepted")
+
+    try:
+        import psycopg
+    except ImportError as exc:  # pragma: no cover - required in CI.
+        raise RuntimeError("Transition rehearsal contract requires psycopg") from exc
+    with psycopg.connect(dsn) as connection:
+        with connection.cursor() as cursor:
+            cursor.execute(CHECK_PATH.read_text(encoding="utf-8"))
+            checks = list(cursor.fetchall())
+    failures = [check for check in checks if check[3] != "pass"]
+    if failures:
+        names = ", ".join(str(check[0]) for check in failures)
+        raise AssertionError("transition rehearsal reconciliation failed: " + names)
+
+    return {
+        "model_version": "portfolio-risk-notification-transition-contract-v1",
+        "record_id": transition_record["record_id"],
+        "exact_retry_converged": True,
+        "conflicting_request_rejected": True,
+        "initial_review_status": "ready",
+        "current_review_status": "transition_rehearsal_superseded",
+        "update_rejected": update_rejected,
+        "delete_rejected": delete_rejected,
+        "consistency_checks": len(checks),
+        "external_request_performed": False,
+        "socket_opened": False,
+        "dns_lookup_performed": False,
+    }
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Exercise append-only destination transition rehearsal history "
+            "against PostgreSQL 16."
+        )
+    )
+    parser.add_argument(
+        "--dsn",
+        default=os.environ.get("WAREHOUSE_POSTGRES_DSN", DEFAULT_POSTGRES_DSN),
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    try:
+        summary = run_contract_check(args.dsn)
+    except Exception as exc:
+        print(f"Destination transition contract failed: {exc}", file=sys.stderr)
+        return 1
+    print(json.dumps(summary, sort_keys=True, allow_nan=False))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/warehouse/notification_destination_transition_rehearsal_recorder.py
+++ b/src/warehouse/notification_destination_transition_rehearsal_recorder.py
@@ -1,0 +1,252 @@
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import sys
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+from src.common.exceptions import StorageError, ValidationError
+from src.warehouse.notification_destination_transition_rehearsal_contract import (
+    canonical_transition_rehearsal_record_bytes,
+    validate_notification_destination_transition_rehearsal_record,
+)
+from src.warehouse.postgres_loader import DEFAULT_POSTGRES_DSN
+
+MAX_RECORD_BYTES = 1_048_576
+
+
+def _result(
+    record: Mapping[str, Any],
+    *,
+    digest: str,
+    created: bool,
+) -> dict[str, Any]:
+    return {
+        "record_id": record["record_id"],
+        "request_id": record["request_id"],
+        "rehearsal_id": record["rehearsal_id"],
+        "destination_id": record["destination_id"],
+        "rotate_plan_id": record["rotate_plan_id"],
+        "disable_plan_id": record["disable_plan_id"],
+        "rollback_plan_id": record["rollback_plan_id"],
+        "document_sha256": digest,
+        "created": created,
+    }
+
+
+def record_notification_destination_transition_rehearsal(
+    *,
+    dsn: str,
+    record: Mapping[str, Any],
+) -> dict[str, Any]:
+    validated = validate_notification_destination_transition_rehearsal_record(
+        record
+    )
+    digest = hashlib.sha256(
+        canonical_transition_rehearsal_record_bytes(validated)
+    ).hexdigest()
+    try:
+        import psycopg
+        from psycopg.types.json import Jsonb
+    except ImportError as exc:  # pragma: no cover - required in CI.
+        raise RuntimeError(
+            "Notification destination transition history requires psycopg"
+        ) from exc
+
+    try:
+        with psycopg.connect(dsn) as connection:
+            with connection.cursor() as cursor:
+                cursor.execute(
+                    """
+                    SELECT record_json, document_sha256
+                    FROM risk_platform.notification_destination_transition_rehearsals
+                    WHERE request_id = %s
+                    """,
+                    (validated["request_id"],),
+                )
+                existing = cursor.fetchone()
+                if existing is not None:
+                    existing_json, existing_digest = existing
+                    if existing_json != validated or existing_digest != digest:
+                        raise ValidationError(
+                            "request_id already exists with different transition evidence"
+                        )
+                    return _result(validated, digest=digest, created=False)
+
+                cursor.execute(
+                    """
+                    INSERT INTO
+                    risk_platform.notification_destination_transition_rehearsals (
+                        record_id,
+                        model_version,
+                        request_id,
+                        rehearsal_id,
+                        destination_id,
+                        rotate_plan_id,
+                        disable_plan_id,
+                        rollback_plan_id,
+                        baseline_authority_id,
+                        rotate_authority_id,
+                        rollback_authority_id,
+                        rotate_checklist_id,
+                        rollback_checklist_id,
+                        rotate_destination_fingerprint,
+                        disable_destination_fingerprint,
+                        rollback_destination_fingerprint,
+                        rotate_endpoint_environment_variable,
+                        disable_endpoint_environment_variable,
+                        rollback_endpoint_environment_variable,
+                        started_at,
+                        finished_at,
+                        recorded_at,
+                        rotate_request_count,
+                        rollback_request_count,
+                        same_content_duplicate_count,
+                        rehearsal_json,
+                        record_json,
+                        document_sha256
+                    )
+                    VALUES (
+                        %s, %s, %s, %s, %s, %s, %s,
+                        %s, %s, %s, %s, %s, %s, %s,
+                        %s, %s, %s, %s, %s, %s, %s,
+                        %s, %s, %s, %s, %s, %s, %s
+                    )
+                    ON CONFLICT DO NOTHING
+                    RETURNING record_id
+                    """,
+                    (
+                        validated["record_id"],
+                        validated["model_version"],
+                        validated["request_id"],
+                        validated["rehearsal_id"],
+                        validated["destination_id"],
+                        validated["rotate_plan_id"],
+                        validated["disable_plan_id"],
+                        validated["rollback_plan_id"],
+                        validated["baseline_authority_id"],
+                        validated["rotate_authority_id"],
+                        validated["rollback_authority_id"],
+                        validated["rotate_checklist_id"],
+                        validated["rollback_checklist_id"],
+                        validated["rotate_destination_fingerprint"],
+                        validated["disable_destination_fingerprint"],
+                        validated["rollback_destination_fingerprint"],
+                        validated["rotate_endpoint_environment_variable"],
+                        validated["disable_endpoint_environment_variable"],
+                        validated["rollback_endpoint_environment_variable"],
+                        validated["started_at"],
+                        validated["finished_at"],
+                        validated["recorded_at"],
+                        validated["rotate_request_count"],
+                        validated["rollback_request_count"],
+                        validated["same_content_duplicate_count"],
+                        Jsonb(validated["rehearsal_summary"]),
+                        Jsonb(validated),
+                        digest,
+                    ),
+                )
+                created = cursor.fetchone() is not None
+                if not created:
+                    cursor.execute(
+                        """
+                        SELECT request_id, record_json, document_sha256
+                        FROM risk_platform.notification_destination_transition_rehearsals
+                        WHERE rehearsal_id = %s
+                        """,
+                        (validated["rehearsal_id"],),
+                    )
+                    rehearsal_conflict = cursor.fetchone()
+                    if rehearsal_conflict is not None:
+                        conflict_request, stored_json, stored_digest = rehearsal_conflict
+                        if (
+                            conflict_request != validated["request_id"]
+                            or stored_json != validated
+                            or stored_digest != digest
+                        ):
+                            raise ValidationError(
+                                "rehearsal_id already exists under different evidence"
+                            )
+
+                cursor.execute(
+                    """
+                    SELECT record_json, document_sha256
+                    FROM risk_platform.notification_destination_transition_rehearsals
+                    WHERE record_id = %s
+                    """,
+                    (validated["record_id"],),
+                )
+                stored = cursor.fetchone()
+                if stored is None:
+                    raise StorageError(
+                        "notification destination transition rehearsal was not retained"
+                    )
+                stored_json, stored_digest = stored
+                if stored_json != validated or stored_digest != digest:
+                    raise ValidationError(
+                        "record_id already exists with different transition evidence"
+                    )
+            connection.commit()
+    except (StorageError, ValidationError):
+        raise
+    except Exception:
+        raise StorageError(
+            "notification destination transition history database operation failed"
+        ) from None
+
+    return _result(validated, digest=digest, created=created)
+
+
+def _read_record(path: Path) -> dict[str, Any]:
+    if path.is_symlink():
+        raise ValidationError("transition rehearsal record must not be a symbolic link")
+    if not path.is_file():
+        raise ValidationError("transition rehearsal record must be a regular file")
+    if path.stat().st_size > MAX_RECORD_BYTES:
+        raise ValidationError("transition rehearsal record exceeds 1 MB")
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, ValueError):
+        raise ValidationError("transition rehearsal record could not be read") from None
+    if not isinstance(value, Mapping):
+        raise ValidationError("transition rehearsal record must be a JSON object")
+    return dict(value)
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Append one notification destination transition rehearsal to PostgreSQL."
+        )
+    )
+    parser.add_argument("--record", required=True, type=Path)
+    parser.add_argument(
+        "--dsn",
+        default=os.environ.get("WAREHOUSE_POSTGRES_DSN", DEFAULT_POSTGRES_DSN),
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    try:
+        result = record_notification_destination_transition_rehearsal(
+            dsn=args.dsn,
+            record=_read_record(args.record),
+        )
+    except ValidationError as exc:
+        print(f"Destination transition rehearsal rejected: {exc}", file=sys.stderr)
+        return 1
+    except (StorageError, RuntimeError) as exc:
+        print(f"Destination transition history failed: {exc}", file=sys.stderr)
+        return 1
+    print(json.dumps(result, sort_keys=True, allow_nan=False))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/test_docker_compose_contract.py
+++ b/tests/unit/test_docker_compose_contract.py
@@ -49,6 +49,7 @@ def test_local_database_seed_mounts_are_read_only_and_ordered() -> None:
         "./sql/portfolio_risk_notification_retry_destination_follow_up_schema.sql:/docker-entrypoint-initdb.d/21_portfolio_risk_notification_retry_destination_follow_up_schema.sql:ro",
         "./sql/controlled_notification_receiver_rehearsal_schema.sql:/docker-entrypoint-initdb.d/22_controlled_notification_receiver_rehearsal_schema.sql:ro",
         "./sql/controlled_notification_receiver_review_schema.sql:/docker-entrypoint-initdb.d/23_controlled_notification_receiver_review_schema.sql:ro",
+        "./sql/notification_destination_transition_rehearsal_schema.sql:/docker-entrypoint-initdb.d/24_notification_destination_transition_rehearsal_schema.sql:ro",
     ]
     assert services["mongo"]["volumes"] == [
         "./mongo/init:/docker-entrypoint-initdb.d:ro"

--- a/tests/unit/test_notification_destination_transition_history_architecture_contract.py
+++ b/tests/unit/test_notification_destination_transition_history_architecture_contract.py
@@ -1,0 +1,99 @@
+from pathlib import Path
+
+
+def test_transition_history_is_append_only_current_and_no_network() -> None:
+    contract = Path(
+        "src/warehouse/notification_destination_transition_rehearsal_contract.py"
+    ).read_text(encoding="utf-8")
+    recorder = Path(
+        "src/warehouse/notification_destination_transition_rehearsal_recorder.py"
+    ).read_text(encoding="utf-8")
+    fixture = Path(
+        "src/warehouse/"
+        "notification_destination_transition_rehearsal_postgres_contract_check.py"
+    ).read_text(encoding="utf-8")
+    schema = Path(
+        "sql/notification_destination_transition_rehearsal_schema.sql"
+    ).read_text(encoding="utf-8")
+    checks = Path(
+        "sql/notification_destination_transition_rehearsal_consistency_checks.sql"
+    ).read_text(encoding="utf-8")
+    docs = Path(
+        "docs/notification-destination-transition-rehearsal-history.md"
+    ).read_text(encoding="utf-8")
+    normalized_docs = " ".join(docs.split()).casefold()
+
+    for required in (
+        "validate_notification_destination_transition_rehearsal",
+        "disable stage must be authority-free and request-free",
+        "receiver receipt ordinals are not contiguous",
+        "duplicate receipt does not reuse identical content",
+        "stale authority rejection evidence is incomplete",
+        "transition rehearsal record is not canonical",
+    ):
+        assert required in contract
+
+    for required in (
+        "where request_id = %s",
+        "request_id already exists with different transition evidence",
+        "rehearsal_id already exists under different evidence",
+        "on conflict do nothing",
+        "record_json, document_sha256",
+    ):
+        assert required in recorder.casefold()
+
+    for view in (
+        "latest_notification_destination_transition_rehearsals",
+        "current_notification_destination_transition_review",
+        "current_notification_destination_transition_review_failures",
+        "current_notification_destination_transition_ready",
+    ):
+        assert f"risk_platform.{view}" in schema
+
+    for status in (
+        "activation_not_ready",
+        "transition_rehearsal_missing",
+        "transition_rehearsal_superseded",
+        "ready",
+    ):
+        assert status in schema
+        assert status in docs
+
+    for required in (
+        "notification_destination_transition_request_ids_unique",
+        "notification_destination_transition_disable_stages_safe",
+        "notification_destination_transition_latest_selection_current",
+        "notification_destination_transition_review_status_reconciles",
+        "notification_destination_transition_append_only_triggers_enabled",
+    ):
+        assert required in checks
+
+    for required in (
+        "initial_review_status",
+        "transition_rehearsal_superseded",
+        "conflicting_request_rejected",
+        "update_rejected",
+        "delete_rejected",
+        "external_request_performed",
+    ):
+        assert required in fixture
+
+    for required in (
+        "primary arc42 blocks: `orchestration` and `warehouse`",
+        "independently checks",
+        "authority-free and request-free disablement stage",
+        "newer receiver checklist and successful controlled rehearsal",
+        "ordinary validation performs no dns lookup",
+        "terraform apply",
+    ):
+        assert required in normalized_docs
+
+    for source in (contract, recorder, fixture):
+        lowered = source.casefold()
+        for forbidden in (
+            "requests.post(",
+            "urllib.request",
+            "httpx.",
+            "socket.socket",
+        ):
+            assert forbidden not in lowered

--- a/tests/unit/test_notification_destination_transition_rehearsal_contract.py
+++ b/tests/unit/test_notification_destination_transition_rehearsal_contract.py
@@ -1,0 +1,359 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+from src.common.exceptions import ValidationError
+from src.orchestration.notification_activation_checklist import (
+    CONTROL_NAMES,
+    build_notification_activation_checklist,
+)
+from src.orchestration.notification_destination_transition_plan import (
+    build_notification_destination_transition_plan,
+)
+from src.orchestration.notification_destination_transition_rehearsal import (
+    rehearse_notification_destination_transition,
+)
+from src.orchestration.portfolio_risk_notification_destination_authority import (
+    resolve_notification_destination_authority,
+)
+from src.warehouse.notification_destination_transition_rehearsal_contract import (
+    MODEL_VERSION,
+    build_notification_destination_transition_rehearsal_record,
+    validate_notification_destination_transition_rehearsal,
+    validate_notification_destination_transition_rehearsal_record,
+)
+
+DESTINATION_ID = "risk-operations-webhook"
+OLD_ENDPOINT_ENV = "RISK_NOTIFICATION_WEBHOOK_URL"
+NEW_ENDPOINT_ENV = "RISK_NOTIFICATION_WEBHOOK_URL_V2"
+PLANNED_AT = datetime(2026, 6, 15, 12, tzinfo=timezone.utc)
+STARTED_AT = PLANNED_AT + timedelta(minutes=1)
+
+
+def _activation(
+    *,
+    enabled: bool,
+    change_request_id: str,
+    reviewed_at: str,
+) -> dict[str, Any]:
+    if not enabled:
+        return {
+            "enabled": False,
+            "change_request_id": None,
+            "reviewed_by": [],
+            "reviewed_at": None,
+            "review_expires_at": None,
+        }
+    return {
+        "enabled": True,
+        "change_request_id": change_request_id,
+        "reviewed_by": ["risk-control-reviewer"],
+        "reviewed_at": reviewed_at,
+        "review_expires_at": "2026-12-31T00:00:00Z",
+    }
+
+
+def _config(
+    *,
+    endpoint_env: str,
+    enabled: bool,
+    change_request_id: str,
+    reviewed_at: str,
+) -> dict[str, Any]:
+    return {
+        "model_version": "portfolio-risk-notification-destination-v1",
+        "destinations": {
+            DESTINATION_ID: {
+                "channel": "webhook",
+                "endpoint_env": endpoint_env,
+                "owner": {
+                    "team": "risk-operations",
+                    "contact": "risk-operations-oncall",
+                },
+                "purpose": "portfolio-risk-breach-lifecycle",
+                "recipient_scope": "risk-operations",
+                "data_classification": "internal",
+                "allowed_event_types": [
+                    "breach_escalated",
+                    "breach_opened",
+                    "breach_resolved",
+                ],
+                "activation": _activation(
+                    enabled=enabled,
+                    change_request_id=change_request_id,
+                    reviewed_at=reviewed_at,
+                ),
+            }
+        },
+    }
+
+
+def _write(tmp_path: Path, name: str, value: dict[str, Any]) -> Path:
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    path = tmp_path / name
+    path.write_text(yaml.safe_dump(value, sort_keys=False), encoding="utf-8")
+    return path
+
+
+def _clock(*values: datetime):
+    iterator = iter(values)
+    return lambda: next(iterator)
+
+
+def _request(endpoint: str, event_id: str) -> dict[str, Any]:
+    return {
+        "endpoint": endpoint,
+        "payload": {
+            "event_id": event_id,
+            "event_type": "breach_opened",
+            "payload": {"severity": "critical"},
+            "policy_id": "us-tech-standard",
+            "portfolio_id": "us-tech-equal",
+        },
+    }
+
+
+def _rehearsal(tmp_path: Path) -> dict[str, Any]:
+    baseline = _write(
+        tmp_path,
+        "baseline.yaml",
+        _config(
+            endpoint_env=OLD_ENDPOINT_ENV,
+            enabled=True,
+            change_request_id="CHG-BASELINE",
+            reviewed_at="2026-01-01T00:00:00Z",
+        ),
+    )
+    rotated = _write(
+        tmp_path,
+        "rotated.yaml",
+        _config(
+            endpoint_env=NEW_ENDPOINT_ENV,
+            enabled=True,
+            change_request_id="CHG-ROTATE",
+            reviewed_at="2026-05-01T00:00:00Z",
+        ),
+    )
+    disabled = _write(
+        tmp_path,
+        "disabled.yaml",
+        _config(
+            endpoint_env=NEW_ENDPOINT_ENV,
+            enabled=False,
+            change_request_id="unused",
+            reviewed_at="2026-05-01T00:00:00Z",
+        ),
+    )
+    rollback = _write(
+        tmp_path,
+        "rollback.yaml",
+        _config(
+            endpoint_env=OLD_ENDPOINT_ENV,
+            enabled=True,
+            change_request_id="CHG-ROLLBACK",
+            reviewed_at="2026-06-01T00:00:00Z",
+        ),
+    )
+    rotate_plan = build_notification_destination_transition_plan(
+        operation="rotate",
+        current_config_path=baseline,
+        target_config_path=rotated,
+        destination_id=DESTINATION_ID,
+        planned_at=PLANNED_AT,
+    )
+    disable_plan = build_notification_destination_transition_plan(
+        operation="disable",
+        current_config_path=rotated,
+        target_config_path=disabled,
+        destination_id=DESTINATION_ID,
+        planned_at=PLANNED_AT,
+    )
+    rollback_plan = build_notification_destination_transition_plan(
+        operation="rollback",
+        current_config_path=disabled,
+        target_config_path=rollback,
+        destination_id=DESTINATION_ID,
+        planned_at=PLANNED_AT,
+        prior_plan_id=disable_plan["plan_id"],
+    )
+    baseline_authority = resolve_notification_destination_authority(
+        destination_config_path=baseline,
+        destination_id=DESTINATION_ID,
+        delivery_endpoint_env=OLD_ENDPOINT_ENV,
+        evaluated_at=PLANNED_AT,
+        event_types=["breach_opened"],
+    )
+    rotate_authority = resolve_notification_destination_authority(
+        destination_config_path=rotated,
+        destination_id=DESTINATION_ID,
+        delivery_endpoint_env=NEW_ENDPOINT_ENV,
+        evaluated_at=PLANNED_AT,
+        event_types=["breach_opened"],
+    )
+    rollback_authority = resolve_notification_destination_authority(
+        destination_config_path=rollback,
+        destination_id=DESTINATION_ID,
+        delivery_endpoint_env=OLD_ENDPOINT_ENV,
+        evaluated_at=PLANNED_AT,
+        event_types=["breach_opened"],
+    )
+    controls = {name: True for name in CONTROL_NAMES}
+    rotate_checklist = build_notification_activation_checklist(
+        destination_id=DESTINATION_ID,
+        destination_fingerprint=rotate_authority["destination_fingerprint"],
+        authority_id=rotate_authority["authority_id"],
+        reviewed_by=["receiver-owner", "risk-control-reviewer"],
+        reviewed_at=PLANNED_AT - timedelta(days=1),
+        review_expires_at=PLANNED_AT + timedelta(days=30),
+        controls=controls,
+    )
+    rollback_checklist = build_notification_activation_checklist(
+        destination_id=DESTINATION_ID,
+        destination_fingerprint=rollback_authority["destination_fingerprint"],
+        authority_id=rollback_authority["authority_id"],
+        reviewed_by=["receiver-owner", "risk-control-reviewer"],
+        reviewed_at=PLANNED_AT - timedelta(hours=1),
+        review_expires_at=PLANNED_AT + timedelta(days=30),
+        controls=controls,
+    )
+    rotate_request = _request(
+        "https://receiver-v2.test/risk",
+        "rotation-event-1",
+    )
+    rollback_request = _request(
+        "https://receiver-v1.test/risk",
+        "rollback-event-1",
+    )
+    return rehearse_notification_destination_transition(
+        rotate_plan=rotate_plan,
+        disable_plan=disable_plan,
+        rollback_plan=rollback_plan,
+        baseline_authority=baseline_authority,
+        rotate_authority=rotate_authority,
+        rollback_authority=rollback_authority,
+        rotate_checklist=rotate_checklist,
+        rollback_checklist=rollback_checklist,
+        rotate_allowed_hosts=["receiver-v2.test"],
+        rollback_allowed_hosts=["receiver-v1.test"],
+        rotate_requests=[rotate_request, rotate_request],
+        rollback_requests=[rollback_request],
+        started_at=STARTED_AT,
+        clock=_clock(
+            STARTED_AT + timedelta(seconds=1),
+            STARTED_AT + timedelta(seconds=2),
+            STARTED_AT + timedelta(seconds=3),
+        ),
+    )
+
+
+def test_record_is_deterministic_canonical_and_count_reconciled(
+    tmp_path: Path,
+) -> None:
+    rehearsal = _rehearsal(tmp_path)
+    recorded_at = STARTED_AT + timedelta(seconds=4)
+
+    first = build_notification_destination_transition_rehearsal_record(
+        request_id="TRANSITION-REHEARSAL-001",
+        recorded_at=recorded_at,
+        rehearsal=rehearsal,
+    )
+    second = build_notification_destination_transition_rehearsal_record(
+        request_id="TRANSITION-REHEARSAL-001",
+        recorded_at=recorded_at,
+        rehearsal=rehearsal,
+    )
+
+    assert first == second
+    assert first["model_version"] == MODEL_VERSION
+    assert first["rotate_request_count"] == 2
+    assert first["rollback_request_count"] == 1
+    assert first["same_content_duplicate_count"] == 1
+    assert first["disable_endpoint_environment_variable"] == NEW_ENDPOINT_ENV
+    assert first["rollback_endpoint_environment_variable"] == OLD_ENDPOINT_ENV
+    assert validate_notification_destination_transition_rehearsal_record(first) == first
+    assert validate_notification_destination_transition_rehearsal(rehearsal) == rehearsal
+
+
+def test_changed_request_or_record_time_changes_record_identity(tmp_path: Path) -> None:
+    rehearsal = _rehearsal(tmp_path)
+    recorded_at = STARTED_AT + timedelta(seconds=4)
+    first = build_notification_destination_transition_rehearsal_record(
+        request_id="TRANSITION-REHEARSAL-001",
+        recorded_at=recorded_at,
+        rehearsal=rehearsal,
+    )
+    changed_request = build_notification_destination_transition_rehearsal_record(
+        request_id="TRANSITION-REHEARSAL-002",
+        recorded_at=recorded_at,
+        rehearsal=rehearsal,
+    )
+    changed_time = build_notification_destination_transition_rehearsal_record(
+        request_id="TRANSITION-REHEARSAL-001",
+        recorded_at=recorded_at + timedelta(seconds=1),
+        rehearsal=rehearsal,
+    )
+
+    assert len({first["record_id"], changed_request["record_id"], changed_time["record_id"]}) == 3
+
+
+def test_record_rejects_time_before_rehearsal_completion(tmp_path: Path) -> None:
+    rehearsal = _rehearsal(tmp_path)
+    with pytest.raises(ValidationError, match="must not precede"):
+        build_notification_destination_transition_rehearsal_record(
+            request_id="TRANSITION-REHEARSAL-001",
+            recorded_at=STARTED_AT,
+            rehearsal=rehearsal,
+        )
+
+
+def test_rehearsal_validation_rejects_disable_stage_side_effects(
+    tmp_path: Path,
+) -> None:
+    rehearsal = _rehearsal(tmp_path)
+    rehearsal["stages"][1]["request_count"] = 1
+
+    with pytest.raises(ValidationError, match="authority-free and request-free"):
+        validate_notification_destination_transition_rehearsal(rehearsal)
+
+
+def test_rehearsal_validation_rejects_changed_receipt_content(
+    tmp_path: Path,
+) -> None:
+    rehearsal = _rehearsal(tmp_path)
+    rehearsal["stages"][0]["receiver_summary"]["receipts"][1][
+        "payload_sha256"
+    ] = "0" * 64
+
+    with pytest.raises(ValidationError, match="identical content"):
+        validate_notification_destination_transition_rehearsal(rehearsal)
+
+
+def test_rehearsal_validation_rejects_changed_safety_or_identity(
+    tmp_path: Path,
+) -> None:
+    rehearsal = _rehearsal(tmp_path)
+    rehearsal["external_request_performed"] = True
+    with pytest.raises(ValidationError, match="side-effect"):
+        validate_notification_destination_transition_rehearsal(rehearsal)
+
+    rehearsal = _rehearsal(tmp_path / "identity")
+    rehearsal["rehearsal_id"] = "portfolio-risk-notification-transition-tampered"
+    with pytest.raises(ValidationError, match="identity"):
+        validate_notification_destination_transition_rehearsal(rehearsal)
+
+
+def test_record_validation_rejects_extracted_field_tampering(tmp_path: Path) -> None:
+    record = build_notification_destination_transition_rehearsal_record(
+        request_id="TRANSITION-REHEARSAL-001",
+        recorded_at=STARTED_AT + timedelta(seconds=4),
+        rehearsal=_rehearsal(tmp_path),
+    )
+    record["rollback_destination_fingerprint"] = "tampered-fingerprint"
+
+    with pytest.raises(ValidationError, match="not canonical"):
+        validate_notification_destination_transition_rehearsal_record(record)

--- a/tests/unit/test_notification_destination_transition_rehearsal_recorder.py
+++ b/tests/unit/test_notification_destination_transition_rehearsal_recorder.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from src.common.exceptions import ValidationError
+from src.warehouse.notification_destination_transition_rehearsal_recorder import (
+    MAX_RECORD_BYTES,
+    _read_record,
+)
+
+
+def test_transition_record_reader_accepts_regular_bounded_json(tmp_path: Path) -> None:
+    path = tmp_path / "record.json"
+    path.write_text(json.dumps({"record_id": "record-1"}), encoding="utf-8")
+
+    assert _read_record(path) == {"record_id": "record-1"}
+
+
+def test_transition_record_reader_rejects_symlink_and_non_file(
+    tmp_path: Path,
+) -> None:
+    target = tmp_path / "target.json"
+    target.write_text("{}", encoding="utf-8")
+    link = tmp_path / "record.json"
+    link.symlink_to(target)
+
+    with pytest.raises(ValidationError, match="symbolic link"):
+        _read_record(link)
+    with pytest.raises(ValidationError, match="regular file"):
+        _read_record(tmp_path)
+
+
+def test_transition_record_reader_rejects_oversized_or_malformed_json(
+    tmp_path: Path,
+) -> None:
+    oversized = tmp_path / "oversized.json"
+    oversized.write_bytes(b"x" * (MAX_RECORD_BYTES + 1))
+    with pytest.raises(ValidationError, match="exceeds 1 MB"):
+        _read_record(oversized)
+
+    malformed = tmp_path / "malformed.json"
+    malformed.write_text("{not-json", encoding="utf-8")
+    with pytest.raises(ValidationError, match="could not be read"):
+        _read_record(malformed)


### PR DESCRIPTION
## Goal

Complete the durable evidence half of **P4d4e — rotation, disablement, and rollback rehearsal**.

```text
canonical no-network rotate/disable/rollback rehearsal
  + operator request identity
  -> independent record revalidation
  -> append-only PostgreSQL history
  -> deterministic latest transition per destination
  -> current ready, missing, superseded, or activation-not-ready state
```

## Record contract

Adds `portfolio-risk-notification-destination-transition-record-v1`.

The validator independently checks exact fields, stage order, plan/authority/checklist identities, receiver receipt ordering and idempotency, the zero-request disablement stage, timestamps, deterministic rehearsal identity, counts, and every no-network declaration before persistence.

## PostgreSQL contract

Adds:

- `notification_destination_transition_rehearsals`;
- append-only UPDATE/DELETE triggers;
- exact request replay convergence and conflicting reuse rejection;
- `latest_notification_destination_transition_rehearsals`;
- `current_notification_destination_transition_review`;
- current failure and ready partitions; and
- sixteen reconciliation checks.

The live fixture first proves `ready`, then persists a newer independently reviewed receiver configuration and proves the retained transition becomes `transition_rehearsal_superseded` without deleting either history.

## Scope

Twelve intended files, 2,746 additions and two deletions. The branch is zero commits behind `main`; squash merge retains one coherent orchestration/warehouse increment.

## Exact-head validation

GitHub Actions run **381** (`33490147920`) passed on final head `b03ed9d053d116aa707a8c5c58b8d09ef3ecedc3`:

- Security guardrails passed.
- Ruff passed.
- mypy passed across **134 source files**.
- **876 tests passed** in quality and **876 passed again** in readiness.
- Dependency integrity and standard replay passed.
- PostgreSQL 16 proved exact replay convergence, conflicting request rejection, append-only UPDATE/DELETE rejection, sixteen transition checks, initial `ready`, and current `transition_rehearsal_superseded` after a newer receiver review.
- Existing model-approval, operational-service-level, retry follow-up, controlled-receiver, daily/portfolio risk, and warehouse reconciliation remained green.
- Kubernetes rendering and Terraform format/init/validate passed without apply.

There are no review submissions or unresolved review threads.

## Safety

The history retains endpoint environment-variable names, hosts, event identities, and payload hashes only. It retains no endpoint value or full URL, path, payload body, response body, credential, environment value, or DSN. Ordinary validation performed no DNS lookup, socket operation, external request, delivery attempt, outbox mutation, acknowledgement, deployment, or `terraform apply`.

Validated and ready for squash merge.