### PR TITLE
docs: add recruiter-facing portfolio overview

### DIFF
--- a/PROJECT_REFERENCE.md
+++ b/PROJECT_REFERENCE.md
@@ -1,0 +1,395 @@
+# Financial Risk Data Platform
+
+A production-style data platform that ingests market data and external risk
+signals, validates and normalises events, and produces decision-ready analytics
+such as returns, volatility, data quality and risk summaries.
+
+This repository is intentionally structured like a small internal platform at a
+bank or fintech. It prioritises reproducibility, replay safety, explicit data
+grains and interview-ready engineering evidence.
+
+## What It Does
+
+1. Ingests market data and external signals.
+2. Validates schemas, normalises symbols and deduplicates events.
+3. Retains immutable, partitioned raw Parquet for replay.
+4. Builds minute-oriented, single-symbol daily, portfolio and attribution analytics.
+5. Stores curated Parquet and serves versioned outputs through PostgreSQL views.
+
+## Quickstart
+
+```bash
+make setup
+make test
+make security-check
+```
+
+The Makefile uses `.venv/bin/python` by default, so commands work without
+activating the environment after `make setup`. Dependency resolution is
+constrained by `requirements.lock`, which is refreshed deliberately after a full
+green CI run.
+
+The equivalent manual setup is:
+
+```bash
+python3 -m venv .venv
+PIP_CONSTRAINT=requirements.lock .venv/bin/python -m pip install -e '.[dev]'
+.venv/bin/python -m pip check
+.venv/bin/python -m pytest -q
+```
+
+## Run The Demo Pipeline
+
+Run the sample event-to-curated path:
+
+```bash
+.venv/bin/python -m src.orchestration.run_pipeline
+```
+
+Provide a JSON list of market events:
+
+```bash
+.venv/bin/python -m src.orchestration.run_pipeline \
+  --input tests/fixtures/sample_events.json
+```
+
+For the fuller local walkthrough with duplicates, a late event and curated
+metrics:
+
+```bash
+make readiness-check
+```
+
+The demo writes `.demo/pipeline-summary.json` and `.demo/lineage.json`. The
+lineage manifest traces source inventory, transformations, raw and curated
+outputs, data-quality checks and the reporting-view dependency. See
+`docs/demo-script.md` for the five-minute interview walkthrough.
+
+Include landed external risk signals when running the sample pipeline:
+
+```bash
+.venv/bin/python -m src.orchestration.run_pipeline \
+  --input tests/fixtures/sample_events.json \
+  --signals path/to/signals.json
+```
+
+## Alpha Vantage Daily Risk Path
+
+With an Alpha Vantage API key already present in the environment, run one
+bounded source-to-curated daily-risk cycle:
+
+```bash
+export ALPHA_VANTAGE_API_KEY='set-locally-do-not-commit'
+make daily-risk-demo SYMBOL=IBM
+```
+
+The command defaults to completed daily bars ending yesterday in UTC. Optional
+bounds and model parameters can be supplied without changing code:
+
+```bash
+make daily-risk-demo \
+  SYMBOL=IBM \
+  START_DATE=2026-01-01 \
+  END_DATE=2026-03-31 \
+  MAX_RECORDS=100 \
+  VOL_WINDOW=20 \
+  VAR_WINDOW=60 \
+  VAR_CONFIDENCE=0.95
+```
+
+The flow is deliberately separate from the minute-labelled demo pipeline:
+
+```text
+Alpha Vantage TIME_SERIES_DAILY
+  -> validated, immutable raw market events
+  -> one-day returns
+  -> annualised rolling volatility
+  -> historical VaR loss and maximum drawdown
+  -> versioned curated Parquet
+  -> PostgreSQL version history and current-serving views
+```
+
+Curated datasets are written under `data/curated/daily_returns`,
+`data/curated/daily_volatility` and `data/curated/daily_risk_summary`. Replaying
+the same source history and parameters writes zero duplicate records. A late
+historical observation produces a new calculation fingerprint rather than
+silently replacing earlier analytical evidence. The command writes a
+credential-free summary to `.demo/daily-risk-summary.json`.
+
+Inspect the warehouse batch before connecting to PostgreSQL:
+
+```bash
+make daily-risk-warehouse-dry-run
+```
+
+Load all available local outputs and run the focused daily reconciliation checks:
+
+```bash
+make local-db-up
+make daily-risk-warehouse-load
+make check-daily-risk-consistency
+```
+
+The warehouse retains every `calculation_id` and exposes
+`risk_platform.latest_daily_risk_summary` for one current row per source,
+symbol, event date, model version and parameter set. The source-aware
+`risk_platform.daily_risk_semantic_model` joins reference data on both `symbol`
+and `source`.
+
+No live provider request runs in CI or `make readiness-check`; tests inject or
+land deterministic Alpha Vantage-shaped events. See
+`docs/daily-risk-pipeline.md` for grains, formulas, replay behaviour and serving
+contracts.
+
+## Portfolio Daily Risk Path
+
+Create daily-return history for every constituent in a configured portfolio:
+
+```bash
+export ALPHA_VANTAGE_API_KEY='set-locally-do-not-commit'
+
+make daily-risk-demo SYMBOL=AAPL END_DATE=2026-03-31
+make daily-risk-demo SYMBOL=MSFT END_DATE=2026-03-31
+```
+
+Then calculate the configured portfolio without another provider request:
+
+```bash
+make portfolio-risk-demo \
+  PORTFOLIO_ID=us-tech-equal \
+  END_DATE=2026-03-31 \
+  VOL_WINDOW=20 \
+  VAR_WINDOW=60 \
+  VAR_CONFIDENCE=0.95
+```
+
+The portfolio definition comes from `config/portfolios.yaml`. The current
+implementation supports two to fifty unique, positive, long-only constituents
+whose weights sum to one. It aligns only dates available for every constituent
+and persists the weighting assumption as:
+
+```text
+constant_weight_daily_rebalanced
+```
+
+The resulting datasets are:
+
+```text
+data/curated/portfolio_daily_returns
+data/curated/portfolio_daily_risk_summary
+```
+
+Each row retains deterministic source calculation IDs, component returns,
+weights and contributions. A corrected component or changed weight definition
+creates a new version rather than overwriting prior evidence.
+
+Inspect, load and reconcile the portfolio warehouse contract:
+
+```bash
+make portfolio-risk-warehouse-dry-run
+make local-db-up
+make portfolio-risk-warehouse-load
+make check-portfolio-risk-consistency
+```
+
+PostgreSQL retains every portfolio calculation in:
+
+```text
+risk_platform.portfolio_daily_returns
+risk_platform.portfolio_daily_risk_summary
+```
+
+Reporting consumers can use:
+
+```text
+risk_platform.latest_portfolio_daily_returns
+risk_platform.latest_portfolio_daily_risk_summary
+risk_platform.portfolio_risk_semantic_model
+risk_platform.portfolio_daily_contribution_model
+```
+
+The definition fingerprint remains part of each current-version grain. Different
+weight sets using the same portfolio name therefore remain independently
+queryable. See `docs/portfolio-risk.md` for alignment, weighting, versioning,
+serving and reconciliation details.
+
+## Portfolio Covariance And Attribution Path
+
+After portfolio returns exist, calculate one bounded latest-window covariance and
+volatility-attribution snapshot without another provider request:
+
+```bash
+make portfolio-attribution-demo \
+  PORTFOLIO_ID=us-tech-equal \
+  END_DATE=2026-03-31 \
+  COVARIANCE_WINDOW=20
+```
+
+The snapshot stores annualised sample covariance, Pearson correlation,
+constituent volatility, marginal volatility contribution, Euler component
+contribution and contribution shares in:
+
+```text
+data/curated/portfolio_risk_attribution
+```
+
+Inspect, load and reconcile the attribution warehouse contract:
+
+```bash
+make portfolio-attribution-warehouse-dry-run
+make local-db-up
+make portfolio-attribution-warehouse-load
+make check-portfolio-attribution-consistency
+```
+
+PostgreSQL retains every snapshot in:
+
+```text
+risk_platform.portfolio_risk_attribution
+```
+
+Current and row-level reporting contracts are:
+
+```text
+risk_platform.latest_portfolio_risk_attribution
+risk_platform.portfolio_attribution_semantic_model
+risk_platform.portfolio_covariance_model
+risk_platform.portfolio_correlation_model
+risk_platform.portfolio_volatility_contribution_model
+```
+
+The current grain preserves the portfolio definition, event date, model,
+weighting method, covariance and correlation methods, covariance window and
+annualisation basis. Matrix views expose one ordered constituent pair per row;
+the volatility-contribution view exposes one constituent per row. Undefined
+zero-variance correlations remain SQL `NULL`, not non-standard `NaN`.
+
+See `docs/portfolio-attribution.md` for formulas, version selection, JSON
+evidence, warehouse constraints and reconciliation.
+
+## Data Sources
+
+The implemented external market source is Alpha Vantage daily time series. The
+repository also demonstrates provider-neutral landed files and external risk
+signals. Stooq, FRED and exchange-calendar integrations remain useful future
+exercises rather than production-owned claims.
+
+See `docs/data-model.md` for the shared event schemas.
+
+## Repository Layout
+
+See `docs/architecture.md` for the end-to-end design.
+
+Additional preparation and operating notes:
+
+0. `AGENTS.md` for durable project instructions used by coding agents
+1. `docs/demo-script.md` for a short technical walkthrough
+2. `docs/daily-risk-pipeline.md` for the real daily source-to-serving path
+3. `docs/portfolio-risk.md` for multi-symbol portfolio analytics and serving
+4. `docs/portfolio-attribution.md` for covariance and component-risk attribution
+5. `docs/preparation-plan.md` for interview preparation
+6. `docs/interview-stories.md` for interview story rehearsal
+7. `docs/mock-interview.md` for timed interview practice
+8. `docs/elt-mapping.md` for connector-based ELT mapping
+9. `docs/source-document-mapping.md` for nested source document flattening
+10. `docs/postgres-mongodb-walkthrough.md` for local source-to-warehouse inspection
+11. `docs/data-consistency-walkthrough.md` for source-to-warehouse reconciliation
+12. `docs/aws-managed-databases.md` for disabled-by-default database IaC
+13. `docs/lambda-s3-orchestration.md` for AWS orchestration mapping
+14. `sql/postgres_schema.sql` and `sql/ops_queries.sql` for warehouse examples
+15. `docs/agentic-workflows.md` for larger delegated development workflows
+16. `docs/engineering-delivery-workflow.md` for the controlled agent loop
+17. `docs/agent-roles.md` for splitting work across bounded roles
+18. `docs/overnight-sandbox.md` for safe unattended validation runs
+19. `docs/overnight-development.md` for guarded candidate-branch controls
+20. `docs/security-protocols.md` for local and cloud safety controls
+21. `docs/operational-runbook.md` for local failure investigation
+22. `docs/iteration-loop.md` and `docs/iteration-backlog.md` for continued iterations
+
+## Local Database Playground
+
+An optional Docker Compose playground starts PostgreSQL and MongoDB with seeded
+demo data:
+
+```bash
+make local-db-up
+make consistency-demo
+make postgres-shell
+make mongo-shell
+make local-db-down
+```
+
+See `docs/postgres-mongodb-walkthrough.md` and
+`docs/data-consistency-walkthrough.md` for the full inspection and reconciliation
+flow. The PostgreSQL serving layer includes:
+
+```text
+symbol_dimension_history -> current_symbol_dimension -> finance_risk_semantic_model
+                                                  \-> daily_risk_semantic_model
+portfolio_daily_returns -> portfolio_daily_risk_summary
+                         -> portfolio current and return-contribution views
+portfolio_risk_attribution
+  -> current attribution
+  -> covariance / correlation / volatility-contribution views
+```
+
+The original semantic view demonstrates SCD Type 2 enrichment for the
+minute-oriented demo. The daily view preserves model versions and performs a
+source-aware dimension join. Portfolio and attribution views preserve definition
+and parameter versions while exposing queryable constituent grains.
+
+## Performance Benchmark
+
+Compare CSV scans with partitioned Parquet scans:
+
+```bash
+make benchmark-io
+```
+
+See `docs/performance-benchmark.md` for details.
+
+## Generated Files
+
+Pipeline runs write generated Parquet under `data/`; demo summaries can be
+written under `.demo/`. Both are ignored by Git. Keep reusable sample inputs
+under `tests/fixtures/` and run `make clean-generated` before a fresh demo.
+
+## Security And Readiness Checks
+
+```bash
+make security-check
+make quality-check
+make readiness-check
+```
+
+`make quality-check` includes linting, type checking, the test suite and
+`pip check`. CI installs through the reviewed constraints file before running
+the same checks.
+
+For validation-only unattended loops:
+
+```bash
+make sandbox-once
+make overnight-sandbox
+```
+
+The sandbox writes ignored logs under `.sandbox/` and never pushes, merges,
+deploys or runs `terraform apply`. For a bounded improvement iteration:
+
+```bash
+make iteration-check
+make morning-review
+```
+
+The review package is evidence for human inspection, not approval.
+
+## Deployment
+
+The deployment scaffold uses Docker, GitHub Actions, Amazon ECR and Kubernetes
+CronJobs with separate `dev` and `prod` overlays. See `deploy/README.md`.
+Managed cloud resources remain disabled by default.
+
+## Notes
+
+This is a portfolio-grade platform. Local behaviour and tests substantiate its
+claims; scaffolded cloud services are not described as production-owned.

--- a/README.md
+++ b/README.md
@@ -1,395 +1,68 @@
 # Financial Risk Data Platform
 
-A production-style data platform that ingests market data and external risk
-signals, validates and normalises events, and produces decision-ready analytics
-such as returns, volatility, data quality and risk summaries.
+A production-style data engineering portfolio project for ingesting market data and external risk signals, retaining replayable evidence, calculating versioned risk analytics, and serving governed PostgreSQL views.
 
-This repository is intentionally structured like a small internal platform at a
-bank or fintech. It prioritises reproducibility, replay safety, explicit data
-grains and interview-ready engineering evidence.
+**Python · SQL · PostgreSQL · Parquet · Docker · GitHub Actions**
 
-## What It Does
+## At a glance
 
-1. Ingests market data and external signals.
-2. Validates schemas, normalises symbols and deduplicates events.
-3. Retains immutable, partitioned raw Parquet for replay.
-4. Builds minute-oriented, single-symbol daily, portfolio and attribution analytics.
-5. Stores curated Parquet and serves versioned outputs through PostgreSQL views.
+| Area | Implementation focus |
+| --- | --- |
+| Ingestion | Schema validation, symbol normalisation, deterministic deduplication and immutable raw Parquet |
+| Analytics | Daily returns, rolling volatility, historical VaR, maximum drawdown, portfolio risk, covariance and attribution |
+| Serving | Append-only PostgreSQL history with current-version and semantic reporting views |
+| Reliability | Explicit grains, replay safety, late-data versioning, reconciliation and data-quality evidence |
+| Delivery | Reproducible dependency resolution, automated tests, security checks and disabled-by-default cloud scaffolding |
 
-## Quickstart
+## Architecture
+
+```text
+market data + external signals
+            ↓
+validation · normalisation · deduplication
+            ↓
+immutable partitioned raw Parquet
+            ↓
+versioned daily, portfolio and attribution models
+            ↓
+curated Parquet + append-only PostgreSQL history
+            ↓
+current views · semantic models · reconciliation evidence
+```
+
+## What this project demonstrates
+
+- Designing data contracts with explicit business and calculation grains.
+- Replaying identical inputs without creating duplicate analytical evidence.
+- Preserving corrected or late observations as new calculation versions rather than silently overwriting history.
+- Separating immutable storage, curated analytical models and consumer-facing database views.
+- Treating lineage, reconciliation, readiness and security checks as part of the product rather than optional documentation.
+- Building a project that can be demonstrated locally without claiming that scaffolded cloud services are production-deployed.
+
+## Run the credential-free walkthrough
 
 ```bash
 make setup
-make test
-make security-check
-```
-
-The Makefile uses `.venv/bin/python` by default, so commands work without
-activating the environment after `make setup`. Dependency resolution is
-constrained by `requirements.lock`, which is refreshed deliberately after a full
-green CI run.
-
-The equivalent manual setup is:
-
-```bash
-python3 -m venv .venv
-PIP_CONSTRAINT=requirements.lock .venv/bin/python -m pip install -e '.[dev]'
-.venv/bin/python -m pip check
-.venv/bin/python -m pytest -q
-```
-
-## Run The Demo Pipeline
-
-Run the sample event-to-curated path:
-
-```bash
-.venv/bin/python -m src.orchestration.run_pipeline
-```
-
-Provide a JSON list of market events:
-
-```bash
-.venv/bin/python -m src.orchestration.run_pipeline \
-  --input tests/fixtures/sample_events.json
-```
-
-For the fuller local walkthrough with duplicates, a late event and curated
-metrics:
-
-```bash
 make readiness-check
 ```
 
-The demo writes `.demo/pipeline-summary.json` and `.demo/lineage.json`. The
-lineage manifest traces source inventory, transformations, raw and curated
-outputs, data-quality checks and the reporting-view dependency. See
-`docs/demo-script.md` for the five-minute interview walkthrough.
+The walkthrough exercises the sample ingestion-to-curated path, including duplicate and late-event behaviour, and writes credential-free evidence under `.demo/`.
 
-Include landed external risk signals when running the sample pipeline:
+For focused commands and a five-minute walkthrough, see [`docs/demo-script.md`](docs/demo-script.md).
 
-```bash
-.venv/bin/python -m src.orchestration.run_pipeline \
-  --input tests/fixtures/sample_events.json \
-  --signals path/to/signals.json
-```
+## Explore the evidence
 
-## Alpha Vantage Daily Risk Path
+| Topic | Starting point |
+| --- | --- |
+| End-to-end architecture | [`docs/architecture.md`](docs/architecture.md) |
+| Daily market-risk path | [`docs/daily-risk-pipeline.md`](docs/daily-risk-pipeline.md) |
+| Portfolio returns and risk | [`docs/portfolio-risk.md`](docs/portfolio-risk.md) |
+| Covariance and attribution | [`docs/portfolio-attribution.md`](docs/portfolio-attribution.md) |
+| Source-to-warehouse reconciliation | [`docs/data-consistency-walkthrough.md`](docs/data-consistency-walkthrough.md) |
+| Security controls | [`docs/security-protocols.md`](docs/security-protocols.md) |
+| Operating and failure investigation | [`docs/operational-runbook.md`](docs/operational-runbook.md) |
+| Complete command and capability reference | [`PROJECT_REFERENCE.md`](PROJECT_REFERENCE.md) |
 
-With an Alpha Vantage API key already present in the environment, run one
-bounded source-to-curated daily-risk cycle:
+## Project boundary
 
-```bash
-export ALPHA_VANTAGE_API_KEY='set-locally-do-not-commit'
-make daily-risk-demo SYMBOL=IBM
-```
-
-The command defaults to completed daily bars ending yesterday in UTC. Optional
-bounds and model parameters can be supplied without changing code:
-
-```bash
-make daily-risk-demo \
-  SYMBOL=IBM \
-  START_DATE=2026-01-01 \
-  END_DATE=2026-03-31 \
-  MAX_RECORDS=100 \
-  VOL_WINDOW=20 \
-  VAR_WINDOW=60 \
-  VAR_CONFIDENCE=0.95
-```
-
-The flow is deliberately separate from the minute-labelled demo pipeline:
-
-```text
-Alpha Vantage TIME_SERIES_DAILY
-  -> validated, immutable raw market events
-  -> one-day returns
-  -> annualised rolling volatility
-  -> historical VaR loss and maximum drawdown
-  -> versioned curated Parquet
-  -> PostgreSQL version history and current-serving views
-```
-
-Curated datasets are written under `data/curated/daily_returns`,
-`data/curated/daily_volatility` and `data/curated/daily_risk_summary`. Replaying
-the same source history and parameters writes zero duplicate records. A late
-historical observation produces a new calculation fingerprint rather than
-silently replacing earlier analytical evidence. The command writes a
-credential-free summary to `.demo/daily-risk-summary.json`.
-
-Inspect the warehouse batch before connecting to PostgreSQL:
-
-```bash
-make daily-risk-warehouse-dry-run
-```
-
-Load all available local outputs and run the focused daily reconciliation checks:
-
-```bash
-make local-db-up
-make daily-risk-warehouse-load
-make check-daily-risk-consistency
-```
-
-The warehouse retains every `calculation_id` and exposes
-`risk_platform.latest_daily_risk_summary` for one current row per source,
-symbol, event date, model version and parameter set. The source-aware
-`risk_platform.daily_risk_semantic_model` joins reference data on both `symbol`
-and `source`.
-
-No live provider request runs in CI or `make readiness-check`; tests inject or
-land deterministic Alpha Vantage-shaped events. See
-`docs/daily-risk-pipeline.md` for grains, formulas, replay behaviour and serving
-contracts.
-
-## Portfolio Daily Risk Path
-
-Create daily-return history for every constituent in a configured portfolio:
-
-```bash
-export ALPHA_VANTAGE_API_KEY='set-locally-do-not-commit'
-
-make daily-risk-demo SYMBOL=AAPL END_DATE=2026-03-31
-make daily-risk-demo SYMBOL=MSFT END_DATE=2026-03-31
-```
-
-Then calculate the configured portfolio without another provider request:
-
-```bash
-make portfolio-risk-demo \
-  PORTFOLIO_ID=us-tech-equal \
-  END_DATE=2026-03-31 \
-  VOL_WINDOW=20 \
-  VAR_WINDOW=60 \
-  VAR_CONFIDENCE=0.95
-```
-
-The portfolio definition comes from `config/portfolios.yaml`. The current
-implementation supports two to fifty unique, positive, long-only constituents
-whose weights sum to one. It aligns only dates available for every constituent
-and persists the weighting assumption as:
-
-```text
-constant_weight_daily_rebalanced
-```
-
-The resulting datasets are:
-
-```text
-data/curated/portfolio_daily_returns
-data/curated/portfolio_daily_risk_summary
-```
-
-Each row retains deterministic source calculation IDs, component returns,
-weights and contributions. A corrected component or changed weight definition
-creates a new version rather than overwriting prior evidence.
-
-Inspect, load and reconcile the portfolio warehouse contract:
-
-```bash
-make portfolio-risk-warehouse-dry-run
-make local-db-up
-make portfolio-risk-warehouse-load
-make check-portfolio-risk-consistency
-```
-
-PostgreSQL retains every portfolio calculation in:
-
-```text
-risk_platform.portfolio_daily_returns
-risk_platform.portfolio_daily_risk_summary
-```
-
-Reporting consumers can use:
-
-```text
-risk_platform.latest_portfolio_daily_returns
-risk_platform.latest_portfolio_daily_risk_summary
-risk_platform.portfolio_risk_semantic_model
-risk_platform.portfolio_daily_contribution_model
-```
-
-The definition fingerprint remains part of each current-version grain. Different
-weight sets using the same portfolio name therefore remain independently
-queryable. See `docs/portfolio-risk.md` for alignment, weighting, versioning,
-serving and reconciliation details.
-
-## Portfolio Covariance And Attribution Path
-
-After portfolio returns exist, calculate one bounded latest-window covariance and
-volatility-attribution snapshot without another provider request:
-
-```bash
-make portfolio-attribution-demo \
-  PORTFOLIO_ID=us-tech-equal \
-  END_DATE=2026-03-31 \
-  COVARIANCE_WINDOW=20
-```
-
-The snapshot stores annualised sample covariance, Pearson correlation,
-constituent volatility, marginal volatility contribution, Euler component
-contribution and contribution shares in:
-
-```text
-data/curated/portfolio_risk_attribution
-```
-
-Inspect, load and reconcile the attribution warehouse contract:
-
-```bash
-make portfolio-attribution-warehouse-dry-run
-make local-db-up
-make portfolio-attribution-warehouse-load
-make check-portfolio-attribution-consistency
-```
-
-PostgreSQL retains every snapshot in:
-
-```text
-risk_platform.portfolio_risk_attribution
-```
-
-Current and row-level reporting contracts are:
-
-```text
-risk_platform.latest_portfolio_risk_attribution
-risk_platform.portfolio_attribution_semantic_model
-risk_platform.portfolio_covariance_model
-risk_platform.portfolio_correlation_model
-risk_platform.portfolio_volatility_contribution_model
-```
-
-The current grain preserves the portfolio definition, event date, model,
-weighting method, covariance and correlation methods, covariance window and
-annualisation basis. Matrix views expose one ordered constituent pair per row;
-the volatility-contribution view exposes one constituent per row. Undefined
-zero-variance correlations remain SQL `NULL`, not non-standard `NaN`.
-
-See `docs/portfolio-attribution.md` for formulas, version selection, JSON
-evidence, warehouse constraints and reconciliation.
-
-## Data Sources
-
-The implemented external market source is Alpha Vantage daily time series. The
-repository also demonstrates provider-neutral landed files and external risk
-signals. Stooq, FRED and exchange-calendar integrations remain useful future
-exercises rather than production-owned claims.
-
-See `docs/data-model.md` for the shared event schemas.
-
-## Repository Layout
-
-See `docs/architecture.md` for the end-to-end design.
-
-Additional preparation and operating notes:
-
-0. `AGENTS.md` for durable project instructions used by coding agents
-1. `docs/demo-script.md` for a short technical walkthrough
-2. `docs/daily-risk-pipeline.md` for the real daily source-to-serving path
-3. `docs/portfolio-risk.md` for multi-symbol portfolio analytics and serving
-4. `docs/portfolio-attribution.md` for covariance and component-risk attribution
-5. `docs/preparation-plan.md` for interview preparation
-6. `docs/interview-stories.md` for interview story rehearsal
-7. `docs/mock-interview.md` for timed interview practice
-8. `docs/elt-mapping.md` for connector-based ELT mapping
-9. `docs/source-document-mapping.md` for nested source document flattening
-10. `docs/postgres-mongodb-walkthrough.md` for local source-to-warehouse inspection
-11. `docs/data-consistency-walkthrough.md` for source-to-warehouse reconciliation
-12. `docs/aws-managed-databases.md` for disabled-by-default database IaC
-13. `docs/lambda-s3-orchestration.md` for AWS orchestration mapping
-14. `sql/postgres_schema.sql` and `sql/ops_queries.sql` for warehouse examples
-15. `docs/agentic-workflows.md` for larger delegated development workflows
-16. `docs/engineering-delivery-workflow.md` for the controlled agent loop
-17. `docs/agent-roles.md` for splitting work across bounded roles
-18. `docs/overnight-sandbox.md` for safe unattended validation runs
-19. `docs/overnight-development.md` for guarded candidate-branch controls
-20. `docs/security-protocols.md` for local and cloud safety controls
-21. `docs/operational-runbook.md` for local failure investigation
-22. `docs/iteration-loop.md` and `docs/iteration-backlog.md` for continued iterations
-
-## Local Database Playground
-
-An optional Docker Compose playground starts PostgreSQL and MongoDB with seeded
-demo data:
-
-```bash
-make local-db-up
-make consistency-demo
-make postgres-shell
-make mongo-shell
-make local-db-down
-```
-
-See `docs/postgres-mongodb-walkthrough.md` and
-`docs/data-consistency-walkthrough.md` for the full inspection and reconciliation
-flow. The PostgreSQL serving layer includes:
-
-```text
-symbol_dimension_history -> current_symbol_dimension -> finance_risk_semantic_model
-                                                  \-> daily_risk_semantic_model
-portfolio_daily_returns -> portfolio_daily_risk_summary
-                         -> portfolio current and return-contribution views
-portfolio_risk_attribution
-  -> current attribution
-  -> covariance / correlation / volatility-contribution views
-```
-
-The original semantic view demonstrates SCD Type 2 enrichment for the
-minute-oriented demo. The daily view preserves model versions and performs a
-source-aware dimension join. Portfolio and attribution views preserve definition
-and parameter versions while exposing queryable constituent grains.
-
-## Performance Benchmark
-
-Compare CSV scans with partitioned Parquet scans:
-
-```bash
-make benchmark-io
-```
-
-See `docs/performance-benchmark.md` for details.
-
-## Generated Files
-
-Pipeline runs write generated Parquet under `data/`; demo summaries can be
-written under `.demo/`. Both are ignored by Git. Keep reusable sample inputs
-under `tests/fixtures/` and run `make clean-generated` before a fresh demo.
-
-## Security And Readiness Checks
-
-```bash
-make security-check
-make quality-check
-make readiness-check
-```
-
-`make quality-check` includes linting, type checking, the test suite and
-`pip check`. CI installs through the reviewed constraints file before running
-the same checks.
-
-For validation-only unattended loops:
-
-```bash
-make sandbox-once
-make overnight-sandbox
-```
-
-The sandbox writes ignored logs under `.sandbox/` and never pushes, merges,
-deploys or runs `terraform apply`. For a bounded improvement iteration:
-
-```bash
-make iteration-check
-make morning-review
-```
-
-The review package is evidence for human inspection, not approval.
-
-## Deployment
-
-The deployment scaffold uses Docker, GitHub Actions, Amazon ECR and Kubernetes
-CronJobs with separate `dev` and `prod` overlays. See `deploy/README.md`.
-Managed cloud resources remain disabled by default.
-
-## Notes
-
-This is a portfolio-grade platform. Local behaviour and tests substantiate its
-claims; scaffolded cloud services are not described as production-owned.
+This is a portfolio-grade engineering project. Local behaviour, tests and generated evidence substantiate the implemented claims. Managed cloud resources and external notification paths remain explicitly disabled or human-controlled unless separately configured.


### PR DESCRIPTION
## Goal

Make the flagship repository understandable to a recruiter or engineering reviewer in under a minute without deleting the detailed technical material.

## Changes

- replaces the very long landing page with a concise portfolio overview;
- surfaces the architecture, engineering guarantees, local walkthrough and strongest evidence links;
- preserves the previous README unchanged as `PROJECT_REFERENCE.md`; and
- leaves source code, tests, dependencies, workflows and runtime behaviour untouched.

## Validation

The exact branch head passed repository CI before this non-draft replacement PR was opened.

This replaces draft PR #128 because the connected GitHub ready-for-review mutation is currently unavailable.