### PR TITLE
Add read-only notification execution readiness gate

### DIFF
--- a/docs/notification-execution-readiness-gate.md
+++ b/docs/notification-execution-readiness-gate.md
@@ -1,0 +1,107 @@
+# Read-Only Notification Execution Readiness Gate
+
+Primary arc42 blocks: `orchestration` and `warehouse`.
+
+## Goal
+
+P4d5a adds a deterministic, read-only decision before notification execution:
+
+```text
+reviewed delivery configuration
+  + reviewed destination fingerprint
+  + current activation and receiver evidence
+  + current rotate / disable / rollback evidence
+  + unresolved persistence ambiguity
+  -> one exact allow or block decision
+```
+
+The model is
+`portfolio-risk-notification-execution-readiness-gate-v1`.
+
+The gate evaluates `initial` and `retry` execution independently. It does not
+send a notification, resolve an endpoint value, write a delivery attempt, mutate
+the outbox, acknowledge a risk event, or deploy infrastructure.
+
+## Evidence
+
+The gate binds the current reviewed evidence for one destination:
+
+- webhook delivery configuration and fingerprint;
+- retry-execution policy and fingerprint;
+- destination ID, fingerprint, endpoint environment-variable identity, and
+  activation status;
+- activation checklist, authority, receiver rehearsal, and current review
+  status;
+- latest destination transition rehearsal and current transition status; and
+- unresolved retry persistence uncertainty, including unbound ambiguity.
+
+PostgreSQL access is read-only. The reader selects from:
+
+```text
+risk_platform.current_notification_activation_rehearsal_review
+risk_platform.current_notification_destination_transition_review
+risk_platform.current_notification_retry_destination_ambiguities
+```
+
+The gate rejects duplicate current grains and bounded ambiguity overflow rather
+than choosing evidence nondeterministically.
+
+## Blocking reasons
+
+Blocking reasons use fixed policy order:
+
+```text
+delivery_disabled
+retry_execution_disabled
+destination_not_active
+configuration_mismatch
+activation_review_missing
+activation_not_ready
+activation_identity_mismatch
+transition_review_missing
+transition_rehearsal_missing
+transition_rehearsal_superseded
+transition_not_ready
+transition_identity_mismatch
+persistence_ambiguity
+```
+
+The order is part of the decision identity. A changed configuration, destination
+fingerprint, checklist, authority, transition rehearsal, ambiguity event,
+execution kind, evaluation time, or reason set produces a different
+`decision_id`.
+
+An `allow` decision therefore means all of the following are true at the
+evaluation time:
+
+```text
+delivery configuration enabled
+destination review active
+delivery endpoint environment identity matches the destination
+activation and controlled-receiver review ready
+transition rehearsal ready and matched to current activation
+no unresolved persistence ambiguity
+retry execution enabled when execution_kind = retry
+```
+
+## Fail-closed behaviour
+
+The gate blocks rather than guessing when evidence is missing, stale,
+superseded, mismatched, or ambiguous. An ambiguity without a destination binding
+also blocks because the system cannot safely prove that it belongs elsewhere.
+
+The gate is evidence, not execution authority on its own. P4d5b will retain the
+decision append-only. P4d5c will refresh and enforce an exact current `allow`
+decision while holding the shared notification delivery lock.
+
+## Safety boundary
+
+Delivery and manual retry execution remain disabled by default. Normal
+validation:
+
+- performs no DNS lookup or socket operation;
+- performs no provider or webhook request;
+- writes no delivery attempt;
+- mutates no outbox or acknowledgement;
+- stores no endpoint value, credential, payload body, response body, or DSN; and
+- does not run `terraform apply`.

--- a/src/warehouse/notification_execution_readiness_gate.py
+++ b/src/warehouse/notification_execution_readiness_gate.py
@@ -631,10 +631,11 @@ def _canonical_ambiguity_summary(value: Any) -> dict[str, Any]:
         values = summary[key]
         if not isinstance(values, list):
             raise ValidationError(f"{key} must be an array")
-        parsed = [_safe_text(item, f"{key} item") for item in values]
+        parsed_optional = [_safe_text(item, f"{key} item") for item in values]
+        parsed = [item for item in parsed_optional if item is not None]
         if parsed != sorted(set(parsed)):
             raise ValidationError(f"{key} must be sorted with no duplicates")
-        parsed_lists[key] = [item for item in parsed if item is not None]
+        parsed_lists[key] = parsed
     if count != len(parsed_lists["event_ids"]) or count != len(
         parsed_lists["record_ids"]
     ):

--- a/src/warehouse/notification_execution_readiness_gate.py
+++ b/src/warehouse/notification_execution_readiness_gate.py
@@ -1,0 +1,972 @@
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import sys
+from collections.abc import Callable, Mapping, Sequence
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from src.common.exceptions import StorageError, ValidationError
+from src.orchestration.deliver_portfolio_risk_notifications import (
+    WebhookDeliveryConfig,
+)
+from src.orchestration.portfolio_risk_notification_destination_contract import (
+    NotificationDestination,
+    evaluate_destination_activation,
+    load_notification_destinations,
+)
+from src.orchestration.portfolio_risk_notification_retry_execution_policy import (
+    RetryExecutionPolicy,
+    aware_utc,
+    load_retry_execution_contract,
+)
+from src.warehouse.postgres_loader import DEFAULT_POSTGRES_DSN
+
+MODEL_VERSION = "portfolio-risk-notification-execution-readiness-gate-v1"
+EXECUTION_KINDS = frozenset({"initial", "retry"})
+MAX_AMBIGUITIES = 500
+SAFE_TEXT = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,511}$")
+ACTIVATION_STATUSES = frozenset(
+    {
+        "checklist_expired",
+        "checklist_incomplete",
+        "checklist_not_yet_active",
+        "ready",
+        "rehearsal_evidence_conflict",
+        "rehearsal_failed",
+        "rehearsal_missing",
+        "rehearsal_rejected",
+        "rehearsal_superseded",
+        "review_required",
+    }
+)
+TRANSITION_STATUSES = frozenset(
+    {
+        "activation_not_ready",
+        "ready",
+        "transition_rehearsal_missing",
+        "transition_rehearsal_superseded",
+    }
+)
+BLOCKING_REASON_ORDER = (
+    "delivery_disabled",
+    "retry_execution_disabled",
+    "destination_not_active",
+    "configuration_mismatch",
+    "activation_review_missing",
+    "activation_not_ready",
+    "activation_identity_mismatch",
+    "transition_review_missing",
+    "transition_rehearsal_missing",
+    "transition_rehearsal_superseded",
+    "transition_not_ready",
+    "transition_identity_mismatch",
+    "persistence_ambiguity",
+)
+SIDE_EFFECT_FLAGS = (
+    "acknowledgement_mutated",
+    "delivery_attempt_written",
+    "external_request_performed",
+    "outbox_mutated",
+)
+
+EvidenceReader = Callable[..., Mapping[str, Any]]
+
+
+def _safe_text(value: Any, label: str, *, optional: bool = False) -> str | None:
+    if value is None and optional:
+        return None
+    if not isinstance(value, str) or not SAFE_TEXT.fullmatch(value):
+        raise ValidationError(f"{label} must be one safe text segment")
+    return value
+
+
+def _aware_utc(value: Any, label: str) -> datetime:
+    return aware_utc(value, label)
+
+
+def _exact_mapping(value: Any, label: str, keys: set[str]) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        raise ValidationError(f"{label} must be a mapping")
+    actual = set(value)
+    if actual != keys:
+        raise ValidationError(
+            f"{label} fields are invalid; "
+            f"missing={sorted(keys - actual)}, unknown={sorted(actual - keys)}"
+        )
+    return value
+
+
+def _quote_identifier(value: str) -> str:
+    if not isinstance(value, str) or not value:
+        raise ValidationError("schema_name must be non-empty text")
+    return '"' + value.replace('"', '""') + '"'
+
+
+def _activation_review(value: Any) -> dict[str, Any] | None:
+    if value is None:
+        return None
+    review = _exact_mapping(
+        value,
+        "activation review",
+        {
+            "authority_id",
+            "checklist_id",
+            "destination_fingerprint",
+            "destination_id",
+            "operational_activation_ready",
+            "review_status",
+        },
+    )
+    ready = review["operational_activation_ready"]
+    if type(ready) is not bool:
+        raise ValidationError("activation review ready flag must be boolean")
+    status = review["review_status"]
+    if status not in ACTIVATION_STATUSES:
+        raise ValidationError("activation review status is unsupported")
+    return {
+        "authority_id": _safe_text(review["authority_id"], "activation authority_id"),
+        "checklist_id": _safe_text(review["checklist_id"], "activation checklist_id"),
+        "destination_fingerprint": _safe_text(
+            review["destination_fingerprint"],
+            "activation destination_fingerprint",
+        ),
+        "destination_id": _safe_text(
+            review["destination_id"],
+            "activation destination_id",
+        ),
+        "operational_activation_ready": ready,
+        "review_status": status,
+    }
+
+
+def _transition_review(value: Any) -> dict[str, Any] | None:
+    if value is None:
+        return None
+    review = _exact_mapping(
+        value,
+        "transition review",
+        {
+            "activation_review_status",
+            "current_authority_id",
+            "current_checklist_id",
+            "current_destination_fingerprint",
+            "destination_id",
+            "operational_activation_ready",
+            "rollback_authority_id",
+            "rollback_checklist_id",
+            "rollback_destination_fingerprint",
+            "rollback_endpoint_environment_variable",
+            "rollback_plan_id",
+            "transition_matches_current_activation",
+            "transition_ready",
+            "transition_record_id",
+            "transition_rehearsal_id",
+            "transition_review_status",
+        },
+    )
+    activation_ready = review["operational_activation_ready"]
+    transition_matches = review["transition_matches_current_activation"]
+    transition_ready = review["transition_ready"]
+    if any(
+        type(value) is not bool
+        for value in (activation_ready, transition_matches, transition_ready)
+    ):
+        raise ValidationError("transition review flags must be boolean")
+    status = review["transition_review_status"]
+    if status not in TRANSITION_STATUSES:
+        raise ValidationError("transition review status is unsupported")
+    activation_status = review["activation_review_status"]
+    if activation_status not in ACTIVATION_STATUSES:
+        raise ValidationError("transition activation status is unsupported")
+    return {
+        "activation_review_status": activation_status,
+        "current_authority_id": _safe_text(
+            review["current_authority_id"],
+            "transition current_authority_id",
+        ),
+        "current_checklist_id": _safe_text(
+            review["current_checklist_id"],
+            "transition current_checklist_id",
+        ),
+        "current_destination_fingerprint": _safe_text(
+            review["current_destination_fingerprint"],
+            "transition current_destination_fingerprint",
+        ),
+        "destination_id": _safe_text(
+            review["destination_id"],
+            "transition destination_id",
+        ),
+        "operational_activation_ready": activation_ready,
+        "rollback_authority_id": _safe_text(
+            review["rollback_authority_id"],
+            "transition rollback_authority_id",
+            optional=True,
+        ),
+        "rollback_checklist_id": _safe_text(
+            review["rollback_checklist_id"],
+            "transition rollback_checklist_id",
+            optional=True,
+        ),
+        "rollback_destination_fingerprint": _safe_text(
+            review["rollback_destination_fingerprint"],
+            "transition rollback_destination_fingerprint",
+            optional=True,
+        ),
+        "rollback_endpoint_environment_variable": _safe_text(
+            review["rollback_endpoint_environment_variable"],
+            "transition rollback_endpoint_environment_variable",
+            optional=True,
+        ),
+        "rollback_plan_id": _safe_text(
+            review["rollback_plan_id"],
+            "transition rollback_plan_id",
+            optional=True,
+        ),
+        "transition_matches_current_activation": transition_matches,
+        "transition_ready": transition_ready,
+        "transition_record_id": _safe_text(
+            review["transition_record_id"],
+            "transition record_id",
+            optional=True,
+        ),
+        "transition_rehearsal_id": _safe_text(
+            review["transition_rehearsal_id"],
+            "transition rehearsal_id",
+            optional=True,
+        ),
+        "transition_review_status": status,
+    }
+
+
+def _ambiguities(
+    values: Any,
+    *,
+    destination_id: str,
+) -> list[dict[str, Any]]:
+    if not isinstance(values, Sequence) or isinstance(values, (str, bytes)):
+        raise ValidationError("ambiguities must be a sequence")
+    if len(values) > MAX_AMBIGUITIES:
+        raise ValidationError("ambiguity evidence exceeds the reviewed maximum")
+    parsed: list[dict[str, Any]] = []
+    for index, value in enumerate(values, start=1):
+        ambiguity = _exact_mapping(
+            value,
+            f"ambiguity {index}",
+            {
+                "destination_binding_status",
+                "destination_bound",
+                "destination_fingerprint",
+                "destination_id",
+                "endpoint_environment_variable",
+                "event_id",
+                "latest_execution_record_id",
+                "uncertainty_record_id",
+            },
+        )
+        bound = ambiguity["destination_bound"]
+        if type(bound) is not bool:
+            raise ValidationError("ambiguity destination_bound must be boolean")
+        selected_destination_id = _safe_text(
+            ambiguity["destination_id"],
+            "ambiguity destination_id",
+            optional=True,
+        )
+        if selected_destination_id not in {None, destination_id}:
+            raise ValidationError("ambiguity belongs to another destination")
+        parsed.append(
+            {
+                "destination_binding_status": _safe_text(
+                    ambiguity["destination_binding_status"],
+                    "ambiguity destination_binding_status",
+                ),
+                "destination_bound": bound,
+                "destination_fingerprint": _safe_text(
+                    ambiguity["destination_fingerprint"],
+                    "ambiguity destination_fingerprint",
+                    optional=True,
+                ),
+                "destination_id": selected_destination_id,
+                "endpoint_environment_variable": _safe_text(
+                    ambiguity["endpoint_environment_variable"],
+                    "ambiguity endpoint_environment_variable",
+                    optional=True,
+                ),
+                "event_id": _safe_text(
+                    ambiguity["event_id"],
+                    "ambiguity event_id",
+                ),
+                "latest_execution_record_id": _safe_text(
+                    ambiguity["latest_execution_record_id"],
+                    "ambiguity latest_execution_record_id",
+                    optional=True,
+                ),
+                "uncertainty_record_id": _safe_text(
+                    ambiguity["uncertainty_record_id"],
+                    "ambiguity uncertainty_record_id",
+                ),
+            }
+        )
+    parsed.sort(key=lambda item: (item["event_id"], item["uncertainty_record_id"]))
+    event_ids = [item["event_id"] for item in parsed]
+    if len(event_ids) != len(set(event_ids)):
+        raise ValidationError("ambiguity event IDs must be unique")
+    return parsed
+
+
+def _configuration(
+    *,
+    delivery_config: WebhookDeliveryConfig,
+    retry_policy_fingerprint: str,
+    retry_execution_policy: RetryExecutionPolicy,
+) -> dict[str, Any]:
+    return {
+        "delivery_enabled": delivery_config.enabled,
+        "delivery_fingerprint": _safe_text(
+            delivery_config.fingerprint,
+            "delivery fingerprint",
+        ),
+        "endpoint_environment_variable": _safe_text(
+            delivery_config.endpoint_env,
+            "delivery endpoint environment variable",
+        ),
+        "retry_execution_enabled": retry_execution_policy.enabled,
+        "retry_execution_policy_fingerprint": _safe_text(
+            retry_execution_policy.fingerprint,
+            "retry execution policy fingerprint",
+        ),
+        "retry_policy_fingerprint": _safe_text(
+            retry_policy_fingerprint,
+            "retry policy fingerprint",
+        ),
+    }
+
+
+def _destination(
+    destination: NotificationDestination,
+    *,
+    evaluated_at: datetime,
+) -> dict[str, Any]:
+    activation = evaluate_destination_activation(
+        destination,
+        evaluated_at=evaluated_at,
+    )
+    return {
+        "activation_status": activation["activation"]["status"],
+        "destination_id": destination.destination_id,
+        "endpoint_environment_variable": destination.endpoint_env,
+        "fingerprint": destination.fingerprint,
+    }
+
+
+def _ambiguity_summary(values: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
+    return {
+        "count": len(values),
+        "event_ids": sorted(value["event_id"] for value in values),
+        "record_ids": sorted(value["uncertainty_record_id"] for value in values),
+        "unbound_event_ids": sorted(
+            value["event_id"]
+            for value in values
+            if value["destination_id"] is None or not value["destination_bound"]
+        ),
+    }
+
+
+def _derive_reasons(
+    *,
+    execution_kind: str,
+    configuration: Mapping[str, Any],
+    destination: Mapping[str, Any],
+    activation_review: Mapping[str, Any] | None,
+    transition_review: Mapping[str, Any] | None,
+    ambiguity: Mapping[str, Any],
+) -> list[str]:
+    present: set[str] = set()
+    if configuration["delivery_enabled"] is not True:
+        present.add("delivery_disabled")
+    if (
+        execution_kind == "retry"
+        and configuration["retry_execution_enabled"] is not True
+    ):
+        present.add("retry_execution_disabled")
+    if destination["activation_status"] != "active":
+        present.add("destination_not_active")
+    if (
+        configuration["endpoint_environment_variable"]
+        != destination["endpoint_environment_variable"]
+    ):
+        present.add("configuration_mismatch")
+
+    if activation_review is None:
+        present.add("activation_review_missing")
+    else:
+        if activation_review["operational_activation_ready"] is not True:
+            present.add("activation_not_ready")
+        if (
+            activation_review["destination_id"] != destination["destination_id"]
+            or activation_review["destination_fingerprint"]
+            != destination["fingerprint"]
+        ):
+            present.add("activation_identity_mismatch")
+
+    if transition_review is None:
+        present.add("transition_review_missing")
+    else:
+        status = transition_review["transition_review_status"]
+        if status == "transition_rehearsal_missing":
+            present.add("transition_rehearsal_missing")
+        elif status == "transition_rehearsal_superseded":
+            present.add("transition_rehearsal_superseded")
+        elif status != "ready":
+            present.add("transition_not_ready")
+        if transition_review["transition_ready"] is not (status == "ready"):
+            present.add("transition_not_ready")
+        if (
+            transition_review["destination_id"] != destination["destination_id"]
+            or transition_review["current_destination_fingerprint"]
+            != destination["fingerprint"]
+        ):
+            present.add("transition_identity_mismatch")
+        if activation_review is not None and (
+            transition_review["current_authority_id"]
+            != activation_review["authority_id"]
+            or transition_review["current_checklist_id"]
+            != activation_review["checklist_id"]
+            or transition_review["activation_review_status"]
+            != activation_review["review_status"]
+            or transition_review["operational_activation_ready"]
+            is not activation_review["operational_activation_ready"]
+        ):
+            present.add("transition_identity_mismatch")
+        if (
+            status == "ready"
+            and transition_review["transition_matches_current_activation"] is not True
+        ):
+            present.add("transition_identity_mismatch")
+
+    if ambiguity["count"] > 0:
+        present.add("persistence_ambiguity")
+    return [reason for reason in BLOCKING_REASON_ORDER if reason in present]
+
+
+def _decision_identity(
+    *,
+    execution_kind: str,
+    evaluated_at: str,
+    configuration: Mapping[str, Any],
+    destination: Mapping[str, Any],
+    activation_review: Mapping[str, Any] | None,
+    transition_review: Mapping[str, Any] | None,
+    ambiguity: Mapping[str, Any],
+    decision: str,
+    blocking_reasons: Sequence[str],
+) -> dict[str, Any]:
+    return {
+        "activation_review": activation_review,
+        "ambiguity": ambiguity,
+        "blocking_reasons": list(blocking_reasons),
+        "configuration": configuration,
+        "decision": decision,
+        "destination": destination,
+        "evaluated_at": evaluated_at,
+        "execution_kind": execution_kind,
+        "model_version": MODEL_VERSION,
+        "transition_review": transition_review,
+    }
+
+
+def _decision_id(identity: Mapping[str, Any]) -> str:
+    digest = hashlib.sha256(
+        json.dumps(
+            identity,
+            sort_keys=True,
+            separators=(",", ":"),
+            allow_nan=False,
+        ).encode("utf-8")
+    ).hexdigest()[:24]
+    return f"{MODEL_VERSION}-decision-{digest}"
+
+
+def evaluate_notification_execution_readiness(
+    *,
+    execution_kind: str,
+    evaluated_at: datetime | str,
+    delivery_config: WebhookDeliveryConfig,
+    retry_policy_fingerprint: str,
+    retry_execution_policy: RetryExecutionPolicy,
+    destination: NotificationDestination,
+    activation_review: Mapping[str, Any] | None,
+    transition_review: Mapping[str, Any] | None,
+    ambiguities: Sequence[Mapping[str, Any]],
+) -> dict[str, Any]:
+    if execution_kind not in EXECUTION_KINDS:
+        raise ValidationError("execution_kind must be initial or retry")
+    as_of = _aware_utc(evaluated_at, "evaluated_at")
+    selected_activation = _activation_review(activation_review)
+    selected_transition = _transition_review(transition_review)
+    selected_ambiguities = _ambiguities(
+        ambiguities,
+        destination_id=destination.destination_id,
+    )
+    configuration = _configuration(
+        delivery_config=delivery_config,
+        retry_policy_fingerprint=retry_policy_fingerprint,
+        retry_execution_policy=retry_execution_policy,
+    )
+    destination_evidence = _destination(destination, evaluated_at=as_of)
+    ambiguity = _ambiguity_summary(selected_ambiguities)
+    reasons = _derive_reasons(
+        execution_kind=execution_kind,
+        configuration=configuration,
+        destination=destination_evidence,
+        activation_review=selected_activation,
+        transition_review=selected_transition,
+        ambiguity=ambiguity,
+    )
+    decision = "allow" if not reasons else "block"
+    identity = _decision_identity(
+        execution_kind=execution_kind,
+        evaluated_at=as_of.isoformat(),
+        configuration=configuration,
+        destination=destination_evidence,
+        activation_review=selected_activation,
+        transition_review=selected_transition,
+        ambiguity=ambiguity,
+        decision=decision,
+        blocking_reasons=reasons,
+    )
+    return {
+        "decision_id": _decision_id(identity),
+        **identity,
+        "read_only": True,
+        "acknowledgement_mutated": False,
+        "delivery_attempt_written": False,
+        "external_request_performed": False,
+        "outbox_mutated": False,
+    }
+
+
+def _canonical_configuration(value: Any) -> dict[str, Any]:
+    configuration = _exact_mapping(
+        value,
+        "readiness configuration",
+        {
+            "delivery_enabled",
+            "delivery_fingerprint",
+            "endpoint_environment_variable",
+            "retry_execution_enabled",
+            "retry_execution_policy_fingerprint",
+            "retry_policy_fingerprint",
+        },
+    )
+    for flag in ("delivery_enabled", "retry_execution_enabled"):
+        if type(configuration[flag]) is not bool:
+            raise ValidationError(f"{flag} must be boolean")
+    return {
+        "delivery_enabled": configuration["delivery_enabled"],
+        "delivery_fingerprint": _safe_text(
+            configuration["delivery_fingerprint"],
+            "delivery_fingerprint",
+        ),
+        "endpoint_environment_variable": _safe_text(
+            configuration["endpoint_environment_variable"],
+            "endpoint_environment_variable",
+        ),
+        "retry_execution_enabled": configuration["retry_execution_enabled"],
+        "retry_execution_policy_fingerprint": _safe_text(
+            configuration["retry_execution_policy_fingerprint"],
+            "retry_execution_policy_fingerprint",
+        ),
+        "retry_policy_fingerprint": _safe_text(
+            configuration["retry_policy_fingerprint"],
+            "retry_policy_fingerprint",
+        ),
+    }
+
+
+def _canonical_destination(value: Any) -> dict[str, Any]:
+    destination = _exact_mapping(
+        value,
+        "readiness destination",
+        {
+            "activation_status",
+            "destination_id",
+            "endpoint_environment_variable",
+            "fingerprint",
+        },
+    )
+    status = destination["activation_status"]
+    if status not in {"active", "disabled", "not_yet_reviewed", "review_expired"}:
+        raise ValidationError("destination activation status is unsupported")
+    return {
+        "activation_status": status,
+        "destination_id": _safe_text(destination["destination_id"], "destination_id"),
+        "endpoint_environment_variable": _safe_text(
+            destination["endpoint_environment_variable"],
+            "destination endpoint environment variable",
+        ),
+        "fingerprint": _safe_text(
+            destination["fingerprint"],
+            "destination fingerprint",
+        ),
+    }
+
+
+def _canonical_ambiguity_summary(value: Any) -> dict[str, Any]:
+    summary = _exact_mapping(
+        value,
+        "readiness ambiguity",
+        {"count", "event_ids", "record_ids", "unbound_event_ids"},
+    )
+    count = summary["count"]
+    if type(count) is not int or not 0 <= count <= MAX_AMBIGUITIES:
+        raise ValidationError("ambiguity count is outside the reviewed maximum")
+    parsed_lists: dict[str, list[str]] = {}
+    for key in ("event_ids", "record_ids", "unbound_event_ids"):
+        values = summary[key]
+        if not isinstance(values, list):
+            raise ValidationError(f"{key} must be an array")
+        parsed = [_safe_text(item, f"{key} item") for item in values]
+        if parsed != sorted(set(parsed)):
+            raise ValidationError(f"{key} must be sorted with no duplicates")
+        parsed_lists[key] = [item for item in parsed if item is not None]
+    if count != len(parsed_lists["event_ids"]) or count != len(
+        parsed_lists["record_ids"]
+    ):
+        raise ValidationError("ambiguity counts do not reconcile")
+    if not set(parsed_lists["unbound_event_ids"]).issubset(
+        parsed_lists["event_ids"]
+    ):
+        raise ValidationError("unbound ambiguity events are inconsistent")
+    return {"count": count, **parsed_lists}
+
+
+def validate_notification_execution_readiness_decision(
+    payload: Mapping[str, Any],
+) -> dict[str, Any]:
+    exact = _exact_mapping(
+        payload,
+        "notification execution readiness decision",
+        {
+            "acknowledgement_mutated",
+            "activation_review",
+            "ambiguity",
+            "blocking_reasons",
+            "configuration",
+            "decision",
+            "decision_id",
+            "delivery_attempt_written",
+            "destination",
+            "evaluated_at",
+            "execution_kind",
+            "external_request_performed",
+            "model_version",
+            "outbox_mutated",
+            "read_only",
+            "transition_review",
+        },
+    )
+    if exact["model_version"] != MODEL_VERSION:
+        raise ValidationError("notification readiness model_version is unsupported")
+    execution_kind = exact["execution_kind"]
+    if execution_kind not in EXECUTION_KINDS:
+        raise ValidationError("execution_kind must be initial or retry")
+    evaluated_at = _aware_utc(exact["evaluated_at"], "evaluated_at")
+    configuration = _canonical_configuration(exact["configuration"])
+    destination = _canonical_destination(exact["destination"])
+    activation = _activation_review(exact["activation_review"])
+    transition = _transition_review(exact["transition_review"])
+    ambiguity = _canonical_ambiguity_summary(exact["ambiguity"])
+    reasons = exact["blocking_reasons"]
+    if not isinstance(reasons, list):
+        raise ValidationError("blocking_reasons must be an array")
+    if any(reason not in BLOCKING_REASON_ORDER for reason in reasons):
+        raise ValidationError("blocking_reasons contains an unsupported reason")
+    expected_order = [reason for reason in BLOCKING_REASON_ORDER if reason in reasons]
+    if reasons != expected_order or len(reasons) != len(set(reasons)):
+        raise ValidationError("blocking_reasons must use canonical order")
+    expected_reasons = _derive_reasons(
+        execution_kind=execution_kind,
+        configuration=configuration,
+        destination=destination,
+        activation_review=activation,
+        transition_review=transition,
+        ambiguity=ambiguity,
+    )
+    if reasons != expected_reasons:
+        raise ValidationError("blocking_reasons do not match retained evidence")
+    decision = exact["decision"]
+    expected_decision = "allow" if not expected_reasons else "block"
+    if decision != expected_decision:
+        raise ValidationError("decision does not match blocking reasons")
+    if exact["read_only"] is not True:
+        raise ValidationError("notification readiness evidence must be read-only")
+    if any(exact[flag] is not False for flag in SIDE_EFFECT_FLAGS):
+        raise ValidationError("notification readiness side-effect evidence is invalid")
+    identity = _decision_identity(
+        execution_kind=execution_kind,
+        evaluated_at=evaluated_at.isoformat(),
+        configuration=configuration,
+        destination=destination,
+        activation_review=activation,
+        transition_review=transition,
+        ambiguity=ambiguity,
+        decision=decision,
+        blocking_reasons=reasons,
+    )
+    if exact["decision_id"] != _decision_id(identity):
+        raise ValidationError("decision_id does not match canonical evidence")
+    return {
+        "decision_id": exact["decision_id"],
+        **identity,
+        "read_only": True,
+        "acknowledgement_mutated": False,
+        "delivery_attempt_written": False,
+        "external_request_performed": False,
+        "outbox_mutated": False,
+    }
+
+
+def canonical_notification_execution_readiness_bytes(
+    decision: Mapping[str, Any],
+) -> bytes:
+    validated = validate_notification_execution_readiness_decision(decision)
+    try:
+        return json.dumps(
+            validated,
+            sort_keys=True,
+            separators=(",", ":"),
+            allow_nan=False,
+        ).encode("utf-8")
+    except (TypeError, ValueError):
+        raise ValidationError("notification readiness decision is not canonical JSON") from None
+
+
+def read_notification_execution_readiness_evidence(
+    *,
+    dsn: str,
+    destination_id: str,
+    schema_name: str = "risk_platform",
+) -> dict[str, Any]:
+    if not isinstance(dsn, str) or not dsn.strip():
+        raise ValidationError("PostgreSQL DSN must be non-empty text")
+    selected_destination_id = _safe_text(destination_id, "destination_id")
+    assert selected_destination_id is not None
+    schema = _quote_identifier(schema_name)
+    try:
+        import psycopg
+        from psycopg.rows import dict_row
+    except ImportError as exc:  # pragma: no cover - required in CI.
+        raise RuntimeError("Notification readiness requires psycopg") from exc
+
+    activation_query = f"""
+        SELECT
+            destination_id,
+            destination_fingerprint,
+            authority_id,
+            checklist_id,
+            review_status,
+            operational_activation_ready
+        FROM {schema}.current_notification_activation_rehearsal_review
+        WHERE destination_id = %s
+        LIMIT 2
+    """
+    transition_query = f"""
+        SELECT
+            destination_id,
+            current_destination_fingerprint,
+            current_authority_id,
+            current_checklist_id,
+            activation_review_status,
+            operational_activation_ready,
+            transition_record_id,
+            transition_rehearsal_id,
+            rollback_plan_id,
+            rollback_authority_id,
+            rollback_checklist_id,
+            rollback_destination_fingerprint,
+            rollback_endpoint_environment_variable,
+            transition_matches_current_activation,
+            transition_review_status,
+            transition_ready
+        FROM {schema}.current_notification_destination_transition_review
+        WHERE destination_id = %s
+        LIMIT 2
+    """
+    ambiguity_query = f"""
+        SELECT
+            event_id,
+            uncertainty_record_id,
+            latest_execution_record_id,
+            destination_id,
+            destination_fingerprint,
+            endpoint_environment_variable,
+            destination_bound,
+            destination_binding_status
+        FROM {schema}.current_notification_retry_destination_ambiguities
+        WHERE destination_id = %s OR destination_id IS NULL
+        ORDER BY event_id, uncertainty_record_id
+        LIMIT %s
+    """
+    try:
+        with psycopg.connect(dsn, row_factory=dict_row) as connection:
+            with connection.cursor() as cursor:
+                cursor.execute(activation_query, (selected_destination_id,))
+                activation_rows = [dict(row) for row in cursor.fetchall()]
+                cursor.execute(transition_query, (selected_destination_id,))
+                transition_rows = [dict(row) for row in cursor.fetchall()]
+                cursor.execute(
+                    ambiguity_query,
+                    (selected_destination_id, MAX_AMBIGUITIES + 1),
+                )
+                ambiguity_rows = [dict(row) for row in cursor.fetchall()]
+    except Exception:
+        raise StorageError("notification readiness evidence could not be read") from None
+    if len(activation_rows) > 1:
+        raise StorageError("current activation review grain is not unique")
+    if len(transition_rows) > 1:
+        raise StorageError("current transition review grain is not unique")
+    if len(ambiguity_rows) > MAX_AMBIGUITIES:
+        raise StorageError("current ambiguity evidence exceeds the reviewed maximum")
+    return {
+        "activation_review": activation_rows[0] if activation_rows else None,
+        "transition_review": transition_rows[0] if transition_rows else None,
+        "ambiguities": ambiguity_rows,
+    }
+
+
+def run_notification_execution_readiness_gate(
+    *,
+    execution_kind: str,
+    destination_id: str,
+    evaluated_at: datetime | str,
+    delivery_config_path: Path,
+    destination_config_path: Path,
+    dsn: str,
+    schema_name: str = "risk_platform",
+    evidence_reader: EvidenceReader | None = None,
+) -> dict[str, Any]:
+    delivery_config, retry_policy, retry_execution_policy = (
+        load_retry_execution_contract(delivery_config_path)
+    )
+    destinations = load_notification_destinations(destination_config_path)
+    destination = destinations.get(destination_id)
+    if destination is None:
+        raise ValidationError("notification destination does not exist")
+    selected_reader = evidence_reader or read_notification_execution_readiness_evidence
+    evidence = selected_reader(
+        dsn=dsn,
+        destination_id=destination_id,
+        schema_name=schema_name,
+    )
+    exact = _exact_mapping(
+        evidence,
+        "notification readiness evidence",
+        {"activation_review", "ambiguities", "transition_review"},
+    )
+    return evaluate_notification_execution_readiness(
+        execution_kind=execution_kind,
+        evaluated_at=evaluated_at,
+        delivery_config=delivery_config,
+        retry_policy_fingerprint=retry_policy.fingerprint,
+        retry_execution_policy=retry_execution_policy,
+        destination=destination,
+        activation_review=exact["activation_review"],
+        transition_review=exact["transition_review"],
+        ambiguities=exact["ambiguities"],
+    )
+
+
+def _timestamp(value: str) -> datetime:
+    try:
+        return _aware_utc(value, "evaluated_at")
+    except ValidationError as exc:
+        raise argparse.ArgumentTypeError(str(exc)) from exc
+
+
+def _write_summary(path: Path, summary: Mapping[str, Any]) -> None:
+    if path.is_symlink():
+        raise StorageError("notification readiness summary must not be a symbolic link")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_suffix(path.suffix + ".tmp")
+    try:
+        temporary.write_text(
+            json.dumps(summary, indent=2, sort_keys=True, allow_nan=False) + "\n",
+            encoding="utf-8",
+        )
+        temporary.replace(path)
+    except (OSError, TypeError, ValueError):
+        temporary.unlink(missing_ok=True)
+        raise StorageError("unable to write notification readiness summary") from None
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Evaluate one read-only notification execution readiness gate."
+    )
+    parser.add_argument(
+        "--execution-kind",
+        required=True,
+        choices=sorted(EXECUTION_KINDS),
+    )
+    parser.add_argument("--destination-id", required=True)
+    parser.add_argument("--evaluated-at", required=True, type=_timestamp)
+    parser.add_argument(
+        "--delivery-config",
+        type=Path,
+        default=Path("config/notification_delivery.yaml"),
+    )
+    parser.add_argument(
+        "--destination-config",
+        type=Path,
+        default=Path("config/notification_destinations.yaml"),
+    )
+    parser.add_argument(
+        "--dsn",
+        default=os.environ.get("WAREHOUSE_POSTGRES_DSN", DEFAULT_POSTGRES_DSN),
+    )
+    parser.add_argument("--schema", default="risk_platform")
+    parser.add_argument("--summary-json", type=Path)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    try:
+        decision = run_notification_execution_readiness_gate(
+            execution_kind=args.execution_kind,
+            destination_id=args.destination_id,
+            evaluated_at=args.evaluated_at,
+            delivery_config_path=args.delivery_config,
+            destination_config_path=args.destination_config,
+            dsn=args.dsn,
+            schema_name=args.schema,
+        )
+        if args.summary_json is not None:
+            _write_summary(args.summary_json, decision)
+    except ValidationError as exc:
+        print(f"Notification readiness rejected: {exc}", file=sys.stderr)
+        return 1
+    except StorageError:
+        print(
+            "Notification readiness failed: PostgreSQL or local evidence could not be read",
+            file=sys.stderr,
+        )
+        return 1
+    except Exception:
+        print(
+            "Notification readiness failed: unexpected local failure",
+            file=sys.stderr,
+        )
+        return 1
+    print(json.dumps(decision, sort_keys=True, allow_nan=False))
+    return 0 if decision["decision"] == "allow" else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/test_notification_execution_readiness_architecture_contract.py
+++ b/tests/unit/test_notification_execution_readiness_architecture_contract.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+MODULE = Path("src/warehouse/notification_execution_readiness_gate.py")
+DOC = Path("docs/notification-execution-readiness-gate.md")
+
+
+def test_readiness_gate_is_present_in_warehouse_boundary() -> None:
+    source = MODULE.read_text(encoding="utf-8")
+
+    assert "portfolio-risk-notification-execution-readiness-gate-v1" in source
+    assert "current_notification_activation_rehearsal_review" in source
+    assert "current_notification_destination_transition_review" in source
+    assert "current_notification_retry_destination_ambiguities" in source
+    assert "BLOCKING_REASON_ORDER" in source
+
+
+def test_readiness_gate_is_read_only_and_has_no_transport() -> None:
+    source = MODULE.read_text(encoding="utf-8")
+    lowered = source.lower()
+
+    assert "urllib" not in source
+    assert "import socket" not in source
+    assert "urlopen" not in source
+    assert "insert into" not in lowered
+    assert "update risk_platform" not in lowered
+    assert "delete from" not in lowered
+    assert "terraform apply" not in lowered
+    assert '"external_request_performed": False' in source
+    assert '"delivery_attempt_written": False' in source
+    assert '"outbox_mutated": False' in source
+    assert '"acknowledgement_mutated": False' in source
+
+
+def test_readiness_gate_has_no_execute_cli_option() -> None:
+    source = MODULE.read_text(encoding="utf-8")
+
+    assert 'add_argument("--execute"' not in source
+    assert "action=\"store_true\"" not in source
+
+
+def test_readiness_gate_documentation_preserves_disabled_default() -> None:
+    document = DOC.read_text(encoding="utf-8")
+
+    assert "read-only" in document.lower()
+    assert "disabled by default" in document.lower()
+    assert "P4d5a" in document
+    assert "persistence_ambiguity" in document

--- a/tests/unit/test_notification_execution_readiness_gate.py
+++ b/tests/unit/test_notification_execution_readiness_gate.py
@@ -1,0 +1,490 @@
+from __future__ import annotations
+
+from copy import deepcopy
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+from src.common.exceptions import StorageError, ValidationError
+from src.orchestration.deliver_portfolio_risk_notifications import (
+    WebhookDeliveryConfig,
+)
+from src.orchestration.portfolio_risk_notification_destination_contract import (
+    DestinationActivation,
+    DestinationOwner,
+    NotificationDestination,
+    load_notification_destinations,
+)
+from src.orchestration.portfolio_risk_notification_retry_execution_policy import (
+    RetryExecutionPolicy,
+)
+from src.warehouse.notification_execution_readiness_gate import (
+    BLOCKING_REASON_ORDER,
+    _build_parser,
+    _write_summary,
+    canonical_notification_execution_readiness_bytes,
+    evaluate_notification_execution_readiness,
+    run_notification_execution_readiness_gate,
+    validate_notification_execution_readiness_decision,
+)
+
+DESTINATION_ID = "risk-operations-webhook"
+ENDPOINT_ENV = "RISK_NOTIFICATION_WEBHOOK_URL"
+OTHER_ENDPOINT_ENV = "ROTATED_RISK_NOTIFICATION_WEBHOOK_URL"
+EVALUATED_AT = datetime(2026, 6, 1, 12, tzinfo=timezone.utc)
+
+
+def _delivery(
+    *,
+    enabled: bool = True,
+    endpoint_env: str = ENDPOINT_ENV,
+) -> WebhookDeliveryConfig:
+    return WebhookDeliveryConfig(
+        enabled=enabled,
+        endpoint_env=endpoint_env,
+        timeout_seconds=5,
+        max_batch_events=25,
+        max_attempts_per_event=3,
+        initial_backoff_seconds=1,
+    )
+
+
+def _retry(*, enabled: bool = True) -> RetryExecutionPolicy:
+    return RetryExecutionPolicy(
+        enabled=enabled,
+        max_plan_age_seconds=3600,
+        max_events=25,
+    )
+
+
+def _destination(
+    *,
+    enabled: bool = True,
+    endpoint_env: str = ENDPOINT_ENV,
+) -> NotificationDestination:
+    if enabled:
+        activation = DestinationActivation(
+            enabled=True,
+            change_request_id="CHG-READY-001",
+            reviewed_by=("platform-reviewer",),
+            reviewed_at=EVALUATED_AT - timedelta(days=1),
+            review_expires_at=EVALUATED_AT + timedelta(days=30),
+        )
+    else:
+        activation = DestinationActivation(
+            enabled=False,
+            change_request_id=None,
+            reviewed_by=(),
+            reviewed_at=None,
+            review_expires_at=None,
+        )
+    return NotificationDestination(
+        destination_id=DESTINATION_ID,
+        channel="webhook",
+        endpoint_env=endpoint_env,
+        owner=DestinationOwner(
+            team="risk-operations",
+            contact="risk-operations-oncall",
+        ),
+        purpose="portfolio-risk-breach-lifecycle",
+        recipient_scope="risk-operations",
+        data_classification="internal",
+        allowed_event_types=(
+            "breach_escalated",
+            "breach_opened",
+            "breach_resolved",
+        ),
+        activation=activation,
+    )
+
+
+def _activation_review(
+    destination: NotificationDestination,
+    *,
+    ready: bool = True,
+    status: str = "ready",
+) -> dict[str, Any]:
+    return {
+        "destination_id": destination.destination_id,
+        "destination_fingerprint": destination.fingerprint,
+        "authority_id": "destination-authority-1",
+        "checklist_id": "activation-checklist-1",
+        "review_status": status,
+        "operational_activation_ready": ready,
+    }
+
+
+def _transition_review(
+    destination: NotificationDestination,
+    activation: dict[str, Any],
+    *,
+    status: str = "ready",
+) -> dict[str, Any]:
+    retained = status == "ready"
+    return {
+        "destination_id": destination.destination_id,
+        "current_destination_fingerprint": destination.fingerprint,
+        "current_authority_id": activation["authority_id"],
+        "current_checklist_id": activation["checklist_id"],
+        "activation_review_status": activation["review_status"],
+        "operational_activation_ready": activation[
+            "operational_activation_ready"
+        ],
+        "transition_record_id": "transition-record-1" if retained else None,
+        "transition_rehearsal_id": (
+            "transition-rehearsal-1" if retained else None
+        ),
+        "rollback_plan_id": "rollback-plan-1" if retained else None,
+        "rollback_authority_id": activation["authority_id"] if retained else None,
+        "rollback_checklist_id": activation["checklist_id"] if retained else None,
+        "rollback_destination_fingerprint": (
+            destination.fingerprint if retained else None
+        ),
+        "rollback_endpoint_environment_variable": (
+            destination.endpoint_env if retained else None
+        ),
+        "transition_matches_current_activation": retained,
+        "transition_review_status": status,
+        "transition_ready": retained,
+    }
+
+
+def _ambiguity(*, destination_id: str | None = DESTINATION_ID) -> dict[str, Any]:
+    return {
+        "event_id": "event-ambiguous-1",
+        "uncertainty_record_id": "uncertainty-record-1",
+        "latest_execution_record_id": "execution-record-1",
+        "destination_id": destination_id,
+        "destination_fingerprint": (
+            "destination-fingerprint-1" if destination_id is not None else None
+        ),
+        "endpoint_environment_variable": (
+            ENDPOINT_ENV if destination_id is not None else None
+        ),
+        "destination_bound": destination_id is not None,
+        "destination_binding_status": (
+            "bound" if destination_id is not None else "destination_binding_missing"
+        ),
+    }
+
+
+def _evaluate(
+    *,
+    execution_kind: str = "initial",
+    delivery: WebhookDeliveryConfig | None = None,
+    retry: RetryExecutionPolicy | None = None,
+    destination: NotificationDestination | None = None,
+    activation_review: dict[str, Any] | None | object = object(),
+    transition_review: dict[str, Any] | None | object = object(),
+    ambiguities: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    selected_destination = destination or _destination()
+    if not isinstance(activation_review, (dict, type(None))):
+        activation = _activation_review(selected_destination)
+    else:
+        activation = activation_review
+    if not isinstance(transition_review, (dict, type(None))):
+        assert activation is not None
+        transition = _transition_review(selected_destination, activation)
+    else:
+        transition = transition_review
+    return evaluate_notification_execution_readiness(
+        execution_kind=execution_kind,
+        evaluated_at=EVALUATED_AT,
+        delivery_config=delivery or _delivery(),
+        retry_policy_fingerprint="retry-planning-policy-1",
+        retry_execution_policy=retry or _retry(),
+        destination=selected_destination,
+        activation_review=activation,
+        transition_review=transition,
+        ambiguities=ambiguities or [],
+    )
+
+
+@pytest.mark.parametrize("execution_kind", ["initial", "retry"])
+def test_ready_decision_is_deterministic_and_read_only(
+    execution_kind: str,
+) -> None:
+    first = _evaluate(execution_kind=execution_kind)
+    second = _evaluate(execution_kind=execution_kind)
+
+    assert first == second
+    assert first["decision"] == "allow"
+    assert first["blocking_reasons"] == []
+    assert first["read_only"] is True
+    assert first["external_request_performed"] is False
+    assert first["delivery_attempt_written"] is False
+    assert first["outbox_mutated"] is False
+    assert first["acknowledgement_mutated"] is False
+    assert validate_notification_execution_readiness_decision(first) == first
+    assert canonical_notification_execution_readiness_bytes(first)
+
+
+def test_execution_kind_and_time_change_decision_identity() -> None:
+    initial = _evaluate(execution_kind="initial")
+    retry = _evaluate(execution_kind="retry")
+    later = evaluate_notification_execution_readiness(
+        execution_kind="initial",
+        evaluated_at=EVALUATED_AT + timedelta(seconds=1),
+        delivery_config=_delivery(),
+        retry_policy_fingerprint="retry-planning-policy-1",
+        retry_execution_policy=_retry(),
+        destination=_destination(),
+        activation_review=_activation_review(_destination()),
+        transition_review=_transition_review(
+            _destination(),
+            _activation_review(_destination()),
+        ),
+        ambiguities=[],
+    )
+
+    assert initial["decision_id"] != retry["decision_id"]
+    assert initial["decision_id"] != later["decision_id"]
+
+
+def test_blocking_reasons_use_fixed_canonical_order() -> None:
+    destination = _destination(enabled=False, endpoint_env=ENDPOINT_ENV)
+    decision = _evaluate(
+        execution_kind="retry",
+        delivery=_delivery(enabled=False, endpoint_env=OTHER_ENDPOINT_ENV),
+        retry=_retry(enabled=False),
+        destination=destination,
+        activation_review=None,
+        transition_review=None,
+        ambiguities=[_ambiguity(destination_id=None)],
+    )
+
+    assert decision["decision"] == "block"
+    assert decision["blocking_reasons"] == [
+        "delivery_disabled",
+        "retry_execution_disabled",
+        "destination_not_active",
+        "configuration_mismatch",
+        "activation_review_missing",
+        "transition_review_missing",
+        "persistence_ambiguity",
+    ]
+    assert decision["blocking_reasons"] == [
+        reason
+        for reason in BLOCKING_REASON_ORDER
+        if reason in decision["blocking_reasons"]
+    ]
+
+
+@pytest.mark.parametrize(
+    ("status", "expected_reason"),
+    [
+        ("transition_rehearsal_missing", "transition_rehearsal_missing"),
+        ("transition_rehearsal_superseded", "transition_rehearsal_superseded"),
+        ("activation_not_ready", "transition_not_ready"),
+    ],
+)
+def test_transition_review_states_fail_closed(
+    status: str,
+    expected_reason: str,
+) -> None:
+    destination = _destination()
+    activation = _activation_review(destination)
+    transition = _transition_review(destination, activation, status=status)
+    decision = _evaluate(
+        destination=destination,
+        activation_review=activation,
+        transition_review=transition,
+    )
+
+    assert decision["decision"] == "block"
+    assert expected_reason in decision["blocking_reasons"]
+
+
+def test_identity_mismatch_and_ambiguity_fail_closed() -> None:
+    destination = _destination()
+    activation = _activation_review(destination)
+    transition = _transition_review(destination, activation)
+    activation["destination_fingerprint"] = "changed-destination-fingerprint"
+
+    decision = _evaluate(
+        destination=destination,
+        activation_review=activation,
+        transition_review=transition,
+        ambiguities=[_ambiguity()],
+    )
+
+    assert decision["blocking_reasons"] == [
+        "activation_identity_mismatch",
+        "persistence_ambiguity",
+    ]
+    assert decision["ambiguity"]["event_ids"] == ["event-ambiguous-1"]
+
+
+def test_validator_rejects_tampering_and_side_effect_claims() -> None:
+    decision = _evaluate()
+
+    reordered = deepcopy(decision)
+    reordered["blocking_reasons"] = [
+        "persistence_ambiguity",
+        "delivery_disabled",
+    ]
+    with pytest.raises(ValidationError, match="canonical order"):
+        validate_notification_execution_readiness_decision(reordered)
+
+    changed = deepcopy(decision)
+    changed["evaluated_at"] = (
+        EVALUATED_AT + timedelta(seconds=1)
+    ).isoformat()
+    with pytest.raises(ValidationError, match="decision_id"):
+        validate_notification_execution_readiness_decision(changed)
+
+    side_effect = deepcopy(decision)
+    side_effect["external_request_performed"] = True
+    with pytest.raises(ValidationError, match="side-effect"):
+        validate_notification_execution_readiness_decision(side_effect)
+
+    unknown = deepcopy(decision)
+    unknown["execute"] = True
+    with pytest.raises(ValidationError, match="fields are invalid"):
+        validate_notification_execution_readiness_decision(unknown)
+
+
+def _write_configs(tmp_path: Path) -> tuple[Path, Path, NotificationDestination]:
+    delivery_path = tmp_path / "notification-delivery.yaml"
+    delivery_path.write_text(
+        yaml.safe_dump(
+            {
+                "delivery": {
+                    "webhook": {
+                        "enabled": True,
+                        "endpoint_env": ENDPOINT_ENV,
+                        "timeout_seconds": 5,
+                        "max_batch_events": 25,
+                        "max_attempts_per_event": 3,
+                        "initial_backoff_seconds": 1,
+                    },
+                    "retry_planning": {
+                        "max_candidate_rows": 500,
+                        "max_plan_events": 25,
+                        "max_event_age_seconds": 604800,
+                        "max_backoff_seconds": 3600,
+                        "retryable_http_statuses": [
+                            408,
+                            425,
+                            429,
+                            500,
+                            502,
+                            503,
+                            504,
+                        ],
+                        "retryable_error_codes": ["network_error"],
+                    },
+                    "retry_execution": {
+                        "enabled": True,
+                        "max_plan_age_seconds": 3600,
+                        "max_events": 25,
+                    },
+                }
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+    destination_path = tmp_path / "notification-destinations.yaml"
+    destination_path.write_text(
+        yaml.safe_dump(
+            {
+                "model_version": "portfolio-risk-notification-destination-v1",
+                "destinations": {
+                    DESTINATION_ID: {
+                        "channel": "webhook",
+                        "endpoint_env": ENDPOINT_ENV,
+                        "owner": {
+                            "team": "risk-operations",
+                            "contact": "risk-operations-oncall",
+                        },
+                        "purpose": "portfolio-risk-breach-lifecycle",
+                        "recipient_scope": "risk-operations",
+                        "data_classification": "internal",
+                        "allowed_event_types": [
+                            "breach_escalated",
+                            "breach_opened",
+                            "breach_resolved",
+                        ],
+                        "activation": {
+                            "enabled": True,
+                            "change_request_id": "CHG-READY-001",
+                            "reviewed_by": ["platform-reviewer"],
+                            "reviewed_at": "2026-05-01T00:00:00Z",
+                            "review_expires_at": "2026-12-01T00:00:00Z",
+                        },
+                    }
+                },
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+    destination = load_notification_destinations(destination_path)[DESTINATION_ID]
+    return delivery_path, destination_path, destination
+
+
+def test_runner_reads_postgres_evidence_without_execution(tmp_path: Path) -> None:
+    delivery_path, destination_path, destination = _write_configs(tmp_path)
+    activation = _activation_review(destination)
+    transition = _transition_review(destination, activation)
+    calls: list[dict[str, Any]] = []
+
+    def reader(**kwargs: Any) -> dict[str, Any]:
+        calls.append(kwargs)
+        return {
+            "activation_review": activation,
+            "transition_review": transition,
+            "ambiguities": [],
+        }
+
+    result = run_notification_execution_readiness_gate(
+        execution_kind="retry",
+        destination_id=DESTINATION_ID,
+        evaluated_at=EVALUATED_AT,
+        delivery_config_path=delivery_path,
+        destination_config_path=destination_path,
+        dsn="postgresql://example.invalid/read-only",
+        schema_name="risk_platform",
+        evidence_reader=reader,
+    )
+
+    assert result["decision"] == "allow"
+    assert calls == [
+        {
+            "dsn": "postgresql://example.invalid/read-only",
+            "destination_id": DESTINATION_ID,
+            "schema_name": "risk_platform",
+        }
+    ]
+    assert result["external_request_performed"] is False
+
+
+def test_cli_exposes_no_execution_switch() -> None:
+    parser = _build_parser()
+    with pytest.raises(SystemExit):
+        parser.parse_args(
+            [
+                "--execution-kind",
+                "initial",
+                "--destination-id",
+                DESTINATION_ID,
+                "--evaluated-at",
+                EVALUATED_AT.isoformat(),
+                "--execute",
+            ]
+        )
+
+
+def test_summary_writer_rejects_symbolic_links(tmp_path: Path) -> None:
+    target = tmp_path / "target.json"
+    target.write_text("{}", encoding="utf-8")
+    link = tmp_path / "summary.json"
+    link.symlink_to(target)
+
+    with pytest.raises(StorageError, match="symbolic link"):
+        _write_summary(link, _evaluate())


### PR DESCRIPTION
## Goal

Complete **P4d5a — read-only notification execution readiness gate**.

```text
reviewed delivery configuration
  + current destination fingerprint
  + current activation and receiver review
  + current rotation / disablement / rollback review
  + unresolved persistence ambiguity
  -> deterministic allow or block decision
```

## Decision contract

Adds `portfolio-risk-notification-execution-readiness-gate-v1` for `initial` and `retry` execution kinds.

The decision binds delivery and retry policy fingerprints, endpoint environment-variable identity, current destination activation/fingerprint, activation checklist and authority, transition rehearsal identity, and bounded unresolved ambiguity evidence.

Blocking reasons use fixed canonical order and distinguish disabled delivery, disabled retry execution, inactive destination, configuration mismatch, missing or unready activation evidence, missing or superseded transition evidence, identity mismatch, and persistence ambiguity.

## Read boundary

PostgreSQL access is limited to current read-only views:

- `current_notification_activation_rehearsal_review`;
- `current_notification_destination_transition_review`; and
- `current_notification_retry_destination_ambiguities`.

Duplicate current grains and ambiguity overflow fail closed.

The first CI run exposed one static type-narrowing defect: validated non-null ambiguity IDs retained the helper's optional return type before `sorted()`. The implementation now narrows those values explicitly; no validation, safety, or behavioural check was weakened.

## Scope

Four intended files, 1,620 additions. The branch is based on current `main`, including merged recruiter-facing PR #132.

## Exact-head validation

GitHub Actions run **386** (`33493994585`) passed on final head `5b3d70a611b08cc492dd4c20fae5f37b33e51b0e`:

- Security guardrails passed.
- Ruff passed.
- mypy passed across **135 source files**.
- **892 tests passed** in quality and **892 passed again** in readiness.
- Dependency integrity and the standard readiness replay passed.
- PostgreSQL 16 contract passed.
- Kubernetes rendering and Terraform format/init/validate passed without apply.

There are no review submissions or unresolved review threads.

## Safety

The gate has no execution switch. It performs no DNS lookup, socket operation, webhook request, delivery-attempt write, outbox mutation, acknowledgement, deployment, or `terraform apply`. Delivery and retry execution remain disabled by default.

Validated and ready for squash merge.