### PR TITLE
Persist append-only notification execution readiness history

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,6 +33,7 @@ services:
       - ./sql/controlled_notification_receiver_rehearsal_schema.sql:/docker-entrypoint-initdb.d/22_controlled_notification_receiver_rehearsal_schema.sql:ro
       - ./sql/controlled_notification_receiver_review_schema.sql:/docker-entrypoint-initdb.d/23_controlled_notification_receiver_review_schema.sql:ro
       - ./sql/notification_destination_transition_rehearsal_schema.sql:/docker-entrypoint-initdb.d/24_notification_destination_transition_rehearsal_schema.sql:ro
+      - ./sql/notification_execution_readiness_schema.sql:/docker-entrypoint-initdb.d/25_notification_execution_readiness_schema.sql:ro
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U risk_user -d risk_platform"]
       interval: 5s

--- a/docs/notification-execution-readiness-history.md
+++ b/docs/notification-execution-readiness-history.md
@@ -1,0 +1,141 @@
+# Append-Only Notification Execution Readiness History
+
+Primary arc42 blocks: `orchestration` and `warehouse`.
+
+## Goal
+
+P4d5b retains the read-only P4d5a decision as durable, reviewable evidence:
+
+```text
+canonical allow or block decision
+  + operator request identity
+  + recording time
+  -> independent decision revalidation
+  -> append-only PostgreSQL history
+  -> deterministic current state per destination and execution kind
+```
+
+The retained wrapper model is
+`portfolio-risk-notification-execution-readiness-record-v1`.
+
+## Record contract
+
+The history contract independently revalidates the complete
+`portfolio-risk-notification-execution-readiness-gate-v1` document before
+constructing a record. It then binds:
+
+```text
+request_id
+recorded_at
+full canonical readiness decision
+```
+
+`recorded_at` may not precede `evaluated_at`. The resulting `record_id` changes
+when the request identity, recording time, or any decision evidence changes.
+
+## Replay and conflict behaviour
+
+The operator request ID is the append-only retry boundary:
+
+```text
+same request ID + same canonical record
+  -> return the retained row
+
+same request ID + changed time or decision
+  -> reject
+```
+
+The decision ID is also unique. Reusing a decision under another request or
+changed canonical wrapper fails closed. Direct `UPDATE` and `DELETE` operations
+are rejected by PostgreSQL triggers.
+
+## Retained evidence
+
+The table
+`risk_platform.notification_execution_readiness_decisions` retains the complete
+canonical decision and queryable fields for:
+
+- destination and execution kind;
+- evaluation and recording time;
+- `allow` or `block` and ordered blocking reasons;
+- delivery, retry-planning, and retry-execution policy fingerprints;
+- endpoint environment-variable identity and destination fingerprint;
+- activation authority, checklist, review status, and ready state;
+- transition record, rehearsal, review status, and ready state; and
+- ambiguity counts and bounded event/record identities.
+
+It retains no endpoint value, credential, payload body, response body, or DSN.
+The canonical JSON must declare read-only execution and all delivery side effects
+as false.
+
+## Current-version selection
+
+`latest_notification_execution_readiness_decisions` selects one decision per:
+
+```text
+destination_id
+execution_kind
+```
+
+using:
+
+```text
+evaluated_at DESC
+record_id DESC
+```
+
+The current review cross-joins every destination transition review with both
+`initial` and `retry`, then emits one of:
+
+```text
+decision_missing
+decision_superseded
+decision_stale
+blocked
+allowed
+```
+
+A decision is superseded when its destination, activation, or transition
+identity no longer matches current reviewed evidence. Supersession takes
+precedence over age because an evidence mismatch is more material than an old
+but otherwise matching decision.
+
+A matching decision becomes stale five minutes after evaluation. This short
+lifetime limits the period in which a later execution increment may rely on
+retained evidence without refreshing current state.
+
+Only `allowed` produces `execution_ready = true`. Separate serving views expose:
+
+```text
+risk_platform.current_notification_execution_readiness_allowed
+risk_platform.current_notification_execution_readiness_blocked
+risk_platform.current_notification_execution_readiness_stale
+risk_platform.current_notification_execution_readiness_superseded
+risk_platform.current_notification_execution_readiness_missing
+```
+
+## PostgreSQL proof
+
+The PostgreSQL 16 contract:
+
+1. Creates current activation and rotate/disable/rollback evidence.
+2. Retains an old matching initial decision and proves `decision_stale`.
+3. Retains a newer initial `allow` and proves `allowed`.
+4. Retains a retry decision with retry execution disabled and proves `blocked`.
+5. Replays the exact initial request and proves convergence.
+6. Rejects changed evidence under the same request ID.
+7. Adds a newer independently reviewed receiver configuration.
+8. Proves both retained decisions become `decision_superseded`.
+9. Rejects direct update and delete operations.
+10. Runs the complete history and serving-view reconciliation suite.
+
+## Safety boundary
+
+This increment records decisions but does not enforce or execute them. It
+performs no DNS lookup, socket operation, webhook request, delivery-attempt
+write, outbox mutation, acknowledgement, cloud scheduling, deployment, or
+`terraform apply`.
+
+P4d5c will require and refresh an exact current `allow` decision while holding
+the shared notification delivery lock. Committed notification delivery and retry
+execution remain disabled by default.

--- a/sql/notification_execution_readiness_consistency_checks.sql
+++ b/sql/notification_execution_readiness_consistency_checks.sql
@@ -1,0 +1,337 @@
+-- Reconciliation for append-only notification execution readiness history.
+
+WITH counts AS (
+    SELECT
+        (SELECT COUNT(*)
+         FROM risk_platform.notification_execution_readiness_decisions)
+            AS decision_rows,
+        (SELECT COUNT(DISTINCT request_id)
+         FROM risk_platform.notification_execution_readiness_decisions)
+            AS distinct_request_ids,
+        (SELECT COUNT(DISTINCT decision_id)
+         FROM risk_platform.notification_execution_readiness_decisions)
+            AS distinct_decision_ids,
+        (SELECT COUNT(*)
+         FROM (
+             SELECT destination_id, execution_kind
+             FROM risk_platform.notification_execution_readiness_decisions
+             GROUP BY destination_id, execution_kind
+         ) grains) AS expected_latest_rows,
+        (SELECT COUNT(*)
+         FROM risk_platform.latest_notification_execution_readiness_decisions)
+            AS latest_rows,
+        (SELECT COUNT(*) * 2
+         FROM risk_platform.current_notification_destination_transition_review)
+            AS expected_review_rows,
+        (SELECT COUNT(*)
+         FROM risk_platform.current_notification_execution_readiness_review)
+            AS review_rows,
+        (SELECT COUNT(*)
+         FROM risk_platform.current_notification_execution_readiness_review
+         WHERE readiness_review_status = 'allowed') AS expected_allowed_rows,
+        (SELECT COUNT(*)
+         FROM risk_platform.current_notification_execution_readiness_allowed)
+            AS allowed_rows,
+        (SELECT COUNT(*)
+         FROM risk_platform.current_notification_execution_readiness_review
+         WHERE readiness_review_status = 'blocked') AS expected_blocked_rows,
+        (SELECT COUNT(*)
+         FROM risk_platform.current_notification_execution_readiness_blocked)
+            AS blocked_rows,
+        (SELECT COUNT(*)
+         FROM risk_platform.current_notification_execution_readiness_review
+         WHERE readiness_review_status = 'decision_stale') AS expected_stale_rows,
+        (SELECT COUNT(*)
+         FROM risk_platform.current_notification_execution_readiness_stale)
+            AS stale_rows,
+        (SELECT COUNT(*)
+         FROM risk_platform.current_notification_execution_readiness_review
+         WHERE readiness_review_status = 'decision_superseded')
+            AS expected_superseded_rows,
+        (SELECT COUNT(*)
+         FROM risk_platform.current_notification_execution_readiness_superseded)
+            AS superseded_rows,
+        (SELECT COUNT(*)
+         FROM risk_platform.current_notification_execution_readiness_review
+         WHERE readiness_review_status = 'decision_missing') AS expected_missing_rows,
+        (SELECT COUNT(*)
+         FROM risk_platform.current_notification_execution_readiness_missing)
+            AS missing_rows
+),
+integrity AS (
+    SELECT
+        (
+            SELECT COUNT(*)
+            FROM risk_platform.notification_execution_readiness_decisions
+            WHERE decision_json ->> 'decision_id' <> decision_id
+               OR decision_json ->> 'execution_kind' <> execution_kind
+               OR decision_json ->> 'decision' <> decision
+               OR decision_json -> 'blocking_reasons' <> blocking_reasons_json
+               OR decision_json -> 'destination' ->> 'destination_id'
+                    <> destination_id
+               OR decision_json -> 'destination' ->> 'fingerprint'
+                    <> destination_fingerprint
+               OR record_json ->> 'record_id' <> record_id
+               OR record_json ->> 'request_id' <> request_id
+               OR record_json -> 'decision' <> decision_json
+        ) AS invalid_document_rows,
+        (
+            SELECT COUNT(*)
+            FROM risk_platform.notification_execution_readiness_decisions
+            WHERE recorded_at < evaluated_at
+               OR jsonb_array_length(ambiguity_event_ids_json) <> ambiguity_count
+               OR jsonb_array_length(ambiguity_record_ids_json) <> ambiguity_count
+               OR jsonb_array_length(unbound_ambiguity_event_ids_json)
+                    > ambiguity_count
+        ) AS invalid_counts_or_timestamps,
+        (
+            SELECT COUNT(*)
+            FROM risk_platform.notification_execution_readiness_decisions
+            WHERE NOT (decision_json ->> 'read_only')::BOOLEAN
+               OR (decision_json ->> 'external_request_performed')::BOOLEAN
+               OR (decision_json ->> 'delivery_attempt_written')::BOOLEAN
+               OR (decision_json ->> 'outbox_mutated')::BOOLEAN
+               OR (decision_json ->> 'acknowledgement_mutated')::BOOLEAN
+        ) AS unsafe_rows,
+        (
+            SELECT COUNT(*)
+            FROM (
+                SELECT destination_id, execution_kind
+                FROM risk_platform.latest_notification_execution_readiness_decisions
+                GROUP BY destination_id, execution_kind
+                HAVING COUNT(*) > 1
+            ) duplicated
+        ) AS duplicate_latest_grains,
+        (
+            SELECT COUNT(*)
+            FROM risk_platform.latest_notification_execution_readiness_decisions latest
+            WHERE EXISTS (
+                SELECT 1
+                FROM risk_platform.notification_execution_readiness_decisions candidate
+                WHERE candidate.destination_id = latest.destination_id
+                  AND candidate.execution_kind = latest.execution_kind
+                  AND (
+                      candidate.evaluated_at > latest.evaluated_at
+                      OR (
+                          candidate.evaluated_at = latest.evaluated_at
+                          AND candidate.record_id > latest.record_id
+                      )
+                  )
+            )
+        ) AS stale_latest_rows,
+        (
+            SELECT COUNT(*)
+            FROM (
+                SELECT destination_id, execution_kind
+                FROM risk_platform.current_notification_execution_readiness_review
+                GROUP BY destination_id, execution_kind
+                HAVING COUNT(*) > 1
+            ) duplicated
+        ) AS duplicate_review_grains,
+        (
+            SELECT COUNT(*)
+            FROM risk_platform.current_notification_execution_readiness_review
+            WHERE readiness_review_status <>
+                CASE
+                    WHEN readiness_record_id IS NULL THEN 'decision_missing'
+                    WHEN NOT decision_matches_current_evidence
+                        THEN 'decision_superseded'
+                    WHEN decision_evaluated_at
+                            < CURRENT_TIMESTAMP - INTERVAL '5 minutes'
+                        THEN 'decision_stale'
+                    WHEN decision = 'block' THEN 'blocked'
+                    ELSE 'allowed'
+                END
+        ) AS invalid_review_statuses,
+        (
+            SELECT COUNT(*)
+            FROM risk_platform.current_notification_execution_readiness_review
+            WHERE readiness_review_required
+                    <> (readiness_review_status <> 'allowed')
+               OR execution_ready <> (readiness_review_status = 'allowed')
+               OR readiness_review_priority <>
+                    CASE readiness_review_status
+                        WHEN 'decision_superseded' THEN 4
+                        WHEN 'decision_stale' THEN 3
+                        WHEN 'blocked' THEN 2
+                        WHEN 'decision_missing' THEN 1
+                        ELSE 0
+                    END
+        ) AS invalid_review_flags,
+        (
+            SELECT COUNT(*)
+            FROM pg_trigger trigger
+            JOIN pg_class relation ON relation.oid = trigger.tgrelid
+            JOIN pg_namespace namespace ON namespace.oid = relation.relnamespace
+            WHERE namespace.nspname = 'risk_platform'
+              AND relation.relname = 'notification_execution_readiness_decisions'
+              AND trigger.tgname IN (
+                  'notification_execution_readiness_reject_update',
+                  'notification_execution_readiness_reject_delete'
+              )
+              AND trigger.tgenabled <> 'D'
+              AND NOT trigger.tgisinternal
+        ) AS append_only_trigger_count
+)
+SELECT
+    'notification_execution_readiness_request_ids_unique' AS check_name,
+    decision_rows::TEXT AS expected,
+    distinct_request_ids::TEXT AS actual,
+    CASE WHEN decision_rows = distinct_request_ids THEN 'pass' ELSE 'fail' END
+        AS status
+FROM counts
+
+UNION ALL
+
+SELECT
+    'notification_execution_readiness_decision_ids_unique',
+    decision_rows::TEXT,
+    distinct_decision_ids::TEXT,
+    CASE WHEN decision_rows = distinct_decision_ids THEN 'pass' ELSE 'fail' END
+FROM counts
+
+UNION ALL
+
+SELECT
+    'notification_execution_readiness_documents_reconcile',
+    '0',
+    invalid_document_rows::TEXT,
+    CASE WHEN invalid_document_rows = 0 THEN 'pass' ELSE 'fail' END
+FROM integrity
+
+UNION ALL
+
+SELECT
+    'notification_execution_readiness_counts_and_timestamps_valid',
+    '0',
+    invalid_counts_or_timestamps::TEXT,
+    CASE WHEN invalid_counts_or_timestamps = 0 THEN 'pass' ELSE 'fail' END
+FROM integrity
+
+UNION ALL
+
+SELECT
+    'notification_execution_readiness_side_effects_safe',
+    '0',
+    unsafe_rows::TEXT,
+    CASE WHEN unsafe_rows = 0 THEN 'pass' ELSE 'fail' END
+FROM integrity
+
+UNION ALL
+
+SELECT
+    'notification_execution_readiness_latest_rows_match_grains',
+    expected_latest_rows::TEXT,
+    latest_rows::TEXT,
+    CASE WHEN expected_latest_rows = latest_rows THEN 'pass' ELSE 'fail' END
+FROM counts
+
+UNION ALL
+
+SELECT
+    'notification_execution_readiness_latest_grain_unique',
+    '0',
+    duplicate_latest_grains::TEXT,
+    CASE WHEN duplicate_latest_grains = 0 THEN 'pass' ELSE 'fail' END
+FROM integrity
+
+UNION ALL
+
+SELECT
+    'notification_execution_readiness_latest_selection_current',
+    '0',
+    stale_latest_rows::TEXT,
+    CASE WHEN stale_latest_rows = 0 THEN 'pass' ELSE 'fail' END
+FROM integrity
+
+UNION ALL
+
+SELECT
+    'notification_execution_readiness_review_covers_execution_kinds',
+    expected_review_rows::TEXT,
+    review_rows::TEXT,
+    CASE WHEN expected_review_rows = review_rows THEN 'pass' ELSE 'fail' END
+FROM counts
+
+UNION ALL
+
+SELECT
+    'notification_execution_readiness_review_grain_unique',
+    '0',
+    duplicate_review_grains::TEXT,
+    CASE WHEN duplicate_review_grains = 0 THEN 'pass' ELSE 'fail' END
+FROM integrity
+
+UNION ALL
+
+SELECT
+    'notification_execution_readiness_review_status_reconciles',
+    '0',
+    invalid_review_statuses::TEXT,
+    CASE WHEN invalid_review_statuses = 0 THEN 'pass' ELSE 'fail' END
+FROM integrity
+
+UNION ALL
+
+SELECT
+    'notification_execution_readiness_review_flags_reconcile',
+    '0',
+    invalid_review_flags::TEXT,
+    CASE WHEN invalid_review_flags = 0 THEN 'pass' ELSE 'fail' END
+FROM integrity
+
+UNION ALL
+
+SELECT
+    'notification_execution_readiness_allowed_partition_matches',
+    expected_allowed_rows::TEXT,
+    allowed_rows::TEXT,
+    CASE WHEN expected_allowed_rows = allowed_rows THEN 'pass' ELSE 'fail' END
+FROM counts
+
+UNION ALL
+
+SELECT
+    'notification_execution_readiness_blocked_partition_matches',
+    expected_blocked_rows::TEXT,
+    blocked_rows::TEXT,
+    CASE WHEN expected_blocked_rows = blocked_rows THEN 'pass' ELSE 'fail' END
+FROM counts
+
+UNION ALL
+
+SELECT
+    'notification_execution_readiness_stale_partition_matches',
+    expected_stale_rows::TEXT,
+    stale_rows::TEXT,
+    CASE WHEN expected_stale_rows = stale_rows THEN 'pass' ELSE 'fail' END
+FROM counts
+
+UNION ALL
+
+SELECT
+    'notification_execution_readiness_superseded_partition_matches',
+    expected_superseded_rows::TEXT,
+    superseded_rows::TEXT,
+    CASE WHEN expected_superseded_rows = superseded_rows THEN 'pass' ELSE 'fail' END
+FROM counts
+
+UNION ALL
+
+SELECT
+    'notification_execution_readiness_missing_partition_matches',
+    expected_missing_rows::TEXT,
+    missing_rows::TEXT,
+    CASE WHEN expected_missing_rows = missing_rows THEN 'pass' ELSE 'fail' END
+FROM counts
+
+UNION ALL
+
+SELECT
+    'notification_execution_readiness_append_only_triggers_enabled',
+    '2',
+    append_only_trigger_count::TEXT,
+    CASE WHEN append_only_trigger_count = 2 THEN 'pass' ELSE 'fail' END
+FROM integrity
+
+ORDER BY check_name;

--- a/sql/notification_execution_readiness_schema.sql
+++ b/sql/notification_execution_readiness_schema.sql
@@ -1,0 +1,330 @@
+-- Append-only notification execution readiness decisions and current review views.
+-- Apply after notification_destination_transition_rehearsal_schema.sql.
+
+CREATE SCHEMA IF NOT EXISTS risk_platform;
+
+CREATE TABLE IF NOT EXISTS
+risk_platform.notification_execution_readiness_decisions (
+    record_id TEXT PRIMARY KEY,
+    model_version TEXT NOT NULL CHECK (
+        model_version =
+            'portfolio-risk-notification-execution-readiness-record-v1'
+    ),
+    request_id TEXT NOT NULL UNIQUE,
+    decision_id TEXT NOT NULL UNIQUE,
+    destination_id TEXT NOT NULL,
+    execution_kind TEXT NOT NULL CHECK (
+        execution_kind IN ('initial', 'retry')
+    ),
+    evaluated_at TIMESTAMPTZ NOT NULL,
+    recorded_at TIMESTAMPTZ NOT NULL,
+    decision TEXT NOT NULL CHECK (decision IN ('allow', 'block')),
+    blocking_reasons_json JSONB NOT NULL CHECK (
+        jsonb_typeof(blocking_reasons_json) = 'array'
+    ),
+    delivery_fingerprint TEXT NOT NULL,
+    retry_policy_fingerprint TEXT NOT NULL,
+    retry_execution_policy_fingerprint TEXT NOT NULL,
+    endpoint_environment_variable TEXT NOT NULL,
+    destination_fingerprint TEXT NOT NULL,
+    destination_activation_status TEXT NOT NULL CHECK (
+        destination_activation_status IN (
+            'active',
+            'disabled',
+            'not_yet_reviewed',
+            'review_expired'
+        )
+    ),
+    activation_authority_id TEXT,
+    activation_checklist_id TEXT,
+    activation_review_status TEXT,
+    activation_ready BOOLEAN,
+    transition_record_id TEXT,
+    transition_rehearsal_id TEXT,
+    transition_review_status TEXT,
+    transition_ready BOOLEAN,
+    ambiguity_count INTEGER NOT NULL CHECK (
+        ambiguity_count BETWEEN 0 AND 500
+    ),
+    ambiguity_event_ids_json JSONB NOT NULL CHECK (
+        jsonb_typeof(ambiguity_event_ids_json) = 'array'
+    ),
+    ambiguity_record_ids_json JSONB NOT NULL CHECK (
+        jsonb_typeof(ambiguity_record_ids_json) = 'array'
+    ),
+    unbound_ambiguity_event_ids_json JSONB NOT NULL CHECK (
+        jsonb_typeof(unbound_ambiguity_event_ids_json) = 'array'
+    ),
+    decision_json JSONB NOT NULL CHECK (
+        jsonb_typeof(decision_json) = 'object'
+    ),
+    record_json JSONB NOT NULL CHECK (
+        jsonb_typeof(record_json) = 'object'
+    ),
+    document_sha256 CHAR(64) NOT NULL CHECK (
+        document_sha256 ~ '^[0-9a-f]{64}$'
+    ),
+    loaded_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    CHECK (record_id <> ''),
+    CHECK (request_id <> ''),
+    CHECK (decision_id <> ''),
+    CHECK (destination_id <> ''),
+    CHECK (recorded_at >= evaluated_at),
+    CHECK (
+        (decision = 'allow' AND jsonb_array_length(blocking_reasons_json) = 0)
+        OR (decision = 'block' AND jsonb_array_length(blocking_reasons_json) > 0)
+    ),
+    CHECK (
+        jsonb_array_length(ambiguity_event_ids_json) = ambiguity_count
+    ),
+    CHECK (
+        jsonb_array_length(ambiguity_record_ids_json) = ambiguity_count
+    ),
+    CHECK (
+        jsonb_array_length(unbound_ambiguity_event_ids_json) <= ambiguity_count
+    ),
+    CHECK (
+        (activation_authority_id IS NULL
+            AND activation_checklist_id IS NULL
+            AND activation_review_status IS NULL
+            AND activation_ready IS NULL)
+        OR
+        (activation_authority_id IS NOT NULL
+            AND activation_checklist_id IS NOT NULL
+            AND activation_review_status IS NOT NULL
+            AND activation_ready IS NOT NULL)
+    ),
+    CHECK (
+        (transition_review_status IS NULL AND transition_ready IS NULL)
+        OR
+        (transition_review_status IS NOT NULL AND transition_ready IS NOT NULL)
+    ),
+    CHECK (decision_json ->> 'decision_id' = decision_id),
+    CHECK (decision_json ->> 'execution_kind' = execution_kind),
+    CHECK (decision_json ->> 'decision' = decision),
+    CHECK (
+        decision_json -> 'destination' ->> 'destination_id' = destination_id
+    ),
+    CHECK (
+        decision_json -> 'destination' ->> 'fingerprint'
+            = destination_fingerprint
+    ),
+    CHECK (
+        decision_json -> 'configuration' ->> 'delivery_fingerprint'
+            = delivery_fingerprint
+    ),
+    CHECK (
+        decision_json -> 'configuration' ->>
+            'retry_execution_policy_fingerprint'
+            = retry_execution_policy_fingerprint
+    ),
+    CHECK (decision_json -> 'blocking_reasons' = blocking_reasons_json),
+    CHECK (
+        (decision_json -> 'ambiguity' ->> 'count')::INTEGER = ambiguity_count
+    ),
+    CHECK (
+        decision_json -> 'ambiguity' -> 'event_ids'
+            = ambiguity_event_ids_json
+    ),
+    CHECK (
+        decision_json -> 'ambiguity' -> 'record_ids'
+            = ambiguity_record_ids_json
+    ),
+    CHECK (
+        decision_json -> 'ambiguity' -> 'unbound_event_ids'
+            = unbound_ambiguity_event_ids_json
+    ),
+    CHECK (record_json ->> 'record_id' = record_id),
+    CHECK (record_json ->> 'model_version' = model_version),
+    CHECK (record_json ->> 'request_id' = request_id),
+    CHECK (record_json -> 'decision' = decision_json),
+    CHECK ((record_json ->> 'recorded_at')::TIMESTAMPTZ = recorded_at),
+    CHECK ((decision_json ->> 'evaluated_at')::TIMESTAMPTZ = evaluated_at),
+    CHECK ((decision_json ->> 'read_only')::BOOLEAN),
+    CHECK (NOT (decision_json ->> 'external_request_performed')::BOOLEAN),
+    CHECK (NOT (decision_json ->> 'delivery_attempt_written')::BOOLEAN),
+    CHECK (NOT (decision_json ->> 'outbox_mutated')::BOOLEAN),
+    CHECK (NOT (decision_json ->> 'acknowledgement_mutated')::BOOLEAN)
+);
+
+CREATE INDEX IF NOT EXISTS
+idx_notification_execution_readiness_current
+ON risk_platform.notification_execution_readiness_decisions (
+    destination_id,
+    execution_kind,
+    evaluated_at DESC,
+    record_id DESC
+);
+
+CREATE OR REPLACE FUNCTION
+risk_platform.reject_notification_execution_readiness_mutation()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    RAISE EXCEPTION 'notification execution readiness history is append-only';
+END;
+$$;
+
+DROP TRIGGER IF EXISTS notification_execution_readiness_reject_update
+ON risk_platform.notification_execution_readiness_decisions;
+CREATE TRIGGER notification_execution_readiness_reject_update
+BEFORE UPDATE ON risk_platform.notification_execution_readiness_decisions
+FOR EACH ROW
+EXECUTE FUNCTION risk_platform.reject_notification_execution_readiness_mutation();
+
+DROP TRIGGER IF EXISTS notification_execution_readiness_reject_delete
+ON risk_platform.notification_execution_readiness_decisions;
+CREATE TRIGGER notification_execution_readiness_reject_delete
+BEFORE DELETE ON risk_platform.notification_execution_readiness_decisions
+FOR EACH ROW
+EXECUTE FUNCTION risk_platform.reject_notification_execution_readiness_mutation();
+
+CREATE OR REPLACE VIEW
+risk_platform.latest_notification_execution_readiness_decisions AS
+SELECT ranked.*
+FROM (
+    SELECT
+        readiness.*,
+        ROW_NUMBER() OVER (
+            PARTITION BY readiness.destination_id, readiness.execution_kind
+            ORDER BY readiness.evaluated_at DESC, readiness.record_id DESC
+        ) AS current_version_rank
+    FROM risk_platform.notification_execution_readiness_decisions readiness
+) ranked
+WHERE ranked.current_version_rank = 1;
+
+CREATE OR REPLACE VIEW
+risk_platform.current_notification_execution_readiness_review AS
+WITH execution_kinds AS (
+    SELECT execution_kind
+    FROM (VALUES ('initial'::TEXT), ('retry'::TEXT)) values_(execution_kind)
+),
+evidence AS (
+    SELECT
+        transition.destination_id,
+        execution.execution_kind,
+        transition.current_destination_fingerprint,
+        transition.current_authority_id,
+        transition.current_checklist_id,
+        transition.activation_review_status,
+        transition.operational_activation_ready,
+        transition.transition_record_id AS current_transition_record_id,
+        transition.transition_rehearsal_id AS current_transition_rehearsal_id,
+        transition.rollback_endpoint_environment_variable
+            AS current_endpoint_environment_variable,
+        transition.transition_review_status AS current_transition_review_status,
+        transition.transition_ready AS current_transition_ready,
+        readiness.record_id AS readiness_record_id,
+        readiness.request_id AS readiness_request_id,
+        readiness.decision_id,
+        readiness.evaluated_at AS decision_evaluated_at,
+        readiness.recorded_at AS decision_recorded_at,
+        readiness.decision,
+        readiness.blocking_reasons_json,
+        readiness.delivery_fingerprint,
+        readiness.retry_policy_fingerprint,
+        readiness.retry_execution_policy_fingerprint,
+        readiness.endpoint_environment_variable,
+        readiness.destination_fingerprint,
+        readiness.activation_authority_id,
+        readiness.activation_checklist_id,
+        readiness.activation_review_status AS decision_activation_review_status,
+        readiness.activation_ready AS decision_activation_ready,
+        readiness.transition_record_id AS decision_transition_record_id,
+        readiness.transition_rehearsal_id AS decision_transition_rehearsal_id,
+        readiness.transition_review_status AS decision_transition_review_status,
+        readiness.transition_ready AS decision_transition_ready,
+        readiness.ambiguity_count,
+        readiness.ambiguity_event_ids_json,
+        readiness.ambiguity_record_ids_json,
+        readiness.unbound_ambiguity_event_ids_json,
+        readiness.record_id IS NOT NULL
+            AND readiness.destination_fingerprint
+                = transition.current_destination_fingerprint
+            AND readiness.activation_authority_id
+                IS NOT DISTINCT FROM transition.current_authority_id
+            AND readiness.activation_checklist_id
+                IS NOT DISTINCT FROM transition.current_checklist_id
+            AND readiness.activation_review_status
+                IS NOT DISTINCT FROM transition.activation_review_status
+            AND readiness.activation_ready
+                IS NOT DISTINCT FROM transition.operational_activation_ready
+            AND readiness.transition_record_id
+                IS NOT DISTINCT FROM transition.transition_record_id
+            AND readiness.transition_rehearsal_id
+                IS NOT DISTINCT FROM transition.transition_rehearsal_id
+            AND readiness.transition_review_status
+                IS NOT DISTINCT FROM transition.transition_review_status
+            AND readiness.transition_ready
+                IS NOT DISTINCT FROM transition.transition_ready
+            AND (
+                transition.rollback_endpoint_environment_variable IS NULL
+                OR readiness.endpoint_environment_variable
+                    = transition.rollback_endpoint_environment_variable
+            ) AS decision_matches_current_evidence
+    FROM risk_platform.current_notification_destination_transition_review transition
+    CROSS JOIN execution_kinds execution
+    LEFT JOIN risk_platform.latest_notification_execution_readiness_decisions readiness
+      ON readiness.destination_id = transition.destination_id
+     AND readiness.execution_kind = execution.execution_kind
+),
+classified AS (
+    SELECT
+        evidence.*,
+        CASE
+            WHEN evidence.readiness_record_id IS NULL
+                THEN 'decision_missing'
+            WHEN NOT evidence.decision_matches_current_evidence
+                THEN 'decision_superseded'
+            WHEN evidence.decision_evaluated_at
+                    < CURRENT_TIMESTAMP - INTERVAL '5 minutes'
+                THEN 'decision_stale'
+            WHEN evidence.decision = 'block'
+                THEN 'blocked'
+            ELSE 'allowed'
+        END AS readiness_review_status
+    FROM evidence
+)
+SELECT
+    classified.*,
+    classified.readiness_review_status <> 'allowed' AS readiness_review_required,
+    classified.readiness_review_status = 'allowed' AS execution_ready,
+    CASE classified.readiness_review_status
+        WHEN 'decision_superseded' THEN 4
+        WHEN 'decision_stale' THEN 3
+        WHEN 'blocked' THEN 2
+        WHEN 'decision_missing' THEN 1
+        ELSE 0
+    END AS readiness_review_priority
+FROM classified;
+
+CREATE OR REPLACE VIEW
+risk_platform.current_notification_execution_readiness_allowed AS
+SELECT *
+FROM risk_platform.current_notification_execution_readiness_review
+WHERE readiness_review_status = 'allowed';
+
+CREATE OR REPLACE VIEW
+risk_platform.current_notification_execution_readiness_blocked AS
+SELECT *
+FROM risk_platform.current_notification_execution_readiness_review
+WHERE readiness_review_status = 'blocked';
+
+CREATE OR REPLACE VIEW
+risk_platform.current_notification_execution_readiness_stale AS
+SELECT *
+FROM risk_platform.current_notification_execution_readiness_review
+WHERE readiness_review_status = 'decision_stale';
+
+CREATE OR REPLACE VIEW
+risk_platform.current_notification_execution_readiness_superseded AS
+SELECT *
+FROM risk_platform.current_notification_execution_readiness_review
+WHERE readiness_review_status = 'decision_superseded';
+
+CREATE OR REPLACE VIEW
+risk_platform.current_notification_execution_readiness_missing AS
+SELECT *
+FROM risk_platform.current_notification_execution_readiness_review
+WHERE readiness_review_status = 'decision_missing';

--- a/src/warehouse/controlled_receiver_rehearsal_postgres_contract_check.py
+++ b/src/warehouse/controlled_receiver_rehearsal_postgres_contract_check.py
@@ -28,6 +28,9 @@ from src.warehouse.controlled_receiver_review_postgres_contract_check import (
 from src.warehouse.notification_destination_transition_rehearsal_postgres_contract_check import (
     run_contract_check as run_transition_contract_check,
 )
+from src.warehouse.notification_execution_readiness_postgres_contract_check import (
+    run_contract_check as run_readiness_history_contract_check,
+)
 from src.warehouse.postgres_loader import DEFAULT_POSTGRES_DSN
 
 CHECK_PATH = Path(
@@ -246,6 +249,7 @@ def run_contract_check(dsn: str) -> dict[str, Any]:
         raise AssertionError("controlled receiver reconciliation failed: " + names)
 
     review_summary = run_review_contract_check(dsn)
+    readiness_history_summary = run_readiness_history_contract_check(dsn)
     transition_summary = run_transition_contract_check(dsn)
     return {
         "model_version": "portfolio-risk-controlled-receiver-contract-v1",
@@ -260,6 +264,7 @@ def run_contract_check(dsn: str) -> dict[str, Any]:
         "delete_rejected": delete_rejected,
         "consistency_checks": len(checks),
         "activation_review": review_summary,
+        "notification_execution_readiness": readiness_history_summary,
         "destination_transition": transition_summary,
         "external_request_performed": False,
         "payload_bodies_recorded": False,
@@ -270,8 +275,9 @@ def run_contract_check(dsn: str) -> dict[str, Any]:
 def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         description=(
-            "Exercise append-only controlled receiver, activation review, and "
-            "destination transition history against PostgreSQL 16."
+            "Exercise append-only controlled receiver, activation review, "
+            "notification readiness, and destination transition history against "
+            "PostgreSQL 16."
         )
     )
     parser.add_argument(

--- a/src/warehouse/notification_execution_readiness_history_contract.py
+++ b/src/warehouse/notification_execution_readiness_history_contract.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from collections.abc import Mapping
+from datetime import datetime, timezone
+from typing import Any
+
+from src.common.exceptions import ValidationError
+from src.warehouse.notification_execution_readiness_gate import (
+    validate_notification_execution_readiness_decision,
+)
+
+MODEL_VERSION = "portfolio-risk-notification-execution-readiness-record-v1"
+SAFE_TEXT = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,511}$")
+
+
+def _safe_text(value: Any, label: str) -> str:
+    if not isinstance(value, str) or not SAFE_TEXT.fullmatch(value):
+        raise ValidationError(f"{label} must be one safe text segment")
+    return value
+
+
+def _aware_utc(value: Any, label: str) -> datetime:
+    if isinstance(value, datetime):
+        parsed = value
+    elif isinstance(value, str):
+        try:
+            parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        except ValueError:
+            raise ValidationError(f"{label} must be ISO-8601") from None
+    else:
+        raise ValidationError(f"{label} must be timezone-aware")
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise ValidationError(f"{label} must be timezone-aware")
+    return parsed.astimezone(timezone.utc)
+
+
+def canonical_notification_execution_readiness_record_bytes(
+    record: Mapping[str, Any],
+) -> bytes:
+    try:
+        return json.dumps(
+            record,
+            sort_keys=True,
+            separators=(",", ":"),
+            allow_nan=False,
+        ).encode("utf-8")
+    except (TypeError, ValueError):
+        raise ValidationError(
+            "notification execution readiness record is not canonical JSON"
+        ) from None
+
+
+def _record_id(identity: Mapping[str, Any]) -> str:
+    digest = hashlib.sha256(
+        canonical_notification_execution_readiness_record_bytes(identity)
+    ).hexdigest()[:24]
+    return f"{MODEL_VERSION}-record-{digest}"
+
+
+def build_notification_execution_readiness_record(
+    *,
+    request_id: str,
+    recorded_at: datetime | str,
+    decision: Mapping[str, Any],
+) -> dict[str, Any]:
+    selected_request_id = _safe_text(request_id, "request_id")
+    selected_decision = validate_notification_execution_readiness_decision(decision)
+    recorded = _aware_utc(recorded_at, "recorded_at")
+    evaluated = _aware_utc(selected_decision["evaluated_at"], "decision.evaluated_at")
+    if recorded < evaluated:
+        raise ValidationError("recorded_at must not precede decision evaluation")
+    identity = {
+        "decision": selected_decision,
+        "model_version": MODEL_VERSION,
+        "recorded_at": recorded.isoformat(),
+        "request_id": selected_request_id,
+    }
+    return {"record_id": _record_id(identity), **identity}
+
+
+def validate_notification_execution_readiness_record(
+    record: Mapping[str, Any],
+) -> dict[str, Any]:
+    if not isinstance(record, Mapping):
+        raise ValidationError("notification readiness record must be a mapping")
+    expected = {
+        "decision",
+        "model_version",
+        "record_id",
+        "recorded_at",
+        "request_id",
+    }
+    actual = set(record)
+    if actual != expected:
+        raise ValidationError(
+            "notification readiness record fields are invalid; "
+            f"missing={sorted(expected - actual)}, unknown={sorted(actual - expected)}"
+        )
+    if record["model_version"] != MODEL_VERSION:
+        raise ValidationError("notification readiness record model_version is unsupported")
+    rebuilt = build_notification_execution_readiness_record(
+        request_id=record["request_id"],
+        recorded_at=record["recorded_at"],
+        decision=record["decision"],
+    )
+    if dict(record) != rebuilt:
+        raise ValidationError("notification readiness record is not canonical")
+    return rebuilt

--- a/src/warehouse/notification_execution_readiness_postgres_contract_check.py
+++ b/src/warehouse/notification_execution_readiness_postgres_contract_check.py
@@ -163,10 +163,11 @@ def _mutation_rejected(dsn: str, statement: str) -> bool:
 
 def run_contract_check(dsn: str) -> dict[str, Any]:
     now = datetime.now(timezone.utc).replace(microsecond=0)
-    rehearsal, rollback_checklist = _transition_evidence(now)
+    transition_time = now - timedelta(minutes=30)
+    rehearsal, rollback_checklist = _transition_evidence(transition_time)
     transition_record = build_notification_destination_transition_rehearsal_record(
         request_id="READINESS-HISTORY-TRANSITION-001",
-        recorded_at=now - timedelta(hours=2, minutes=59, seconds=56),
+        recorded_at=transition_time - timedelta(hours=2, minutes=59, seconds=56),
         rehearsal=rehearsal,
     )
     rollback_receiver = _controlled_receiver_record(
@@ -182,7 +183,7 @@ def run_contract_check(dsn: str) -> dict[str, Any]:
         record=transition_record,
     )
 
-    destination = _destination(now)
+    destination = _destination(transition_time)
     if destination.fingerprint != rollback_checklist["destination_fingerprint"]:
         raise AssertionError("readiness destination fingerprint does not match transition")
     evidence = _evidence(dsn)

--- a/src/warehouse/notification_execution_readiness_postgres_contract_check.py
+++ b/src/warehouse/notification_execution_readiness_postgres_contract_check.py
@@ -4,13 +4,25 @@ import argparse
 import json
 import os
 import sys
+import tempfile
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
 
+import yaml
+
 from src.common.exceptions import ValidationError
 from src.orchestration.deliver_portfolio_risk_notifications import (
     WebhookDeliveryConfig,
+)
+from src.orchestration.notification_destination_transition_plan import (
+    build_notification_destination_transition_plan,
+)
+from src.orchestration.notification_destination_transition_rehearsal import (
+    rehearse_notification_destination_transition,
+)
+from src.orchestration.portfolio_risk_notification_destination_authority import (
+    resolve_notification_destination_authority,
 )
 from src.orchestration.portfolio_risk_notification_destination_contract import (
     DestinationActivation,
@@ -27,11 +39,12 @@ from src.warehouse.notification_destination_transition_rehearsal_contract import
     build_notification_destination_transition_rehearsal_record,
 )
 from src.warehouse.notification_destination_transition_rehearsal_postgres_contract_check import (
-    DESTINATION_ID,
+    NEW_ENDPOINT_ENV,
     OLD_ENDPOINT_ENV,
     _checklist,
+    _clock,
     _controlled_receiver_record,
-    _transition_evidence,
+    _request,
 )
 from src.warehouse.notification_destination_transition_rehearsal_recorder import (
     record_notification_destination_transition_rehearsal,
@@ -49,6 +62,219 @@ from src.warehouse.notification_execution_readiness_recorder import (
 from src.warehouse.postgres_loader import DEFAULT_POSTGRES_DSN
 
 CHECK_PATH = Path("sql/notification_execution_readiness_consistency_checks.sql")
+DESTINATION_ID = "readiness-history-webhook"
+
+
+def _iso(value: datetime) -> str:
+    return value.astimezone(timezone.utc).isoformat()
+
+
+def _activation(
+    *,
+    enabled: bool,
+    change_request_id: str,
+    reviewed_at: datetime,
+    expires_at: datetime,
+) -> dict[str, Any]:
+    if not enabled:
+        return {
+            "enabled": False,
+            "change_request_id": None,
+            "reviewed_by": [],
+            "reviewed_at": None,
+            "review_expires_at": None,
+        }
+    return {
+        "enabled": True,
+        "change_request_id": change_request_id,
+        "reviewed_by": ["readiness-history-reviewer"],
+        "reviewed_at": _iso(reviewed_at),
+        "review_expires_at": _iso(expires_at),
+    }
+
+
+def _destination_config(
+    *,
+    endpoint_env: str,
+    enabled: bool,
+    change_request_id: str,
+    reviewed_at: datetime,
+    expires_at: datetime,
+) -> dict[str, Any]:
+    return {
+        "model_version": "portfolio-risk-notification-destination-v1",
+        "destinations": {
+            DESTINATION_ID: {
+                "channel": "webhook",
+                "endpoint_env": endpoint_env,
+                "owner": {
+                    "team": "risk-operations",
+                    "contact": "risk-operations-oncall",
+                },
+                "purpose": "portfolio-risk-breach-lifecycle",
+                "recipient_scope": "risk-operations",
+                "data_classification": "internal",
+                "allowed_event_types": [
+                    "breach_escalated",
+                    "breach_opened",
+                    "breach_resolved",
+                ],
+                "activation": _activation(
+                    enabled=enabled,
+                    change_request_id=change_request_id,
+                    reviewed_at=reviewed_at,
+                    expires_at=expires_at,
+                ),
+            }
+        },
+    }
+
+
+def _write_config(root: Path, name: str, value: dict[str, Any]) -> Path:
+    path = root / name
+    path.write_text(yaml.safe_dump(value, sort_keys=False), encoding="utf-8")
+    return path
+
+
+def _transition_evidence(now: datetime) -> tuple[dict[str, Any], dict[str, Any]]:
+    planned_at = now - timedelta(hours=4)
+    started_at = now - timedelta(hours=3)
+    expires_at = now + timedelta(days=30)
+    with tempfile.TemporaryDirectory(
+        prefix="readiness-history-transition-"
+    ) as directory:
+        root = Path(directory)
+        baseline_path = _write_config(
+            root,
+            "baseline.yaml",
+            _destination_config(
+                endpoint_env=OLD_ENDPOINT_ENV,
+                enabled=True,
+                change_request_id="CHG-READINESS-BASELINE",
+                reviewed_at=planned_at - timedelta(days=30),
+                expires_at=expires_at,
+            ),
+        )
+        rotated_path = _write_config(
+            root,
+            "rotated.yaml",
+            _destination_config(
+                endpoint_env=NEW_ENDPOINT_ENV,
+                enabled=True,
+                change_request_id="CHG-READINESS-ROTATE",
+                reviewed_at=planned_at - timedelta(days=10),
+                expires_at=expires_at,
+            ),
+        )
+        disabled_path = _write_config(
+            root,
+            "disabled.yaml",
+            _destination_config(
+                endpoint_env=NEW_ENDPOINT_ENV,
+                enabled=False,
+                change_request_id="unused",
+                reviewed_at=planned_at,
+                expires_at=expires_at,
+            ),
+        )
+        rollback_path = _write_config(
+            root,
+            "rollback.yaml",
+            _destination_config(
+                endpoint_env=OLD_ENDPOINT_ENV,
+                enabled=True,
+                change_request_id="CHG-READINESS-ROLLBACK",
+                reviewed_at=planned_at - timedelta(days=1),
+                expires_at=expires_at,
+            ),
+        )
+        rotate_plan = build_notification_destination_transition_plan(
+            operation="rotate",
+            current_config_path=baseline_path,
+            target_config_path=rotated_path,
+            destination_id=DESTINATION_ID,
+            planned_at=planned_at,
+        )
+        disable_plan = build_notification_destination_transition_plan(
+            operation="disable",
+            current_config_path=rotated_path,
+            target_config_path=disabled_path,
+            destination_id=DESTINATION_ID,
+            planned_at=planned_at,
+        )
+        rollback_plan = build_notification_destination_transition_plan(
+            operation="rollback",
+            current_config_path=disabled_path,
+            target_config_path=rollback_path,
+            destination_id=DESTINATION_ID,
+            planned_at=planned_at,
+            prior_plan_id=disable_plan["plan_id"],
+        )
+        baseline_authority = resolve_notification_destination_authority(
+            destination_config_path=baseline_path,
+            destination_id=DESTINATION_ID,
+            delivery_endpoint_env=OLD_ENDPOINT_ENV,
+            evaluated_at=planned_at,
+            event_types=["breach_opened"],
+        )
+        rotate_authority = resolve_notification_destination_authority(
+            destination_config_path=rotated_path,
+            destination_id=DESTINATION_ID,
+            delivery_endpoint_env=NEW_ENDPOINT_ENV,
+            evaluated_at=planned_at,
+            event_types=["breach_opened"],
+        )
+        rollback_authority = resolve_notification_destination_authority(
+            destination_config_path=rollback_path,
+            destination_id=DESTINATION_ID,
+            delivery_endpoint_env=OLD_ENDPOINT_ENV,
+            evaluated_at=planned_at,
+            event_types=["breach_opened"],
+        )
+
+    rotate_checklist = _checklist(
+        destination_id=DESTINATION_ID,
+        fingerprint=rotate_authority["destination_fingerprint"],
+        authority_id=rotate_authority["authority_id"],
+        reviewed_at=planned_at - timedelta(hours=2),
+        expires_at=expires_at,
+    )
+    rollback_checklist = _checklist(
+        destination_id=DESTINATION_ID,
+        fingerprint=rollback_authority["destination_fingerprint"],
+        authority_id=rollback_authority["authority_id"],
+        reviewed_at=planned_at - timedelta(hours=1),
+        expires_at=expires_at,
+    )
+    rotate_request = _request(
+        "https://readiness-receiver-v2.test/controlled",
+        "readiness-history-transition-rotate",
+    )
+    rollback_request = _request(
+        "https://readiness-receiver-v1.test/controlled",
+        "readiness-history-transition-rollback",
+    )
+    rehearsal = rehearse_notification_destination_transition(
+        rotate_plan=rotate_plan,
+        disable_plan=disable_plan,
+        rollback_plan=rollback_plan,
+        baseline_authority=baseline_authority,
+        rotate_authority=rotate_authority,
+        rollback_authority=rollback_authority,
+        rotate_checklist=rotate_checklist,
+        rollback_checklist=rollback_checklist,
+        rotate_allowed_hosts=["readiness-receiver-v2.test"],
+        rollback_allowed_hosts=["readiness-receiver-v1.test"],
+        rotate_requests=[rotate_request, rotate_request],
+        rollback_requests=[rollback_request],
+        started_at=started_at,
+        clock=_clock(
+            started_at + timedelta(seconds=1),
+            started_at + timedelta(seconds=2),
+            started_at + timedelta(seconds=3),
+        ),
+    )
+    return rehearsal, rollback_checklist
 
 
 def _destination(now: datetime) -> NotificationDestination:
@@ -71,8 +297,8 @@ def _destination(now: datetime) -> NotificationDestination:
         ),
         activation=DestinationActivation(
             enabled=True,
-            change_request_id="CHG-CONTRACT-ROLLBACK",
-            reviewed_by=("transition-contract-reviewer",),
+            change_request_id="CHG-READINESS-ROLLBACK",
+            reviewed_by=("readiness-history-reviewer",),
             reviewed_at=planned_at - timedelta(days=1),
             review_expires_at=now + timedelta(days=30),
         ),
@@ -92,7 +318,6 @@ def _evidence(dsn: str) -> dict[str, Any]:
 
 def _decision(
     *,
-    now: datetime,
     evaluated_at: datetime,
     execution_kind: str,
     retry_enabled: bool,
@@ -192,7 +417,6 @@ def run_contract_check(dsn: str) -> dict[str, Any]:
         raise AssertionError("readiness fixture transition did not become ready")
 
     stale_decision = _decision(
-        now=now,
         evaluated_at=now - timedelta(minutes=10),
         execution_kind="initial",
         retry_enabled=True,
@@ -209,7 +433,6 @@ def run_contract_check(dsn: str) -> dict[str, Any]:
         raise AssertionError("old current readiness decision was not stale")
 
     current_decision = _decision(
-        now=now,
         evaluated_at=now - timedelta(minutes=1),
         execution_kind="initial",
         retry_enabled=True,
@@ -231,7 +454,6 @@ def run_contract_check(dsn: str) -> dict[str, Any]:
         raise AssertionError("current initial readiness decision was not allowed")
 
     retry_decision = _decision(
-        now=now,
         evaluated_at=now - timedelta(seconds=30),
         execution_kind="retry",
         retry_enabled=False,
@@ -322,6 +544,7 @@ def run_contract_check(dsn: str) -> dict[str, Any]:
 
     return {
         "model_version": "portfolio-risk-notification-readiness-history-contract-v1",
+        "destination_id": DESTINATION_ID,
         "current_initial_decision_id": current_decision["decision_id"],
         "current_retry_decision_id": retry_decision["decision_id"],
         "stale_status_proved": True,

--- a/src/warehouse/notification_execution_readiness_postgres_contract_check.py
+++ b/src/warehouse/notification_execution_readiness_postgres_contract_check.py
@@ -1,0 +1,368 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+from src.common.exceptions import ValidationError
+from src.orchestration.deliver_portfolio_risk_notifications import (
+    WebhookDeliveryConfig,
+)
+from src.orchestration.portfolio_risk_notification_destination_contract import (
+    DestinationActivation,
+    DestinationOwner,
+    NotificationDestination,
+)
+from src.orchestration.portfolio_risk_notification_retry_execution_policy import (
+    RetryExecutionPolicy,
+)
+from src.warehouse.controlled_receiver_rehearsal_recorder import (
+    record_controlled_receiver_rehearsal,
+)
+from src.warehouse.notification_destination_transition_rehearsal_contract import (
+    build_notification_destination_transition_rehearsal_record,
+)
+from src.warehouse.notification_destination_transition_rehearsal_postgres_contract_check import (
+    DESTINATION_ID,
+    OLD_ENDPOINT_ENV,
+    _checklist,
+    _controlled_receiver_record,
+    _transition_evidence,
+)
+from src.warehouse.notification_destination_transition_rehearsal_recorder import (
+    record_notification_destination_transition_rehearsal,
+)
+from src.warehouse.notification_execution_readiness_gate import (
+    evaluate_notification_execution_readiness,
+    read_notification_execution_readiness_evidence,
+)
+from src.warehouse.notification_execution_readiness_history_contract import (
+    build_notification_execution_readiness_record,
+)
+from src.warehouse.notification_execution_readiness_recorder import (
+    record_notification_execution_readiness,
+)
+from src.warehouse.postgres_loader import DEFAULT_POSTGRES_DSN
+
+CHECK_PATH = Path("sql/notification_execution_readiness_consistency_checks.sql")
+
+
+def _destination(now: datetime) -> NotificationDestination:
+    planned_at = now - timedelta(hours=4)
+    return NotificationDestination(
+        destination_id=DESTINATION_ID,
+        channel="webhook",
+        endpoint_env=OLD_ENDPOINT_ENV,
+        owner=DestinationOwner(
+            team="risk-operations",
+            contact="risk-operations-oncall",
+        ),
+        purpose="portfolio-risk-breach-lifecycle",
+        recipient_scope="risk-operations",
+        data_classification="internal",
+        allowed_event_types=(
+            "breach_escalated",
+            "breach_opened",
+            "breach_resolved",
+        ),
+        activation=DestinationActivation(
+            enabled=True,
+            change_request_id="CHG-CONTRACT-ROLLBACK",
+            reviewed_by=("transition-contract-reviewer",),
+            reviewed_at=planned_at - timedelta(days=1),
+            review_expires_at=now + timedelta(days=30),
+        ),
+    )
+
+
+def _evidence(dsn: str) -> dict[str, Any]:
+    evidence = dict(
+        read_notification_execution_readiness_evidence(
+            dsn=dsn,
+            destination_id=DESTINATION_ID,
+        )
+    )
+    evidence["ambiguities"] = []
+    return evidence
+
+
+def _decision(
+    *,
+    now: datetime,
+    evaluated_at: datetime,
+    execution_kind: str,
+    retry_enabled: bool,
+    destination: NotificationDestination,
+    evidence: dict[str, Any],
+) -> dict[str, Any]:
+    return evaluate_notification_execution_readiness(
+        execution_kind=execution_kind,
+        evaluated_at=evaluated_at,
+        delivery_config=WebhookDeliveryConfig(
+            enabled=True,
+            endpoint_env=OLD_ENDPOINT_ENV,
+            timeout_seconds=5,
+            max_batch_events=25,
+            max_attempts_per_event=3,
+            initial_backoff_seconds=1,
+        ),
+        retry_policy_fingerprint="readiness-contract-retry-policy",
+        retry_execution_policy=RetryExecutionPolicy(
+            enabled=retry_enabled,
+            max_plan_age_seconds=3600,
+            max_events=25,
+        ),
+        destination=destination,
+        activation_review=evidence["activation_review"],
+        transition_review=evidence["transition_review"],
+        ambiguities=evidence["ambiguities"],
+    )
+
+
+def _review_status(dsn: str, execution_kind: str) -> str:
+    try:
+        import psycopg
+    except ImportError as exc:  # pragma: no cover - required in CI.
+        raise RuntimeError("Notification readiness contract requires psycopg") from exc
+    with psycopg.connect(dsn) as connection:
+        with connection.cursor() as cursor:
+            cursor.execute(
+                """
+                SELECT readiness_review_status
+                FROM risk_platform.current_notification_execution_readiness_review
+                WHERE destination_id = %s AND execution_kind = %s
+                """,
+                (DESTINATION_ID, execution_kind),
+            )
+            row = cursor.fetchone()
+    if row is None:
+        raise AssertionError("notification readiness review row was not produced")
+    return str(row[0])
+
+
+def _mutation_rejected(dsn: str, statement: str) -> bool:
+    try:
+        import psycopg
+    except ImportError as exc:  # pragma: no cover - required in CI.
+        raise RuntimeError("Notification readiness contract requires psycopg") from exc
+    try:
+        with psycopg.connect(dsn) as connection:
+            with connection.cursor() as cursor:
+                cursor.execute(statement)
+            connection.commit()
+    except Exception as exc:
+        if "append-only" not in str(exc):
+            raise
+        return True
+    return False
+
+
+def run_contract_check(dsn: str) -> dict[str, Any]:
+    now = datetime.now(timezone.utc).replace(microsecond=0)
+    rehearsal, rollback_checklist = _transition_evidence(now)
+    transition_record = build_notification_destination_transition_rehearsal_record(
+        request_id="READINESS-HISTORY-TRANSITION-001",
+        recorded_at=now - timedelta(hours=2, minutes=59, seconds=56),
+        rehearsal=rehearsal,
+    )
+    rollback_receiver = _controlled_receiver_record(
+        checklist=rollback_checklist,
+        request_id="READINESS-HISTORY-CURRENT-RECEIVER",
+        event_id="readiness-history-current-receiver",
+        host="readiness-receiver-v1.test",
+        started_at=now - timedelta(hours=2),
+    )
+    record_controlled_receiver_rehearsal(dsn=dsn, record=rollback_receiver)
+    record_notification_destination_transition_rehearsal(
+        dsn=dsn,
+        record=transition_record,
+    )
+
+    destination = _destination(now)
+    if destination.fingerprint != rollback_checklist["destination_fingerprint"]:
+        raise AssertionError("readiness destination fingerprint does not match transition")
+    evidence = _evidence(dsn)
+    transition = evidence["transition_review"]
+    if transition is None or transition["transition_review_status"] != "ready":
+        raise AssertionError("readiness fixture transition did not become ready")
+
+    stale_decision = _decision(
+        now=now,
+        evaluated_at=now - timedelta(minutes=10),
+        execution_kind="initial",
+        retry_enabled=True,
+        destination=destination,
+        evidence=evidence,
+    )
+    stale_record = build_notification_execution_readiness_record(
+        request_id="READINESS-HISTORY-STALE-INITIAL",
+        recorded_at=now - timedelta(minutes=9, seconds=59),
+        decision=stale_decision,
+    )
+    record_notification_execution_readiness(dsn=dsn, record=stale_record)
+    if _review_status(dsn, "initial") != "decision_stale":
+        raise AssertionError("old current readiness decision was not stale")
+
+    current_decision = _decision(
+        now=now,
+        evaluated_at=now - timedelta(minutes=1),
+        execution_kind="initial",
+        retry_enabled=True,
+        destination=destination,
+        evidence=evidence,
+    )
+    current_record = build_notification_execution_readiness_record(
+        request_id="READINESS-HISTORY-CURRENT-INITIAL",
+        recorded_at=now - timedelta(seconds=59),
+        decision=current_decision,
+    )
+    created = record_notification_execution_readiness(
+        dsn=dsn,
+        record=current_record,
+    )
+    if created["created"] is not True:
+        raise AssertionError("current readiness decision was not retained")
+    if _review_status(dsn, "initial") != "allowed":
+        raise AssertionError("current initial readiness decision was not allowed")
+
+    retry_decision = _decision(
+        now=now,
+        evaluated_at=now - timedelta(seconds=30),
+        execution_kind="retry",
+        retry_enabled=False,
+        destination=destination,
+        evidence=evidence,
+    )
+    retry_record = build_notification_execution_readiness_record(
+        request_id="READINESS-HISTORY-CURRENT-RETRY",
+        recorded_at=now - timedelta(seconds=29),
+        decision=retry_decision,
+    )
+    record_notification_execution_readiness(dsn=dsn, record=retry_record)
+    if _review_status(dsn, "retry") != "blocked":
+        raise AssertionError("current retry readiness decision was not blocked")
+
+    replay = record_notification_execution_readiness(
+        dsn=dsn,
+        record=current_record,
+    )
+    if replay["created"] is not False:
+        raise AssertionError("exact readiness decision retry did not converge")
+
+    conflicting = build_notification_execution_readiness_record(
+        request_id=current_record["request_id"],
+        recorded_at=datetime.fromisoformat(current_record["recorded_at"])
+        + timedelta(seconds=1),
+        decision=current_decision,
+    )
+    try:
+        record_notification_execution_readiness(dsn=dsn, record=conflicting)
+    except ValidationError:
+        conflict_rejected = True
+    else:
+        conflict_rejected = False
+    if not conflict_rejected:
+        raise AssertionError("conflicting readiness request identity was accepted")
+
+    replacement_checklist = _checklist(
+        destination_id=DESTINATION_ID,
+        fingerprint="readiness-post-transition-fingerprint",
+        authority_id="readiness-post-transition-authority",
+        reviewed_at=now - timedelta(minutes=20),
+        expires_at=now + timedelta(days=30),
+    )
+    replacement_receiver = _controlled_receiver_record(
+        checklist=replacement_checklist,
+        request_id="READINESS-HISTORY-REPLACEMENT-RECEIVER",
+        event_id="readiness-history-replacement-receiver",
+        host="readiness-receiver-v2.test",
+        started_at=now - timedelta(minutes=10),
+    )
+    record_controlled_receiver_rehearsal(dsn=dsn, record=replacement_receiver)
+    if _review_status(dsn, "initial") != "decision_superseded":
+        raise AssertionError("new activation evidence did not supersede initial decision")
+    if _review_status(dsn, "retry") != "decision_superseded":
+        raise AssertionError("new activation evidence did not supersede retry decision")
+
+    update_rejected = _mutation_rejected(
+        dsn,
+        """
+        UPDATE risk_platform.notification_execution_readiness_decisions
+        SET decision = 'block'
+        WHERE request_id = 'READINESS-HISTORY-CURRENT-INITIAL'
+        """,
+    )
+    delete_rejected = _mutation_rejected(
+        dsn,
+        """
+        DELETE FROM risk_platform.notification_execution_readiness_decisions
+        WHERE request_id = 'READINESS-HISTORY-CURRENT-INITIAL'
+        """,
+    )
+    if not update_rejected or not delete_rejected:
+        raise AssertionError("append-only readiness mutation was accepted")
+
+    try:
+        import psycopg
+    except ImportError as exc:  # pragma: no cover - required in CI.
+        raise RuntimeError("Notification readiness contract requires psycopg") from exc
+    with psycopg.connect(dsn) as connection:
+        with connection.cursor() as cursor:
+            cursor.execute(CHECK_PATH.read_text(encoding="utf-8"))
+            checks = list(cursor.fetchall())
+    failures = [check for check in checks if check[3] != "pass"]
+    if failures:
+        names = ", ".join(str(check[0]) for check in failures)
+        raise AssertionError("notification readiness reconciliation failed: " + names)
+
+    return {
+        "model_version": "portfolio-risk-notification-readiness-history-contract-v1",
+        "current_initial_decision_id": current_decision["decision_id"],
+        "current_retry_decision_id": retry_decision["decision_id"],
+        "stale_status_proved": True,
+        "allowed_status_proved": True,
+        "blocked_status_proved": True,
+        "superseded_status_proved": True,
+        "exact_retry_converged": True,
+        "conflicting_request_rejected": True,
+        "update_rejected": update_rejected,
+        "delete_rejected": delete_rejected,
+        "consistency_checks": len(checks),
+        "external_request_performed": False,
+        "delivery_attempt_written": False,
+        "outbox_mutated": False,
+        "acknowledgement_mutated": False,
+    }
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Exercise append-only notification execution readiness history "
+            "against PostgreSQL 16."
+        )
+    )
+    parser.add_argument(
+        "--dsn",
+        default=os.environ.get("WAREHOUSE_POSTGRES_DSN", DEFAULT_POSTGRES_DSN),
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    try:
+        summary = run_contract_check(args.dsn)
+    except Exception as exc:
+        print(f"Notification readiness history contract failed: {exc}", file=sys.stderr)
+        return 1
+    print(json.dumps(summary, sort_keys=True, allow_nan=False))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/warehouse/notification_execution_readiness_recorder.py
+++ b/src/warehouse/notification_execution_readiness_recorder.py
@@ -1,0 +1,256 @@
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import sys
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+from src.common.exceptions import StorageError, ValidationError
+from src.warehouse.notification_execution_readiness_history_contract import (
+    canonical_notification_execution_readiness_record_bytes,
+    validate_notification_execution_readiness_record,
+)
+from src.warehouse.postgres_loader import DEFAULT_POSTGRES_DSN
+
+MAX_RECORD_BYTES = 1_048_576
+
+
+def _result(
+    record: Mapping[str, Any],
+    *,
+    digest: str,
+    created: bool,
+) -> dict[str, Any]:
+    decision = record["decision"]
+    return {
+        "record_id": record["record_id"],
+        "request_id": record["request_id"],
+        "decision_id": decision["decision_id"],
+        "destination_id": decision["destination"]["destination_id"],
+        "execution_kind": decision["execution_kind"],
+        "decision": decision["decision"],
+        "document_sha256": digest,
+        "created": created,
+    }
+
+
+def record_notification_execution_readiness(
+    *,
+    dsn: str,
+    record: Mapping[str, Any],
+) -> dict[str, Any]:
+    validated = validate_notification_execution_readiness_record(record)
+    canonical = canonical_notification_execution_readiness_record_bytes(validated)
+    digest = hashlib.sha256(canonical).hexdigest()
+    decision = validated["decision"]
+    configuration = decision["configuration"]
+    destination = decision["destination"]
+    activation = decision["activation_review"] or {}
+    transition = decision["transition_review"] or {}
+    ambiguity = decision["ambiguity"]
+
+    try:
+        import psycopg
+        from psycopg.types.json import Jsonb
+    except ImportError as exc:  # pragma: no cover - required in CI.
+        raise RuntimeError("Notification readiness history requires psycopg") from exc
+
+    try:
+        with psycopg.connect(dsn) as connection:
+            with connection.cursor() as cursor:
+                cursor.execute(
+                    """
+                    SELECT record_json, document_sha256
+                    FROM risk_platform.notification_execution_readiness_decisions
+                    WHERE request_id = %s
+                    """,
+                    (validated["request_id"],),
+                )
+                existing = cursor.fetchone()
+                if existing is not None:
+                    stored_json, stored_digest = existing
+                    if stored_json != validated or stored_digest != digest:
+                        raise ValidationError(
+                            "request_id already exists with different readiness evidence"
+                        )
+                    return _result(validated, digest=digest, created=False)
+
+                cursor.execute(
+                    """
+                    INSERT INTO
+                    risk_platform.notification_execution_readiness_decisions (
+                        record_id,
+                        model_version,
+                        request_id,
+                        decision_id,
+                        destination_id,
+                        execution_kind,
+                        evaluated_at,
+                        recorded_at,
+                        decision,
+                        blocking_reasons_json,
+                        delivery_fingerprint,
+                        retry_policy_fingerprint,
+                        retry_execution_policy_fingerprint,
+                        endpoint_environment_variable,
+                        destination_fingerprint,
+                        destination_activation_status,
+                        activation_authority_id,
+                        activation_checklist_id,
+                        activation_review_status,
+                        activation_ready,
+                        transition_record_id,
+                        transition_rehearsal_id,
+                        transition_review_status,
+                        transition_ready,
+                        ambiguity_count,
+                        ambiguity_event_ids_json,
+                        ambiguity_record_ids_json,
+                        unbound_ambiguity_event_ids_json,
+                        decision_json,
+                        record_json,
+                        document_sha256
+                    )
+                    VALUES (
+                        %s, %s, %s, %s, %s, %s, %s, %s,
+                        %s, %s, %s, %s, %s, %s, %s, %s,
+                        %s, %s, %s, %s, %s, %s, %s, %s,
+                        %s, %s, %s, %s, %s, %s, %s
+                    )
+                    ON CONFLICT DO NOTHING
+                    RETURNING record_id
+                    """,
+                    (
+                        validated["record_id"],
+                        validated["model_version"],
+                        validated["request_id"],
+                        decision["decision_id"],
+                        destination["destination_id"],
+                        decision["execution_kind"],
+                        decision["evaluated_at"],
+                        validated["recorded_at"],
+                        decision["decision"],
+                        Jsonb(decision["blocking_reasons"]),
+                        configuration["delivery_fingerprint"],
+                        configuration["retry_policy_fingerprint"],
+                        configuration["retry_execution_policy_fingerprint"],
+                        configuration["endpoint_environment_variable"],
+                        destination["fingerprint"],
+                        destination["activation_status"],
+                        activation.get("authority_id"),
+                        activation.get("checklist_id"),
+                        activation.get("review_status"),
+                        activation.get("operational_activation_ready"),
+                        transition.get("transition_record_id"),
+                        transition.get("transition_rehearsal_id"),
+                        transition.get("transition_review_status"),
+                        transition.get("transition_ready"),
+                        ambiguity["count"],
+                        Jsonb(ambiguity["event_ids"]),
+                        Jsonb(ambiguity["record_ids"]),
+                        Jsonb(ambiguity["unbound_event_ids"]),
+                        Jsonb(decision),
+                        Jsonb(validated),
+                        digest,
+                    ),
+                )
+                created = cursor.fetchone() is not None
+                if not created:
+                    cursor.execute(
+                        """
+                        SELECT request_id, record_json, document_sha256
+                        FROM risk_platform.notification_execution_readiness_decisions
+                        WHERE decision_id = %s
+                        """,
+                        (decision["decision_id"],),
+                    )
+                    conflict = cursor.fetchone()
+                    if conflict is not None:
+                        conflict_request_id, stored_json, stored_digest = conflict
+                        if (
+                            conflict_request_id != validated["request_id"]
+                            or stored_json != validated
+                            or stored_digest != digest
+                        ):
+                            raise ValidationError(
+                                "decision_id already exists under different readiness evidence"
+                            )
+
+                cursor.execute(
+                    """
+                    SELECT record_json, document_sha256
+                    FROM risk_platform.notification_execution_readiness_decisions
+                    WHERE record_id = %s
+                    """,
+                    (validated["record_id"],),
+                )
+                stored = cursor.fetchone()
+                if stored is None:
+                    raise StorageError("notification readiness decision was not retained")
+                stored_json, stored_digest = stored
+                if stored_json != validated or stored_digest != digest:
+                    raise ValidationError(
+                        "record_id already exists with different readiness evidence"
+                    )
+            connection.commit()
+    except (StorageError, ValidationError):
+        raise
+    except Exception:
+        raise StorageError(
+            "notification readiness history database operation failed"
+        ) from None
+
+    return _result(validated, digest=digest, created=created)
+
+
+def _read_record(path: Path) -> dict[str, Any]:
+    if path.is_symlink():
+        raise ValidationError("notification readiness record must not be a symbolic link")
+    if not path.is_file():
+        raise ValidationError("notification readiness record must be a regular file")
+    if path.stat().st_size > MAX_RECORD_BYTES:
+        raise ValidationError("notification readiness record exceeds 1 MB")
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, ValueError):
+        raise ValidationError("notification readiness record could not be read") from None
+    if not isinstance(value, Mapping):
+        raise ValidationError("notification readiness record must be a JSON object")
+    return dict(value)
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Append one notification execution readiness decision to PostgreSQL."
+    )
+    parser.add_argument("--record", required=True, type=Path)
+    parser.add_argument(
+        "--dsn",
+        default=os.environ.get("WAREHOUSE_POSTGRES_DSN", DEFAULT_POSTGRES_DSN),
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    try:
+        result = record_notification_execution_readiness(
+            dsn=args.dsn,
+            record=_read_record(args.record),
+        )
+    except ValidationError as exc:
+        print(f"Notification readiness record rejected: {exc}", file=sys.stderr)
+        return 1
+    except (StorageError, RuntimeError) as exc:
+        print(f"Notification readiness history failed: {exc}", file=sys.stderr)
+        return 1
+    print(json.dumps(result, sort_keys=True, allow_nan=False))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/test_docker_compose_contract.py
+++ b/tests/unit/test_docker_compose_contract.py
@@ -50,6 +50,7 @@ def test_local_database_seed_mounts_are_read_only_and_ordered() -> None:
         "./sql/controlled_notification_receiver_rehearsal_schema.sql:/docker-entrypoint-initdb.d/22_controlled_notification_receiver_rehearsal_schema.sql:ro",
         "./sql/controlled_notification_receiver_review_schema.sql:/docker-entrypoint-initdb.d/23_controlled_notification_receiver_review_schema.sql:ro",
         "./sql/notification_destination_transition_rehearsal_schema.sql:/docker-entrypoint-initdb.d/24_notification_destination_transition_rehearsal_schema.sql:ro",
+        "./sql/notification_execution_readiness_schema.sql:/docker-entrypoint-initdb.d/25_notification_execution_readiness_schema.sql:ro",
     ]
     assert services["mongo"]["volumes"] == [
         "./mongo/init:/docker-entrypoint-initdb.d:ro"

--- a/tests/unit/test_notification_execution_readiness_history_architecture_contract.py
+++ b/tests/unit/test_notification_execution_readiness_history_architecture_contract.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+CONTRACT = Path("src/warehouse/notification_execution_readiness_history_contract.py")
+RECORDER = Path("src/warehouse/notification_execution_readiness_recorder.py")
+SCHEMA = Path("sql/notification_execution_readiness_schema.sql")
+CHECKS = Path("sql/notification_execution_readiness_consistency_checks.sql")
+DOC = Path("docs/notification-execution-readiness-history.md")
+
+
+def test_history_contract_and_schema_are_present() -> None:
+    contract = CONTRACT.read_text(encoding="utf-8")
+    schema = SCHEMA.read_text(encoding="utf-8")
+
+    assert "portfolio-risk-notification-execution-readiness-record-v1" in contract
+    assert "notification_execution_readiness_decisions" in schema
+    assert "latest_notification_execution_readiness_decisions" in schema
+    assert "current_notification_execution_readiness_review" in schema
+
+
+def test_current_views_partition_all_review_states() -> None:
+    schema = SCHEMA.read_text(encoding="utf-8")
+
+    for status in (
+        "decision_missing",
+        "decision_superseded",
+        "decision_stale",
+        "blocked",
+        "allowed",
+    ):
+        assert status in schema
+    for suffix in ("allowed", "blocked", "stale", "superseded", "missing"):
+        assert f"current_notification_execution_readiness_{suffix}" in schema
+
+
+def test_history_is_append_only_and_reconciled() -> None:
+    schema = SCHEMA.read_text(encoding="utf-8")
+    checks = CHECKS.read_text(encoding="utf-8")
+
+    assert "notification_execution_readiness_reject_update" in schema
+    assert "notification_execution_readiness_reject_delete" in schema
+    assert "append-only" in schema
+    assert "notification_execution_readiness_append_only_triggers_enabled" in checks
+    assert "notification_execution_readiness_review_status_reconciles" in checks
+
+
+def test_history_code_has_no_notification_transport() -> None:
+    source = CONTRACT.read_text(encoding="utf-8") + RECORDER.read_text(
+        encoding="utf-8"
+    )
+    lowered = source.lower()
+
+    assert "urllib" not in source
+    assert "import socket" not in source
+    assert "urlopen" not in source
+    assert "terraform apply" not in lowered
+    assert "delivery_attempts" not in source
+    assert "notification_outbox" not in source
+
+
+def test_documentation_preserves_disabled_default_and_next_boundary() -> None:
+    document = DOC.read_text(encoding="utf-8")
+
+    assert "P4d5b" in document
+    assert "P4d5c" in document
+    assert "disabled by default" in document
+    assert "five minutes" in document

--- a/tests/unit/test_notification_execution_readiness_history_contract.py
+++ b/tests/unit/test_notification_execution_readiness_history_contract.py
@@ -1,0 +1,167 @@
+from __future__ import annotations
+
+from copy import deepcopy
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from src.common.exceptions import ValidationError
+from src.orchestration.deliver_portfolio_risk_notifications import (
+    WebhookDeliveryConfig,
+)
+from src.orchestration.portfolio_risk_notification_destination_contract import (
+    DestinationActivation,
+    DestinationOwner,
+    NotificationDestination,
+)
+from src.orchestration.portfolio_risk_notification_retry_execution_policy import (
+    RetryExecutionPolicy,
+)
+from src.warehouse.notification_execution_readiness_gate import (
+    evaluate_notification_execution_readiness,
+)
+from src.warehouse.notification_execution_readiness_history_contract import (
+    MODEL_VERSION,
+    build_notification_execution_readiness_record,
+    canonical_notification_execution_readiness_record_bytes,
+    validate_notification_execution_readiness_record,
+)
+
+NOW = datetime(2026, 6, 1, 12, tzinfo=timezone.utc)
+DESTINATION_ID = "risk-operations-webhook"
+ENDPOINT_ENV = "RISK_NOTIFICATION_WEBHOOK_URL"
+
+
+def _decision(*, allowed: bool = True) -> dict[str, object]:
+    destination = NotificationDestination(
+        destination_id=DESTINATION_ID,
+        channel="webhook",
+        endpoint_env=ENDPOINT_ENV,
+        owner=DestinationOwner(
+            team="risk-operations",
+            contact="risk-operations-oncall",
+        ),
+        purpose="portfolio-risk-breach-lifecycle",
+        recipient_scope="risk-operations",
+        data_classification="internal",
+        allowed_event_types=("breach_opened",),
+        activation=DestinationActivation(
+            enabled=True,
+            change_request_id="CHG-READY-001",
+            reviewed_by=("platform-reviewer",),
+            reviewed_at=NOW - timedelta(days=1),
+            review_expires_at=NOW + timedelta(days=30),
+        ),
+    )
+    activation = {
+        "destination_id": DESTINATION_ID,
+        "destination_fingerprint": destination.fingerprint,
+        "authority_id": "destination-authority-1",
+        "checklist_id": "activation-checklist-1",
+        "review_status": "ready",
+        "operational_activation_ready": True,
+    }
+    transition = {
+        "destination_id": DESTINATION_ID,
+        "current_destination_fingerprint": destination.fingerprint,
+        "current_authority_id": activation["authority_id"],
+        "current_checklist_id": activation["checklist_id"],
+        "activation_review_status": activation["review_status"],
+        "operational_activation_ready": True,
+        "transition_record_id": "transition-record-1",
+        "transition_rehearsal_id": "transition-rehearsal-1",
+        "rollback_plan_id": "rollback-plan-1",
+        "rollback_authority_id": activation["authority_id"],
+        "rollback_checklist_id": activation["checklist_id"],
+        "rollback_destination_fingerprint": destination.fingerprint,
+        "rollback_endpoint_environment_variable": ENDPOINT_ENV,
+        "transition_matches_current_activation": True,
+        "transition_review_status": "ready",
+        "transition_ready": True,
+    }
+    return evaluate_notification_execution_readiness(
+        execution_kind="initial",
+        evaluated_at=NOW,
+        delivery_config=WebhookDeliveryConfig(
+            enabled=allowed,
+            endpoint_env=ENDPOINT_ENV,
+            timeout_seconds=5,
+            max_batch_events=25,
+            max_attempts_per_event=3,
+            initial_backoff_seconds=1,
+        ),
+        retry_policy_fingerprint="retry-policy-1",
+        retry_execution_policy=RetryExecutionPolicy(
+            enabled=True,
+            max_plan_age_seconds=3600,
+            max_events=25,
+        ),
+        destination=destination,
+        activation_review=activation,
+        transition_review=transition,
+        ambiguities=[],
+    )
+
+
+def test_readiness_record_is_deterministic_and_canonical() -> None:
+    decision = _decision()
+    first = build_notification_execution_readiness_record(
+        request_id="READINESS-DECISION-001",
+        recorded_at=NOW + timedelta(seconds=1),
+        decision=decision,
+    )
+    second = build_notification_execution_readiness_record(
+        request_id="READINESS-DECISION-001",
+        recorded_at=NOW + timedelta(seconds=1),
+        decision=decision,
+    )
+
+    assert first == second
+    assert first["model_version"] == MODEL_VERSION
+    assert validate_notification_execution_readiness_record(first) == first
+    assert canonical_notification_execution_readiness_record_bytes(first)
+
+
+def test_changed_request_time_or_decision_changes_record_identity() -> None:
+    base = build_notification_execution_readiness_record(
+        request_id="READINESS-DECISION-001",
+        recorded_at=NOW + timedelta(seconds=1),
+        decision=_decision(),
+    )
+    later = build_notification_execution_readiness_record(
+        request_id="READINESS-DECISION-001",
+        recorded_at=NOW + timedelta(seconds=2),
+        decision=_decision(),
+    )
+    blocked = build_notification_execution_readiness_record(
+        request_id="READINESS-DECISION-001",
+        recorded_at=NOW + timedelta(seconds=1),
+        decision=_decision(allowed=False),
+    )
+
+    assert base["record_id"] != later["record_id"]
+    assert base["record_id"] != blocked["record_id"]
+
+
+def test_record_rejects_tampering_and_invalid_time_order() -> None:
+    record = build_notification_execution_readiness_record(
+        request_id="READINESS-DECISION-001",
+        recorded_at=NOW + timedelta(seconds=1),
+        decision=_decision(),
+    )
+    changed = deepcopy(record)
+    changed["request_id"] = "READINESS-DECISION-002"
+    with pytest.raises(ValidationError, match="not canonical"):
+        validate_notification_execution_readiness_record(changed)
+
+    unknown = deepcopy(record)
+    unknown["execute"] = True
+    with pytest.raises(ValidationError, match="fields are invalid"):
+        validate_notification_execution_readiness_record(unknown)
+
+    with pytest.raises(ValidationError, match="must not precede"):
+        build_notification_execution_readiness_record(
+            request_id="READINESS-DECISION-003",
+            recorded_at=NOW - timedelta(seconds=1),
+            decision=_decision(),
+        )

--- a/tests/unit/test_notification_execution_readiness_recorder.py
+++ b/tests/unit/test_notification_execution_readiness_recorder.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from src.common.exceptions import ValidationError
+from src.warehouse.notification_execution_readiness_recorder import (
+    MAX_RECORD_BYTES,
+    _build_parser,
+    _read_record,
+)
+
+
+def test_record_reader_rejects_symbolic_links(tmp_path: Path) -> None:
+    target = tmp_path / "target.json"
+    target.write_text("{}", encoding="utf-8")
+    link = tmp_path / "record.json"
+    link.symlink_to(target)
+
+    with pytest.raises(ValidationError, match="symbolic link"):
+        _read_record(link)
+
+
+def test_record_reader_rejects_non_object_and_oversized_files(
+    tmp_path: Path,
+) -> None:
+    array = tmp_path / "array.json"
+    array.write_text("[]", encoding="utf-8")
+    with pytest.raises(ValidationError, match="JSON object"):
+        _read_record(array)
+
+    oversized = tmp_path / "oversized.json"
+    oversized.write_bytes(b" " * (MAX_RECORD_BYTES + 1))
+    with pytest.raises(ValidationError, match="exceeds 1 MB"):
+        _read_record(oversized)
+
+
+def test_recorder_cli_has_no_execution_switch() -> None:
+    parser = _build_parser()
+    with pytest.raises(SystemExit):
+        parser.parse_args(["--record", "decision.json", "--execute"])


### PR DESCRIPTION
## Goal

Complete **P4d5b — append-only notification execution readiness history**.

```text
canonical P4d5a allow or block decision
  + operator request identity
  + recording time
  -> independent revalidation
  -> append-only PostgreSQL history
  -> current state per destination and execution kind
```

## Record and replay contract

Adds `portfolio-risk-notification-execution-readiness-record-v1`.

The wrapper independently validates the complete readiness decision, requires `recorded_at >= evaluated_at`, and binds request identity, recording time, and canonical decision into a deterministic record ID.

Exact request replay converges. Changed evidence under the same request ID is rejected. A readiness decision ID cannot be reused under another request or altered wrapper. PostgreSQL triggers reject direct UPDATE and DELETE operations.

## Current review states

The current view selects one decision per destination and `initial` or `retry` execution kind, then emits:

- `decision_missing`;
- `decision_superseded`;
- `decision_stale` after five minutes;
- `blocked`; or
- `allowed`.

Supersession compares destination, activation, transition, checklist, authority, and endpoint-environment identities against current reviewed evidence. Only `allowed` sets `execution_ready=true`.

## PostgreSQL proof

The transaction-scoped fixture proves stale, allowed, blocked, and superseded states; exact retry convergence; conflicting request rejection; append-only mutation rejection; and eighteen readiness-history reconciliation checks.

The first PostgreSQL run exposed a deterministic rehearsal collision between two fixtures using the same second but different operator request IDs. The readiness fixture was moved to distinct canonical time evidence. The next run exposed test-order coupling because both fixtures shared one destination grain; the readiness fixture now uses the isolated `readiness-history-webhook` destination. Existing transition behaviour and all validation controls were preserved.

## Scope

Twelve intended files, 2,055 additions and two deletions. The branch is zero commits behind current `main`.

## Exact-head validation

GitHub Actions run **390** (`33497152827`) passed on final head `94a2e9818f796f4f534faa3416068e6d77e10519`:

- Security guardrails passed.
- Ruff passed.
- mypy passed across **138 source files**.
- **903 tests passed** in quality and **903 passed again** in readiness.
- Dependency integrity and standard readiness replay passed.
- PostgreSQL 16 proved `decision_stale`, `allowed`, `blocked`, and `decision_superseded`, exact request convergence, conflicting request rejection, UPDATE/DELETE rejection, and all **18** readiness-history checks.
- Existing destination-transition, controlled-receiver, retry-follow-up, model-approval, service-level, daily/portfolio risk, and warehouse reconciliation remained green.
- Kubernetes rendering and Terraform format/init/validate passed without apply.

There are no review submissions or unresolved review threads.

## Safety

This increment records decisions but performs no DNS lookup, socket operation, webhook request, delivery-attempt write, outbox mutation, acknowledgement, deployment, or `terraform apply`. Delivery and retry execution remain disabled by default.

Validated and ready for squash merge.