### PR TITLE
Enforce readiness before initial notification delivery

### DIFF
--- a/docs/notification-execution-readiness-enforcement.md
+++ b/docs/notification-execution-readiness-enforcement.md
@@ -1,0 +1,106 @@
+# Notification Execution Readiness Enforcement
+
+Primary arc42 blocks: `orchestration` and `warehouse`.
+
+## Goal
+
+P4d5c applies the retained readiness decision to the initial webhook execution
+boundary:
+
+```text
+current allowed serving row
+  + independently validated append-only readiness record
+  + fresh gate evaluation
+  + acquired shared delivery lock
+  -> fail-closed execution authority
+  -> first network request may begin
+```
+
+The enforcement model is
+`portfolio-risk-notification-execution-readiness-enforcement-v1`.
+
+## Exact retained authority
+
+Execution reads exactly one row for the destination and `initial` execution kind
+from:
+
+```text
+risk_platform.current_notification_execution_readiness_review
+```
+
+The row must be `allowed` with `execution_ready = true`. Its record, request,
+decision, destination, execution kind, evaluation time and recording time must
+all match the canonical append-only document retained in:
+
+```text
+risk_platform.notification_execution_readiness_decisions
+```
+
+Missing, blocked, stale, superseded, duplicate or internally inconsistent
+evidence fails closed before transport or delivery-attempt persistence.
+
+## Fresh under-lock evaluation
+
+The initial sender first acquires the same shared delivery lock used by governed
+retry execution. While that lock remains held it:
+
+1. selects the zero-attempt candidates;
+2. resolves the active destination and event allow-list;
+3. reads and validates the current retained readiness record;
+4. reruns the P4d5a gate at the sender's exact execution timestamp; and
+5. compares the retained and refreshed substantive governed evidence.
+
+The refresh receives a new timestamp-derived decision ID. Enforcement therefore
+retains both IDs but compares the configuration, destination, activation,
+transition, ambiguity, decision and side-effect evidence after excluding only
+the decision ID and evaluation timestamp.
+
+A retained decision may be at most five minutes old. A refreshed block or any
+substantive mismatch is treated as supersession during preflight.
+
+## Delivery evidence
+
+A successful preflight adds credential-free evidence to the delivery summary:
+
+- enforcement model and deterministic enforcement ID;
+- destination and execution kind;
+- readiness record and request IDs;
+- retained and refreshed decision IDs and evaluation times;
+- shared lock model, scope and key fingerprint;
+- `allowed` review status; and
+- confirmation that substantive evidence matched.
+
+It does not retain the endpoint value, endpoint path, headers, credentials,
+response body, payload body or PostgreSQL DSN.
+
+## Ordering guarantee
+
+The call order is intentionally:
+
+```text
+acquire lock
+  -> candidate read
+  -> destination authority
+  -> readiness enforcement
+  -> transport
+  -> append-only attempt write
+  -> release lock
+```
+
+A readiness failure therefore occurs before the first network request. The lock
+remains held through every request and attempt insert.
+
+## Operational boundary
+
+Plan-only delivery remains read-only and does not require execution authority or
+acquire the lock. Explicit execution now requires current retained and refreshed
+readiness authority in addition to the existing destination and endpoint checks.
+
+Committed webhook delivery, destination activation and retry execution remain
+disabled by default. This increment does not schedule delivery, enable a
+destination, resolve an endpoint value during CI, perform DNS in tests, mutate
+the outbox, acknowledge a breach, deploy infrastructure or run `terraform
+apply`.
+
+Retry execution adopts the same shared enforcement contract in the next bounded
+increment, with a separate append-only binding to terminal retry evidence.

--- a/src/orchestration/deliver_portfolio_risk_notifications.py
+++ b/src/orchestration/deliver_portfolio_risk_notifications.py
@@ -143,6 +143,44 @@ def load_webhook_delivery_config(path: Path) -> WebhookDeliveryConfig:
     return parse_webhook_delivery_config(payload)
 
 
+def _enforce_initial_delivery_readiness(
+    *,
+    dsn: str,
+    destination_id: str,
+    evaluated_at: datetime,
+    delivery_config_path: Path,
+    destination_config_path: Path,
+    lock_evidence: Mapping[str, Any],
+) -> dict[str, Any]:
+    # Local import avoids a module cycle: the gate reuses WebhookDeliveryConfig.
+    from src.warehouse.notification_execution_readiness_enforcement import (
+        enforce_notification_execution_readiness,
+    )
+
+    return enforce_notification_execution_readiness(
+        dsn=dsn,
+        destination_id=destination_id,
+        execution_kind="initial",
+        evaluated_at=evaluated_at,
+        delivery_config_path=delivery_config_path,
+        destination_config_path=destination_config_path,
+        lock_evidence=lock_evidence,
+    )
+
+
+def _validate_initial_delivery_readiness(
+    value: Mapping[str, Any],
+) -> dict[str, Any]:
+    from src.warehouse.notification_execution_readiness_enforcement import (
+        validate_notification_execution_readiness_enforcement,
+    )
+
+    validated = validate_notification_execution_readiness_enforcement(value)
+    if validated["execution_kind"] != "initial":
+        raise ValidationError("initial delivery requires initial readiness evidence")
+    return validated
+
+
 def _endpoint(value: str) -> tuple[str, str]:
     endpoint = _required_text(value, "webhook endpoint", maximum=2_048)
     parsed = urlparse(endpoint)
@@ -382,6 +420,7 @@ def _delivery_summary(
     execute: bool,
     destination_authority: Mapping[str, Any],
     lock_evidence: Mapping[str, Any] | None = None,
+    execution_readiness: Mapping[str, Any] | None = None,
 ) -> dict[str, Any]:
     plan = [
         {
@@ -406,7 +445,7 @@ def _delivery_summary(
             lock_evidence.get("key_fingerprint") if lock_evidence is not None else None
         ),
     }
-    return {
+    summary = {
         "run_id": str(uuid4()),
         "config_fingerprint": config.fingerprint,
         "channel": CHANNEL,
@@ -432,6 +471,9 @@ def _delivery_summary(
         "concurrency_control": concurrency_control,
         "response_bodies_recorded": False,
     }
+    if execution_readiness is not None:
+        summary["execution_readiness"] = dict(execution_readiness)
+    return summary
 
 
 def _execute_initial_attempts(
@@ -593,13 +635,24 @@ def deliver_portfolio_risk_notifications(
             dsn=dsn,
             max_events=config.max_batch_events,
         )
+        execution_time = selected_clock()
         destination_authority = resolve_notification_destination_authority(
             destination_config_path=selected_destination_path,
             destination_id=destination_id,
             delivery_endpoint_env=config.endpoint_env,
-            evaluated_at=selected_clock(),
+            evaluated_at=execution_time,
             event_types=_event_types(candidates),
             require_active=True,
+        )
+        execution_readiness = _validate_initial_delivery_readiness(
+            _enforce_initial_delivery_readiness(
+                dsn=dsn,
+                destination_id=destination_id,
+                evaluated_at=execution_time,
+                delivery_config_path=config_path,
+                destination_config_path=selected_destination_path,
+                lock_evidence=lock_evidence,
+            )
         )
         summary = _delivery_summary(
             config=config,
@@ -608,6 +661,7 @@ def deliver_portfolio_risk_notifications(
             execute=True,
             destination_authority=destination_authority,
             lock_evidence=lock_evidence,
+            execution_readiness=execution_readiness,
         )
         summary["execution"] = _execute_initial_attempts(
             candidates=candidates,
@@ -692,15 +746,16 @@ def main(argv: Sequence[str] | None = None) -> int:
         return 1
     except ValidationError:
         print(
-            "Webhook delivery failed: configuration, destination, endpoint, "
-            "candidate, or options were invalid",
+            "Webhook delivery failed: configuration, destination, readiness, "
+            "endpoint, candidate, or options were invalid",
             file=sys.stderr,
         )
         return 1
     except StorageError:
         print(
-            "Webhook delivery failed: PostgreSQL, lock, or attempt persistence "
-            "failed; remote receivers should deduplicate by Idempotency-Key",
+            "Webhook delivery failed: PostgreSQL, lock, readiness, or attempt "
+            "persistence failed; remote receivers should deduplicate by "
+            "Idempotency-Key",
             file=sys.stderr,
         )
         return 1

--- a/src/warehouse/notification_execution_readiness_enforcement.py
+++ b/src/warehouse/notification_execution_readiness_enforcement.py
@@ -1,0 +1,442 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from collections.abc import Callable, Mapping
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+from src.common.exceptions import StorageError, ValidationError
+from src.warehouse.notification_execution_readiness_gate import (
+    run_notification_execution_readiness_gate,
+    validate_notification_execution_readiness_decision,
+)
+from src.warehouse.notification_execution_readiness_history_contract import (
+    validate_notification_execution_readiness_record,
+)
+
+MODEL_VERSION = "portfolio-risk-notification-execution-readiness-enforcement-v1"
+EXECUTION_KINDS = frozenset({"initial", "retry"})
+REVIEW_STATUSES = frozenset(
+    {
+        "allowed",
+        "blocked",
+        "decision_missing",
+        "decision_stale",
+        "decision_superseded",
+    }
+)
+MAX_READINESS_AGE = timedelta(minutes=5)
+SAFE_TEXT = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,511}$")
+
+ReviewReader = Callable[..., Mapping[str, Any] | None]
+GateRunner = Callable[..., Mapping[str, Any]]
+
+
+def _safe_text(value: Any, label: str) -> str:
+    if not isinstance(value, str) or not SAFE_TEXT.fullmatch(value):
+        raise ValidationError(f"{label} must be one safe text segment")
+    return value
+
+
+def _aware_utc(value: Any, label: str) -> datetime:
+    if isinstance(value, datetime):
+        parsed = value
+    elif isinstance(value, str):
+        try:
+            parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        except ValueError:
+            raise ValidationError(f"{label} must be ISO-8601") from None
+    else:
+        raise ValidationError(f"{label} must be timezone-aware")
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise ValidationError(f"{label} must be timezone-aware")
+    return parsed.astimezone(timezone.utc)
+
+
+def _exact_mapping(value: Any, label: str, keys: set[str]) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        raise ValidationError(f"{label} must be a mapping")
+    actual = set(value)
+    if actual != keys:
+        raise ValidationError(
+            f"{label} fields are invalid; "
+            f"missing={sorted(keys - actual)}, unknown={sorted(actual - keys)}"
+        )
+    return value
+
+
+def _quote_identifier(value: str) -> str:
+    if not isinstance(value, str) or not value:
+        raise ValidationError("schema_name must be non-empty text")
+    return '"' + value.replace('"', '""') + '"'
+
+
+def _lock_identity(value: Any) -> dict[str, str]:
+    lock = _exact_mapping(
+        value,
+        "notification delivery lock evidence",
+        {"acquired", "key_fingerprint", "model_version", "scope"},
+    )
+    if lock["acquired"] is not True:
+        raise ValidationError("notification execution readiness requires an acquired lock")
+    return {
+        "key_fingerprint": _safe_text(
+            lock["key_fingerprint"],
+            "delivery lock key_fingerprint",
+        ),
+        "model_version": _safe_text(
+            lock["model_version"],
+            "delivery lock model_version",
+        ),
+        "scope": _safe_text(lock["scope"], "delivery lock scope"),
+    }
+
+
+def read_current_notification_execution_readiness_review(
+    *,
+    dsn: str,
+    destination_id: str,
+    execution_kind: str,
+    schema_name: str = "risk_platform",
+) -> Mapping[str, Any] | None:
+    if not isinstance(dsn, str) or not dsn.strip():
+        raise ValidationError("PostgreSQL DSN must be non-empty text")
+    selected_destination_id = _safe_text(destination_id, "destination_id")
+    if execution_kind not in EXECUTION_KINDS:
+        raise ValidationError("execution_kind must be initial or retry")
+    schema = _quote_identifier(schema_name)
+    try:
+        import psycopg
+        from psycopg.rows import dict_row
+    except ImportError as exc:  # pragma: no cover - required in CI.
+        raise RuntimeError("Notification readiness enforcement requires psycopg") from exc
+
+    statement = f"""
+        SELECT
+            review.destination_id,
+            review.execution_kind,
+            review.readiness_record_id,
+            review.readiness_request_id,
+            review.decision_id,
+            review.decision_evaluated_at,
+            review.decision_recorded_at,
+            review.decision,
+            review.blocking_reasons_json,
+            review.readiness_review_status,
+            review.execution_ready,
+            retained.record_json
+        FROM {schema}.current_notification_execution_readiness_review review
+        LEFT JOIN {schema}.notification_execution_readiness_decisions retained
+          ON retained.record_id = review.readiness_record_id
+        WHERE review.destination_id = %s
+          AND review.execution_kind = %s
+        LIMIT 2
+    """
+    try:
+        with psycopg.connect(dsn, row_factory=dict_row) as connection:
+            with connection.cursor() as cursor:
+                cursor.execute(statement, (selected_destination_id, execution_kind))
+                rows = [dict(row) for row in cursor.fetchall()]
+    except Exception:
+        raise StorageError(
+            "current notification execution readiness review could not be read"
+        ) from None
+    if len(rows) > 1:
+        raise StorageError("current notification execution readiness grain is not unique")
+    return rows[0] if rows else None
+
+
+def _allowed_record(
+    value: Mapping[str, Any] | None,
+    *,
+    destination_id: str,
+    execution_kind: str,
+) -> dict[str, Any]:
+    if value is None:
+        raise ValidationError("notification execution readiness decision is missing")
+    review = _exact_mapping(
+        value,
+        "current notification execution readiness review",
+        {
+            "blocking_reasons_json",
+            "decision",
+            "decision_evaluated_at",
+            "decision_id",
+            "decision_recorded_at",
+            "destination_id",
+            "execution_kind",
+            "execution_ready",
+            "readiness_record_id",
+            "readiness_request_id",
+            "readiness_review_status",
+            "record_json",
+        },
+    )
+    if review["destination_id"] != destination_id:
+        raise ValidationError("readiness review belongs to another destination")
+    if review["execution_kind"] != execution_kind:
+        raise ValidationError("readiness review belongs to another execution kind")
+    status = review["readiness_review_status"]
+    if status not in REVIEW_STATUSES:
+        raise ValidationError("readiness review status is unsupported")
+    if type(review["execution_ready"]) is not bool:
+        raise ValidationError("readiness execution_ready must be boolean")
+    if status != "allowed" or review["execution_ready"] is not True:
+        raise ValidationError(
+            f"notification execution readiness is not allowed: {status}"
+        )
+    if review["decision"] != "allow":
+        raise ValidationError("allowed readiness review must retain an allow decision")
+    if review["blocking_reasons_json"] != []:
+        raise ValidationError("allowed readiness review must have no blocking reasons")
+    record_json = review["record_json"]
+    if not isinstance(record_json, Mapping):
+        raise StorageError("allowed readiness review has no retained canonical record")
+    record = validate_notification_execution_readiness_record(record_json)
+    decision = record["decision"]
+
+    row_identity = {
+        "record_id": _safe_text(review["readiness_record_id"], "readiness_record_id"),
+        "request_id": _safe_text(
+            review["readiness_request_id"],
+            "readiness_request_id",
+        ),
+        "decision_id": _safe_text(review["decision_id"], "decision_id"),
+        "decision_evaluated_at": _aware_utc(
+            review["decision_evaluated_at"],
+            "decision_evaluated_at",
+        ).isoformat(),
+        "decision_recorded_at": _aware_utc(
+            review["decision_recorded_at"],
+            "decision_recorded_at",
+        ).isoformat(),
+    }
+    expected_identity = {
+        "record_id": record["record_id"],
+        "request_id": record["request_id"],
+        "decision_id": decision["decision_id"],
+        "decision_evaluated_at": decision["evaluated_at"],
+        "decision_recorded_at": record["recorded_at"],
+    }
+    if row_identity != expected_identity:
+        raise ValidationError("readiness serving row does not match its retained record")
+    if decision["destination"]["destination_id"] != destination_id:
+        raise ValidationError("retained readiness record belongs to another destination")
+    if decision["execution_kind"] != execution_kind:
+        raise ValidationError("retained readiness record belongs to another execution kind")
+    if decision["decision"] != "allow" or decision["blocking_reasons"]:
+        raise ValidationError("retained readiness record does not grant execution")
+    return record
+
+
+def _substantive_decision(value: Mapping[str, Any]) -> dict[str, Any]:
+    decision = validate_notification_execution_readiness_decision(value)
+    return {
+        key: decision[key]
+        for key in decision
+        if key not in {"decision_id", "evaluated_at"}
+    }
+
+
+def _enforcement_id(identity: Mapping[str, Any]) -> str:
+    digest = hashlib.sha256(
+        json.dumps(
+            identity,
+            sort_keys=True,
+            separators=(",", ":"),
+            allow_nan=False,
+        ).encode("utf-8")
+    ).hexdigest()[:24]
+    return f"{MODEL_VERSION}-enforcement-{digest}"
+
+
+def _enforcement_evidence(
+    *,
+    destination_id: str,
+    execution_kind: str,
+    enforced_at: datetime,
+    record: Mapping[str, Any],
+    refreshed_decision: Mapping[str, Any],
+    lock: Mapping[str, str],
+) -> dict[str, Any]:
+    retained_decision = record["decision"]
+    identity = {
+        "destination_id": destination_id,
+        "enforced_at": enforced_at.isoformat(),
+        "execution_kind": execution_kind,
+        "lock": dict(lock),
+        "model_version": MODEL_VERSION,
+        "readiness_record_id": record["record_id"],
+        "readiness_request_id": record["request_id"],
+        "refreshed_decision_id": refreshed_decision["decision_id"],
+        "retained_decision_id": retained_decision["decision_id"],
+    }
+    return {
+        "enforcement_id": _enforcement_id(identity),
+        **identity,
+        "execution_ready": True,
+        "readiness_review_status": "allowed",
+        "refreshed_decision_evaluated_at": refreshed_decision["evaluated_at"],
+        "retained_decision_evaluated_at": retained_decision["evaluated_at"],
+        "substantive_evidence_match": True,
+    }
+
+
+def validate_notification_execution_readiness_enforcement(
+    value: Mapping[str, Any],
+) -> dict[str, Any]:
+    evidence = _exact_mapping(
+        value,
+        "notification execution readiness enforcement",
+        {
+            "destination_id",
+            "enforced_at",
+            "enforcement_id",
+            "execution_kind",
+            "execution_ready",
+            "lock",
+            "model_version",
+            "readiness_record_id",
+            "readiness_request_id",
+            "readiness_review_status",
+            "refreshed_decision_evaluated_at",
+            "refreshed_decision_id",
+            "retained_decision_evaluated_at",
+            "retained_decision_id",
+            "substantive_evidence_match",
+        },
+    )
+    if evidence["model_version"] != MODEL_VERSION:
+        raise ValidationError("readiness enforcement model_version is unsupported")
+    execution_kind = evidence["execution_kind"]
+    if execution_kind not in EXECUTION_KINDS:
+        raise ValidationError("execution_kind must be initial or retry")
+    if evidence["execution_ready"] is not True:
+        raise ValidationError("readiness enforcement must grant execution")
+    if evidence["readiness_review_status"] != "allowed":
+        raise ValidationError("readiness enforcement must retain allowed status")
+    if evidence["substantive_evidence_match"] is not True:
+        raise ValidationError("readiness enforcement must match substantive evidence")
+    enforced_at = _aware_utc(evidence["enforced_at"], "enforced_at")
+    refreshed_at = _aware_utc(
+        evidence["refreshed_decision_evaluated_at"],
+        "refreshed_decision_evaluated_at",
+    )
+    retained_at = _aware_utc(
+        evidence["retained_decision_evaluated_at"],
+        "retained_decision_evaluated_at",
+    )
+    if refreshed_at != enforced_at:
+        raise ValidationError("refreshed decision time must equal enforcement time")
+    if enforced_at < retained_at or enforced_at - retained_at > MAX_READINESS_AGE:
+        raise ValidationError("retained readiness decision is outside the enforcement age")
+    stored_lock = evidence["lock"]
+    if not isinstance(stored_lock, Mapping):
+        raise ValidationError("readiness enforcement lock must be a mapping")
+    lock = _lock_identity({**dict(stored_lock), "acquired": True})
+    identity = {
+        "destination_id": _safe_text(evidence["destination_id"], "destination_id"),
+        "enforced_at": enforced_at.isoformat(),
+        "execution_kind": execution_kind,
+        "lock": lock,
+        "model_version": MODEL_VERSION,
+        "readiness_record_id": _safe_text(
+            evidence["readiness_record_id"],
+            "readiness_record_id",
+        ),
+        "readiness_request_id": _safe_text(
+            evidence["readiness_request_id"],
+            "readiness_request_id",
+        ),
+        "refreshed_decision_id": _safe_text(
+            evidence["refreshed_decision_id"],
+            "refreshed_decision_id",
+        ),
+        "retained_decision_id": _safe_text(
+            evidence["retained_decision_id"],
+            "retained_decision_id",
+        ),
+    }
+    if evidence["enforcement_id"] != _enforcement_id(identity):
+        raise ValidationError("readiness enforcement_id does not match canonical evidence")
+    return {
+        "enforcement_id": evidence["enforcement_id"],
+        **identity,
+        "execution_ready": True,
+        "readiness_review_status": "allowed",
+        "refreshed_decision_evaluated_at": refreshed_at.isoformat(),
+        "retained_decision_evaluated_at": retained_at.isoformat(),
+        "substantive_evidence_match": True,
+    }
+
+
+def enforce_notification_execution_readiness(
+    *,
+    dsn: str,
+    destination_id: str,
+    execution_kind: str,
+    evaluated_at: datetime | str,
+    delivery_config_path: Path,
+    destination_config_path: Path,
+    lock_evidence: Mapping[str, Any],
+    schema_name: str = "risk_platform",
+    review_reader: ReviewReader | None = None,
+    gate_runner: GateRunner | None = None,
+) -> dict[str, Any]:
+    selected_destination_id = _safe_text(destination_id, "destination_id")
+    if execution_kind not in EXECUTION_KINDS:
+        raise ValidationError("execution_kind must be initial or retry")
+    as_of = _aware_utc(evaluated_at, "evaluated_at")
+    lock = _lock_identity(lock_evidence)
+    selected_reader = review_reader or read_current_notification_execution_readiness_review
+    review = selected_reader(
+        dsn=dsn,
+        destination_id=selected_destination_id,
+        execution_kind=execution_kind,
+        schema_name=schema_name,
+    )
+    record = _allowed_record(
+        review,
+        destination_id=selected_destination_id,
+        execution_kind=execution_kind,
+    )
+    retained_decision = record["decision"]
+    retained_at = _aware_utc(retained_decision["evaluated_at"], "decision.evaluated_at")
+    if as_of < retained_at:
+        raise ValidationError("execution time precedes retained readiness decision")
+    if as_of - retained_at > MAX_READINESS_AGE:
+        raise ValidationError("retained readiness decision is stale")
+
+    selected_gate_runner = gate_runner or run_notification_execution_readiness_gate
+    refreshed = validate_notification_execution_readiness_decision(
+        selected_gate_runner(
+            execution_kind=execution_kind,
+            destination_id=selected_destination_id,
+            evaluated_at=as_of,
+            delivery_config_path=delivery_config_path,
+            destination_config_path=destination_config_path,
+            dsn=dsn,
+            schema_name=schema_name,
+        )
+    )
+    if refreshed["decision"] != "allow":
+        reasons = ",".join(refreshed["blocking_reasons"])
+        raise ValidationError(
+            f"refreshed notification execution readiness is blocked: {reasons}"
+        )
+    if _substantive_decision(retained_decision) != _substantive_decision(refreshed):
+        raise ValidationError(
+            "retained notification execution readiness was superseded during preflight"
+        )
+    evidence = _enforcement_evidence(
+        destination_id=selected_destination_id,
+        execution_kind=execution_kind,
+        enforced_at=as_of,
+        record=record,
+        refreshed_decision=refreshed,
+        lock=lock,
+    )
+    return validate_notification_execution_readiness_enforcement(evidence)

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -54,3 +54,54 @@ def _retry_destination_authority_unit_test_seam(
         }
 
     monkeypatch.setattr(target, "resolve_notification_destination_authority", resolver)
+
+
+@pytest.fixture(autouse=True)
+def _initial_delivery_readiness_unit_test_seam(
+    monkeypatch: pytest.MonkeyPatch,
+    request: pytest.FixtureRequest,
+) -> None:
+    """Keep legacy sender tests focused on transport and attempt semantics."""
+
+    module = getattr(request.node, "module", None)
+    if module is None or not module.__name__.endswith(
+        "test_portfolio_risk_webhook_delivery"
+    ):
+        return
+
+    from src.orchestration import deliver_portfolio_risk_notifications as target
+
+    evidence = {
+        "model_version": (
+            "portfolio-risk-notification-execution-readiness-enforcement-v1"
+        ),
+        "enforcement_id": "readiness-enforcement-test",
+        "destination_id": "risk-operations-webhook",
+        "execution_kind": "initial",
+        "enforced_at": "2026-06-01T00:00:00+00:00",
+        "lock": {
+            "key_fingerprint": "readiness-lock-test",
+            "model_version": "portfolio-risk-notification-delivery-lock-v1",
+            "scope": "portfolio-risk-notification-delivery",
+        },
+        "readiness_record_id": "readiness-record-test",
+        "readiness_request_id": "readiness-request-test",
+        "retained_decision_id": "retained-decision-test",
+        "refreshed_decision_id": "refreshed-decision-test",
+        "execution_ready": True,
+        "readiness_review_status": "allowed",
+        "retained_decision_evaluated_at": "2026-06-01T00:00:00+00:00",
+        "refreshed_decision_evaluated_at": "2026-06-01T00:00:00+00:00",
+        "substantive_evidence_match": True,
+    }
+
+    monkeypatch.setattr(
+        target,
+        "_enforce_initial_delivery_readiness",
+        lambda **_: dict(evidence),
+    )
+    monkeypatch.setattr(
+        target,
+        "_validate_initial_delivery_readiness",
+        lambda value: dict(value),
+    )

--- a/tests/unit/test_initial_delivery_readiness_enforcement.py
+++ b/tests/unit/test_initial_delivery_readiness_enforcement.py
@@ -1,0 +1,220 @@
+from __future__ import annotations
+
+from collections.abc import Iterator, Mapping
+from contextlib import contextmanager
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+from src.common.exceptions import ValidationError
+from src.orchestration import deliver_portfolio_risk_notifications as target
+
+
+def _write_contracts(tmp_path: Path) -> tuple[Path, Path]:
+    delivery_path = tmp_path / "notification_delivery.yaml"
+    delivery_path.write_text(
+        yaml.safe_dump(
+            {
+                "delivery": {
+                    "webhook": {
+                        "enabled": True,
+                        "endpoint_env": "RISK_NOTIFICATION_WEBHOOK_URL",
+                        "timeout_seconds": 5,
+                        "max_batch_events": 25,
+                        "max_attempts_per_event": 3,
+                        "initial_backoff_seconds": 1,
+                    }
+                }
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+    destination_path = tmp_path / "notification_destinations.yaml"
+    destination_path.write_text(
+        yaml.safe_dump(
+            {
+                "model_version": "portfolio-risk-notification-destination-v1",
+                "destinations": {
+                    "risk-operations-webhook": {
+                        "channel": "webhook",
+                        "endpoint_env": "RISK_NOTIFICATION_WEBHOOK_URL",
+                        "owner": {
+                            "team": "risk-operations",
+                            "contact": "risk-operations-oncall",
+                        },
+                        "purpose": "portfolio-risk-breach-lifecycle",
+                        "recipient_scope": "risk-operations",
+                        "data_classification": "internal",
+                        "allowed_event_types": ["breach_opened"],
+                        "activation": {
+                            "enabled": True,
+                            "change_request_id": "CHG-2026-READINESS",
+                            "reviewed_by": ["risk-control-reviewer"],
+                            "reviewed_at": "2026-01-01T00:00:00Z",
+                            "review_expires_at": "2027-01-01T00:00:00Z",
+                        },
+                    }
+                },
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+    return delivery_path, destination_path
+
+
+def _candidate() -> dict[str, Any]:
+    return {
+        "event_id": "event-1",
+        "event_type": "breach_opened",
+        "transition_type": "opened",
+        "policy_id": "us-tech-standard",
+        "policy_fingerprint": "policy-1",
+        "portfolio_id": "us-tech-equal",
+        "definition_fingerprint": "definition-1",
+        "metric_name": "portfolio_volatility_annualized",
+        "subject_type": "portfolio",
+        "subject_key": "us-tech-equal",
+        "current_status": "critical",
+        "ts_event": datetime(2026, 1, 9, tzinfo=timezone.utc),
+        "payload_json": {"event_id": "event-1", "severity": "critical"},
+        "attempts_so_far": 0,
+    }
+
+
+def _readiness() -> dict[str, Any]:
+    return {
+        "model_version": (
+            "portfolio-risk-notification-execution-readiness-enforcement-v1"
+        ),
+        "enforcement_id": "readiness-enforcement-1",
+        "destination_id": "risk-operations-webhook",
+        "execution_kind": "initial",
+        "enforced_at": "2026-06-01T12:00:00+00:00",
+        "lock": {
+            "key_fingerprint": "lock-fingerprint-1",
+            "model_version": "portfolio-risk-notification-delivery-lock-v1",
+            "scope": "portfolio-risk-notification-delivery",
+        },
+        "readiness_record_id": "readiness-record-1",
+        "readiness_request_id": "readiness-request-1",
+        "retained_decision_id": "retained-decision-1",
+        "refreshed_decision_id": "refreshed-decision-1",
+        "execution_ready": True,
+        "readiness_review_status": "allowed",
+        "retained_decision_evaluated_at": "2026-06-01T11:59:00+00:00",
+        "refreshed_decision_evaluated_at": "2026-06-01T12:00:00+00:00",
+        "substantive_evidence_match": True,
+    }
+
+
+def test_readiness_is_enforced_inside_lock_before_transport(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    delivery_path, destination_path = _write_contracts(tmp_path)
+    events: list[str] = []
+    attempts: list[dict[str, Any]] = []
+
+    @contextmanager
+    def lock(**_: Any) -> Iterator[Mapping[str, Any]]:
+        events.append("lock-acquired")
+        yield {
+            "model_version": "portfolio-risk-notification-delivery-lock-v1",
+            "scope": "portfolio-risk-notification-delivery",
+            "key_fingerprint": "lock-fingerprint-1",
+            "acquired": True,
+        }
+        events.append("lock-released")
+
+    def enforce(**kwargs: Any) -> dict[str, Any]:
+        events.append("readiness")
+        assert kwargs["lock_evidence"]["acquired"] is True
+        assert kwargs["evaluated_at"] == datetime(
+            2026,
+            6,
+            1,
+            12,
+            0,
+            tzinfo=timezone.utc,
+        )
+        return _readiness()
+
+    monkeypatch.setattr(target, "_enforce_initial_delivery_readiness", enforce)
+    monkeypatch.setattr(
+        target,
+        "_validate_initial_delivery_readiness",
+        lambda value: dict(value),
+    )
+
+    summary = target.deliver_portfolio_risk_notifications(
+        config_path=delivery_path,
+        destination_config_path=destination_path,
+        dsn="dsn",
+        execute=True,
+        environment={
+            "RISK_NOTIFICATION_WEBHOOK_URL": "https://alerts.example.test/risk"
+        },
+        reader=lambda **_: events.append("candidate-read") or [_candidate()],
+        attempt_writer=lambda attempt: attempts.append(dict(attempt)),
+        transport=lambda *_: events.append("transport") or 204,
+        lock_factory=lock,
+        clock=lambda: datetime(2026, 6, 1, 12, 0, tzinfo=timezone.utc),
+    )
+
+    assert events == [
+        "lock-acquired",
+        "candidate-read",
+        "readiness",
+        "transport",
+        "lock-released",
+    ]
+    assert len(attempts) == 1
+    assert summary["execution_readiness"] == _readiness()
+    assert summary["concurrency_control"]["released"] is True
+
+
+def test_readiness_rejection_prevents_transport_and_attempt_persistence(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    delivery_path, destination_path = _write_contracts(tmp_path)
+    sends: list[bool] = []
+    attempts: list[dict[str, Any]] = []
+
+    @contextmanager
+    def lock(**_: Any) -> Iterator[Mapping[str, Any]]:
+        yield {
+            "model_version": "portfolio-risk-notification-delivery-lock-v1",
+            "scope": "portfolio-risk-notification-delivery",
+            "key_fingerprint": "lock-fingerprint-1",
+            "acquired": True,
+        }
+
+    def reject(**_: Any) -> dict[str, Any]:
+        raise ValidationError("notification execution readiness is not allowed")
+
+    monkeypatch.setattr(target, "_enforce_initial_delivery_readiness", reject)
+
+    with pytest.raises(ValidationError, match="not allowed"):
+        target.deliver_portfolio_risk_notifications(
+            config_path=delivery_path,
+            destination_config_path=destination_path,
+            dsn="dsn",
+            execute=True,
+            environment={
+                "RISK_NOTIFICATION_WEBHOOK_URL": "https://alerts.example.test/risk"
+            },
+            reader=lambda **_: [_candidate()],
+            attempt_writer=lambda attempt: attempts.append(dict(attempt)),
+            transport=lambda *_: sends.append(True) or 204,
+            lock_factory=lock,
+            clock=lambda: datetime(2026, 6, 1, 12, 0, tzinfo=timezone.utc),
+        )
+
+    assert sends == []
+    assert attempts == []

--- a/tests/unit/test_notification_execution_readiness_enforcement.py
+++ b/tests/unit/test_notification_execution_readiness_enforcement.py
@@ -1,0 +1,296 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from src.common.exceptions import ValidationError
+from src.orchestration.deliver_portfolio_risk_notifications import (
+    WebhookDeliveryConfig,
+)
+from src.orchestration.portfolio_risk_notification_destination_contract import (
+    DestinationActivation,
+    DestinationOwner,
+    NotificationDestination,
+)
+from src.orchestration.portfolio_risk_notification_retry_execution_policy import (
+    RetryExecutionPolicy,
+)
+from src.warehouse.notification_execution_readiness_enforcement import (
+    MAX_READINESS_AGE,
+    enforce_notification_execution_readiness,
+    validate_notification_execution_readiness_enforcement,
+)
+from src.warehouse.notification_execution_readiness_gate import (
+    evaluate_notification_execution_readiness,
+)
+from src.warehouse.notification_execution_readiness_history_contract import (
+    build_notification_execution_readiness_record,
+)
+
+DESTINATION_ID = "risk-operations-webhook"
+BASE_TIME = datetime(2026, 6, 1, 12, 0, tzinfo=timezone.utc)
+
+
+def _delivery_config(*, enabled: bool = True, timeout_seconds: int = 5):
+    return WebhookDeliveryConfig(
+        enabled=enabled,
+        endpoint_env="RISK_NOTIFICATION_WEBHOOK_URL",
+        timeout_seconds=timeout_seconds,
+        max_batch_events=25,
+        max_attempts_per_event=3,
+        initial_backoff_seconds=1,
+    )
+
+
+def _destination() -> NotificationDestination:
+    return NotificationDestination(
+        destination_id=DESTINATION_ID,
+        channel="webhook",
+        endpoint_env="RISK_NOTIFICATION_WEBHOOK_URL",
+        owner=DestinationOwner(
+            team="risk-operations",
+            contact="risk-operations-oncall",
+        ),
+        purpose="portfolio-risk-breach-lifecycle",
+        recipient_scope="risk-operations",
+        data_classification="internal",
+        allowed_event_types=(
+            "breach_escalated",
+            "breach_opened",
+            "breach_resolved",
+        ),
+        activation=DestinationActivation(
+            enabled=True,
+            change_request_id="CHG-2026-READINESS",
+            reviewed_by=("risk-control-reviewer",),
+            reviewed_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+            review_expires_at=datetime(2027, 1, 1, tzinfo=timezone.utc),
+        ),
+    )
+
+
+def _decision(
+    *,
+    evaluated_at: datetime,
+    execution_kind: str = "initial",
+    delivery_config: WebhookDeliveryConfig | None = None,
+) -> dict[str, Any]:
+    destination = _destination()
+    return evaluate_notification_execution_readiness(
+        execution_kind=execution_kind,
+        evaluated_at=evaluated_at,
+        delivery_config=delivery_config or _delivery_config(),
+        retry_policy_fingerprint="retry-policy-fingerprint-1",
+        retry_execution_policy=RetryExecutionPolicy(
+            enabled=True,
+            max_plan_age_seconds=3600,
+            max_events=25,
+        ),
+        destination=destination,
+        activation_review={
+            "authority_id": "authority-1",
+            "checklist_id": "checklist-1",
+            "destination_fingerprint": destination.fingerprint,
+            "destination_id": DESTINATION_ID,
+            "operational_activation_ready": True,
+            "review_status": "ready",
+        },
+        transition_review={
+            "activation_review_status": "ready",
+            "current_authority_id": "authority-1",
+            "current_checklist_id": "checklist-1",
+            "current_destination_fingerprint": destination.fingerprint,
+            "destination_id": DESTINATION_ID,
+            "operational_activation_ready": True,
+            "rollback_authority_id": None,
+            "rollback_checklist_id": None,
+            "rollback_destination_fingerprint": None,
+            "rollback_endpoint_environment_variable": None,
+            "rollback_plan_id": None,
+            "transition_matches_current_activation": True,
+            "transition_ready": True,
+            "transition_record_id": "transition-record-1",
+            "transition_rehearsal_id": "transition-rehearsal-1",
+            "transition_review_status": "ready",
+        },
+        ambiguities=[],
+    )
+
+
+def _record(
+    *,
+    evaluated_at: datetime = BASE_TIME,
+    execution_kind: str = "initial",
+) -> dict[str, Any]:
+    return build_notification_execution_readiness_record(
+        request_id=f"readiness-request-{execution_kind}",
+        recorded_at=evaluated_at + timedelta(seconds=1),
+        decision=_decision(
+            evaluated_at=evaluated_at,
+            execution_kind=execution_kind,
+        ),
+    )
+
+
+def _review(
+    record: dict[str, Any],
+    *,
+    status: str = "allowed",
+    execution_ready: bool = True,
+) -> dict[str, Any]:
+    decision = record["decision"]
+    return {
+        "destination_id": decision["destination"]["destination_id"],
+        "execution_kind": decision["execution_kind"],
+        "readiness_record_id": record["record_id"],
+        "readiness_request_id": record["request_id"],
+        "decision_id": decision["decision_id"],
+        "decision_evaluated_at": decision["evaluated_at"],
+        "decision_recorded_at": record["recorded_at"],
+        "decision": decision["decision"],
+        "blocking_reasons_json": decision["blocking_reasons"],
+        "readiness_review_status": status,
+        "execution_ready": execution_ready,
+        "record_json": record,
+    }
+
+
+def _lock() -> dict[str, Any]:
+    return {
+        "model_version": "portfolio-risk-notification-delivery-lock-v1",
+        "scope": "portfolio-risk-notification-delivery",
+        "key_fingerprint": "lock-key-fingerprint-1",
+        "acquired": True,
+    }
+
+
+def _run(
+    *,
+    review: dict[str, Any],
+    as_of: datetime,
+    refreshed: dict[str, Any],
+) -> dict[str, Any]:
+    return enforce_notification_execution_readiness(
+        dsn="dsn",
+        destination_id=DESTINATION_ID,
+        execution_kind="initial",
+        evaluated_at=as_of,
+        delivery_config_path=Path("config/notification_delivery.yaml"),
+        destination_config_path=Path("config/notification_destinations.yaml"),
+        lock_evidence=_lock(),
+        review_reader=lambda **_: review,
+        gate_runner=lambda **_: refreshed,
+    )
+
+
+def test_matching_current_allow_is_refreshed_and_bound_to_lock() -> None:
+    record = _record()
+    as_of = BASE_TIME + timedelta(minutes=2)
+    refreshed = _decision(evaluated_at=as_of)
+
+    evidence = _run(review=_review(record), as_of=as_of, refreshed=refreshed)
+
+    assert evidence["execution_ready"] is True
+    assert evidence["readiness_review_status"] == "allowed"
+    assert evidence["readiness_record_id"] == record["record_id"]
+    assert evidence["retained_decision_id"] == record["decision"]["decision_id"]
+    assert evidence["refreshed_decision_id"] == refreshed["decision_id"]
+    assert evidence["substantive_evidence_match"] is True
+    assert evidence["lock"] == {
+        "key_fingerprint": "lock-key-fingerprint-1",
+        "model_version": "portfolio-risk-notification-delivery-lock-v1",
+        "scope": "portfolio-risk-notification-delivery",
+    }
+    assert validate_notification_execution_readiness_enforcement(evidence) == evidence
+
+
+def test_non_allowed_current_state_rejects_before_refresh() -> None:
+    record = _record()
+    refreshes: list[bool] = []
+
+    with pytest.raises(ValidationError, match="decision_stale"):
+        enforce_notification_execution_readiness(
+            dsn="dsn",
+            destination_id=DESTINATION_ID,
+            execution_kind="initial",
+            evaluated_at=BASE_TIME + timedelta(minutes=1),
+            delivery_config_path=Path("delivery.yaml"),
+            destination_config_path=Path("destinations.yaml"),
+            lock_evidence=_lock(),
+            review_reader=lambda **_: _review(
+                record,
+                status="decision_stale",
+                execution_ready=False,
+            ),
+            gate_runner=lambda **_: refreshes.append(True) or {},
+        )
+
+    assert refreshes == []
+
+
+def test_retained_allow_expires_after_reviewed_five_minute_window() -> None:
+    record = _record()
+    as_of = BASE_TIME + MAX_READINESS_AGE + timedelta(microseconds=1)
+
+    with pytest.raises(ValidationError, match="stale"):
+        _run(
+            review=_review(record),
+            as_of=as_of,
+            refreshed=_decision(evaluated_at=as_of),
+        )
+
+
+def test_refreshed_block_rejects_before_execution_authority_is_returned() -> None:
+    record = _record()
+    as_of = BASE_TIME + timedelta(minutes=1)
+    blocked = _decision(
+        evaluated_at=as_of,
+        delivery_config=_delivery_config(enabled=False),
+    )
+
+    with pytest.raises(ValidationError, match="delivery_disabled"):
+        _run(review=_review(record), as_of=as_of, refreshed=blocked)
+
+
+def test_changed_live_configuration_supersedes_retained_allow() -> None:
+    record = _record()
+    as_of = BASE_TIME + timedelta(minutes=1)
+    changed = _decision(
+        evaluated_at=as_of,
+        delivery_config=_delivery_config(timeout_seconds=6),
+    )
+    assert changed["decision"] == "allow"
+
+    with pytest.raises(ValidationError, match="superseded during preflight"):
+        _run(review=_review(record), as_of=as_of, refreshed=changed)
+
+
+def test_serving_row_must_match_retained_canonical_record() -> None:
+    record = _record()
+    review = _review(record)
+    review["decision_id"] = "another-decision-id"
+    as_of = BASE_TIME + timedelta(minutes=1)
+
+    with pytest.raises(ValidationError, match="serving row"):
+        _run(
+            review=review,
+            as_of=as_of,
+            refreshed=_decision(evaluated_at=as_of),
+        )
+
+
+def test_enforcement_evidence_rejects_identity_tampering() -> None:
+    record = _record()
+    as_of = BASE_TIME + timedelta(minutes=1)
+    evidence = _run(
+        review=_review(record),
+        as_of=as_of,
+        refreshed=_decision(evaluated_at=as_of),
+    )
+    evidence["enforcement_id"] = "tampered-enforcement-id"
+
+    with pytest.raises(ValidationError, match="enforcement_id"):
+        validate_notification_execution_readiness_enforcement(evidence)

--- a/tests/unit/test_notification_execution_readiness_enforcement_architecture_contract.py
+++ b/tests/unit/test_notification_execution_readiness_enforcement_architecture_contract.py
@@ -1,0 +1,57 @@
+from pathlib import Path
+
+
+def test_initial_delivery_requires_current_refreshed_readiness_under_shared_lock() -> None:
+    enforcement = Path(
+        "src/warehouse/notification_execution_readiness_enforcement.py"
+    ).read_text(encoding="utf-8")
+    delivery = Path(
+        "src/orchestration/deliver_portfolio_risk_notifications.py"
+    ).read_text(encoding="utf-8")
+    docs = Path(
+        "docs/notification-execution-readiness-enforcement.md"
+    ).read_text(encoding="utf-8")
+    config = Path("config/notification_delivery.yaml").read_text(encoding="utf-8")
+
+    for required in (
+        "portfolio-risk-notification-execution-readiness-enforcement-v1",
+        "current_notification_execution_readiness_review",
+        "notification_execution_readiness_decisions",
+        "validate_notification_execution_readiness_record",
+        "run_notification_execution_readiness_gate",
+        "MAX_READINESS_AGE = timedelta(minutes=5)",
+        "substantive_evidence_match",
+        "readiness serving row does not match its retained record",
+        "superseded during preflight",
+    ):
+        assert required in enforcement
+
+    for required in (
+        "_enforce_initial_delivery_readiness",
+        "_validate_initial_delivery_readiness",
+        'execution_kind="initial"',
+        "execution_readiness",
+        "lock_evidence=lock_evidence",
+    ):
+        assert required in delivery
+
+    lock_index = delivery.index("with selected_lock_factory(dsn=dsn) as lock_evidence:")
+    readiness_index = delivery.index(
+        "execution_readiness = _validate_initial_delivery_readiness("
+    )
+    transport_index = delivery.index('summary["execution"] = _execute_initial_attempts(')
+    assert lock_index < readiness_index < transport_index
+
+    for required in (
+        "Primary arc42 blocks",
+        "current allowed serving row",
+        "append-only readiness record",
+        "fresh gate evaluation",
+        "same shared delivery lock",
+        "substantive governed evidence",
+        "before the first network request",
+        "disabled by default",
+    ):
+        assert required.lower() in docs.lower()
+
+    assert "enabled: false" in config


### PR DESCRIPTION
## Goal

Apply the retained notification execution-readiness decision to the initial webhook delivery boundary.

## What changes

- adds the shared fail-closed `portfolio-risk-notification-execution-readiness-enforcement-v1` contract;
- requires one current `allowed` serving row and its exact append-only canonical record;
- rejects missing, blocked, stale, superseded, duplicate, or internally inconsistent evidence;
- refreshes the P4d5a gate at the exact execution timestamp while the existing global delivery lock is held;
- compares retained and refreshed substantive governed evidence, excluding only timestamp-derived identity fields;
- retains credential-free record, request, retained-decision, refreshed-decision, and lock identities in the delivery summary;
- enforces the five-minute readiness lifetime before the first network request; and
- leaves plan-only delivery unchanged.

## Ordering

```text
acquire shared lock
  -> select zero-attempt candidates
  -> resolve destination authority
  -> validate retained readiness
  -> refresh readiness gate
  -> compare substantive evidence
  -> transport
  -> append-only attempt persistence
  -> release lock
```

## Scope

Seven intended files, one commit, 1,233 additions and six deletions. The branch is zero commits behind `main`.

## Exact-head validation

GitHub Actions run **392** (`33510198359`) passed on head `df2198a6675f380184337ccae00c1555173ca687`:

- Security guardrails passed.
- Ruff passed.
- mypy passed across **139 source files**.
- **913 tests passed** in quality and **913 passed again** in readiness.
- Dependency integrity and the standard replay demonstration passed.
- PostgreSQL 16 contract passed.
- Kubernetes rendering and Terraform format/init/validate passed without apply.
- No review submissions or unresolved review threads exist.

## Safety

Webhook delivery, destination activation, and retry execution remain disabled in committed configuration. Tests use fake transport and injected evidence. No endpoint value, credentials, payload body, response body, headers, or DSN are retained. No deployment, provider call, live webhook request, or `terraform apply` occurred.

Validated and ready for squash merge.