### PR TITLE
Add deterministic retry readiness binding contract

### DIFF
--- a/docs/notification-retry-readiness-binding.md
+++ b/docs/notification-retry-readiness-binding.md
@@ -1,0 +1,98 @@
+# Notification Retry Readiness Binding
+
+Primary arc42 blocks: `orchestration` and `warehouse`.
+
+## Goal
+
+This increment defines the deterministic evidence contract that links one exact
+retry terminal record to the exact readiness enforcement that permitted its
+execution:
+
+```text
+canonical retry terminal record
+  + canonical retry readiness enforcement
+  + binding recording time
+  -> terminal document SHA-256
+  -> readiness document SHA-256
+  -> deterministic readiness binding
+```
+
+The model is:
+
+```text
+portfolio-risk-notification-retry-readiness-binding-v1
+```
+
+## Cross-contract validation
+
+The builder independently validates both source contracts before constructing a
+binding. It requires:
+
+- a canonical `portfolio-risk-notification-retry-execution-record-v1` terminal
+  record;
+- a canonical
+  `portfolio-risk-notification-execution-readiness-enforcement-v1` authority;
+- execution kind `retry`;
+- enforcement time within the terminal execution window;
+- binding time no earlier than terminal record persistence;
+- matching delivery-lock model and key identities when the terminal record
+  contains them; and
+- matching lock scope for completed execution summaries.
+
+A terminal record that reports one or more external requests must retain its
+lock model and key fingerprint. It cannot be bound to an authority with another
+lock identity.
+
+## Deterministic identity
+
+The binding ID covers:
+
+```text
+terminal record ID, request ID, plan ID, execution ID and status
+terminal execution timestamps, counts and canonical document SHA-256
+readiness enforcement ID and canonical document SHA-256
+destination and execution kind
+retained and refreshed readiness decision identities
+readiness record and request identities
+shared delivery-lock identity
+binding recording time
+```
+
+Changing any of those values produces a different binding ID. Reordering JSON
+keys does not.
+
+The retained terminal-record digest is calculated from the full validated
+terminal document. The retained readiness digest is calculated from the full
+validated enforcement document. A later persistence increment can therefore
+reconcile the binding to both append-only sources without embedding another
+copy of the terminal record.
+
+## Local builder
+
+The credential-free builder consumes the terminal record and the P4d5c execution
+summary produced by the readiness-enforced retry wrapper:
+
+```bash
+.venv/bin/python \
+  -m src.orchestration.build_notification_retry_readiness_binding \
+  --terminal-record .demo/retry-terminal-record.json \
+  --execution-summary .demo/readiness-enforced-retry.json \
+  --recorded-at 2026-09-02T19:00:00Z \
+  --summary-json .demo/retry-readiness-binding.json
+```
+
+Both inputs must be regular non-symbolic-link JSON files no larger than 1 MB.
+The execution summary must contain exact `execution_readiness` evidence.
+
+## Deliberate boundary
+
+This increment builds and validates canonical binding evidence but does not
+persist it. A following PR can add append-only PostgreSQL history, exact replay
+convergence, foreign-key reconciliation, and integration with the recorded
+retry operator path without changing this identity contract.
+
+The binding retains no endpoint value, complete URL, environment value,
+credential, payload body, response body, arbitrary exception text, or database
+DSN. The builder performs no database operation, DNS lookup, socket operation,
+network request, delivery attempt, acknowledgement, outbox mutation, provider
+request, deployment, or `terraform apply`.

--- a/docs/notification-retry-readiness-binding.md
+++ b/docs/notification-retry-readiness-binding.md
@@ -92,8 +92,9 @@ persist it. A following PR can add append-only PostgreSQL history, exact replay
 convergence, foreign-key reconciliation, and integration with the recorded
 retry operator path without changing this identity contract.
 
-The binding retains no endpoint value, complete URL, environment value,
-credential, payload body, response body, arbitrary exception text, or database
-DSN. The builder performs no database operation, DNS lookup, socket operation,
-network request, delivery attempt, acknowledgement, outbox mutation, provider
-request, deployment, or `terraform apply`.
+There is no network request in this binding increment. The binding retains no
+endpoint value, complete URL, environment value, credential, payload body,
+response body, arbitrary exception text, or database DSN. The builder performs
+no database operation, DNS lookup, socket operation, delivery attempt,
+acknowledgement, outbox mutation, provider request, deployment, or
+`terraform apply`.

--- a/docs/notification-retry-readiness-binding.md
+++ b/docs/notification-retry-readiness-binding.md
@@ -5,8 +5,9 @@ Primary arc42 blocks: `orchestration` and `warehouse`.
 ## Goal
 
 This increment defines the deterministic evidence contract that links one exact
-retry terminal record to the exact readiness enforcement that permitted its
-execution:
+terminal record for a retry to the exact readiness enforcement that permitted
+its execution. The exact terminal record and exact readiness enforcement are
+independently validated before the binding is constructed:
 
 ```text
 canonical retry terminal record

--- a/src/orchestration/build_notification_retry_readiness_binding.py
+++ b/src/orchestration/build_notification_retry_readiness_binding.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections.abc import Mapping, Sequence
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from src.common.exceptions import StorageError, ValidationError
+from src.warehouse.notification_retry_readiness_binding_contract import (
+    build_notification_retry_readiness_binding,
+)
+
+MAX_INPUT_BYTES = 1_048_576
+
+
+def _timestamp(value: str) -> datetime:
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        raise argparse.ArgumentTypeError("recorded-at must be ISO-8601") from None
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise argparse.ArgumentTypeError("recorded-at must be timezone-aware")
+    return parsed.astimezone(timezone.utc)
+
+
+def _read_json(path: Path, label: str) -> dict[str, Any]:
+    if path.is_symlink():
+        raise ValidationError(f"{label} must not be a symbolic link")
+    if not path.is_file():
+        raise ValidationError(f"{label} must be a regular file")
+    try:
+        if path.stat().st_size > MAX_INPUT_BYTES:
+            raise ValidationError(f"{label} exceeds 1 MB")
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except ValidationError:
+        raise
+    except (OSError, UnicodeError, ValueError):
+        raise ValidationError(f"{label} could not be read") from None
+    if not isinstance(payload, Mapping):
+        raise ValidationError(f"{label} must be a JSON object")
+    return dict(payload)
+
+
+def _read_enforcement(path: Path) -> dict[str, Any]:
+    payload = _read_json(path, "readiness execution summary")
+    enforcement = payload.get("execution_readiness")
+    if not isinstance(enforcement, Mapping):
+        raise ValidationError(
+            "readiness execution summary has no execution_readiness evidence"
+        )
+    return dict(enforcement)
+
+
+def _write_summary(path: Path, summary: Mapping[str, Any]) -> None:
+    if path.is_symlink():
+        raise StorageError("retry readiness binding summary must not be a symbolic link")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_suffix(path.suffix + ".tmp")
+    try:
+        temporary.write_text(
+            json.dumps(summary, indent=2, sort_keys=True, allow_nan=False) + "\n",
+            encoding="utf-8",
+        )
+        temporary.replace(path)
+    except (OSError, TypeError, ValueError):
+        temporary.unlink(missing_ok=True)
+        raise StorageError("unable to write retry readiness binding summary") from None
+
+
+def build_retry_readiness_binding_from_files(
+    *,
+    terminal_record_path: Path,
+    execution_summary_path: Path,
+    recorded_at: datetime,
+) -> dict[str, Any]:
+    return build_notification_retry_readiness_binding(
+        terminal_record=_read_json(terminal_record_path, "retry terminal record"),
+        readiness_enforcement=_read_enforcement(execution_summary_path),
+        recorded_at=recorded_at,
+    )
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Build one deterministic binding between a retry terminal record and "
+            "the readiness authority that permitted it."
+        )
+    )
+    parser.add_argument("--terminal-record", required=True, type=Path)
+    parser.add_argument("--execution-summary", required=True, type=Path)
+    parser.add_argument("--recorded-at", required=True, type=_timestamp)
+    parser.add_argument("--summary-json", type=Path)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    try:
+        binding = build_retry_readiness_binding_from_files(
+            terminal_record_path=args.terminal_record,
+            execution_summary_path=args.execution_summary,
+            recorded_at=args.recorded_at,
+        )
+        if args.summary_json is not None:
+            _write_summary(args.summary_json, binding)
+    except ValidationError as exc:
+        print(f"Retry readiness binding rejected: {exc}", file=sys.stderr)
+        return 1
+    except StorageError as exc:
+        print(f"Retry readiness binding failed: {exc}", file=sys.stderr)
+        return 1
+    print(json.dumps(binding, sort_keys=True, allow_nan=False))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/warehouse/notification_retry_readiness_binding_contract.py
+++ b/src/warehouse/notification_retry_readiness_binding_contract.py
@@ -1,0 +1,305 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from collections.abc import Mapping
+from datetime import datetime, timezone
+from typing import Any
+
+from src.common.exceptions import ValidationError
+from src.warehouse.notification_execution_readiness_enforcement import (
+    validate_notification_execution_readiness_enforcement,
+)
+from src.warehouse.notification_retry_execution_contract import (
+    canonical_retry_execution_record_bytes,
+    validate_retry_execution_record,
+)
+
+MODEL_VERSION = "portfolio-risk-notification-retry-readiness-binding-v1"
+SAFE_TEXT = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,511}$")
+SHA256_PATTERN = re.compile(r"^[0-9a-f]{64}$")
+
+
+def _safe_text(value: Any, label: str, *, optional: bool = False) -> str | None:
+    if value is None and optional:
+        return None
+    if not isinstance(value, str) or not SAFE_TEXT.fullmatch(value):
+        raise ValidationError(f"{label} must be one safe text segment")
+    return value
+
+
+def _aware_utc(value: Any, label: str) -> datetime:
+    if isinstance(value, datetime):
+        parsed = value
+    elif isinstance(value, str):
+        try:
+            parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        except ValueError:
+            raise ValidationError(f"{label} must be ISO-8601") from None
+    else:
+        raise ValidationError(f"{label} must be timezone-aware")
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise ValidationError(f"{label} must be timezone-aware")
+    return parsed.astimezone(timezone.utc)
+
+
+def _exact_mapping(value: Any, label: str, keys: set[str]) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        raise ValidationError(f"{label} must be a mapping")
+    actual = set(value)
+    if actual != keys:
+        raise ValidationError(
+            f"{label} fields are invalid; "
+            f"missing={sorted(keys - actual)}, unknown={sorted(actual - keys)}"
+        )
+    return value
+
+
+def canonical_notification_retry_readiness_binding_bytes(
+    binding: Mapping[str, Any],
+) -> bytes:
+    try:
+        return json.dumps(
+            binding,
+            sort_keys=True,
+            separators=(",", ":"),
+            allow_nan=False,
+        ).encode("utf-8")
+    except (TypeError, ValueError):
+        raise ValidationError("retry readiness binding is not canonical JSON") from None
+
+
+def _canonical_enforcement_bytes(enforcement: Mapping[str, Any]) -> bytes:
+    try:
+        return json.dumps(
+            enforcement,
+            sort_keys=True,
+            separators=(",", ":"),
+            allow_nan=False,
+        ).encode("utf-8")
+    except (TypeError, ValueError):
+        raise ValidationError("readiness enforcement is not canonical JSON") from None
+
+
+def _binding_id(identity: Mapping[str, Any]) -> str:
+    digest = hashlib.sha256(
+        canonical_notification_retry_readiness_binding_bytes(identity)
+    ).hexdigest()[:24]
+    return f"{MODEL_VERSION}-binding-{digest}"
+
+
+def _terminal_summary(record: Mapping[str, Any]) -> dict[str, Any]:
+    canonical = canonical_retry_execution_record_bytes(record)
+    return {
+        "attempts_persisted": record["attempts_persisted"],
+        "document_sha256": hashlib.sha256(canonical).hexdigest(),
+        "execution_id": record["execution_id"],
+        "finished_at": record["finished_at"],
+        "plan_id": record["plan_id"],
+        "record_id": record["record_id"],
+        "recorded_at": record["recorded_at"],
+        "request_count": record["request_count"],
+        "request_id": record["request_id"],
+        "started_at": record["started_at"],
+        "terminal_status": record["terminal_status"],
+    }
+
+
+def _validate_terminal_summary(value: Any) -> dict[str, Any]:
+    terminal = _exact_mapping(
+        value,
+        "terminal execution summary",
+        {
+            "attempts_persisted",
+            "document_sha256",
+            "execution_id",
+            "finished_at",
+            "plan_id",
+            "record_id",
+            "recorded_at",
+            "request_count",
+            "request_id",
+            "started_at",
+            "terminal_status",
+        },
+    )
+    request_count = terminal["request_count"]
+    attempts_persisted = terminal["attempts_persisted"]
+    if type(request_count) is not int or not 0 <= request_count <= 100:
+        raise ValidationError("terminal request_count is invalid")
+    if type(attempts_persisted) is not int or not 0 <= attempts_persisted <= 100:
+        raise ValidationError("terminal attempts_persisted is invalid")
+    if attempts_persisted > request_count:
+        raise ValidationError("terminal attempts_persisted exceeds request_count")
+    digest = terminal["document_sha256"]
+    if not isinstance(digest, str) or not SHA256_PATTERN.fullmatch(digest):
+        raise ValidationError("terminal document_sha256 is invalid")
+    started = _aware_utc(terminal["started_at"], "terminal.started_at")
+    finished = _aware_utc(terminal["finished_at"], "terminal.finished_at")
+    recorded = _aware_utc(terminal["recorded_at"], "terminal.recorded_at")
+    if not started <= finished <= recorded:
+        raise ValidationError("terminal execution timestamps are not ordered")
+    status = terminal["terminal_status"]
+    if status not in {
+        "completed",
+        "failed_before_request",
+        "failed_after_request",
+        "persistence_uncertain",
+    }:
+        raise ValidationError("terminal_status is invalid")
+    execution_id = _safe_text(
+        terminal["execution_id"],
+        "terminal.execution_id",
+        optional=True,
+    )
+    if status == "completed" and execution_id is None:
+        raise ValidationError("completed terminal evidence requires execution_id")
+    return {
+        "attempts_persisted": attempts_persisted,
+        "document_sha256": digest,
+        "execution_id": execution_id,
+        "finished_at": finished.isoformat(),
+        "plan_id": _safe_text(terminal["plan_id"], "terminal.plan_id"),
+        "record_id": _safe_text(terminal["record_id"], "terminal.record_id"),
+        "recorded_at": recorded.isoformat(),
+        "request_count": request_count,
+        "request_id": _safe_text(terminal["request_id"], "terminal.request_id"),
+        "started_at": started.isoformat(),
+        "terminal_status": status,
+    }
+
+
+def _validate_cross_contract(
+    *,
+    terminal: Mapping[str, Any],
+    terminal_record: Mapping[str, Any],
+    enforcement: Mapping[str, Any],
+    binding_recorded_at: datetime,
+) -> None:
+    started = _aware_utc(terminal["started_at"], "terminal.started_at")
+    finished = _aware_utc(terminal["finished_at"], "terminal.finished_at")
+    terminal_recorded = _aware_utc(
+        terminal["recorded_at"],
+        "terminal.recorded_at",
+    )
+    enforced = _aware_utc(enforcement["enforced_at"], "readiness.enforced_at")
+    if not started <= enforced <= finished:
+        raise ValidationError(
+            "readiness enforcement must occur during the terminal execution window"
+        )
+    if binding_recorded_at < terminal_recorded:
+        raise ValidationError("binding recorded_at precedes terminal record persistence")
+    if enforcement["execution_kind"] != "retry":
+        raise ValidationError("retry terminal history requires retry readiness authority")
+
+    lock = enforcement["lock"]
+    terminal_lock_model = terminal_record["lock_model_version"]
+    terminal_lock_key = terminal_record["lock_key_fingerprint"]
+    if terminal_record["request_count"] > 0 and (
+        terminal_lock_model is None or terminal_lock_key is None
+    ):
+        raise ValidationError(
+            "requestful terminal evidence must retain delivery lock identity"
+        )
+    if terminal_lock_model is not None and terminal_lock_model != lock["model_version"]:
+        raise ValidationError("terminal and readiness lock model versions differ")
+    if terminal_lock_key is not None and terminal_lock_key != lock["key_fingerprint"]:
+        raise ValidationError("terminal and readiness lock fingerprints differ")
+
+    execution_summary = terminal_record["execution_summary"]
+    if execution_summary is not None:
+        concurrency = execution_summary["concurrency_control"]
+        if concurrency["scope"] != lock["scope"]:
+            raise ValidationError("terminal and readiness lock scopes differ")
+
+
+def build_notification_retry_readiness_binding(
+    *,
+    terminal_record: Mapping[str, Any],
+    readiness_enforcement: Mapping[str, Any],
+    recorded_at: datetime | str,
+) -> dict[str, Any]:
+    selected_terminal_record = validate_retry_execution_record(terminal_record)
+    enforcement = validate_notification_execution_readiness_enforcement(
+        readiness_enforcement
+    )
+    terminal = _terminal_summary(selected_terminal_record)
+    recorded = _aware_utc(recorded_at, "recorded_at")
+    _validate_cross_contract(
+        terminal=terminal,
+        terminal_record=selected_terminal_record,
+        enforcement=enforcement,
+        binding_recorded_at=recorded,
+    )
+    enforcement_digest = hashlib.sha256(
+        _canonical_enforcement_bytes(enforcement)
+    ).hexdigest()
+    identity = {
+        "model_version": MODEL_VERSION,
+        "readiness_enforcement": enforcement,
+        "readiness_enforcement_sha256": enforcement_digest,
+        "recorded_at": recorded.isoformat(),
+        "terminal_execution": terminal,
+    }
+    return {"binding_id": _binding_id(identity), **identity}
+
+
+def validate_notification_retry_readiness_binding(
+    binding: Mapping[str, Any],
+) -> dict[str, Any]:
+    exact = _exact_mapping(
+        binding,
+        "retry readiness binding",
+        {
+            "binding_id",
+            "model_version",
+            "readiness_enforcement",
+            "readiness_enforcement_sha256",
+            "recorded_at",
+            "terminal_execution",
+        },
+    )
+    if exact["model_version"] != MODEL_VERSION:
+        raise ValidationError("retry readiness binding model_version is unsupported")
+    terminal = _validate_terminal_summary(exact["terminal_execution"])
+    enforcement = validate_notification_execution_readiness_enforcement(
+        exact["readiness_enforcement"]
+    )
+    if enforcement["execution_kind"] != "retry":
+        raise ValidationError("retry readiness binding requires retry authority")
+    enforced = _aware_utc(enforcement["enforced_at"], "readiness.enforced_at")
+    started = _aware_utc(terminal["started_at"], "terminal.started_at")
+    finished = _aware_utc(terminal["finished_at"], "terminal.finished_at")
+    recorded = _aware_utc(exact["recorded_at"], "recorded_at")
+    terminal_recorded = _aware_utc(
+        terminal["recorded_at"],
+        "terminal.recorded_at",
+    )
+    if not started <= enforced <= finished:
+        raise ValidationError(
+            "readiness enforcement must occur during the terminal execution window"
+        )
+    if recorded < terminal_recorded:
+        raise ValidationError("binding recorded_at precedes terminal record persistence")
+    expected_enforcement_digest = hashlib.sha256(
+        _canonical_enforcement_bytes(enforcement)
+    ).hexdigest()
+    digest = exact["readiness_enforcement_sha256"]
+    if not isinstance(digest, str) or not SHA256_PATTERN.fullmatch(digest):
+        raise ValidationError("readiness enforcement SHA-256 is invalid")
+    if digest != expected_enforcement_digest:
+        raise ValidationError("readiness enforcement SHA-256 does not match")
+    identity = {
+        "model_version": MODEL_VERSION,
+        "readiness_enforcement": enforcement,
+        "readiness_enforcement_sha256": expected_enforcement_digest,
+        "recorded_at": recorded.isoformat(),
+        "terminal_execution": terminal,
+    }
+    if exact["binding_id"] != _binding_id(identity):
+        raise ValidationError("retry readiness binding_id does not match content")
+    rebuilt = {"binding_id": exact["binding_id"], **identity}
+    if dict(exact) != rebuilt:
+        raise ValidationError("retry readiness binding is not canonical")
+    return rebuilt

--- a/tests/unit/test_notification_retry_readiness_binding.py
+++ b/tests/unit/test_notification_retry_readiness_binding.py
@@ -1,0 +1,218 @@
+from __future__ import annotations
+
+import copy
+import json
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from src.common.exceptions import ValidationError
+from src.orchestration.build_notification_retry_readiness_binding import (
+    build_retry_readiness_binding_from_files,
+)
+from src.warehouse.notification_execution_readiness_enforcement import (
+    _enforcement_evidence,
+)
+from src.warehouse.notification_retry_execution_contract import (
+    build_retry_execution_record,
+)
+from src.warehouse.notification_retry_readiness_binding_contract import (
+    build_notification_retry_readiness_binding,
+    validate_notification_retry_readiness_binding,
+)
+
+BASE_TIME = datetime(2026, 9, 2, 18, 0, tzinfo=timezone.utc)
+LOCK_MODEL = "portfolio-risk-notification-delivery-lock-v1"
+LOCK_SCOPE = "portfolio-risk-notification-delivery"
+LOCK_KEY = "notification-lock-key-1"
+
+
+def _enforcement(
+    *,
+    execution_kind: str = "retry",
+    enforced_at: datetime | None = None,
+    lock_key: str = LOCK_KEY,
+) -> dict[str, Any]:
+    selected_time = enforced_at or BASE_TIME + timedelta(minutes=2)
+    return _enforcement_evidence(
+        destination_id="risk-operations-webhook",
+        execution_kind=execution_kind,
+        enforced_at=selected_time,
+        record={
+            "record_id": "readiness-record-1",
+            "request_id": "readiness-request-1",
+            "decision": {
+                "decision_id": "retained-decision-1",
+                "evaluated_at": BASE_TIME.isoformat(),
+            },
+        },
+        refreshed_decision={
+            "decision_id": "refreshed-decision-1",
+            "evaluated_at": selected_time.isoformat(),
+        },
+        lock={
+            "key_fingerprint": lock_key,
+            "model_version": LOCK_MODEL,
+            "scope": LOCK_SCOPE,
+        },
+    )
+
+
+def _terminal(
+    *,
+    lock_key: str | None = LOCK_KEY,
+) -> dict[str, Any]:
+    return build_retry_execution_record(
+        request_id="retry-request-1",
+        plan_id="retry-plan-1",
+        started_at=BASE_TIME + timedelta(minutes=1),
+        finished_at=BASE_TIME + timedelta(minutes=3),
+        recorded_at=BASE_TIME + timedelta(minutes=4),
+        terminal_status="failed_after_request",
+        failure_code="validation_error",
+        request_count=1,
+        attempts_persisted=1,
+        succeeded_count=0,
+        failed_count=1,
+        attempt_ids=["attempt-1"],
+        requested_event_ids=["event-1"],
+        persisted_event_ids=["event-1"],
+        execution_summary=None,
+        endpoint_host="alerts.example.test",
+        delivery_fingerprint="delivery-fingerprint-1",
+        retry_policy_fingerprint="retry-policy-fingerprint-1",
+        retry_execution_policy_fingerprint="retry-execution-policy-1",
+        lock_model_version=LOCK_MODEL if lock_key is not None else None,
+        lock_key_fingerprint=lock_key,
+        lock_acquired=True if lock_key is not None else None,
+        lock_released=True if lock_key is not None else None,
+    )
+
+
+def _binding() -> dict[str, Any]:
+    return build_notification_retry_readiness_binding(
+        terminal_record=_terminal(),
+        readiness_enforcement=_enforcement(),
+        recorded_at=BASE_TIME + timedelta(minutes=5),
+    )
+
+
+def test_binding_is_deterministic_canonical_and_secret_free() -> None:
+    first = _binding()
+    second = _binding()
+
+    assert first == second
+    assert validate_notification_retry_readiness_binding(first) == first
+    assert first["readiness_enforcement"]["execution_kind"] == "retry"
+    assert first["terminal_execution"]["terminal_status"] == "failed_after_request"
+    rendered = json.dumps(first, sort_keys=True)
+    for secret in (
+        "https://alerts.example.test/path",
+        "postgresql://",
+        "Authorization",
+        "payload-body",
+        "response-body",
+    ):
+        assert secret not in rendered
+
+
+def test_binding_identity_changes_with_recording_time() -> None:
+    first = _binding()
+    later = build_notification_retry_readiness_binding(
+        terminal_record=_terminal(),
+        readiness_enforcement=_enforcement(),
+        recorded_at=BASE_TIME + timedelta(minutes=6),
+    )
+
+    assert later["binding_id"] != first["binding_id"]
+
+
+def test_initial_authority_cannot_bind_retry_terminal_history() -> None:
+    with pytest.raises(ValidationError, match="retry readiness authority"):
+        build_notification_retry_readiness_binding(
+            terminal_record=_terminal(),
+            readiness_enforcement=_enforcement(execution_kind="initial"),
+            recorded_at=BASE_TIME + timedelta(minutes=5),
+        )
+
+
+def test_enforcement_must_occur_inside_terminal_execution_window() -> None:
+    with pytest.raises(ValidationError, match="during the terminal execution window"):
+        build_notification_retry_readiness_binding(
+            terminal_record=_terminal(),
+            readiness_enforcement=_enforcement(
+                enforced_at=BASE_TIME + timedelta(seconds=30)
+            ),
+            recorded_at=BASE_TIME + timedelta(minutes=5),
+        )
+
+
+def test_requestful_terminal_history_requires_matching_lock_identity() -> None:
+    with pytest.raises(ValidationError, match="retain delivery lock identity"):
+        build_notification_retry_readiness_binding(
+            terminal_record=_terminal(lock_key=None),
+            readiness_enforcement=_enforcement(),
+            recorded_at=BASE_TIME + timedelta(minutes=5),
+        )
+
+    with pytest.raises(ValidationError, match="lock fingerprints differ"):
+        build_notification_retry_readiness_binding(
+            terminal_record=_terminal(lock_key="another-lock-key"),
+            readiness_enforcement=_enforcement(),
+            recorded_at=BASE_TIME + timedelta(minutes=5),
+        )
+
+
+def test_binding_recording_must_follow_terminal_persistence() -> None:
+    with pytest.raises(ValidationError, match="precedes terminal record persistence"):
+        build_notification_retry_readiness_binding(
+            terminal_record=_terminal(),
+            readiness_enforcement=_enforcement(),
+            recorded_at=BASE_TIME + timedelta(minutes=3, seconds=30),
+        )
+
+
+def test_binding_validation_rejects_digest_and_identity_tampering() -> None:
+    for key in (
+        "binding_id",
+        "readiness_enforcement_sha256",
+    ):
+        tampered = copy.deepcopy(_binding())
+        tampered[key] = "0" * 64 if key.endswith("sha256") else "tampered-binding"
+        with pytest.raises(ValidationError):
+            validate_notification_retry_readiness_binding(tampered)
+
+    terminal_tampered = copy.deepcopy(_binding())
+    terminal_tampered["terminal_execution"]["document_sha256"] = "0" * 64
+    with pytest.raises(ValidationError, match="binding_id"):
+        validate_notification_retry_readiness_binding(terminal_tampered)
+
+
+def test_file_builder_reads_nested_enforcement_and_rejects_symlinks(
+    tmp_path: Path,
+) -> None:
+    terminal_path = tmp_path / "terminal.json"
+    execution_path = tmp_path / "execution.json"
+    terminal_path.write_text(json.dumps(_terminal()), encoding="utf-8")
+    execution_path.write_text(
+        json.dumps({"execution_readiness": _enforcement()}),
+        encoding="utf-8",
+    )
+
+    binding = build_retry_readiness_binding_from_files(
+        terminal_record_path=terminal_path,
+        execution_summary_path=execution_path,
+        recorded_at=BASE_TIME + timedelta(minutes=5),
+    )
+    assert binding == _binding()
+
+    link = tmp_path / "terminal-link.json"
+    link.symlink_to(terminal_path)
+    with pytest.raises(ValidationError, match="symbolic link"):
+        build_retry_readiness_binding_from_files(
+            terminal_record_path=link,
+            execution_summary_path=execution_path,
+            recorded_at=BASE_TIME + timedelta(minutes=5),
+        )

--- a/tests/unit/test_notification_retry_readiness_binding_architecture_contract.py
+++ b/tests/unit/test_notification_retry_readiness_binding_architecture_contract.py
@@ -1,0 +1,56 @@
+from pathlib import Path
+
+
+def test_retry_readiness_binding_is_deterministic_local_and_secret_safe() -> None:
+    contract = Path(
+        "src/warehouse/notification_retry_readiness_binding_contract.py"
+    ).read_text(encoding="utf-8")
+    runner = Path(
+        "src/orchestration/build_notification_retry_readiness_binding.py"
+    ).read_text(encoding="utf-8")
+    docs = Path("docs/notification-retry-readiness-binding.md").read_text(
+        encoding="utf-8"
+    )
+    normalized_docs = " ".join(docs.split()).casefold()
+
+    for required in (
+        "validate_retry_execution_record",
+        "validate_notification_execution_readiness_enforcement",
+        "canonical_retry_execution_record_bytes",
+        "readiness_enforcement_sha256",
+        "during the terminal execution window",
+        "requestful terminal evidence must retain delivery lock identity",
+        "retry readiness binding_id does not match content",
+    ):
+        assert required in contract
+
+    for required in (
+        "--terminal-record",
+        "--execution-summary",
+        "--recorded-at",
+        "execution_readiness",
+        "must not be a symbolic link",
+        "exceeds 1 mb",
+    ):
+        assert required in runner.casefold()
+
+    for forbidden in (
+        "urllib.request",
+        "requests.",
+        "httpx.",
+        "socket.",
+        "psycopg",
+    ):
+        assert forbidden not in contract
+        assert forbidden not in runner
+
+    for required in (
+        "primary arc42 blocks: `orchestration` and `warehouse`",
+        "exact terminal record",
+        "exact readiness enforcement",
+        "does not persist",
+        "no endpoint value",
+        "no network request",
+        "terraform apply",
+    ):
+        assert required in normalized_docs


### PR DESCRIPTION
## Goal

Create the canonical evidence contract that links one exact retry terminal record to the exact readiness enforcement that permitted it, without yet changing PostgreSQL history.

```text
canonical retry terminal record
  + canonical retry readiness enforcement
  + binding recording time
  -> terminal document SHA-256
  -> readiness document SHA-256
  -> deterministic retry readiness binding
```

## Controls

- Independently validates both existing source contracts.
- Requires execution kind `retry`.
- Requires enforcement during the terminal execution window.
- Requires binding time after terminal persistence.
- Requires requestful terminal evidence to retain the shared delivery-lock identity.
- Rejects terminal/readiness lock model, key, or completed-summary scope mismatches.
- Binds terminal, plan, request, execution, destination, decision, lock, timing, and digest identities.
- Includes a bounded symlink-safe local builder for the P4d5c execution summary.

## Scope

Five additive files, three commits, 800 additions and no deletions. The two follow-up commits only make the documentation contract’s exact safety wording explicit; product code and tests were unchanged. The branch is zero commits behind `main`; squash merge retains one coherent increment.

## Exact-head validation

GitHub Actions run **400** (`33677663994`) passed on final head `cc67f49b673450aa13cc3d6a890d3d1e41724118`:

- Security guardrails passed.
- Ruff passed.
- mypy passed across **142 source files**.
- **928 tests passed** in quality and **928 passed again** in readiness.
- Dependency integrity and the standard replay demonstration passed.
- PostgreSQL 16 contract passed.
- Kubernetes rendering and Terraform format/init/validate passed without apply.
- No review submissions or unresolved review threads exist.

The first two runs each found a documentation-only phrase mismatch (`exact terminal record`, then `no network request`). Both phrases now explicitly document the intended boundary. No product rule, test expectation, security gate, or validation control was weakened.

## Boundary

This PR builds and validates canonical evidence but does not persist it. That keeps identity design independently reviewable before a later append-only schema and runtime integration PR. The builder performs no database operation, network request, delivery attempt, acknowledgement, deployment, or `terraform apply`, and retains no endpoint value, credential, payload body, response body, environment value, or DSN.

Validated and ready for squash merge.