### PR TITLE
Persist append-only retry readiness binding history

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,10 @@ jobs:
 
       - run: PIP_CONSTRAINT=requirements.lock python -m pip install -e '.[dev]'
       - run: PYTHON=python make postgres-contract-check
+      - run: >-
+          python -m
+          src.warehouse.notification_retry_readiness_binding_postgres_contract_check
+          --dsn postgresql://risk_user:risk_password@localhost:5433/risk_platform
       - run: python -m src.warehouse.model_approval_contract_check
       - run: >-
           python -m src.warehouse.postgres_consistency

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,10 +63,6 @@ jobs:
 
       - run: PIP_CONSTRAINT=requirements.lock python -m pip install -e '.[dev]'
       - run: PYTHON=python make postgres-contract-check
-      - run: >-
-          python -m
-          src.warehouse.notification_retry_readiness_binding_postgres_contract_check
-          --dsn postgresql://risk_user:risk_password@localhost:5433/risk_platform
       - run: python -m src.warehouse.model_approval_contract_check
       - run: >-
           python -m src.warehouse.postgres_consistency

--- a/Makefile
+++ b/Makefile
@@ -267,6 +267,8 @@ postgres-contract-check:
 		--dsn "$(LOCAL_POSTGRES_DSN)"
 	$(PYTHON) -m src.warehouse.controlled_receiver_rehearsal_postgres_contract_check \
 		--dsn "$(LOCAL_POSTGRES_DSN)"
+	$(PYTHON) -m src.warehouse.notification_retry_readiness_binding_postgres_contract_check \
+		--dsn "$(LOCAL_POSTGRES_DSN)"
 
 local-db-up:
 	docker compose up -d postgres mongo

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,6 +34,7 @@ services:
       - ./sql/controlled_notification_receiver_review_schema.sql:/docker-entrypoint-initdb.d/23_controlled_notification_receiver_review_schema.sql:ro
       - ./sql/notification_destination_transition_rehearsal_schema.sql:/docker-entrypoint-initdb.d/24_notification_destination_transition_rehearsal_schema.sql:ro
       - ./sql/notification_execution_readiness_schema.sql:/docker-entrypoint-initdb.d/25_notification_execution_readiness_schema.sql:ro
+      - ./sql/notification_retry_readiness_binding_schema.sql:/docker-entrypoint-initdb.d/26_notification_retry_readiness_binding_schema.sql:ro
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U risk_user -d risk_platform"]
       interval: 5s

--- a/docs/notification-retry-readiness-binding-history.md
+++ b/docs/notification-retry-readiness-binding-history.md
@@ -1,0 +1,93 @@
+# Notification Retry Readiness Binding History
+
+Primary arc42 blocks: `warehouse` and `orchestration`.
+
+## Goal
+
+P4d5d makes the deterministic retry-readiness binding from PR #138 durable:
+
+```text
+append-only retry terminal record
+  + append-only retained retry readiness decision
+  + exact under-lock readiness enforcement
+  -> independently reconciled canonical binding
+  -> append-only PostgreSQL history
+  -> bound or binding_missing operational state
+```
+
+The canonical document remains
+`portfolio-risk-notification-retry-readiness-binding-v1`. Persistence does not
+introduce a competing identity model.
+
+## Source reconciliation
+
+Before insertion, the recorder independently reloads and validates both source
+documents.
+
+For terminal history it verifies the record, request, plan, execution, status,
+timestamps, request and attempt counts, and canonical document SHA-256 against
+`portfolio_risk_notification_retry_executions`.
+
+For readiness history it verifies the readiness record and request IDs, retained
+decision ID, destination, `retry` execution kind, decision evaluation time and
+canonical source digest against
+`notification_execution_readiness_decisions`. The retained decision must be an
+`allow` decision with no blocking reasons.
+
+A binding cannot be inserted for a missing, changed, blocked or initial-delivery
+readiness source.
+
+## Append-only identity and replay
+
+Each terminal record can have at most one readiness binding. Each enforcement
+identity can also be retained at most once.
+
+```text
+same terminal record + identical canonical binding
+  -> exact replay converges with created = false
+
+same terminal record + changed binding time, authority or decision evidence
+  -> reject
+
+same enforcement identity under another terminal record
+  -> reject
+```
+
+Direct `UPDATE` and `DELETE` operations are rejected by PostgreSQL triggers.
+
+## Legacy visibility
+
+The status view preserves every terminal retry record. History created before
+this contract is not rewritten or assigned inferred authority:
+
+```text
+retained binding present -> bound
+retained binding absent  -> binding_missing
+```
+
+The `binding_missing` view is therefore an explicit governance-review queue,
+not evidence that the historical retry was authorised by the new contract.
+
+## PostgreSQL evidence
+
+The transaction-independent contract fixture proves:
+
+- canonical source decision and terminal retention;
+- first insert and exact replay convergence;
+- canonical reader round-trip;
+- conflicting terminal binding rejection;
+- missing readiness source rejection;
+- visible legacy `binding_missing` classification;
+- direct update and delete rejection; and
+- twelve reconciliation checks across source identity, view grain and
+  append-only controls.
+
+## Safety boundary
+
+This increment persists credential-free evidence only. It performs no network
+request, DNS lookup, socket operation, webhook delivery, provider request,
+delivery-attempt write, acknowledgement, outbox mutation, schedule activation,
+deployment or `terraform apply`. It retains no endpoint value, complete URL,
+credential, payload body, response body, environment value or PostgreSQL DSN.
+Committed notification delivery, destination activation and retry execution
+remain disabled.

--- a/sql/notification_retry_readiness_binding_consistency_checks.sql
+++ b/sql/notification_retry_readiness_binding_consistency_checks.sql
@@ -1,0 +1,254 @@
+-- Reconciliation for append-only retry readiness binding history.
+
+WITH counts AS (
+    SELECT
+        (SELECT COUNT(*)
+         FROM risk_platform.portfolio_risk_notification_retry_executions)
+            AS terminal_rows,
+        (SELECT COUNT(*)
+         FROM risk_platform.notification_retry_readiness_bindings)
+            AS binding_rows,
+        (SELECT COUNT(DISTINCT terminal_record_id)
+         FROM risk_platform.notification_retry_readiness_bindings)
+            AS distinct_terminal_record_ids,
+        (SELECT COUNT(DISTINCT enforcement_id)
+         FROM risk_platform.notification_retry_readiness_bindings)
+            AS distinct_enforcement_ids,
+        (SELECT COUNT(*)
+         FROM risk_platform.notification_retry_readiness_binding_status)
+            AS status_rows,
+        (SELECT COUNT(*)
+         FROM risk_platform.notification_retry_readiness_bound)
+            AS bound_rows,
+        (SELECT COUNT(*)
+         FROM risk_platform.notification_retry_readiness_binding_missing)
+            AS missing_rows
+),
+integrity AS (
+    SELECT
+        (
+            SELECT COUNT(*)
+            FROM risk_platform.notification_retry_readiness_bindings binding
+            JOIN risk_platform.portfolio_risk_notification_retry_executions terminal
+              ON terminal.record_id = binding.terminal_record_id
+            WHERE binding.terminal_request_id <> terminal.request_id
+               OR binding.terminal_plan_id <> terminal.plan_id
+               OR binding.terminal_execution_id
+                    IS DISTINCT FROM terminal.execution_id
+               OR binding.terminal_status <> terminal.terminal_status
+               OR binding.terminal_started_at <> terminal.started_at
+               OR binding.terminal_finished_at <> terminal.finished_at
+               OR binding.terminal_recorded_at <> terminal.recorded_at
+               OR binding.terminal_request_count <> terminal.request_count
+               OR binding.terminal_attempts_persisted
+                    <> terminal.attempts_persisted
+               OR binding.terminal_document_sha256
+                    <> terminal.document_sha256
+        ) AS invalid_terminal_source_rows,
+        (
+            SELECT COUNT(*)
+            FROM risk_platform.notification_retry_readiness_bindings binding
+            JOIN risk_platform.notification_execution_readiness_decisions readiness
+              ON readiness.record_id = binding.readiness_record_id
+            WHERE binding.readiness_request_id <> readiness.request_id
+               OR binding.retained_decision_id <> readiness.decision_id
+               OR binding.destination_id <> readiness.destination_id
+               OR readiness.execution_kind <> 'retry'
+               OR readiness.decision <> 'allow'
+               OR jsonb_array_length(readiness.blocking_reasons_json) <> 0
+               OR binding.retained_decision_evaluated_at
+                    <> readiness.evaluated_at
+        ) AS invalid_readiness_source_rows,
+        (
+            SELECT COUNT(*)
+            FROM risk_platform.notification_retry_readiness_bindings binding
+            WHERE binding.binding_json ->> 'binding_id' <> binding.binding_id
+               OR binding.binding_json ->> 'model_version'
+                    <> binding.model_version
+               OR binding.binding_json -> 'terminal_execution' ->> 'record_id'
+                    <> binding.terminal_record_id
+               OR binding.binding_json -> 'terminal_execution' ->> 'request_id'
+                    <> binding.terminal_request_id
+               OR binding.binding_json -> 'terminal_execution' ->> 'plan_id'
+                    <> binding.terminal_plan_id
+               OR binding.binding_json -> 'terminal_execution'
+                    ->> 'document_sha256' <> binding.terminal_document_sha256
+               OR binding.binding_json -> 'readiness_enforcement'
+                    <> binding.readiness_enforcement_json
+               OR binding.binding_json ->> 'readiness_enforcement_sha256'
+                    <> binding.readiness_enforcement_sha256
+               OR (binding.binding_json ->> 'recorded_at')::TIMESTAMPTZ
+                    <> binding.binding_recorded_at
+        ) AS invalid_binding_document_rows,
+        (
+            SELECT COUNT(*)
+            FROM risk_platform.notification_retry_readiness_bindings binding
+            WHERE binding.execution_kind <> 'retry'
+               OR binding.refreshed_decision_evaluated_at
+                    <> binding.enforced_at
+               OR binding.retained_decision_evaluated_at
+                    > binding.enforced_at
+               OR binding.terminal_started_at > binding.enforced_at
+               OR binding.enforced_at > binding.terminal_finished_at
+               OR binding.terminal_recorded_at > binding.binding_recorded_at
+               OR NOT (
+                    binding.readiness_enforcement_json
+                        ->> 'execution_ready'
+               )::BOOLEAN
+               OR binding.readiness_enforcement_json
+                    ->> 'readiness_review_status' <> 'allowed'
+               OR NOT (
+                    binding.readiness_enforcement_json
+                        ->> 'substantive_evidence_match'
+               )::BOOLEAN
+        ) AS invalid_authority_rows,
+        (
+            SELECT COUNT(*)
+            FROM (
+                SELECT terminal_record_id
+                FROM risk_platform.notification_retry_readiness_binding_status
+                GROUP BY terminal_record_id
+                HAVING COUNT(*) > 1
+            ) duplicated
+        ) AS duplicate_status_grains,
+        (
+            SELECT COUNT(*)
+            FROM risk_platform.notification_retry_readiness_binding_status
+            WHERE readiness_binding_status NOT IN ('bound', 'binding_missing')
+               OR readiness_binding_review_required
+                    <> (readiness_binding_status = 'binding_missing')
+               OR (readiness_binding_status = 'bound' AND binding_id IS NULL)
+               OR (
+                    readiness_binding_status = 'binding_missing'
+                    AND binding_id IS NOT NULL
+               )
+        ) AS invalid_status_rows,
+        (
+            SELECT COUNT(*)
+            FROM pg_trigger trigger
+            JOIN pg_class relation ON relation.oid = trigger.tgrelid
+            JOIN pg_namespace namespace ON namespace.oid = relation.relnamespace
+            WHERE namespace.nspname = 'risk_platform'
+              AND relation.relname = 'notification_retry_readiness_bindings'
+              AND trigger.tgname IN (
+                  'notification_retry_readiness_binding_reject_update',
+                  'notification_retry_readiness_binding_reject_delete'
+              )
+              AND trigger.tgenabled <> 'D'
+              AND NOT trigger.tgisinternal
+        ) AS append_only_trigger_count
+)
+SELECT
+    'notification_retry_readiness_terminal_ids_unique' AS check_name,
+    binding_rows::TEXT AS expected,
+    distinct_terminal_record_ids::TEXT AS actual,
+    CASE
+        WHEN binding_rows = distinct_terminal_record_ids THEN 'pass'
+        ELSE 'fail'
+    END AS status
+FROM counts
+
+UNION ALL
+
+SELECT
+    'notification_retry_readiness_enforcement_ids_unique',
+    binding_rows::TEXT,
+    distinct_enforcement_ids::TEXT,
+    CASE
+        WHEN binding_rows = distinct_enforcement_ids THEN 'pass'
+        ELSE 'fail'
+    END
+FROM counts
+
+UNION ALL
+
+SELECT
+    'notification_retry_readiness_status_covers_terminal_history',
+    terminal_rows::TEXT,
+    status_rows::TEXT,
+    CASE WHEN terminal_rows = status_rows THEN 'pass' ELSE 'fail' END
+FROM counts
+
+UNION ALL
+
+SELECT
+    'notification_retry_readiness_bound_partition_matches',
+    binding_rows::TEXT,
+    bound_rows::TEXT,
+    CASE WHEN binding_rows = bound_rows THEN 'pass' ELSE 'fail' END
+FROM counts
+
+UNION ALL
+
+SELECT
+    'notification_retry_readiness_missing_partition_matches',
+    (terminal_rows - binding_rows)::TEXT,
+    missing_rows::TEXT,
+    CASE
+        WHEN terminal_rows - binding_rows = missing_rows THEN 'pass'
+        ELSE 'fail'
+    END
+FROM counts
+
+UNION ALL
+
+SELECT
+    'notification_retry_readiness_terminal_sources_reconcile',
+    '0',
+    invalid_terminal_source_rows::TEXT,
+    CASE WHEN invalid_terminal_source_rows = 0 THEN 'pass' ELSE 'fail' END
+FROM integrity
+
+UNION ALL
+
+SELECT
+    'notification_retry_readiness_decision_sources_reconcile',
+    '0',
+    invalid_readiness_source_rows::TEXT,
+    CASE WHEN invalid_readiness_source_rows = 0 THEN 'pass' ELSE 'fail' END
+FROM integrity
+
+UNION ALL
+
+SELECT
+    'notification_retry_readiness_documents_reconcile',
+    '0',
+    invalid_binding_document_rows::TEXT,
+    CASE WHEN invalid_binding_document_rows = 0 THEN 'pass' ELSE 'fail' END
+FROM integrity
+
+UNION ALL
+
+SELECT
+    'notification_retry_readiness_authority_is_valid',
+    '0',
+    invalid_authority_rows::TEXT,
+    CASE WHEN invalid_authority_rows = 0 THEN 'pass' ELSE 'fail' END
+FROM integrity
+
+UNION ALL
+
+SELECT
+    'notification_retry_readiness_status_grain_is_unique',
+    '0',
+    duplicate_status_grains::TEXT,
+    CASE WHEN duplicate_status_grains = 0 THEN 'pass' ELSE 'fail' END
+FROM integrity
+
+UNION ALL
+
+SELECT
+    'notification_retry_readiness_status_flags_are_valid',
+    '0',
+    invalid_status_rows::TEXT,
+    CASE WHEN invalid_status_rows = 0 THEN 'pass' ELSE 'fail' END
+FROM integrity
+
+UNION ALL
+
+SELECT
+    'notification_retry_readiness_history_is_append_only',
+    '2',
+    append_only_trigger_count::TEXT,
+    CASE WHEN append_only_trigger_count = 2 THEN 'pass' ELSE 'fail' END
+FROM integrity;

--- a/sql/notification_retry_readiness_binding_schema.sql
+++ b/sql/notification_retry_readiness_binding_schema.sql
@@ -1,0 +1,244 @@
+-- Append-only readiness bindings for terminal notification retry history.
+-- Apply after notification_execution_readiness_schema.sql.
+
+CREATE SCHEMA IF NOT EXISTS risk_platform;
+
+CREATE TABLE IF NOT EXISTS
+risk_platform.notification_retry_readiness_bindings (
+    binding_id TEXT PRIMARY KEY,
+    model_version TEXT NOT NULL CHECK (
+        model_version = 'portfolio-risk-notification-retry-readiness-binding-v1'
+    ),
+    terminal_record_id TEXT NOT NULL UNIQUE REFERENCES
+        risk_platform.portfolio_risk_notification_retry_executions (record_id),
+    terminal_request_id TEXT NOT NULL,
+    terminal_plan_id TEXT NOT NULL,
+    terminal_execution_id TEXT,
+    terminal_status TEXT NOT NULL CHECK (
+        terminal_status IN (
+            'completed',
+            'failed_before_request',
+            'failed_after_request',
+            'persistence_uncertain'
+        )
+    ),
+    terminal_started_at TIMESTAMPTZ NOT NULL,
+    terminal_finished_at TIMESTAMPTZ NOT NULL,
+    terminal_recorded_at TIMESTAMPTZ NOT NULL,
+    terminal_request_count INTEGER NOT NULL CHECK (
+        terminal_request_count BETWEEN 0 AND 100
+    ),
+    terminal_attempts_persisted INTEGER NOT NULL CHECK (
+        terminal_attempts_persisted BETWEEN 0 AND terminal_request_count
+    ),
+    terminal_document_sha256 CHAR(64) NOT NULL CHECK (
+        terminal_document_sha256 ~ '^[0-9a-f]{64}$'
+    ),
+    readiness_record_id TEXT NOT NULL REFERENCES
+        risk_platform.notification_execution_readiness_decisions (record_id),
+    readiness_request_id TEXT NOT NULL,
+    retained_decision_id TEXT NOT NULL REFERENCES
+        risk_platform.notification_execution_readiness_decisions (decision_id),
+    refreshed_decision_id TEXT NOT NULL,
+    enforcement_id TEXT NOT NULL UNIQUE,
+    destination_id TEXT NOT NULL,
+    execution_kind TEXT NOT NULL CHECK (execution_kind = 'retry'),
+    enforced_at TIMESTAMPTZ NOT NULL,
+    retained_decision_evaluated_at TIMESTAMPTZ NOT NULL,
+    refreshed_decision_evaluated_at TIMESTAMPTZ NOT NULL,
+    lock_model_version TEXT NOT NULL,
+    lock_scope TEXT NOT NULL,
+    lock_key_fingerprint TEXT NOT NULL,
+    readiness_enforcement_sha256 CHAR(64) NOT NULL CHECK (
+        readiness_enforcement_sha256 ~ '^[0-9a-f]{64}$'
+    ),
+    binding_recorded_at TIMESTAMPTZ NOT NULL,
+    readiness_enforcement_json JSONB NOT NULL CHECK (
+        jsonb_typeof(readiness_enforcement_json) = 'object'
+    ),
+    binding_json JSONB NOT NULL CHECK (
+        jsonb_typeof(binding_json) = 'object'
+    ),
+    document_sha256 CHAR(64) NOT NULL CHECK (
+        document_sha256 ~ '^[0-9a-f]{64}$'
+    ),
+    loaded_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    CHECK (binding_id <> ''),
+    CHECK (terminal_record_id <> ''),
+    CHECK (terminal_request_id <> ''),
+    CHECK (terminal_plan_id <> ''),
+    CHECK (terminal_execution_id IS NULL OR terminal_execution_id <> ''),
+    CHECK (readiness_record_id <> ''),
+    CHECK (readiness_request_id <> ''),
+    CHECK (retained_decision_id <> ''),
+    CHECK (refreshed_decision_id <> ''),
+    CHECK (enforcement_id <> ''),
+    CHECK (destination_id <> ''),
+    CHECK (lock_model_version <> ''),
+    CHECK (lock_scope <> ''),
+    CHECK (lock_key_fingerprint <> ''),
+    CHECK (
+        terminal_started_at <= enforced_at
+        AND enforced_at <= terminal_finished_at
+    ),
+    CHECK (terminal_started_at <= terminal_finished_at),
+    CHECK (terminal_finished_at <= terminal_recorded_at),
+    CHECK (terminal_recorded_at <= binding_recorded_at),
+    CHECK (refreshed_decision_evaluated_at = enforced_at),
+    CHECK (retained_decision_evaluated_at <= enforced_at),
+    CHECK (binding_json ->> 'binding_id' = binding_id),
+    CHECK (binding_json ->> 'model_version' = model_version),
+    CHECK (
+        binding_json -> 'terminal_execution' ->> 'record_id'
+            = terminal_record_id
+    ),
+    CHECK (
+        binding_json -> 'terminal_execution' ->> 'request_id'
+            = terminal_request_id
+    ),
+    CHECK (
+        binding_json -> 'terminal_execution' ->> 'plan_id'
+            = terminal_plan_id
+    ),
+    CHECK (
+        binding_json -> 'terminal_execution' ->> 'terminal_status'
+            = terminal_status
+    ),
+    CHECK (
+        binding_json -> 'terminal_execution' ->> 'document_sha256'
+            = terminal_document_sha256
+    ),
+    CHECK (
+        binding_json ->> 'readiness_enforcement_sha256'
+            = readiness_enforcement_sha256
+    ),
+    CHECK (
+        binding_json -> 'readiness_enforcement'
+            = readiness_enforcement_json
+    ),
+    CHECK (
+        binding_json -> 'readiness_enforcement' ->> 'readiness_record_id'
+            = readiness_record_id
+    ),
+    CHECK (
+        binding_json -> 'readiness_enforcement' ->> 'readiness_request_id'
+            = readiness_request_id
+    ),
+    CHECK (
+        binding_json -> 'readiness_enforcement' ->> 'retained_decision_id'
+            = retained_decision_id
+    ),
+    CHECK (
+        binding_json -> 'readiness_enforcement' ->> 'refreshed_decision_id'
+            = refreshed_decision_id
+    ),
+    CHECK (
+        binding_json -> 'readiness_enforcement' ->> 'enforcement_id'
+            = enforcement_id
+    ),
+    CHECK (
+        binding_json -> 'readiness_enforcement' ->> 'destination_id'
+            = destination_id
+    ),
+    CHECK (
+        binding_json -> 'readiness_enforcement' ->> 'execution_kind'
+            = execution_kind
+    ),
+    CHECK (
+        (binding_json ->> 'recorded_at')::TIMESTAMPTZ
+            = binding_recorded_at
+    ),
+    CHECK (
+        (readiness_enforcement_json ->> 'execution_ready')::BOOLEAN
+    ),
+    CHECK (
+        readiness_enforcement_json ->> 'readiness_review_status' = 'allowed'
+    ),
+    CHECK (
+        (readiness_enforcement_json ->> 'substantive_evidence_match')::BOOLEAN
+    )
+);
+
+CREATE INDEX IF NOT EXISTS idx_notification_retry_readiness_destination
+ON risk_platform.notification_retry_readiness_bindings (
+    destination_id,
+    enforced_at DESC,
+    terminal_record_id
+);
+
+CREATE INDEX IF NOT EXISTS idx_notification_retry_readiness_decision
+ON risk_platform.notification_retry_readiness_bindings (
+    readiness_record_id,
+    retained_decision_id
+);
+
+CREATE OR REPLACE FUNCTION
+risk_platform.reject_notification_retry_readiness_binding_mutation()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    RAISE EXCEPTION 'notification retry readiness bindings are append-only';
+END;
+$$;
+
+DROP TRIGGER IF EXISTS notification_retry_readiness_binding_reject_update
+ON risk_platform.notification_retry_readiness_bindings;
+CREATE TRIGGER notification_retry_readiness_binding_reject_update
+BEFORE UPDATE ON risk_platform.notification_retry_readiness_bindings
+FOR EACH ROW
+EXECUTE FUNCTION
+    risk_platform.reject_notification_retry_readiness_binding_mutation();
+
+DROP TRIGGER IF EXISTS notification_retry_readiness_binding_reject_delete
+ON risk_platform.notification_retry_readiness_bindings;
+CREATE TRIGGER notification_retry_readiness_binding_reject_delete
+BEFORE DELETE ON risk_platform.notification_retry_readiness_bindings
+FOR EACH ROW
+EXECUTE FUNCTION
+    risk_platform.reject_notification_retry_readiness_binding_mutation();
+
+CREATE OR REPLACE VIEW
+risk_platform.notification_retry_readiness_binding_status AS
+SELECT
+    terminal.record_id AS terminal_record_id,
+    terminal.request_id AS terminal_request_id,
+    terminal.plan_id AS terminal_plan_id,
+    terminal.execution_id AS terminal_execution_id,
+    terminal.terminal_status,
+    terminal.started_at AS terminal_started_at,
+    terminal.finished_at AS terminal_finished_at,
+    terminal.recorded_at AS terminal_recorded_at,
+    terminal.request_count AS terminal_request_count,
+    terminal.attempts_persisted AS terminal_attempts_persisted,
+    terminal.document_sha256 AS terminal_document_sha256,
+    binding.binding_id,
+    binding.readiness_record_id,
+    binding.readiness_request_id,
+    binding.retained_decision_id,
+    binding.refreshed_decision_id,
+    binding.enforcement_id,
+    binding.destination_id,
+    binding.enforced_at,
+    binding.binding_recorded_at,
+    binding.document_sha256 AS binding_document_sha256,
+    CASE
+        WHEN binding.binding_id IS NULL THEN 'binding_missing'
+        ELSE 'bound'
+    END AS readiness_binding_status,
+    binding.binding_id IS NULL AS readiness_binding_review_required
+FROM risk_platform.portfolio_risk_notification_retry_executions terminal
+LEFT JOIN risk_platform.notification_retry_readiness_bindings binding
+  ON binding.terminal_record_id = terminal.record_id;
+
+CREATE OR REPLACE VIEW
+risk_platform.notification_retry_readiness_bound AS
+SELECT *
+FROM risk_platform.notification_retry_readiness_binding_status
+WHERE readiness_binding_status = 'bound';
+
+CREATE OR REPLACE VIEW
+risk_platform.notification_retry_readiness_binding_missing AS
+SELECT *
+FROM risk_platform.notification_retry_readiness_binding_status
+WHERE readiness_binding_status = 'binding_missing';

--- a/src/warehouse/notification_retry_readiness_binding_postgres_contract_check.py
+++ b/src/warehouse/notification_retry_readiness_binding_postgres_contract_check.py
@@ -1,0 +1,467 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+from src.common.exceptions import ValidationError
+from src.orchestration.deliver_portfolio_risk_notifications import (
+    WebhookDeliveryConfig,
+)
+from src.orchestration.portfolio_risk_notification_destination_contract import (
+    DestinationActivation,
+    DestinationOwner,
+    NotificationDestination,
+)
+from src.orchestration.portfolio_risk_notification_retry_execution_policy import (
+    RetryExecutionPolicy,
+)
+from src.warehouse.notification_execution_readiness_enforcement import (
+    _enforcement_evidence,
+)
+from src.warehouse.notification_execution_readiness_gate import (
+    evaluate_notification_execution_readiness,
+)
+from src.warehouse.notification_execution_readiness_history_contract import (
+    build_notification_execution_readiness_record,
+)
+from src.warehouse.notification_execution_readiness_recorder import (
+    record_notification_execution_readiness,
+)
+from src.warehouse.notification_retry_execution_contract import (
+    build_retry_execution_record,
+)
+from src.warehouse.notification_retry_execution_recorder import (
+    record_notification_retry_execution,
+)
+from src.warehouse.notification_retry_readiness_binding_contract import (
+    build_notification_retry_readiness_binding,
+)
+from src.warehouse.notification_retry_readiness_binding_reader import (
+    read_notification_retry_readiness_binding,
+)
+from src.warehouse.notification_retry_readiness_binding_recorder import (
+    record_notification_retry_readiness_binding,
+)
+from src.warehouse.postgres_loader import DEFAULT_POSTGRES_DSN
+
+CHECK_PATH = Path("sql/notification_retry_readiness_binding_consistency_checks.sql")
+BASE_TIME = datetime(2026, 8, 1, 12, 0, tzinfo=timezone.utc)
+DESTINATION_ID = "binding-history-webhook"
+LOCK_MODEL = "portfolio-risk-notification-delivery-lock-v1"
+LOCK_SCOPE = "portfolio-risk-notification-delivery"
+LOCK_KEY = "binding-history-lock-key"
+
+
+def _destination() -> NotificationDestination:
+    return NotificationDestination(
+        destination_id=DESTINATION_ID,
+        channel="webhook",
+        endpoint_env="RISK_NOTIFICATION_WEBHOOK_URL",
+        owner=DestinationOwner(
+            team="risk-operations",
+            contact="risk-operations-oncall",
+        ),
+        purpose="portfolio-risk-breach-lifecycle",
+        recipient_scope="risk-operations",
+        data_classification="internal",
+        allowed_event_types=(
+            "breach_escalated",
+            "breach_opened",
+            "breach_resolved",
+        ),
+        activation=DestinationActivation(
+            enabled=True,
+            change_request_id="CHG-BINDING-HISTORY",
+            reviewed_by=("risk-control-reviewer",),
+            reviewed_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+            review_expires_at=datetime(2027, 1, 1, tzinfo=timezone.utc),
+        ),
+    )
+
+
+def _decision(*, evaluated_at: datetime) -> dict[str, Any]:
+    destination = _destination()
+    return evaluate_notification_execution_readiness(
+        execution_kind="retry",
+        evaluated_at=evaluated_at,
+        delivery_config=WebhookDeliveryConfig(
+            enabled=True,
+            endpoint_env="RISK_NOTIFICATION_WEBHOOK_URL",
+            timeout_seconds=5,
+            max_batch_events=25,
+            max_attempts_per_event=3,
+            initial_backoff_seconds=1,
+        ),
+        retry_policy_fingerprint="binding-history-retry-policy",
+        retry_execution_policy=RetryExecutionPolicy(
+            enabled=True,
+            max_plan_age_seconds=3600,
+            max_events=25,
+        ),
+        destination=destination,
+        activation_review={
+            "authority_id": "binding-history-authority",
+            "checklist_id": "binding-history-checklist",
+            "destination_fingerprint": destination.fingerprint,
+            "destination_id": DESTINATION_ID,
+            "operational_activation_ready": True,
+            "review_status": "ready",
+        },
+        transition_review={
+            "activation_review_status": "ready",
+            "current_authority_id": "binding-history-authority",
+            "current_checklist_id": "binding-history-checklist",
+            "current_destination_fingerprint": destination.fingerprint,
+            "destination_id": DESTINATION_ID,
+            "operational_activation_ready": True,
+            "rollback_authority_id": None,
+            "rollback_checklist_id": None,
+            "rollback_destination_fingerprint": None,
+            "rollback_endpoint_environment_variable": None,
+            "rollback_plan_id": None,
+            "transition_matches_current_activation": True,
+            "transition_ready": True,
+            "transition_record_id": "binding-history-transition-record",
+            "transition_rehearsal_id": "binding-history-transition-rehearsal",
+            "transition_review_status": "ready",
+        },
+        ambiguities=[],
+    )
+
+
+def _readiness_record(*, request_id: str) -> dict[str, Any]:
+    decision = _decision(evaluated_at=BASE_TIME)
+    return build_notification_execution_readiness_record(
+        request_id=request_id,
+        recorded_at=BASE_TIME + timedelta(seconds=1),
+        decision=decision,
+    )
+
+
+def _terminal(
+    *,
+    request_id: str,
+    plan_id: str,
+    started_at: datetime,
+    finished_at: datetime,
+    recorded_at: datetime,
+    requestful: bool,
+) -> dict[str, Any]:
+    if requestful:
+        return build_retry_execution_record(
+            request_id=request_id,
+            plan_id=plan_id,
+            started_at=started_at,
+            finished_at=finished_at,
+            recorded_at=recorded_at,
+            terminal_status="failed_after_request",
+            failure_code="validation_error",
+            request_count=1,
+            attempts_persisted=1,
+            succeeded_count=0,
+            failed_count=1,
+            attempt_ids=[f"{request_id}-attempt"],
+            requested_event_ids=[f"{request_id}-event"],
+            persisted_event_ids=[f"{request_id}-event"],
+            execution_summary=None,
+            endpoint_host="alerts.example.test",
+            delivery_fingerprint="binding-history-delivery",
+            retry_policy_fingerprint="binding-history-retry-policy",
+            retry_execution_policy_fingerprint="binding-history-execution-policy",
+            lock_model_version=LOCK_MODEL,
+            lock_key_fingerprint=LOCK_KEY,
+            lock_acquired=True,
+            lock_released=True,
+        )
+    return build_retry_execution_record(
+        request_id=request_id,
+        plan_id=plan_id,
+        started_at=started_at,
+        finished_at=finished_at,
+        recorded_at=recorded_at,
+        terminal_status="failed_before_request",
+        failure_code="validation_error",
+        request_count=0,
+        attempts_persisted=0,
+        succeeded_count=0,
+        failed_count=0,
+        attempt_ids=[],
+        requested_event_ids=[],
+        persisted_event_ids=[],
+        execution_summary=None,
+    )
+
+
+def _enforcement(
+    *,
+    record: dict[str, Any],
+    enforced_at: datetime,
+    suffix: str,
+) -> dict[str, Any]:
+    decision = record["decision"]
+    return _enforcement_evidence(
+        destination_id=DESTINATION_ID,
+        execution_kind="retry",
+        enforced_at=enforced_at,
+        record={
+            "record_id": record["record_id"],
+            "request_id": record["request_id"],
+            "decision": {
+                "decision_id": decision["decision_id"],
+                "evaluated_at": decision["evaluated_at"],
+            },
+        },
+        refreshed_decision={
+            "decision_id": f"binding-history-refreshed-{suffix}",
+            "evaluated_at": enforced_at.isoformat(),
+        },
+        lock={
+            "key_fingerprint": LOCK_KEY,
+            "model_version": LOCK_MODEL,
+            "scope": LOCK_SCOPE,
+        },
+    )
+
+
+def _mutation_rejected(dsn: str, statement: str) -> bool:
+    try:
+        import psycopg
+    except ImportError as exc:  # pragma: no cover - required in CI.
+        raise RuntimeError("Notification retry readiness history requires psycopg") from exc
+    try:
+        with psycopg.connect(dsn) as connection:
+            with connection.cursor() as cursor:
+                cursor.execute(statement)
+            connection.commit()
+    except Exception as exc:
+        if "append-only" not in str(exc):
+            raise
+        return True
+    return False
+
+
+def _status(dsn: str, terminal_record_id: str) -> str:
+    try:
+        import psycopg
+    except ImportError as exc:  # pragma: no cover - required in CI.
+        raise RuntimeError("Notification retry readiness history requires psycopg") from exc
+    with psycopg.connect(dsn) as connection:
+        with connection.cursor() as cursor:
+            cursor.execute(
+                """
+                SELECT readiness_binding_status
+                FROM risk_platform.notification_retry_readiness_binding_status
+                WHERE terminal_record_id = %s
+                """,
+                (terminal_record_id,),
+            )
+            row = cursor.fetchone()
+    if row is None:
+        raise AssertionError("retry readiness binding status row is missing")
+    return str(row[0])
+
+
+def run_contract_check(dsn: str) -> dict[str, Any]:
+    readiness_record = _readiness_record(
+        request_id="BINDING-HISTORY-READINESS-001"
+    )
+    record_notification_execution_readiness(dsn=dsn, record=readiness_record)
+
+    terminal = _terminal(
+        request_id="BINDING-HISTORY-TERMINAL-001",
+        plan_id="binding-history-plan-001",
+        started_at=BASE_TIME + timedelta(minutes=1),
+        finished_at=BASE_TIME + timedelta(minutes=3),
+        recorded_at=BASE_TIME + timedelta(minutes=4),
+        requestful=True,
+    )
+    record_notification_retry_execution(dsn=dsn, record=terminal)
+    enforcement = _enforcement(
+        record=readiness_record,
+        enforced_at=BASE_TIME + timedelta(minutes=2),
+        suffix="current",
+    )
+    binding = build_notification_retry_readiness_binding(
+        terminal_record=terminal,
+        readiness_enforcement=enforcement,
+        recorded_at=BASE_TIME + timedelta(minutes=5),
+    )
+    created = record_notification_retry_readiness_binding(
+        dsn=dsn,
+        binding=binding,
+    )
+    if created["created"] is not True:
+        existing = read_notification_retry_readiness_binding(
+            dsn=dsn,
+            terminal_record_id=terminal["record_id"],
+        )
+        if existing is None or existing["binding"] != binding:
+            raise AssertionError("retry readiness binding was not retained")
+
+    replay = record_notification_retry_readiness_binding(
+        dsn=dsn,
+        binding=binding,
+    )
+    if replay["created"] is not False:
+        raise AssertionError("exact retry readiness binding replay did not converge")
+    retained = read_notification_retry_readiness_binding(
+        dsn=dsn,
+        terminal_record_id=terminal["record_id"],
+    )
+    if retained is None or retained["binding"] != binding:
+        raise AssertionError("retry readiness binding reader changed canonical evidence")
+    if _status(dsn, terminal["record_id"]) != "bound":
+        raise AssertionError("retained retry readiness binding was not classified bound")
+
+    conflicting = build_notification_retry_readiness_binding(
+        terminal_record=terminal,
+        readiness_enforcement=enforcement,
+        recorded_at=BASE_TIME + timedelta(minutes=6),
+    )
+    try:
+        record_notification_retry_readiness_binding(
+            dsn=dsn,
+            binding=conflicting,
+        )
+    except ValidationError:
+        conflict_rejected = True
+    else:
+        conflict_rejected = False
+    if not conflict_rejected:
+        raise AssertionError("conflicting terminal readiness evidence was accepted")
+
+    legacy_terminal = _terminal(
+        request_id="BINDING-HISTORY-LEGACY-001",
+        plan_id="binding-history-plan-legacy",
+        started_at=BASE_TIME + timedelta(minutes=10),
+        finished_at=BASE_TIME + timedelta(minutes=10, seconds=1),
+        recorded_at=BASE_TIME + timedelta(minutes=10, seconds=2),
+        requestful=False,
+    )
+    record_notification_retry_execution(dsn=dsn, record=legacy_terminal)
+    if _status(dsn, legacy_terminal["record_id"]) != "binding_missing":
+        raise AssertionError("legacy terminal history was not visibly unbound")
+
+    unretained_readiness = _readiness_record(
+        request_id="BINDING-HISTORY-UNRETAINED-READINESS"
+    )
+    missing_source_terminal = _terminal(
+        request_id="BINDING-HISTORY-MISSING-SOURCE-TERMINAL",
+        plan_id="binding-history-plan-missing-source",
+        started_at=BASE_TIME + timedelta(minutes=1, seconds=30),
+        finished_at=BASE_TIME + timedelta(minutes=2, seconds=30),
+        recorded_at=BASE_TIME + timedelta(minutes=4, seconds=30),
+        requestful=False,
+    )
+    record_notification_retry_execution(dsn=dsn, record=missing_source_terminal)
+    missing_source_binding = build_notification_retry_readiness_binding(
+        terminal_record=missing_source_terminal,
+        readiness_enforcement=_enforcement(
+            record=unretained_readiness,
+            enforced_at=BASE_TIME + timedelta(minutes=2),
+            suffix="missing-source",
+        ),
+        recorded_at=BASE_TIME + timedelta(minutes=5),
+    )
+    try:
+        record_notification_retry_readiness_binding(
+            dsn=dsn,
+            binding=missing_source_binding,
+        )
+    except ValidationError:
+        missing_source_rejected = True
+    else:
+        missing_source_rejected = False
+    if not missing_source_rejected:
+        raise AssertionError("missing readiness source was accepted")
+
+    update_rejected = _mutation_rejected(
+        dsn,
+        """
+        UPDATE risk_platform.notification_retry_readiness_bindings
+        SET destination_id = 'changed-destination'
+        WHERE terminal_record_id = (
+            SELECT record_id
+            FROM risk_platform.portfolio_risk_notification_retry_executions
+            WHERE request_id = 'BINDING-HISTORY-TERMINAL-001'
+        )
+        """,
+    )
+    delete_rejected = _mutation_rejected(
+        dsn,
+        """
+        DELETE FROM risk_platform.notification_retry_readiness_bindings
+        WHERE terminal_record_id = (
+            SELECT record_id
+            FROM risk_platform.portfolio_risk_notification_retry_executions
+            WHERE request_id = 'BINDING-HISTORY-TERMINAL-001'
+        )
+        """,
+    )
+    if not update_rejected or not delete_rejected:
+        raise AssertionError("append-only retry readiness mutation was accepted")
+
+    try:
+        import psycopg
+    except ImportError as exc:  # pragma: no cover - required in CI.
+        raise RuntimeError("Notification retry readiness history requires psycopg") from exc
+    with psycopg.connect(dsn) as connection:
+        with connection.cursor() as cursor:
+            cursor.execute(CHECK_PATH.read_text(encoding="utf-8"))
+            checks = list(cursor.fetchall())
+    failures = [check for check in checks if check[3] != "pass"]
+    if failures:
+        names = ", ".join(str(check[0]) for check in failures)
+        raise AssertionError("retry readiness binding reconciliation failed: " + names)
+
+    return {
+        "model_version": "portfolio-risk-notification-retry-readiness-history-v1",
+        "binding_id": binding["binding_id"],
+        "terminal_record_id": terminal["record_id"],
+        "readiness_record_id": readiness_record["record_id"],
+        "exact_replay_converged": True,
+        "conflicting_terminal_binding_rejected": conflict_rejected,
+        "missing_readiness_source_rejected": missing_source_rejected,
+        "legacy_binding_missing_visible": True,
+        "update_rejected": update_rejected,
+        "delete_rejected": delete_rejected,
+        "consistency_checks": len(checks),
+        "external_request_performed": False,
+        "delivery_attempt_written": False,
+        "outbox_mutated": False,
+        "acknowledgement_mutated": False,
+    }
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Exercise append-only notification retry readiness binding history "
+            "against PostgreSQL 16."
+        )
+    )
+    parser.add_argument(
+        "--dsn",
+        default=os.environ.get("WAREHOUSE_POSTGRES_DSN", DEFAULT_POSTGRES_DSN),
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    try:
+        summary = run_contract_check(args.dsn)
+    except Exception as exc:
+        print(f"Retry readiness binding history failed: {exc}", file=sys.stderr)
+        return 1
+    print(json.dumps(summary, sort_keys=True, allow_nan=False))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/warehouse/notification_retry_readiness_binding_reader.py
+++ b/src/warehouse/notification_retry_readiness_binding_reader.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import hashlib
+import re
+from collections.abc import Mapping
+from typing import Any
+
+from src.common.exceptions import StorageError, ValidationError
+from src.warehouse.notification_retry_readiness_binding_contract import (
+    canonical_notification_retry_readiness_binding_bytes,
+    validate_notification_retry_readiness_binding,
+)
+
+SAFE_ID = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,511}$")
+
+
+def _safe_id(value: str, label: str) -> str:
+    if not isinstance(value, str) or not SAFE_ID.fullmatch(value):
+        raise ValidationError(f"{label} must be one safe text segment")
+    return value
+
+
+def read_notification_retry_readiness_binding(
+    *,
+    dsn: str,
+    terminal_record_id: str,
+) -> dict[str, Any] | None:
+    if not isinstance(dsn, str) or not dsn.strip():
+        raise ValidationError("PostgreSQL DSN must be non-empty text")
+    selected_record_id = _safe_id(terminal_record_id, "terminal_record_id")
+    try:
+        import psycopg
+    except ImportError as exc:  # pragma: no cover - required in CI.
+        raise RuntimeError("Notification retry readiness history requires psycopg") from exc
+
+    try:
+        with psycopg.connect(dsn) as connection:
+            with connection.cursor() as cursor:
+                cursor.execute(
+                    """
+                    SELECT binding_json, document_sha256
+                    FROM risk_platform.notification_retry_readiness_bindings
+                    WHERE terminal_record_id = %s
+                    """,
+                    (selected_record_id,),
+                )
+                row = cursor.fetchone()
+    except Exception:
+        raise StorageError(
+            "notification retry readiness history lookup failed"
+        ) from None
+
+    if row is None:
+        return None
+    binding_json, stored_digest = row
+    if not isinstance(binding_json, Mapping):
+        raise StorageError("retained retry readiness binding is invalid")
+    binding = validate_notification_retry_readiness_binding(binding_json)
+    digest = hashlib.sha256(
+        canonical_notification_retry_readiness_binding_bytes(binding)
+    ).hexdigest()
+    if stored_digest != digest:
+        raise ValidationError("retained retry readiness binding digest is invalid")
+    terminal = binding["terminal_execution"]
+    enforcement = binding["readiness_enforcement"]
+    if terminal["record_id"] != selected_record_id:
+        raise ValidationError("retained retry readiness terminal identity is invalid")
+    return {
+        "binding": binding,
+        "history": {
+            "binding_id": binding["binding_id"],
+            "terminal_record_id": terminal["record_id"],
+            "terminal_request_id": terminal["request_id"],
+            "readiness_record_id": enforcement["readiness_record_id"],
+            "retained_decision_id": enforcement["retained_decision_id"],
+            "refreshed_decision_id": enforcement["refreshed_decision_id"],
+            "enforcement_id": enforcement["enforcement_id"],
+            "destination_id": enforcement["destination_id"],
+            "document_sha256": digest,
+        },
+    }

--- a/src/warehouse/notification_retry_readiness_binding_recorder.py
+++ b/src/warehouse/notification_retry_readiness_binding_recorder.py
@@ -1,0 +1,353 @@
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import sys
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+from src.common.exceptions import StorageError, ValidationError
+from src.warehouse.notification_execution_readiness_history_contract import (
+    canonical_notification_execution_readiness_record_bytes,
+    validate_notification_execution_readiness_record,
+)
+from src.warehouse.notification_retry_execution_contract import (
+    canonical_retry_execution_record_bytes,
+    validate_retry_execution_record,
+)
+from src.warehouse.notification_retry_readiness_binding_contract import (
+    canonical_notification_retry_readiness_binding_bytes,
+    validate_notification_retry_readiness_binding,
+)
+from src.warehouse.postgres_loader import DEFAULT_POSTGRES_DSN
+
+MAX_RECORD_BYTES = 1_048_576
+
+
+def _result(
+    binding: Mapping[str, Any],
+    *,
+    digest: str,
+    created: bool,
+) -> dict[str, Any]:
+    terminal = binding["terminal_execution"]
+    enforcement = binding["readiness_enforcement"]
+    return {
+        "binding_id": binding["binding_id"],
+        "terminal_record_id": terminal["record_id"],
+        "terminal_request_id": terminal["request_id"],
+        "readiness_record_id": enforcement["readiness_record_id"],
+        "retained_decision_id": enforcement["retained_decision_id"],
+        "refreshed_decision_id": enforcement["refreshed_decision_id"],
+        "enforcement_id": enforcement["enforcement_id"],
+        "destination_id": enforcement["destination_id"],
+        "document_sha256": digest,
+        "created": created,
+    }
+
+
+def _reconcile_terminal_source(
+    cursor: Any,
+    *,
+    binding: Mapping[str, Any],
+) -> None:
+    terminal = binding["terminal_execution"]
+    cursor.execute(
+        """
+        SELECT record_json, document_sha256
+        FROM risk_platform.portfolio_risk_notification_retry_executions
+        WHERE record_id = %s
+        """,
+        (terminal["record_id"],),
+    )
+    row = cursor.fetchone()
+    if row is None:
+        raise ValidationError("retry readiness binding terminal source is missing")
+    source_json, stored_digest = row
+    if not isinstance(source_json, Mapping):
+        raise StorageError("retry readiness binding terminal source is invalid")
+    source = validate_retry_execution_record(source_json)
+    source_digest = hashlib.sha256(
+        canonical_retry_execution_record_bytes(source)
+    ).hexdigest()
+    if stored_digest != source_digest:
+        raise ValidationError("retry terminal source digest is invalid")
+    expected = {
+        "attempts_persisted": source["attempts_persisted"],
+        "document_sha256": source_digest,
+        "execution_id": source["execution_id"],
+        "finished_at": source["finished_at"],
+        "plan_id": source["plan_id"],
+        "record_id": source["record_id"],
+        "recorded_at": source["recorded_at"],
+        "request_count": source["request_count"],
+        "request_id": source["request_id"],
+        "started_at": source["started_at"],
+        "terminal_status": source["terminal_status"],
+    }
+    if terminal != expected:
+        raise ValidationError(
+            "retry readiness binding does not match retained terminal evidence"
+        )
+
+
+def _reconcile_readiness_source(
+    cursor: Any,
+    *,
+    binding: Mapping[str, Any],
+) -> None:
+    enforcement = binding["readiness_enforcement"]
+    cursor.execute(
+        """
+        SELECT record_json, document_sha256
+        FROM risk_platform.notification_execution_readiness_decisions
+        WHERE record_id = %s
+        """,
+        (enforcement["readiness_record_id"],),
+    )
+    row = cursor.fetchone()
+    if row is None:
+        raise ValidationError("retry readiness binding readiness source is missing")
+    source_json, stored_digest = row
+    if not isinstance(source_json, Mapping):
+        raise StorageError("retry readiness binding readiness source is invalid")
+    source = validate_notification_execution_readiness_record(source_json)
+    source_digest = hashlib.sha256(
+        canonical_notification_execution_readiness_record_bytes(source)
+    ).hexdigest()
+    if stored_digest != source_digest:
+        raise ValidationError("retained readiness source digest is invalid")
+    decision = source["decision"]
+    if source["request_id"] != enforcement["readiness_request_id"]:
+        raise ValidationError("retry readiness binding readiness request changed")
+    if decision["decision_id"] != enforcement["retained_decision_id"]:
+        raise ValidationError("retry readiness binding retained decision changed")
+    if decision["execution_kind"] != "retry":
+        raise ValidationError("retry readiness binding source is not retry readiness")
+    if decision["decision"] != "allow" or decision["blocking_reasons"]:
+        raise ValidationError("retry readiness binding source does not allow execution")
+    if (
+        decision["destination"]["destination_id"]
+        != enforcement["destination_id"]
+    ):
+        raise ValidationError("retry readiness binding destination changed")
+    if decision["evaluated_at"] != enforcement["retained_decision_evaluated_at"]:
+        raise ValidationError("retry readiness binding evaluation time changed")
+
+
+def record_notification_retry_readiness_binding_with_cursor(
+    cursor: Any,
+    *,
+    binding: Mapping[str, Any],
+) -> dict[str, Any]:
+    validated = validate_notification_retry_readiness_binding(binding)
+    canonical = canonical_notification_retry_readiness_binding_bytes(validated)
+    digest = hashlib.sha256(canonical).hexdigest()
+    terminal = validated["terminal_execution"]
+    enforcement = validated["readiness_enforcement"]
+    lock = enforcement["lock"]
+
+    _reconcile_terminal_source(cursor, binding=validated)
+    _reconcile_readiness_source(cursor, binding=validated)
+
+    cursor.execute(
+        """
+        SELECT binding_json, document_sha256
+        FROM risk_platform.notification_retry_readiness_bindings
+        WHERE terminal_record_id = %s
+        """,
+        (terminal["record_id"],),
+    )
+    existing = cursor.fetchone()
+    if existing is not None:
+        existing_json, existing_digest = existing
+        if existing_json != validated or existing_digest != digest:
+            raise ValidationError(
+                "retry terminal record already has different readiness evidence"
+            )
+        return _result(validated, digest=digest, created=False)
+
+    try:
+        from psycopg.types.json import Jsonb
+    except ImportError as exc:  # pragma: no cover - required in CI.
+        raise RuntimeError("Notification retry readiness history requires psycopg") from exc
+
+    cursor.execute(
+        """
+        INSERT INTO risk_platform.notification_retry_readiness_bindings (
+            binding_id,
+            model_version,
+            terminal_record_id,
+            terminal_request_id,
+            terminal_plan_id,
+            terminal_execution_id,
+            terminal_status,
+            terminal_started_at,
+            terminal_finished_at,
+            terminal_recorded_at,
+            terminal_request_count,
+            terminal_attempts_persisted,
+            terminal_document_sha256,
+            readiness_record_id,
+            readiness_request_id,
+            retained_decision_id,
+            refreshed_decision_id,
+            enforcement_id,
+            destination_id,
+            execution_kind,
+            enforced_at,
+            retained_decision_evaluated_at,
+            refreshed_decision_evaluated_at,
+            lock_model_version,
+            lock_scope,
+            lock_key_fingerprint,
+            readiness_enforcement_sha256,
+            binding_recorded_at,
+            readiness_enforcement_json,
+            binding_json,
+            document_sha256
+        )
+        VALUES (
+            %s, %s, %s, %s, %s, %s, %s, %s,
+            %s, %s, %s, %s, %s, %s, %s, %s,
+            %s, %s, %s, %s, %s, %s, %s, %s,
+            %s, %s, %s, %s, %s, %s, %s
+        )
+        ON CONFLICT DO NOTHING
+        RETURNING binding_id
+        """,
+        (
+            validated["binding_id"],
+            validated["model_version"],
+            terminal["record_id"],
+            terminal["request_id"],
+            terminal["plan_id"],
+            terminal["execution_id"],
+            terminal["terminal_status"],
+            terminal["started_at"],
+            terminal["finished_at"],
+            terminal["recorded_at"],
+            terminal["request_count"],
+            terminal["attempts_persisted"],
+            terminal["document_sha256"],
+            enforcement["readiness_record_id"],
+            enforcement["readiness_request_id"],
+            enforcement["retained_decision_id"],
+            enforcement["refreshed_decision_id"],
+            enforcement["enforcement_id"],
+            enforcement["destination_id"],
+            enforcement["execution_kind"],
+            enforcement["enforced_at"],
+            enforcement["retained_decision_evaluated_at"],
+            enforcement["refreshed_decision_evaluated_at"],
+            lock["model_version"],
+            lock["scope"],
+            lock["key_fingerprint"],
+            validated["readiness_enforcement_sha256"],
+            validated["recorded_at"],
+            Jsonb(enforcement),
+            Jsonb(validated),
+            digest,
+        ),
+    )
+    created = cursor.fetchone() is not None
+    cursor.execute(
+        """
+        SELECT binding_json, document_sha256
+        FROM risk_platform.notification_retry_readiness_bindings
+        WHERE terminal_record_id = %s
+        """,
+        (terminal["record_id"],),
+    )
+    stored = cursor.fetchone()
+    if stored is None:
+        raise ValidationError(
+            "binding or enforcement identity already exists under different evidence"
+        )
+    stored_json, stored_digest = stored
+    if stored_json != validated or stored_digest != digest:
+        raise ValidationError(
+            "retry readiness binding identity already exists under different evidence"
+        )
+    return _result(validated, digest=digest, created=created)
+
+
+def record_notification_retry_readiness_binding(
+    *,
+    dsn: str,
+    binding: Mapping[str, Any],
+) -> dict[str, Any]:
+    if not isinstance(dsn, str) or not dsn.strip():
+        raise ValidationError("PostgreSQL DSN must be non-empty text")
+    try:
+        import psycopg
+    except ImportError as exc:  # pragma: no cover - required in CI.
+        raise RuntimeError("Notification retry readiness history requires psycopg") from exc
+
+    try:
+        with psycopg.connect(dsn) as connection:
+            with connection.cursor() as cursor:
+                result = record_notification_retry_readiness_binding_with_cursor(
+                    cursor,
+                    binding=binding,
+                )
+            connection.commit()
+    except (StorageError, ValidationError):
+        raise
+    except Exception:
+        raise StorageError(
+            "notification retry readiness history database operation failed"
+        ) from None
+    return result
+
+
+def _read_binding(path: Path) -> dict[str, Any]:
+    if path.is_symlink():
+        raise ValidationError("retry readiness binding must not be a symbolic link")
+    if not path.is_file():
+        raise ValidationError("retry readiness binding must be a regular file")
+    if path.stat().st_size > MAX_RECORD_BYTES:
+        raise ValidationError("retry readiness binding exceeds 1 MB")
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, ValueError):
+        raise ValidationError("retry readiness binding could not be read") from None
+    if not isinstance(value, Mapping):
+        raise ValidationError("retry readiness binding must be a JSON object")
+    return dict(value)
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Append one retry readiness binding to PostgreSQL."
+    )
+    parser.add_argument("--binding", required=True, type=Path)
+    parser.add_argument(
+        "--dsn",
+        default=os.environ.get("WAREHOUSE_POSTGRES_DSN", DEFAULT_POSTGRES_DSN),
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    try:
+        result = record_notification_retry_readiness_binding(
+            dsn=args.dsn,
+            binding=_read_binding(args.binding),
+        )
+    except ValidationError as exc:
+        print(f"Retry readiness binding rejected: {exc}", file=sys.stderr)
+        return 1
+    except (StorageError, RuntimeError) as exc:
+        print(f"Retry readiness binding history failed: {exc}", file=sys.stderr)
+        return 1
+    print(json.dumps(result, sort_keys=True, allow_nan=False))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/test_docker_compose_contract.py
+++ b/tests/unit/test_docker_compose_contract.py
@@ -51,6 +51,7 @@ def test_local_database_seed_mounts_are_read_only_and_ordered() -> None:
         "./sql/controlled_notification_receiver_review_schema.sql:/docker-entrypoint-initdb.d/23_controlled_notification_receiver_review_schema.sql:ro",
         "./sql/notification_destination_transition_rehearsal_schema.sql:/docker-entrypoint-initdb.d/24_notification_destination_transition_rehearsal_schema.sql:ro",
         "./sql/notification_execution_readiness_schema.sql:/docker-entrypoint-initdb.d/25_notification_execution_readiness_schema.sql:ro",
+        "./sql/notification_retry_readiness_binding_schema.sql:/docker-entrypoint-initdb.d/26_notification_retry_readiness_binding_schema.sql:ro",
     ]
     assert services["mongo"]["volumes"] == [
         "./mongo/init:/docker-entrypoint-initdb.d:ro"

--- a/tests/unit/test_notification_retry_readiness_binding_history_architecture_contract.py
+++ b/tests/unit/test_notification_retry_readiness_binding_history_architecture_contract.py
@@ -19,6 +19,7 @@ def test_retry_readiness_binding_history_is_append_only_and_source_reconciled() 
     )
     compose = Path("docker-compose.yml").read_text(encoding="utf-8")
     makefile = Path("Makefile").read_text(encoding="utf-8")
+    normalized_schema = schema.casefold()
     normalized_docs = " ".join(docs.split()).casefold()
 
     for required in (
@@ -31,7 +32,7 @@ def test_retry_readiness_binding_history_is_append_only_and_source_reconciled() 
         "references\n        risk_platform.portfolio_risk_notification_retry_executions",
         "references\n        risk_platform.notification_execution_readiness_decisions",
     ):
-        assert required in schema
+        assert required in normalized_schema
 
     for required in (
         "record_notification_retry_readiness_binding_with_cursor",

--- a/tests/unit/test_notification_retry_readiness_binding_history_architecture_contract.py
+++ b/tests/unit/test_notification_retry_readiness_binding_history_architecture_contract.py
@@ -1,0 +1,88 @@
+from pathlib import Path
+
+
+def test_retry_readiness_binding_history_is_append_only_and_source_reconciled() -> None:
+    schema = Path("sql/notification_retry_readiness_binding_schema.sql").read_text(
+        encoding="utf-8"
+    )
+    checks = Path(
+        "sql/notification_retry_readiness_binding_consistency_checks.sql"
+    ).read_text(encoding="utf-8")
+    recorder = Path(
+        "src/warehouse/notification_retry_readiness_binding_recorder.py"
+    ).read_text(encoding="utf-8")
+    fixture = Path(
+        "src/warehouse/notification_retry_readiness_binding_postgres_contract_check.py"
+    ).read_text(encoding="utf-8")
+    docs = Path("docs/notification-retry-readiness-binding-history.md").read_text(
+        encoding="utf-8"
+    )
+    compose = Path("docker-compose.yml").read_text(encoding="utf-8")
+    workflow = Path(".github/workflows/ci.yml").read_text(encoding="utf-8")
+    normalized_docs = " ".join(docs.split()).casefold()
+
+    for required in (
+        "notification_retry_readiness_bindings",
+        "notification_retry_readiness_binding_status",
+        "notification_retry_readiness_bound",
+        "notification_retry_readiness_binding_missing",
+        "notification_retry_readiness_binding_reject_update",
+        "notification_retry_readiness_binding_reject_delete",
+        "references\n        risk_platform.portfolio_risk_notification_retry_executions",
+        "references\n        risk_platform.notification_execution_readiness_decisions",
+    ):
+        assert required in schema
+
+    for required in (
+        "record_notification_retry_readiness_binding_with_cursor",
+        "validate_notification_retry_readiness_binding",
+        "validate_retry_execution_record",
+        "validate_notification_execution_readiness_record",
+        "retry readiness binding terminal source is missing",
+        "retry readiness binding readiness source is missing",
+        "does not allow execution",
+        "already has different readiness evidence",
+    ):
+        assert required in recorder
+
+    for required in (
+        "notification_retry_readiness_terminal_sources_reconcile",
+        "notification_retry_readiness_decision_sources_reconcile",
+        "notification_retry_readiness_missing_partition_matches",
+        "notification_retry_readiness_history_is_append_only",
+    ):
+        assert required in checks
+
+    for required in (
+        "exact_replay_converged",
+        "conflicting_terminal_binding_rejected",
+        "missing_readiness_source_rejected",
+        "legacy_binding_missing_visible",
+        "update_rejected",
+        "delete_rejected",
+    ):
+        assert required in fixture
+
+    assert "26_notification_retry_readiness_binding_schema.sql:ro" in compose
+    assert (
+        "notification_retry_readiness_binding_postgres_contract_check" in workflow
+    )
+
+    for required in (
+        "primary arc42 blocks: `warehouse` and `orchestration`",
+        "independently reloads and validates both source documents",
+        "exact replay converges",
+        "binding_missing",
+        "performs no network request",
+        "terraform apply",
+    ):
+        assert required in normalized_docs
+
+    for forbidden in (
+        "urllib.request",
+        "requests.",
+        "httpx.",
+        "socket.",
+    ):
+        assert forbidden not in recorder
+        assert forbidden not in fixture

--- a/tests/unit/test_notification_retry_readiness_binding_history_architecture_contract.py
+++ b/tests/unit/test_notification_retry_readiness_binding_history_architecture_contract.py
@@ -18,7 +18,7 @@ def test_retry_readiness_binding_history_is_append_only_and_source_reconciled() 
         encoding="utf-8"
     )
     compose = Path("docker-compose.yml").read_text(encoding="utf-8")
-    workflow = Path(".github/workflows/ci.yml").read_text(encoding="utf-8")
+    makefile = Path("Makefile").read_text(encoding="utf-8")
     normalized_docs = " ".join(docs.split()).casefold()
 
     for required in (
@@ -65,7 +65,7 @@ def test_retry_readiness_binding_history_is_append_only_and_source_reconciled() 
 
     assert "26_notification_retry_readiness_binding_schema.sql:ro" in compose
     assert (
-        "notification_retry_readiness_binding_postgres_contract_check" in workflow
+        "notification_retry_readiness_binding_postgres_contract_check" in makefile
     )
 
     for required in (


### PR DESCRIPTION
## Goal

Complete **P4d5d** by persisting the deterministic retry-readiness binding introduced in PR #138.

```text
append-only retry terminal record
  + append-only retained retry readiness decision
  + exact under-lock readiness enforcement
  -> independently reconciled canonical binding
  -> append-only PostgreSQL history
  -> bound or binding_missing operational state
```

## What changes

- adds `notification_retry_readiness_bindings` with foreign keys to terminal retry and retained readiness history;
- independently reloads and validates both source documents before insertion;
- requires a retained `retry` allow decision with no blocking reasons;
- reconciles terminal, request, plan, decision, destination, timing, lock and document-digest identities;
- converges exact terminal-record replay and rejects conflicting binding or enforcement reuse;
- rejects direct PostgreSQL update and deletion;
- preserves legacy terminal history through explicit `binding_missing` views;
- adds a canonical reader, PostgreSQL fixture, twelve reconciliation checks and local schema loading.

## Scope

Ten intended files, fourteen working commits, 1,585 additions and no deletions. Squash merge retains one coherent warehouse increment. The branch is zero commits behind `main`.

## Exact-head validation

GitHub Actions run **406** (`33927132140`) passed on final head `19c825c1e8bd198b28cb752b73ed638848533cca`:

- Security guardrails passed with the byte-pinned CI workflow unchanged.
- Ruff passed.
- mypy passed across **145 source files**.
- **929 tests passed** in quality and **929 passed again** in readiness.
- Dependency integrity and the standard pipeline replay passed.
- PostgreSQL 16 passed, including the new binding-history fixture and reconciliation.
- Kubernetes rendering and Terraform format/init/validate passed without apply.
- No review submissions or unresolved review threads exist.

The first CI run correctly rejected a direct workflow edit because the workflow is byte-pinned. The workflow was restored unchanged and the new database proof was wired through the existing reviewed `postgres-contract-check` Make target. A later run identified only a case-sensitive architecture assertion; it was made case-insensitive without changing schema or runtime behavior.

## Safety boundary

This change persists credential-free evidence only. It performs no network request, webhook delivery, provider request, delivery-attempt write, acknowledgement, outbox mutation, deployment or `terraform apply`. No endpoint value, full URL, credential, payload body, response body, environment value or DSN is retained. Committed delivery, destination activation and retry execution remain disabled.

Validated and ready for squash merge.