### PR TITLE
Record readiness-enforced notification retries atomically

### DIFF
--- a/docs/recorded-readiness-enforced-notification-retries.md
+++ b/docs/recorded-readiness-enforced-notification-retries.md
@@ -1,0 +1,117 @@
+# Recorded Readiness-Enforced Notification Retries
+
+Primary arc42 blocks: `orchestration` and `warehouse`.
+
+## Goal
+
+This increment completes the operator-facing half of P4d5e:
+
+```text
+exact retained retry plan
+  + current retained retry allow decision
+  + fresh under-lock readiness evaluation
+  + exact destination authority
+  -> bounded retry execution
+  -> terminal retry record
+  -> readiness binding
+  -> atomic terminal-plus-readiness commit
+```
+
+The entry point is
+`src.orchestration.run_recorded_readiness_enforced_portfolio_risk_notification_retries`.
+It composes the P4d5c single-lock executor with the P4d5d binding contract and
+the P4d5e atomic storage primitive rather than introducing another readiness
+model.
+
+## Execution ordering
+
+The command first validates `--execute`, the operator request ID and the exact
+retained plan confirmation. Before a new request it checks for an existing
+terminal record under that request ID.
+
+For a new execution it then delegates to the established readiness-enforced
+retry path. That path:
+
+1. acquires the shared notification-delivery advisory lock;
+2. validates one retained current `retry` allow record;
+3. reruns the readiness gate beneath the same lock;
+4. rejects changed, stale, blocked or superseded evidence;
+5. revalidates the exact retry plan and current event evidence;
+6. performs only the bounded planned requests; and
+7. persists the existing append-only delivery-attempt evidence.
+
+The recorded wrapper observes and validates the exact readiness enforcement and
+destination authority returned by that path. It never creates readiness
+authority after transport.
+
+## Terminal outcomes
+
+Once readiness has been granted, every terminal outcome receives a readiness
+binding:
+
+```text
+all requests and attempts retained -> completed or failed_after_request
+request without attempt evidence   -> persistence_uncertain
+failure before the first request   -> failed_before_request
+```
+
+The terminal record and readiness binding are passed to the atomic governance
+bundle recorder, so both commit or both roll back. The destination-authority
+binding remains the established separate append-only evidence stream and is
+recorded after the atomic terminal/readiness bundle.
+
+A failure before readiness authority exists is rejected without a terminal
+record. Such a rejection did not receive permission to execute and must not be
+represented as an authorised terminal attempt.
+
+## Exact replay
+
+The operator request ID remains the idempotency boundary. Before any network or
+attempt side effect, replay reads the retained terminal record and requires its
+exact readiness binding.
+
+```text
+matching completed terminal + matching readiness binding
+  -> reconstruct governed summary
+  -> no external request is replayed
+
+matching failed terminal + matching readiness binding
+  -> return the retained bounded failure
+  -> no external request is replayed
+
+terminal present + readiness binding absent
+  -> reject as legacy or incomplete evidence
+
+changed plan under the same request ID
+  -> reject
+```
+
+Replay validates that the binding was built from the exact retained terminal.
+It does not infer or backfill readiness authority for older history.
+
+## Operator command
+
+```bash
+.venv/bin/python \
+  -m src.orchestration.run_recorded_readiness_enforced_portfolio_risk_notification_retries \
+  --plan .demo/notification-retry-plan.json \
+  --confirm-plan-id '<exact-plan-id>' \
+  --request-id 'RETRY-2026-001' \
+  --destination-id risk-operations-webhook \
+  --execute \
+  --summary-json .demo/recorded-readiness-retry.json
+```
+
+Committed webhook delivery, destination activation and retry execution remain
+disabled. The operator must still supply reviewed configuration and the endpoint
+environment value outside source control.
+
+## Safety boundary
+
+Ordinary CI uses injected readiness, transport, attempt, history and persistence
+functions. It performs no network request, DNS lookup, socket operation,
+webhook delivery, provider request, real delivery-attempt write,
+acknowledgement, outbox mutation, schedule activation, deployment or
+`terraform apply`. Retained governance evidence contains no endpoint value,
+complete URL, credential, payload body, response body, environment value or
+PostgreSQL DSN.

--- a/src/orchestration/run_recorded_readiness_enforced_portfolio_risk_notification_retries.py
+++ b/src/orchestration/run_recorded_readiness_enforced_portfolio_risk_notification_retries.py
@@ -553,13 +553,15 @@ def execute_and_record_readiness_enforced_portfolio_risk_notification_retries(
         terminal_record=terminal_record,
         readiness_binding=readiness_binding,
     )
-    terminal_history = bundle_history.get("terminal_history")
-    readiness_history = bundle_history.get("readiness_history")
-    if not isinstance(terminal_history, Mapping) or not isinstance(
-        readiness_history,
+    terminal_history_value = bundle_history.get("terminal_history")
+    readiness_history_value = bundle_history.get("readiness_history")
+    if not isinstance(terminal_history_value, Mapping) or not isinstance(
+        readiness_history_value,
         Mapping,
     ):
         raise StorageError("atomic retry governance history result is invalid")
+    terminal_history = dict(terminal_history_value)
+    readiness_history = dict(readiness_history_value)
     destination_history = _record_destination_binding(
         dsn=dsn,
         terminal_record=terminal_record,
@@ -577,8 +579,8 @@ def execute_and_record_readiness_enforced_portfolio_risk_notification_retries(
 
     return {
         "execution_summary": execution_summary,
-        "terminal_history": dict(terminal_history),
-        "readiness_history": dict(readiness_history),
+        "terminal_history": terminal_history,
+        "readiness_history": readiness_history,
         "destination_history": destination_history,
         "replayed": False,
         "atomic_commit": True,

--- a/src/orchestration/run_recorded_readiness_enforced_portfolio_risk_notification_retries.py
+++ b/src/orchestration/run_recorded_readiness_enforced_portfolio_risk_notification_retries.py
@@ -1,0 +1,671 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from collections.abc import Callable, Mapping, Sequence
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, cast
+
+from src.common.exceptions import OverlapError, StorageError, ValidationError
+from src.orchestration.deliver_portfolio_risk_notifications import (
+    DEFAULT_DESTINATION_CONFIG,
+    DEFAULT_DESTINATION_ID,
+    AttemptWriter,
+    Transport,
+    _default_transport,
+    _endpoint,
+    write_delivery_attempt,
+)
+from src.orchestration.portfolio_risk_notification_retry_execution_policy import (
+    aware_utc,
+    load_retry_execution_contract,
+    safe_segment,
+)
+from src.orchestration.portfolio_risk_notification_retry_plan_contract import (
+    load_retry_plan,
+)
+from src.orchestration.run_readiness_enforced_portfolio_risk_notification_retries import (
+    MODEL_VERSION as GOVERNED_EXECUTION_MODEL_VERSION,
+    execute_readiness_enforced_portfolio_risk_notification_retries,
+)
+from src.warehouse.notification_execution_readiness_enforcement import (
+    enforce_notification_execution_readiness,
+    validate_notification_execution_readiness_enforcement,
+)
+from src.warehouse.notification_retry_destination_binding_contract import (
+    build_retry_destination_binding,
+)
+from src.warehouse.notification_retry_destination_binding_reader import (
+    read_notification_retry_destination_binding,
+)
+from src.warehouse.notification_retry_destination_binding_recorder import (
+    record_notification_retry_destination_binding,
+)
+from src.warehouse.notification_retry_execution_contract import (
+    build_retry_execution_record,
+    validate_retry_execution_record,
+)
+from src.warehouse.notification_retry_execution_reader import (
+    read_notification_retry_execution_request,
+)
+from src.warehouse.notification_retry_governance_bundle_recorder import (
+    record_notification_retry_governance_bundle,
+    validate_notification_retry_governance_bundle,
+)
+from src.warehouse.notification_retry_readiness_binding_contract import (
+    build_notification_retry_readiness_binding,
+)
+from src.warehouse.notification_retry_readiness_binding_reader import (
+    read_notification_retry_readiness_binding,
+)
+from src.warehouse.postgres_loader import DEFAULT_POSTGRES_DSN
+
+Clock = Callable[[], datetime]
+Executor = Callable[..., dict[str, Any]]
+PlanLoader = Callable[[Path], Mapping[str, Any]]
+HistoryReader = Callable[..., Mapping[str, Any] | None]
+ReadinessBindingReader = Callable[..., Mapping[str, Any] | None]
+BundleRecorder = Callable[..., dict[str, Any]]
+DestinationRecorder = Callable[..., dict[str, Any]]
+DestinationReader = Callable[..., dict[str, Any] | None]
+ReadinessEnforcer = Callable[..., Mapping[str, Any]]
+
+
+class RecordedReadinessRetryExecutionError(RuntimeError):
+    def __init__(
+        self,
+        *,
+        failure_code: str,
+        terminal_history: Mapping[str, Any],
+        readiness_history: Mapping[str, Any],
+        destination_history: Mapping[str, Any] | None = None,
+    ) -> None:
+        super().__init__(failure_code)
+        self.failure_code = failure_code
+        self.terminal_history = dict(terminal_history)
+        self.readiness_history = dict(readiness_history)
+        self.destination_history = (
+            None if destination_history is None else dict(destination_history)
+        )
+
+
+def _failure_code(exc: Exception) -> str:
+    if isinstance(exc, OverlapError):
+        return "overlap_error"
+    if isinstance(exc, ValidationError):
+        return "validation_error"
+    if isinstance(exc, StorageError):
+        return "storage_error"
+    return "unexpected_error"
+
+
+def _terminal_status(*, requests: int, attempts_persisted: int) -> str:
+    if requests == 0:
+        return "failed_before_request"
+    if requests > attempts_persisted:
+        return "persistence_uncertain"
+    return "failed_after_request"
+
+
+def _next_utc(clock: Clock, *, minimum: datetime, label: str) -> datetime:
+    value = aware_utc(clock(), label)
+    return value if value >= minimum else minimum
+
+
+def _retained_fingerprint(
+    retained_plan: Mapping[str, Any],
+    group: str,
+) -> str | None:
+    value = retained_plan.get(group)
+    if not isinstance(value, Mapping):
+        return None
+    fingerprint = value.get("fingerprint")
+    return fingerprint if isinstance(fingerprint, str) else None
+
+
+def _terminal_execution_summary(summary: Mapping[str, Any]) -> dict[str, Any]:
+    canonical = dict(summary)
+    canonical.pop("destination_authority", None)
+    canonical.pop("execution_readiness", None)
+    canonical.pop("governed_execution", None)
+    return canonical
+
+
+def _destination_authority(summary: Mapping[str, Any]) -> dict[str, Any] | None:
+    value = summary.get("destination_authority")
+    return dict(value) if isinstance(value, Mapping) else None
+
+
+def _record_destination_binding(
+    *,
+    dsn: str,
+    terminal_record: Mapping[str, Any],
+    destination_authority: Mapping[str, Any] | None,
+    recorder: DestinationRecorder | None,
+) -> dict[str, Any] | None:
+    if destination_authority is None or recorder is None:
+        return None
+    binding = build_retry_destination_binding(
+        record_id=cast(str, terminal_record["record_id"]),
+        request_id=cast(str, terminal_record["request_id"]),
+        plan_id=cast(str, terminal_record["plan_id"]),
+        execution_id=cast(str | None, terminal_record["execution_id"]),
+        destination_authority=destination_authority,
+        recorded_at=cast(str, terminal_record["recorded_at"]),
+    )
+    return recorder(dsn=dsn, binding=binding)
+
+
+def _replay_summary(
+    *,
+    terminal_record: Mapping[str, Any],
+    readiness_binding: Mapping[str, Any],
+) -> dict[str, Any]:
+    base = terminal_record.get("execution_summary")
+    if not isinstance(base, Mapping):
+        raise StorageError("completed retry execution summary is unavailable")
+    readiness = readiness_binding["readiness_enforcement"]
+    if not isinstance(readiness, Mapping):
+        raise StorageError("retained retry readiness enforcement is unavailable")
+    summary = dict(base)
+    summary["execution_readiness"] = dict(readiness)
+    summary["governed_execution"] = {
+        "model_version": GOVERNED_EXECUTION_MODEL_VERSION,
+        "plan_id": terminal_record["plan_id"],
+        "destination_id": readiness["destination_id"],
+        "readiness_enforcement_id": readiness["enforcement_id"],
+        "single_physical_lock_acquisition": True,
+        "nested_lock_reacquisition_performed": False,
+        "lock_reused_by_retry_executor": True,
+        "outer_lock_released": True,
+    }
+    return summary
+
+
+def _existing_result(
+    *,
+    existing: Mapping[str, Any],
+    readiness_evidence: Mapping[str, Any] | None,
+    request_id: str,
+    plan_id: str,
+) -> tuple[dict[str, Any], dict[str, Any], dict[str, Any]]:
+    record_value = existing.get("record")
+    history_value = existing.get("history")
+    if not isinstance(record_value, Mapping) or not isinstance(history_value, Mapping):
+        raise StorageError("retained retry terminal history is invalid")
+    terminal = validate_retry_execution_record(record_value)
+    if terminal["request_id"] != request_id:
+        raise StorageError("retained retry execution request identity changed")
+    if terminal["plan_id"] != plan_id:
+        raise ValidationError(
+            "request_id already exists for a different notification retry plan"
+        )
+    if readiness_evidence is None:
+        raise ValidationError(
+            "retained retry terminal has no readiness binding; replay is blocked"
+        )
+    binding_value = readiness_evidence.get("binding")
+    readiness_history = readiness_evidence.get("history")
+    if not isinstance(binding_value, Mapping) or not isinstance(
+        readiness_history,
+        Mapping,
+    ):
+        raise StorageError("retained retry readiness history is invalid")
+    _, binding = validate_notification_retry_governance_bundle(
+        terminal_record=terminal,
+        readiness_binding=binding_value,
+    )
+    return terminal, dict(history_value), {
+        "binding": binding,
+        "history": dict(readiness_history),
+    }
+
+
+def execute_and_record_readiness_enforced_portfolio_risk_notification_retries(
+    *,
+    plan_path: Path,
+    confirm_plan_id: str,
+    request_id: str,
+    config_path: Path,
+    dsn: str,
+    execute: bool = False,
+    destination_config_path: Path | None = None,
+    destination_id: str = DEFAULT_DESTINATION_ID,
+    environment: Mapping[str, str] | None = None,
+    executor: Executor | None = None,
+    plan_loader: PlanLoader | None = None,
+    history_reader: HistoryReader | None = None,
+    readiness_binding_reader: ReadinessBindingReader | None = None,
+    bundle_recorder: BundleRecorder | None = None,
+    destination_binding_recorder: DestinationRecorder | None = None,
+    destination_binding_reader: DestinationReader | None = None,
+    readiness_enforcer: ReadinessEnforcer | None = None,
+    transport: Transport | None = None,
+    attempt_writer: AttemptWriter | None = None,
+    clock: Clock | None = None,
+    reader: Callable[..., list[dict[str, Any]]] | None = None,
+    lock_factory: Callable[..., Any] | None = None,
+    destination_authority_resolver: Callable[..., dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    if execute is not True:
+        raise ValidationError(
+            "explicit --execute is required for recorded readiness-enforced retries"
+        )
+    selected_plan_loader = plan_loader or load_retry_plan
+    retained_plan = selected_plan_loader(plan_path)
+    if not isinstance(retained_plan, Mapping):
+        raise ValidationError("retry plan loader returned invalid evidence")
+    selected_request_id = safe_segment(request_id, "request_id")
+    assert selected_request_id is not None
+    plan_id = safe_segment(retained_plan.get("plan_id"), "retry plan_id")
+    assert plan_id is not None
+    confirmed = safe_segment(confirm_plan_id, "confirm_plan_id")
+    if confirmed != plan_id:
+        raise ValidationError("confirm_plan_id does not match the retained retry plan")
+    selected_destination_id = safe_segment(destination_id, "destination_id")
+    assert selected_destination_id is not None
+
+    selected_history_reader = history_reader or read_notification_retry_execution_request
+    selected_readiness_reader = (
+        readiness_binding_reader or read_notification_retry_readiness_binding
+    )
+    selected_destination_reader = (
+        destination_binding_reader or read_notification_retry_destination_binding
+    )
+    existing = selected_history_reader(
+        dsn=dsn,
+        request_id=selected_request_id,
+    )
+    if existing is not None:
+        record_value = existing.get("record")
+        if not isinstance(record_value, Mapping):
+            raise StorageError("retained retry terminal record is invalid")
+        readiness_evidence = selected_readiness_reader(
+            dsn=dsn,
+            terminal_record_id=record_value.get("record_id"),
+        )
+        terminal, terminal_history, retained_readiness = _existing_result(
+            existing=existing,
+            readiness_evidence=readiness_evidence,
+            request_id=selected_request_id,
+            plan_id=plan_id,
+        )
+        destination_history = selected_destination_reader(
+            dsn=dsn,
+            record_id=terminal["record_id"],
+        )
+        result = {
+            "terminal_history": terminal_history,
+            "readiness_history": retained_readiness["history"],
+            "destination_history": destination_history,
+            "replayed": True,
+            "external_request_replayed": False,
+        }
+        if terminal["terminal_status"] == "completed":
+            result["execution_summary"] = _replay_summary(
+                terminal_record=terminal,
+                readiness_binding=retained_readiness["binding"],
+            )
+            return result
+        failure_code = terminal["failure_code"]
+        if not isinstance(failure_code, str):
+            raise StorageError("failed retry terminal has no failure code")
+        raise RecordedReadinessRetryExecutionError(
+            failure_code=failure_code,
+            terminal_history=terminal_history,
+            readiness_history=cast(Mapping[str, Any], retained_readiness["history"]),
+            destination_history=destination_history,
+        )
+
+    selected_clock = clock or (lambda: datetime.now(timezone.utc))
+    started_at = aware_utc(selected_clock(), "recorded governed retry started_at")
+    clock_calls = 0
+
+    def execution_clock() -> datetime:
+        nonlocal clock_calls
+        if clock_calls < 2:
+            clock_calls += 1
+            return started_at
+        clock_calls += 1
+        return _next_utc(
+            selected_clock,
+            minimum=started_at,
+            label="recorded governed retry clock",
+        )
+
+    selected_environment = environment if environment is not None else os.environ
+    selected_transport = transport or _default_transport
+    selected_writer = attempt_writer or (
+        lambda attempt: write_delivery_attempt(attempt, dsn=dsn)
+    )
+    selected_executor = (
+        executor or execute_readiness_enforced_portfolio_risk_notification_retries
+    )
+    selected_bundle_recorder = bundle_recorder or record_notification_retry_governance_bundle
+    selected_destination_recorder = (
+        destination_binding_recorder or record_notification_retry_destination_binding
+    )
+    base_readiness_enforcer = readiness_enforcer or enforce_notification_execution_readiness
+
+    requested_event_ids: list[str] = []
+    persisted_attempts: list[dict[str, Any]] = []
+    observed_readiness: dict[str, Any] | None = None
+    observed_authority: dict[str, Any] | None = None
+
+    def observing_readiness_enforcer(**kwargs: Any) -> Mapping[str, Any]:
+        nonlocal observed_readiness
+        candidate = validate_notification_execution_readiness_enforcement(
+            base_readiness_enforcer(**kwargs)
+        )
+        if observed_readiness is not None and observed_readiness != candidate:
+            raise ValidationError("readiness authority changed during retry execution")
+        observed_readiness = candidate
+        return candidate
+
+    def observe_destination_authority(value: Mapping[str, Any]) -> None:
+        nonlocal observed_authority
+        candidate = dict(value)
+        if observed_authority is not None and observed_authority != candidate:
+            raise ValidationError("destination authority changed during retry execution")
+        observed_authority = candidate
+
+    def tracking_transport(
+        endpoint: str,
+        payload: bytes,
+        headers: Mapping[str, str],
+        timeout_seconds: float,
+    ) -> int:
+        event_id = headers.get("Idempotency-Key")
+        if not isinstance(event_id, str) or not event_id:
+            raise ValidationError("retry transport is missing Idempotency-Key")
+        requested_event_ids.append(event_id)
+        return selected_transport(endpoint, payload, headers, timeout_seconds)
+
+    def tracking_writer(attempt: Mapping[str, Any]) -> None:
+        selected_writer(attempt)
+        persisted_attempts.append(dict(attempt))
+
+    delivery_config, retry_policy, execution_policy = load_retry_execution_contract(
+        config_path
+    )
+    endpoint_host: str | None = None
+    raw_endpoint = selected_environment.get(delivery_config.endpoint_env)
+    if raw_endpoint is not None:
+        _, endpoint_host = _endpoint(raw_endpoint)
+    destination_path = (
+        destination_config_path
+        if destination_config_path is not None
+        else (
+            config_path.parent / "notification_destinations.yaml"
+            if (config_path.parent / "notification_destinations.yaml").is_file()
+            else DEFAULT_DESTINATION_CONFIG
+        )
+    )
+
+    execution_summary: dict[str, Any] | None = None
+    execution_error: Exception | None = None
+    try:
+        execution_summary = selected_executor(
+            plan_path=plan_path,
+            confirm_plan_id=confirm_plan_id,
+            request_id=selected_request_id,
+            config_path=config_path,
+            dsn=dsn,
+            execute=True,
+            destination_config_path=destination_path,
+            destination_id=selected_destination_id,
+            environment=selected_environment,
+            reader=reader,
+            attempt_writer=tracking_writer,
+            transport=tracking_transport,
+            clock=execution_clock,
+            lock_factory=lock_factory,
+            destination_authority_resolver=destination_authority_resolver,
+            destination_authority_observer=observe_destination_authority,
+            readiness_enforcer=observing_readiness_enforcer,
+            readiness_validator=validate_notification_execution_readiness_enforcement,
+        )
+        if not isinstance(execution_summary, Mapping):
+            raise StorageError("readiness-enforced retry returned invalid evidence")
+        execution_summary = dict(execution_summary)
+        summary_readiness = execution_summary.get("execution_readiness")
+        if not isinstance(summary_readiness, Mapping):
+            raise ValidationError("retry execution summary lacks readiness evidence")
+        summary_readiness_validated = (
+            validate_notification_execution_readiness_enforcement(summary_readiness)
+        )
+        if observed_readiness is None:
+            observed_readiness = summary_readiness_validated
+        elif observed_readiness != summary_readiness_validated:
+            raise ValidationError("retry summary readiness authority changed")
+        summary_authority = _destination_authority(execution_summary)
+        if summary_authority is not None:
+            observe_destination_authority(summary_authority)
+    except Exception as exc:
+        if observed_readiness is None:
+            raise
+        execution_error = exc
+
+    finished_at = _next_utc(
+        selected_clock,
+        minimum=started_at,
+        label="recorded governed retry finished_at",
+    )
+    terminal_recorded_at = _next_utc(
+        selected_clock,
+        minimum=finished_at,
+        label="recorded governed retry recorded_at",
+    )
+    binding_recorded_at = _next_utc(
+        selected_clock,
+        minimum=terminal_recorded_at,
+        label="recorded governed retry binding recorded_at",
+    )
+
+    if execution_error is None:
+        assert execution_summary is not None
+        outcomes = execution_summary.get("outcomes")
+        if not isinstance(outcomes, list):
+            raise ValidationError("retry execution summary outcomes are unavailable")
+        attempt_ids = [str(outcome["attempt_id"]) for outcome in outcomes]
+        event_ids = [str(outcome["event_id"]) for outcome in outcomes]
+        succeeded = sum(outcome.get("outcome") == "succeeded" for outcome in outcomes)
+        failed = sum(outcome.get("outcome") == "failed" for outcome in outcomes)
+        terminal_record = build_retry_execution_record(
+            request_id=selected_request_id,
+            plan_id=plan_id,
+            started_at=started_at,
+            finished_at=finished_at,
+            recorded_at=terminal_recorded_at,
+            terminal_status="completed",
+            failure_code=None,
+            request_count=len(requested_event_ids),
+            attempts_persisted=len(persisted_attempts),
+            succeeded_count=succeeded,
+            failed_count=failed,
+            attempt_ids=attempt_ids,
+            requested_event_ids=event_ids,
+            persisted_event_ids=event_ids,
+            execution_summary=_terminal_execution_summary(execution_summary),
+        )
+    else:
+        attempt_ids = [
+            str(attempt["attempt_id"])
+            for attempt in persisted_attempts
+            if attempt.get("attempt_id") is not None
+        ]
+        persisted_event_ids = [
+            str(attempt["event_id"])
+            for attempt in persisted_attempts
+            if attempt.get("event_id") is not None
+        ]
+        succeeded = sum(
+            attempt.get("outcome") == "succeeded" for attempt in persisted_attempts
+        )
+        failed = sum(
+            attempt.get("outcome") == "failed" for attempt in persisted_attempts
+        )
+        lock = observed_readiness["lock"]
+        terminal_record = build_retry_execution_record(
+            request_id=selected_request_id,
+            plan_id=plan_id,
+            started_at=started_at,
+            finished_at=finished_at,
+            recorded_at=terminal_recorded_at,
+            terminal_status=_terminal_status(
+                requests=len(requested_event_ids),
+                attempts_persisted=len(persisted_attempts),
+            ),
+            failure_code=_failure_code(execution_error),
+            request_count=len(requested_event_ids),
+            attempts_persisted=len(persisted_attempts),
+            succeeded_count=succeeded,
+            failed_count=failed,
+            attempt_ids=attempt_ids,
+            requested_event_ids=requested_event_ids,
+            persisted_event_ids=persisted_event_ids,
+            execution_summary=None,
+            endpoint_host=endpoint_host,
+            delivery_fingerprint=delivery_config.fingerprint,
+            retry_policy_fingerprint=retry_policy.fingerprint,
+            retry_execution_policy_fingerprint=execution_policy.fingerprint,
+            lock_model_version=lock["model_version"],
+            lock_key_fingerprint=lock["key_fingerprint"],
+            lock_acquired=True,
+            lock_released=True,
+        )
+
+    assert observed_readiness is not None
+    readiness_binding = build_notification_retry_readiness_binding(
+        terminal_record=terminal_record,
+        readiness_enforcement=observed_readiness,
+        recorded_at=binding_recorded_at,
+    )
+    bundle_history = selected_bundle_recorder(
+        dsn=dsn,
+        terminal_record=terminal_record,
+        readiness_binding=readiness_binding,
+    )
+    terminal_history = bundle_history.get("terminal_history")
+    readiness_history = bundle_history.get("readiness_history")
+    if not isinstance(terminal_history, Mapping) or not isinstance(
+        readiness_history,
+        Mapping,
+    ):
+        raise StorageError("atomic retry governance history result is invalid")
+    destination_history = _record_destination_binding(
+        dsn=dsn,
+        terminal_record=terminal_record,
+        destination_authority=observed_authority,
+        recorder=selected_destination_recorder,
+    )
+
+    if execution_error is not None:
+        raise RecordedReadinessRetryExecutionError(
+            failure_code=_failure_code(execution_error),
+            terminal_history=terminal_history,
+            readiness_history=readiness_history,
+            destination_history=destination_history,
+        ) from None
+
+    return {
+        "execution_summary": execution_summary,
+        "terminal_history": dict(terminal_history),
+        "readiness_history": dict(readiness_history),
+        "destination_history": destination_history,
+        "replayed": False,
+        "atomic_commit": True,
+    }
+
+
+def _write_summary(path: Path, summary: Mapping[str, Any]) -> None:
+    if path.is_symlink():
+        raise StorageError("recorded governed retry summary must not be a symbolic link")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_suffix(path.suffix + ".tmp")
+    try:
+        temporary.write_text(
+            json.dumps(summary, indent=2, sort_keys=True, allow_nan=False) + "\n",
+            encoding="utf-8",
+        )
+        temporary.replace(path)
+    except (OSError, TypeError, ValueError):
+        temporary.unlink(missing_ok=True)
+        raise StorageError("unable to write recorded governed retry summary") from None
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Execute one readiness-enforced notification retry plan and atomically "
+            "retain terminal and readiness evidence."
+        )
+    )
+    parser.add_argument("--plan", required=True, type=Path)
+    parser.add_argument("--confirm-plan-id", required=True)
+    parser.add_argument("--request-id", required=True)
+    parser.add_argument(
+        "--config",
+        type=Path,
+        default=Path("config/notification_delivery.yaml"),
+    )
+    parser.add_argument(
+        "--destination-config",
+        type=Path,
+        default=DEFAULT_DESTINATION_CONFIG,
+    )
+    parser.add_argument("--destination-id", default=DEFAULT_DESTINATION_ID)
+    parser.add_argument(
+        "--dsn",
+        default=os.environ.get("WAREHOUSE_POSTGRES_DSN", DEFAULT_POSTGRES_DSN),
+    )
+    parser.add_argument("--execute", action="store_true")
+    parser.add_argument("--summary-json", type=Path)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    try:
+        result = execute_and_record_readiness_enforced_portfolio_risk_notification_retries(
+            plan_path=args.plan,
+            confirm_plan_id=args.confirm_plan_id,
+            request_id=args.request_id,
+            config_path=args.config,
+            destination_config_path=args.destination_config,
+            destination_id=args.destination_id,
+            dsn=args.dsn,
+            execute=args.execute,
+        )
+        if args.summary_json is not None:
+            _write_summary(args.summary_json, result)
+    except RecordedReadinessRetryExecutionError as exc:
+        print(
+            "Recorded readiness-enforced retry failed with terminal evidence: "
+            f"{exc.failure_code}; "
+            f"record_id={exc.terminal_history['record_id']}; "
+            f"binding_id={exc.readiness_history['binding_id']}",
+            file=sys.stderr,
+        )
+        return 1
+    except ValidationError as exc:
+        print(f"Recorded readiness-enforced retry rejected: {exc}", file=sys.stderr)
+        return 1
+    except (StorageError, RuntimeError) as exc:
+        print(f"Recorded readiness-enforced retry history failed: {exc}", file=sys.stderr)
+        return 1
+    except Exception:
+        print(
+            "Recorded readiness-enforced retry failed: unexpected local failure",
+            file=sys.stderr,
+        )
+        return 1
+    print(json.dumps(result, sort_keys=True, allow_nan=False))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/orchestration/run_recorded_readiness_enforced_portfolio_risk_notification_retries.py
+++ b/src/orchestration/run_recorded_readiness_enforced_portfolio_risk_notification_retries.py
@@ -275,6 +275,7 @@ def execute_and_record_readiness_enforced_portfolio_risk_notification_retries(
     selected_destination_reader = (
         destination_binding_reader or read_notification_retry_destination_binding
     )
+    destination_history: dict[str, Any] | None
     existing = selected_history_reader(
         dsn=dsn,
         request_id=selected_request_id,
@@ -283,9 +284,12 @@ def execute_and_record_readiness_enforced_portfolio_risk_notification_retries(
         record_value = existing.get("record")
         if not isinstance(record_value, Mapping):
             raise StorageError("retained retry terminal record is invalid")
+        terminal_record_id = record_value.get("record_id")
+        if not isinstance(terminal_record_id, str):
+            raise StorageError("retained retry terminal record identity is invalid")
         readiness_evidence = selected_readiness_reader(
             dsn=dsn,
-            terminal_record_id=record_value.get("record_id"),
+            terminal_record_id=terminal_record_id,
         )
         terminal, terminal_history, retained_readiness = _existing_result(
             existing=existing,

--- a/tests/unit/test_recorded_readiness_enforced_notification_retries.py
+++ b/tests/unit/test_recorded_readiness_enforced_notification_retries.py
@@ -1,0 +1,430 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from src.common.exceptions import StorageError, ValidationError
+from src.orchestration.run_recorded_readiness_enforced_portfolio_risk_notification_retries import (
+    RecordedReadinessRetryExecutionError,
+    execute_and_record_readiness_enforced_portfolio_risk_notification_retries,
+)
+from src.warehouse.notification_execution_readiness_enforcement import (
+    _enforcement_evidence,
+)
+from src.warehouse.notification_retry_execution_contract import (
+    build_retry_execution_record,
+)
+from src.warehouse.notification_retry_governance_bundle_recorder import (
+    validate_notification_retry_governance_bundle,
+)
+from src.warehouse.notification_retry_readiness_binding_contract import (
+    build_notification_retry_readiness_binding,
+)
+
+BASE_TIME = datetime(2026, 8, 4, 12, 0, tzinfo=timezone.utc)
+CONFIG_PATH = Path("config/notification_delivery.yaml")
+DESTINATION_PATH = Path("config/notification_destinations.yaml")
+DESTINATION_ID = "risk-operations-webhook"
+PLAN_ID = "recorded-readiness-plan-1"
+REQUEST_ID = "RECORDED-READINESS-REQUEST-1"
+LOCK_MODEL = "portfolio-risk-notification-delivery-lock-v1"
+LOCK_SCOPE = "portfolio-risk-notification-delivery"
+LOCK_KEY = "recorded-readiness-lock-key"
+PAYLOAD_SHA256 = "0" * 64
+
+
+def _clock(*values: datetime):
+    remaining = iter(values)
+    return lambda: next(remaining)
+
+
+def _plan_loader(_: Path) -> dict[str, Any]:
+    return {"plan_id": PLAN_ID}
+
+
+def _readiness(*, enforced_at: datetime = BASE_TIME) -> dict[str, Any]:
+    return _enforcement_evidence(
+        destination_id=DESTINATION_ID,
+        execution_kind="retry",
+        enforced_at=enforced_at,
+        record={
+            "record_id": "recorded-readiness-record-1",
+            "request_id": "recorded-readiness-decision-request-1",
+            "decision": {
+                "decision_id": "recorded-retained-decision-1",
+                "evaluated_at": (enforced_at - timedelta(minutes=1)).isoformat(),
+            },
+        },
+        refreshed_decision={
+            "decision_id": "recorded-refreshed-decision-1",
+            "evaluated_at": enforced_at.isoformat(),
+        },
+        lock={
+            "key_fingerprint": LOCK_KEY,
+            "model_version": LOCK_MODEL,
+            "scope": LOCK_SCOPE,
+        },
+    )
+
+
+def _authority(*, evaluated_at: datetime = BASE_TIME) -> dict[str, Any]:
+    return {
+        "authority_id": "recorded-destination-authority-1",
+        "destination_fingerprint": "recorded-destination-fingerprint-1",
+        "destination_id": DESTINATION_ID,
+        "endpoint_environment_variable": "RISK_NOTIFICATION_WEBHOOK_URL",
+        "evaluated_at": evaluated_at.isoformat(),
+        "evaluated_event_types": ["breach_opened"],
+        "model_version": "portfolio-risk-notification-destination-authority-v1",
+        "channel": "webhook",
+        "activation": {
+            "enabled": True,
+            "status": "active",
+            "change_request_id": "CHG-RECORDED-READINESS",
+            "reviewed_at": datetime(2026, 1, 1, tzinfo=timezone.utc).isoformat(),
+            "review_expires_at": datetime(2027, 1, 1, tzinfo=timezone.utc).isoformat(),
+        },
+        "allowed_event_types": [
+            "breach_escalated",
+            "breach_opened",
+            "breach_resolved",
+        ],
+        "active": True,
+        "endpoint_value_recorded": False,
+        "external_request_performed": False,
+        "delivery_attempt_written": False,
+        "outbox_mutated": False,
+        "acknowledgement_mutated": False,
+    }
+
+
+def _base_summary(
+    *,
+    executed_at: datetime,
+    request_id: str = REQUEST_ID,
+    plan_id: str = PLAN_ID,
+) -> dict[str, Any]:
+    outcome = {
+        "attempt_id": f"{request_id}-attempt-1",
+        "attempt_number": 1,
+        "attempted_at": executed_at.isoformat(),
+        "error_code": None,
+        "event_id": f"{request_id}-event-1",
+        "http_status": 200,
+        "outcome": "succeeded",
+        "payload_sha256": PAYLOAD_SHA256,
+    }
+    return {
+        "execution_id": f"{request_id}-execution",
+        "model_version": "portfolio-risk-manual-retry-execution-v1",
+        "request_id": request_id,
+        "plan_id": plan_id,
+        "executed_at": executed_at.isoformat(),
+        "channel": "webhook",
+        "endpoint": {
+            "host": "alerts.example.test",
+            "full_url_recorded": False,
+        },
+        "configuration": {
+            "delivery_fingerprint": "recorded-delivery-fingerprint-1",
+            "retry_execution_policy_fingerprint": (
+                "recorded-retry-execution-fingerprint-1"
+            ),
+            "retry_policy_fingerprint": "recorded-retry-policy-fingerprint-1",
+        },
+        "revalidation": {
+            "performed": True,
+            "current_plan_id": plan_id,
+            "events_checked": 1,
+            "exact_event_evidence_unchanged": True,
+        },
+        "selection": {
+            "planned_retryable_events": 1,
+            "executed_events": 1,
+            "max_events": 25,
+        },
+        "outcomes": [outcome],
+        "outcome_counts": {"succeeded": 1, "failed": 0},
+        "execution": {
+            "requested": True,
+            "performed": True,
+            "external_requests_performed": 1,
+            "delivery_attempts_written": 1,
+        },
+        "concurrency_control": {
+            "performed": True,
+            "acquired": True,
+            "released": True,
+            "held_through_revalidation": True,
+            "held_through_attempt_persistence": True,
+            "model_version": LOCK_MODEL,
+            "scope": LOCK_SCOPE,
+            "key_fingerprint": LOCK_KEY,
+        },
+        "response_bodies_recorded": False,
+        "plan_mutated": False,
+        "acknowledgement_mutated": False,
+        "dead_letter_mutated": False,
+    }
+
+
+def _successful_executor(**kwargs: Any) -> dict[str, Any]:
+    enforced_at = kwargs["clock"]()
+    readiness = kwargs["readiness_enforcer"](evaluated_at=enforced_at)
+    executed_at = kwargs["clock"]()
+    authority = _authority(evaluated_at=executed_at)
+    kwargs["destination_authority_observer"](authority)
+    event_id = f"{kwargs['request_id']}-event-1"
+    status = kwargs["transport"](
+        "https://alerts.example.test/hook",
+        b"{}",
+        {"Idempotency-Key": event_id},
+        5.0,
+    )
+    attempt = {
+        "attempt_id": f"{kwargs['request_id']}-attempt-1",
+        "event_id": event_id,
+        "outcome": "succeeded",
+    }
+    kwargs["attempt_writer"](attempt)
+    summary = _base_summary(
+        executed_at=executed_at,
+        request_id=kwargs["request_id"],
+        plan_id=kwargs["confirm_plan_id"],
+    )
+    summary["outcomes"][0]["http_status"] = status
+    summary["destination_authority"] = authority
+    summary["execution_readiness"] = readiness
+    summary["governed_execution"] = {
+        "model_version": "portfolio-risk-notification-retry-readiness-enforced-v1",
+        "plan_id": kwargs["confirm_plan_id"],
+        "destination_id": kwargs["destination_id"],
+        "readiness_enforcement_id": readiness["enforcement_id"],
+        "single_physical_lock_acquisition": True,
+        "nested_lock_reacquisition_performed": False,
+        "lock_reused_by_retry_executor": True,
+        "outer_lock_released": True,
+    }
+    return summary
+
+
+def _bundle_recorder(calls: list[tuple[dict[str, Any], dict[str, Any]]]):
+    def record(**kwargs: Any) -> dict[str, Any]:
+        terminal, binding = validate_notification_retry_governance_bundle(
+            terminal_record=kwargs["terminal_record"],
+            readiness_binding=kwargs["readiness_binding"],
+        )
+        calls.append((terminal, binding))
+        return {
+            "terminal_history": {
+                "record_id": terminal["record_id"],
+                "terminal_status": terminal["terminal_status"],
+                "created": True,
+            },
+            "readiness_history": {
+                "binding_id": binding["binding_id"],
+                "terminal_record_id": terminal["record_id"],
+                "created": True,
+            },
+            "created": True,
+            "atomic_commit": True,
+        }
+
+    return record
+
+
+def _execute(**overrides: Any) -> dict[str, Any]:
+    arguments: dict[str, Any] = {
+        "plan_path": Path("retry-plan.json"),
+        "confirm_plan_id": PLAN_ID,
+        "request_id": REQUEST_ID,
+        "config_path": CONFIG_PATH,
+        "destination_config_path": DESTINATION_PATH,
+        "destination_id": DESTINATION_ID,
+        "dsn": "postgresql://unit-test",
+        "execute": True,
+        "environment": {
+            "RISK_NOTIFICATION_WEBHOOK_URL": "https://alerts.example.test/hook"
+        },
+        "plan_loader": _plan_loader,
+        "history_reader": lambda **_: None,
+        "readiness_binding_reader": lambda **_: None,
+        "destination_binding_reader": lambda **_: None,
+    }
+    arguments.update(overrides)
+    return execute_and_record_readiness_enforced_portfolio_risk_notification_retries(
+        **arguments
+    )
+
+
+def test_successful_execution_atomically_records_terminal_and_readiness() -> None:
+    bundle_calls: list[tuple[dict[str, Any], dict[str, Any]]] = []
+    destination_bindings: list[dict[str, Any]] = []
+    attempts: list[dict[str, Any]] = []
+
+    result = _execute(
+        executor=_successful_executor,
+        readiness_enforcer=lambda **_: _readiness(),
+        transport=lambda *_: 200,
+        attempt_writer=lambda attempt: attempts.append(dict(attempt)),
+        bundle_recorder=_bundle_recorder(bundle_calls),
+        destination_binding_recorder=lambda **kwargs: (
+            destination_bindings.append(dict(kwargs["binding"]))
+            or {"binding_id": kwargs["binding"]["binding_id"]}
+        ),
+        clock=_clock(
+            BASE_TIME,
+            BASE_TIME + timedelta(minutes=3),
+            BASE_TIME + timedelta(minutes=4),
+            BASE_TIME + timedelta(minutes=5),
+        ),
+    )
+
+    assert result["atomic_commit"] is True
+    assert result["replayed"] is False
+    assert len(attempts) == 1
+    assert len(bundle_calls) == 1
+    terminal, binding = bundle_calls[0]
+    assert terminal["terminal_status"] == "completed"
+    assert terminal["request_count"] == 1
+    assert terminal["attempts_persisted"] == 1
+    assert binding["terminal_execution"]["record_id"] == terminal["record_id"]
+    assert binding["readiness_enforcement"]["execution_kind"] == "retry"
+    assert len(destination_bindings) == 1
+
+
+def test_readiness_rejection_occurs_before_transport_and_history() -> None:
+    transports: list[bool] = []
+    bundles: list[tuple[dict[str, Any], dict[str, Any]]] = []
+
+    def reject_readiness(**_: Any) -> dict[str, Any]:
+        raise ValidationError("readiness decision is blocked")
+
+    with pytest.raises(ValidationError, match="blocked"):
+        _execute(
+            executor=_successful_executor,
+            readiness_enforcer=reject_readiness,
+            transport=lambda *_: transports.append(True) or 200,
+            attempt_writer=lambda _: None,
+            bundle_recorder=_bundle_recorder(bundles),
+            destination_binding_recorder=lambda **_: {},
+            clock=_clock(BASE_TIME),
+        )
+
+    assert transports == []
+    assert bundles == []
+
+
+def test_request_without_attempt_evidence_records_persistence_uncertainty() -> None:
+    bundle_calls: list[tuple[dict[str, Any], dict[str, Any]]] = []
+
+    def failing_executor(**kwargs: Any) -> dict[str, Any]:
+        enforced_at = kwargs["clock"]()
+        kwargs["readiness_enforcer"](evaluated_at=enforced_at)
+        kwargs["clock"]()
+        kwargs["transport"](
+            "https://alerts.example.test/hook",
+            b"{}",
+            {"Idempotency-Key": f"{kwargs['request_id']}-event-1"},
+            5.0,
+        )
+        raise StorageError("attempt persistence unavailable")
+
+    with pytest.raises(RecordedReadinessRetryExecutionError) as captured:
+        _execute(
+            executor=failing_executor,
+            readiness_enforcer=lambda **_: _readiness(),
+            transport=lambda *_: 200,
+            attempt_writer=lambda _: None,
+            bundle_recorder=_bundle_recorder(bundle_calls),
+            destination_binding_recorder=lambda **_: {},
+            clock=_clock(
+                BASE_TIME,
+                BASE_TIME + timedelta(minutes=3),
+                BASE_TIME + timedelta(minutes=4),
+                BASE_TIME + timedelta(minutes=5),
+            ),
+        )
+
+    assert captured.value.failure_code == "storage_error"
+    assert len(bundle_calls) == 1
+    terminal, binding = bundle_calls[0]
+    assert terminal["terminal_status"] == "persistence_uncertain"
+    assert terminal["request_count"] == 1
+    assert terminal["attempts_persisted"] == 0
+    assert binding["terminal_execution"]["record_id"] == terminal["record_id"]
+
+
+def _retained_completed_bundle() -> tuple[dict[str, Any], dict[str, Any]]:
+    readiness = _readiness(enforced_at=BASE_TIME + timedelta(minutes=1))
+    summary = _base_summary(executed_at=BASE_TIME)
+    terminal = build_retry_execution_record(
+        request_id=REQUEST_ID,
+        plan_id=PLAN_ID,
+        started_at=BASE_TIME,
+        finished_at=BASE_TIME + timedelta(minutes=3),
+        recorded_at=BASE_TIME + timedelta(minutes=4),
+        terminal_status="completed",
+        failure_code=None,
+        request_count=1,
+        attempts_persisted=1,
+        succeeded_count=1,
+        failed_count=0,
+        attempt_ids=[f"{REQUEST_ID}-attempt-1"],
+        requested_event_ids=[f"{REQUEST_ID}-event-1"],
+        persisted_event_ids=[f"{REQUEST_ID}-event-1"],
+        execution_summary=summary,
+    )
+    binding = build_notification_retry_readiness_binding(
+        terminal_record=terminal,
+        readiness_enforcement=readiness,
+        recorded_at=BASE_TIME + timedelta(minutes=5),
+    )
+    return terminal, binding
+
+
+def test_exact_replay_returns_retained_evidence_without_another_request() -> None:
+    terminal, binding = _retained_completed_bundle()
+    executions: list[bool] = []
+
+    result = _execute(
+        history_reader=lambda **_: {
+            "record": terminal,
+            "history": {"record_id": terminal["record_id"]},
+        },
+        readiness_binding_reader=lambda **_: {
+            "binding": binding,
+            "history": {"binding_id": binding["binding_id"]},
+        },
+        destination_binding_reader=lambda **_: None,
+        executor=lambda **_: executions.append(True) or {},
+    )
+
+    assert executions == []
+    assert result["replayed"] is True
+    assert result["external_request_replayed"] is False
+    assert result["terminal_history"]["record_id"] == terminal["record_id"]
+    assert result["readiness_history"]["binding_id"] == binding["binding_id"]
+    assert result["execution_summary"]["execution_readiness"] == (
+        binding["readiness_enforcement"]
+    )
+
+
+def test_replay_rejects_terminal_history_without_readiness_binding() -> None:
+    terminal, _ = _retained_completed_bundle()
+    executions: list[bool] = []
+
+    with pytest.raises(ValidationError, match="replay is blocked"):
+        _execute(
+            history_reader=lambda **_: {
+                "record": terminal,
+                "history": {"record_id": terminal["record_id"]},
+            },
+            readiness_binding_reader=lambda **_: None,
+            executor=lambda **_: executions.append(True) or {},
+        )
+
+    assert executions == []

--- a/tests/unit/test_recorded_readiness_enforced_notification_retries_architecture_contract.py
+++ b/tests/unit/test_recorded_readiness_enforced_notification_retries_architecture_contract.py
@@ -1,0 +1,56 @@
+from pathlib import Path
+
+
+def test_recorded_readiness_retry_is_replay_safe_and_atomically_governed() -> None:
+    runner = Path(
+        "src/orchestration/"
+        "run_recorded_readiness_enforced_portfolio_risk_notification_retries.py"
+    ).read_text(encoding="utf-8")
+    docs = Path(
+        "docs/recorded-readiness-enforced-notification-retries.md"
+    ).read_text(encoding="utf-8")
+    normalized_docs = " ".join(docs.split()).casefold()
+
+    for required in (
+        "execute_readiness_enforced_portfolio_risk_notification_retries",
+        "validate_notification_execution_readiness_enforcement",
+        "build_notification_retry_readiness_binding",
+        "record_notification_retry_governance_bundle",
+        "validate_notification_retry_governance_bundle",
+        "read_notification_retry_execution_request",
+        "read_notification_retry_readiness_binding",
+        "retained retry terminal has no readiness binding",
+        "external_request_replayed",
+        "atomic_commit",
+    ):
+        assert required in runner
+
+    assert runner.index("selected_history_reader(") < runner.index(
+        "selected_executor("
+    )
+    assert runner.index("observing_readiness_enforcer") < runner.index(
+        "tracking_transport"
+    )
+    assert runner.index("build_notification_retry_readiness_binding(") < (
+        runner.index("selected_bundle_recorder(")
+    )
+
+    for required in (
+        "primary arc42 blocks: `orchestration` and `warehouse`",
+        "atomic terminal-plus-readiness commit",
+        "failure before readiness authority exists",
+        "no external request is replayed",
+        "does not infer or backfill readiness authority",
+        "ordinary ci uses injected readiness, transport, attempt, history and persistence functions",
+        "performs no network request",
+        "terraform apply",
+    ):
+        assert required in normalized_docs
+
+    for forbidden in (
+        "urllib.request",
+        "requests.",
+        "httpx.",
+        "socket.",
+    ):
+        assert forbidden not in runner


### PR DESCRIPTION
## Goal

Complete the operator-facing half of **P4d5e** by composing the single-lock readiness-enforced retry path with atomic terminal-plus-readiness persistence.

```text
exact retained retry plan
  + current retained retry allow decision
  + fresh under-lock readiness evaluation
  + exact destination authority
  -> bounded retry execution
  -> terminal record + readiness binding
  -> atomic commit
```

## What changes

- adds a recorded readiness-enforced retry entry point;
- checks retained terminal history before any new request;
- requires an exact retained readiness binding on replay;
- reconstructs completed governed summaries without replaying transport;
- rejects legacy or incomplete terminal history rather than inferring readiness authority;
- observes the exact under-lock readiness enforcement used by execution;
- records completed, failed-before-request, failed-after-request and persistence-uncertain outcomes after readiness has been granted;
- persists the terminal and readiness binding through the atomic bundle from PR #140; and
- preserves the established separate destination-authority binding stream.

## Scope

Four additive files, six working commits, 1,280 additions and no deletions. The final two commits only narrow validated mapping and identifier types at the persistence boundary. Squash merge retains one coherent orchestration increment. The branch is zero commits behind `main`.

## Exact-head validation

GitHub Actions run **413** (`33990674489`) passed on final head `bd3a52912a720b8e580e2ed0e3d2be0d9f9600f7`:

- Security guardrails passed.
- Ruff passed.
- mypy passed across **148 source files**.
- **938 tests passed** in quality and **938 passed again** in readiness.
- Dependency integrity and the standard pipeline replay passed.
- PostgreSQL 16 contracts passed.
- Kubernetes rendering and Terraform format/init/validate passed without apply.
- No submitted reviews or unresolved review threads exist.

The first exact-head run exposed two broad `Any | None` types at the retained terminal and atomic bundle boundaries. Both were narrowed through explicit runtime checks and concrete dictionaries. No validation, persistence, or safety rule was weakened.

## Safety boundary

Committed delivery, destination activation and retry execution remain disabled. Tests use injected readiness, transport, attempt, history and persistence functions. No live network request, provider call, delivery attempt, acknowledgement, outbox mutation, deployment or `terraform apply` occurred, and no endpoint value, credential, payload body, response body, environment value or DSN is retained.

Validated and ready for squash merge.