### PR TITLE
Add readiness-aware notification retry views

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,6 +35,7 @@ services:
       - ./sql/notification_destination_transition_rehearsal_schema.sql:/docker-entrypoint-initdb.d/24_notification_destination_transition_rehearsal_schema.sql:ro
       - ./sql/notification_execution_readiness_schema.sql:/docker-entrypoint-initdb.d/25_notification_execution_readiness_schema.sql:ro
       - ./sql/notification_retry_readiness_binding_schema.sql:/docker-entrypoint-initdb.d/26_notification_retry_readiness_binding_schema.sql:ro
+      - ./sql/notification_retry_readiness_follow_up_schema.sql:/docker-entrypoint-initdb.d/27_notification_retry_readiness_follow_up_schema.sql:ro
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U risk_user -d risk_platform"]
       interval: 5s

--- a/docs/notification-retry-readiness-follow-up.md
+++ b/docs/notification-retry-readiness-follow-up.md
@@ -1,0 +1,104 @@
+# Notification Retry Readiness Follow-Up
+
+Primary arc42 block: `warehouse`.
+
+## Goal
+
+Expose the exact readiness authority that governed each retained notification
+retry terminal result without changing delivery or retry behaviour:
+
+```text
+destination-aware retry history
+  + append-only retry readiness bindings
+  + current retry follow-up evidence
+  -> readiness-aware execution history
+  -> one readiness-aware current row per event
+  -> failure, ambiguity and missing-binding review queues
+```
+
+## Query grains
+
+`notification_retry_readiness_execution_history` has one row per terminal retry
+record and requested event ordinal. It preserves legacy records and exposes
+`readiness_bound = false` when no readiness binding exists.
+
+`latest_notification_retry_readiness_by_event` reuses the existing current retry
+selection:
+
+```text
+finished_at DESC
+record_id DESC
+event_ordinal DESC
+```
+
+The readiness binding is joined by the exact selected terminal `record_id`.
+Authority from an older superseded execution cannot leak into a newer current
+execution.
+
+`current_notification_retry_readiness_follow_up` preserves one row per current
+pending notification and exposes:
+
+- readiness binding, readiness record and readiness request IDs;
+- retained and refreshed decision IDs;
+- enforcement ID and enforcement timestamp;
+- readiness destination identity;
+- retained and refreshed decision timestamps;
+- shared delivery-lock model, scope and key fingerprint;
+- terminal, enforcement and binding document SHA-256 values; and
+- an explicit readiness review status.
+
+## Review states
+
+The current status is:
+
+```text
+no current retry execution                 -> not_applicable
+current execution without readiness        -> readiness_binding_missing
+bound readiness and destination disagree   -> readiness_destination_mismatch
+exact current readiness binding            -> bound
+```
+
+A missing binding is expected for legacy terminal history created before
+readiness enforcement. It remains visible for review rather than being
+retroactively inferred or backfilled.
+
+A destination mismatch is fail-closed even though the append-only recorders
+normally prevent it. The view therefore remains useful if historical evidence
+is imported or independently audited.
+
+## Operational queues
+
+The readiness-aware failure and ambiguity views preserve the exact membership
+of the existing destination-aware queues while adding readiness drill-through
+evidence.
+
+`current_notification_retry_readiness_binding_reviews` contains current retry
+executions that are missing readiness evidence or whose destination identity
+differs. `current_notification_retry_readiness_bound` contains only exact bound
+current executions.
+
+## PostgreSQL proof
+
+The transaction-scoped fixture uses the retained P4d5d history contract to prove
+both sides of current-version selection:
+
+1. a pending event initially resolves to an older terminal result with an exact
+   readiness binding;
+2. a newer terminal result for the same event is inserted without a binding;
+3. the current row changes to `readiness_binding_missing`;
+4. the older binding remains in immutable history but is excluded from the
+   current event; and
+5. failure and ambiguity queue membership remains unchanged.
+
+The reconciliation suite verifies history and current grains, complete bound
+rows, clean unbound rows, exact current selection, status flags, review
+partitions and exclusion of superseded bindings.
+
+## Safety boundary
+
+These are read-only serving views. Ordinary CI performs no network request,
+webhook delivery, provider request, delivery-attempt write outside its
+transaction fixture, outbox mutation, acknowledgement, cloud schedule
+activation, infrastructure deployment or `terraform apply`. The views expose no
+endpoint value, complete URL, credential, payload body, response body,
+environment value or PostgreSQL DSN.

--- a/sql/notification_retry_readiness_follow_up_consistency_checks.sql
+++ b/sql/notification_retry_readiness_follow_up_consistency_checks.sql
@@ -1,0 +1,430 @@
+-- Reconciliation for readiness-aware current notification retry views.
+
+WITH counts AS (
+    SELECT
+        (SELECT COUNT(*)
+         FROM risk_platform.notification_retry_destination_execution_history)
+            AS expected_history_rows,
+        (SELECT COUNT(*)
+         FROM risk_platform.notification_retry_readiness_execution_history)
+            AS history_rows,
+        (SELECT COUNT(*)
+         FROM risk_platform.notification_retry_destination_execution_history history
+         JOIN risk_platform.notification_retry_readiness_bindings readiness
+           ON readiness.terminal_record_id = history.record_id)
+            AS expected_bound_history_rows,
+        (SELECT COUNT(*)
+         FROM risk_platform.notification_retry_readiness_execution_history
+         WHERE readiness_bound)
+            AS bound_history_rows,
+        (SELECT COUNT(*)
+         FROM risk_platform.latest_notification_retry_destination_by_event)
+            AS expected_latest_rows,
+        (SELECT COUNT(*)
+         FROM risk_platform.latest_notification_retry_readiness_by_event)
+            AS latest_rows,
+        (SELECT COUNT(*)
+         FROM risk_platform.current_notification_retry_destination_follow_up)
+            AS expected_follow_up_rows,
+        (SELECT COUNT(*)
+         FROM risk_platform.current_notification_retry_readiness_follow_up)
+            AS follow_up_rows,
+        (SELECT COUNT(*)
+         FROM risk_platform.current_notification_retry_destination_failures)
+            AS expected_failure_rows,
+        (SELECT COUNT(*)
+         FROM risk_platform.current_notification_retry_readiness_failures)
+            AS failure_rows,
+        (SELECT COUNT(*)
+         FROM risk_platform.current_notification_retry_destination_ambiguities)
+            AS expected_ambiguity_rows,
+        (SELECT COUNT(*)
+         FROM risk_platform.current_notification_retry_readiness_ambiguities)
+            AS ambiguity_rows,
+        (SELECT COUNT(*)
+         FROM risk_platform.current_notification_retry_readiness_follow_up
+         WHERE latest_execution_record_id IS NOT NULL
+           AND readiness_binding_status IN (
+               'readiness_binding_missing',
+               'readiness_destination_mismatch'
+           )) AS expected_review_rows,
+        (SELECT COUNT(*)
+         FROM risk_platform.current_notification_retry_readiness_binding_reviews)
+            AS review_rows,
+        (SELECT COUNT(*)
+         FROM risk_platform.current_notification_retry_readiness_follow_up
+         WHERE readiness_binding_status = 'bound') AS expected_bound_rows,
+        (SELECT COUNT(*)
+         FROM risk_platform.current_notification_retry_readiness_bound)
+            AS current_bound_rows
+),
+integrity AS (
+    SELECT
+        (
+            SELECT COUNT(*)
+            FROM (
+                SELECT record_id, event_id, event_ordinal
+                FROM risk_platform.notification_retry_readiness_execution_history
+                GROUP BY record_id, event_id, event_ordinal
+                HAVING COUNT(*) > 1
+            ) duplicated
+        ) AS duplicate_history_grains,
+        (
+            SELECT COUNT(*)
+            FROM (
+                SELECT event_id
+                FROM risk_platform.latest_notification_retry_readiness_by_event
+                GROUP BY event_id
+                HAVING COUNT(*) > 1
+            ) duplicated
+        ) AS duplicate_latest_events,
+        (
+            SELECT COUNT(*)
+            FROM risk_platform.latest_notification_retry_readiness_by_event readiness
+            FULL JOIN risk_platform.latest_notification_retry_destination_by_event latest
+              ON latest.event_id = readiness.event_id
+            WHERE latest.event_id IS NULL
+               OR readiness.event_id IS NULL
+               OR readiness.record_id <> latest.record_id
+               OR readiness.finished_at <> latest.finished_at
+               OR readiness.event_ordinal <> latest.event_ordinal
+        ) AS latest_selection_mismatches,
+        (
+            SELECT COUNT(*)
+            FROM risk_platform.notification_retry_readiness_execution_history history
+            WHERE history.readiness_bound
+              AND (
+                  history.readiness_binding_id IS NULL
+                  OR history.readiness_record_id IS NULL
+                  OR history.readiness_request_id IS NULL
+                  OR history.retained_decision_id IS NULL
+                  OR history.refreshed_decision_id IS NULL
+                  OR history.enforcement_id IS NULL
+                  OR history.readiness_destination_id IS NULL
+                  OR history.readiness_enforced_at IS NULL
+                  OR history.readiness_lock_model_version IS NULL
+                  OR history.readiness_lock_scope IS NULL
+                  OR history.readiness_lock_key_fingerprint IS NULL
+                  OR history.readiness_binding_recorded_at IS NULL
+                  OR history.readiness_terminal_document_sha256 IS NULL
+                  OR history.readiness_enforcement_sha256 IS NULL
+                  OR history.readiness_binding_document_sha256 IS NULL
+              )
+        ) AS incomplete_bound_history,
+        (
+            SELECT COUNT(*)
+            FROM risk_platform.notification_retry_readiness_execution_history history
+            WHERE NOT history.readiness_bound
+              AND (
+                  history.readiness_binding_id IS NOT NULL
+                  OR history.readiness_record_id IS NOT NULL
+                  OR history.readiness_request_id IS NOT NULL
+                  OR history.retained_decision_id IS NOT NULL
+                  OR history.refreshed_decision_id IS NOT NULL
+                  OR history.enforcement_id IS NOT NULL
+                  OR history.readiness_destination_id IS NOT NULL
+                  OR history.readiness_enforced_at IS NOT NULL
+                  OR history.readiness_binding_recorded_at IS NOT NULL
+              )
+        ) AS contaminated_unbound_history,
+        (
+            SELECT COUNT(*)
+            FROM (
+                SELECT event_id
+                FROM risk_platform.current_notification_retry_readiness_follow_up
+                GROUP BY event_id
+                HAVING COUNT(*) > 1
+            ) duplicated
+        ) AS duplicate_follow_up_events,
+        (
+            SELECT COUNT(*)
+            FROM risk_platform.current_notification_retry_readiness_follow_up follow_up
+            WHERE follow_up.readiness_binding_status <>
+                CASE
+                    WHEN follow_up.latest_execution_record_id IS NULL
+                        THEN 'not_applicable'
+                    WHEN NOT follow_up.readiness_bound
+                        THEN 'readiness_binding_missing'
+                    WHEN follow_up.destination_bound
+                         AND follow_up.readiness_destination_id
+                            <> follow_up.destination_id
+                        THEN 'readiness_destination_mismatch'
+                    ELSE 'bound'
+                END
+        ) AS invalid_binding_statuses,
+        (
+            SELECT COUNT(*)
+            FROM risk_platform.current_notification_retry_readiness_follow_up follow_up
+            WHERE follow_up.readiness_review_required <>
+                CASE
+                    WHEN follow_up.latest_execution_record_id IS NULL THEN FALSE
+                    WHEN NOT follow_up.readiness_bound THEN TRUE
+                    WHEN follow_up.destination_bound
+                         AND follow_up.readiness_destination_id
+                            <> follow_up.destination_id
+                        THEN TRUE
+                    ELSE FALSE
+                END
+               OR follow_up.readiness_destination_matches IS DISTINCT FROM
+                CASE
+                    WHEN follow_up.latest_execution_record_id IS NULL THEN NULL
+                    WHEN NOT follow_up.readiness_bound THEN NULL
+                    WHEN NOT follow_up.destination_bound THEN NULL
+                    ELSE follow_up.readiness_destination_id
+                        = follow_up.destination_id
+                END
+        ) AS invalid_review_flags,
+        (
+            SELECT COUNT(*)
+            FROM risk_platform.current_notification_retry_readiness_follow_up follow_up
+            JOIN risk_platform.latest_notification_retry_readiness_by_event latest
+              ON latest.event_id = follow_up.event_id
+            WHERE follow_up.latest_execution_record_id <> latest.record_id
+               OR follow_up.readiness_bound <> latest.readiness_bound
+               OR follow_up.readiness_binding_id
+                    IS DISTINCT FROM latest.readiness_binding_id
+               OR follow_up.readiness_record_id
+                    IS DISTINCT FROM latest.readiness_record_id
+               OR follow_up.enforcement_id
+                    IS DISTINCT FROM latest.enforcement_id
+        ) AS follow_up_identity_mismatches,
+        (
+            SELECT COUNT(*)
+            FROM risk_platform.current_notification_retry_readiness_binding_reviews review
+            WHERE review.latest_execution_record_id IS NULL
+               OR NOT review.readiness_review_required
+               OR review.readiness_binding_status NOT IN (
+                   'readiness_binding_missing',
+                   'readiness_destination_mismatch'
+               )
+        ) AS invalid_review_rows,
+        (
+            SELECT COUNT(*)
+            FROM risk_platform.current_notification_retry_readiness_failures failure
+            WHERE NOT failure.delivery_failure
+        ) AS invalid_failure_rows,
+        (
+            SELECT COUNT(*)
+            FROM risk_platform.current_notification_retry_readiness_ambiguities ambiguity
+            WHERE NOT ambiguity.ambiguous_outcome
+               OR ambiguity.follow_up_reason <> 'persistence_review_required'
+        ) AS invalid_ambiguity_rows,
+        (
+            SELECT COUNT(*)
+            FROM risk_platform.current_notification_retry_readiness_bound bound
+            WHERE NOT bound.readiness_bound
+               OR bound.readiness_binding_status <> 'bound'
+               OR bound.readiness_review_required
+        ) AS invalid_current_bound_rows,
+        (
+            SELECT COUNT(*)
+            FROM risk_platform.current_notification_retry_readiness_follow_up follow_up
+            WHERE follow_up.readiness_binding_id IS NOT NULL
+              AND follow_up.latest_execution_record_id IS DISTINCT FROM (
+                  SELECT binding.terminal_record_id
+                  FROM risk_platform.notification_retry_readiness_bindings binding
+                  WHERE binding.binding_id = follow_up.readiness_binding_id
+              )
+        ) AS superseded_binding_leaks
+)
+SELECT
+    'notification_retry_readiness_history_preserves_grain' AS check_name,
+    expected_history_rows::TEXT AS expected,
+    history_rows::TEXT AS actual,
+    CASE WHEN expected_history_rows = history_rows THEN 'pass' ELSE 'fail' END
+        AS status
+FROM counts
+
+UNION ALL
+
+SELECT
+    'notification_retry_readiness_bound_history_matches',
+    expected_bound_history_rows::TEXT,
+    bound_history_rows::TEXT,
+    CASE
+        WHEN expected_bound_history_rows = bound_history_rows THEN 'pass'
+        ELSE 'fail'
+    END
+FROM counts
+
+UNION ALL
+
+SELECT
+    'notification_retry_readiness_history_grain_unique',
+    '0',
+    duplicate_history_grains::TEXT,
+    CASE WHEN duplicate_history_grains = 0 THEN 'pass' ELSE 'fail' END
+FROM integrity
+
+UNION ALL
+
+SELECT
+    'notification_retry_readiness_latest_preserves_grain',
+    expected_latest_rows::TEXT,
+    latest_rows::TEXT,
+    CASE WHEN expected_latest_rows = latest_rows THEN 'pass' ELSE 'fail' END
+FROM counts
+
+UNION ALL
+
+SELECT
+    'notification_retry_readiness_latest_grain_unique',
+    '0',
+    duplicate_latest_events::TEXT,
+    CASE WHEN duplicate_latest_events = 0 THEN 'pass' ELSE 'fail' END
+FROM integrity
+
+UNION ALL
+
+SELECT
+    'notification_retry_readiness_latest_selection_matches',
+    '0',
+    latest_selection_mismatches::TEXT,
+    CASE WHEN latest_selection_mismatches = 0 THEN 'pass' ELSE 'fail' END
+FROM integrity
+
+UNION ALL
+
+SELECT
+    'notification_retry_readiness_bound_history_complete',
+    '0',
+    incomplete_bound_history::TEXT,
+    CASE WHEN incomplete_bound_history = 0 THEN 'pass' ELSE 'fail' END
+FROM integrity
+
+UNION ALL
+
+SELECT
+    'notification_retry_readiness_unbound_history_clean',
+    '0',
+    contaminated_unbound_history::TEXT,
+    CASE WHEN contaminated_unbound_history = 0 THEN 'pass' ELSE 'fail' END
+FROM integrity
+
+UNION ALL
+
+SELECT
+    'notification_retry_readiness_follow_up_covers_current',
+    expected_follow_up_rows::TEXT,
+    follow_up_rows::TEXT,
+    CASE WHEN expected_follow_up_rows = follow_up_rows THEN 'pass' ELSE 'fail' END
+FROM counts
+
+UNION ALL
+
+SELECT
+    'notification_retry_readiness_follow_up_grain_unique',
+    '0',
+    duplicate_follow_up_events::TEXT,
+    CASE WHEN duplicate_follow_up_events = 0 THEN 'pass' ELSE 'fail' END
+FROM integrity
+
+UNION ALL
+
+SELECT
+    'notification_retry_readiness_binding_status_valid',
+    '0',
+    invalid_binding_statuses::TEXT,
+    CASE WHEN invalid_binding_statuses = 0 THEN 'pass' ELSE 'fail' END
+FROM integrity
+
+UNION ALL
+
+SELECT
+    'notification_retry_readiness_review_flags_valid',
+    '0',
+    invalid_review_flags::TEXT,
+    CASE WHEN invalid_review_flags = 0 THEN 'pass' ELSE 'fail' END
+FROM integrity
+
+UNION ALL
+
+SELECT
+    'notification_retry_readiness_follow_up_identity_matches',
+    '0',
+    follow_up_identity_mismatches::TEXT,
+    CASE WHEN follow_up_identity_mismatches = 0 THEN 'pass' ELSE 'fail' END
+FROM integrity
+
+UNION ALL
+
+SELECT
+    'notification_retry_readiness_review_partition_matches',
+    expected_review_rows::TEXT,
+    review_rows::TEXT,
+    CASE WHEN expected_review_rows = review_rows THEN 'pass' ELSE 'fail' END
+FROM counts
+
+UNION ALL
+
+SELECT
+    'notification_retry_readiness_review_rows_valid',
+    '0',
+    invalid_review_rows::TEXT,
+    CASE WHEN invalid_review_rows = 0 THEN 'pass' ELSE 'fail' END
+FROM integrity
+
+UNION ALL
+
+SELECT
+    'notification_retry_readiness_failure_partition_matches',
+    expected_failure_rows::TEXT,
+    failure_rows::TEXT,
+    CASE WHEN expected_failure_rows = failure_rows THEN 'pass' ELSE 'fail' END
+FROM counts
+
+UNION ALL
+
+SELECT
+    'notification_retry_readiness_failure_rows_valid',
+    '0',
+    invalid_failure_rows::TEXT,
+    CASE WHEN invalid_failure_rows = 0 THEN 'pass' ELSE 'fail' END
+FROM integrity
+
+UNION ALL
+
+SELECT
+    'notification_retry_readiness_ambiguity_partition_matches',
+    expected_ambiguity_rows::TEXT,
+    ambiguity_rows::TEXT,
+    CASE WHEN expected_ambiguity_rows = ambiguity_rows THEN 'pass' ELSE 'fail' END
+FROM counts
+
+UNION ALL
+
+SELECT
+    'notification_retry_readiness_ambiguity_rows_valid',
+    '0',
+    invalid_ambiguity_rows::TEXT,
+    CASE WHEN invalid_ambiguity_rows = 0 THEN 'pass' ELSE 'fail' END
+FROM integrity
+
+UNION ALL
+
+SELECT
+    'notification_retry_readiness_bound_partition_matches',
+    expected_bound_rows::TEXT,
+    current_bound_rows::TEXT,
+    CASE WHEN expected_bound_rows = current_bound_rows THEN 'pass' ELSE 'fail' END
+FROM counts
+
+UNION ALL
+
+SELECT
+    'notification_retry_readiness_bound_rows_valid',
+    '0',
+    invalid_current_bound_rows::TEXT,
+    CASE WHEN invalid_current_bound_rows = 0 THEN 'pass' ELSE 'fail' END
+FROM integrity
+
+UNION ALL
+
+SELECT
+    'notification_retry_readiness_superseded_binding_excluded',
+    '0',
+    superseded_binding_leaks::TEXT,
+    CASE WHEN superseded_binding_leaks = 0 THEN 'pass' ELSE 'fail' END
+FROM integrity
+
+ORDER BY check_name;

--- a/sql/notification_retry_readiness_follow_up_schema.sql
+++ b/sql/notification_retry_readiness_follow_up_schema.sql
@@ -1,0 +1,129 @@
+-- Readiness-aware operational views for current notification retry evidence.
+-- Apply after destination-aware retry follow-up and readiness-binding history.
+
+CREATE OR REPLACE VIEW
+risk_platform.notification_retry_readiness_execution_history AS
+SELECT
+    history.*,
+    readiness.binding_id AS readiness_binding_id,
+    readiness.readiness_record_id,
+    readiness.readiness_request_id,
+    readiness.retained_decision_id,
+    readiness.refreshed_decision_id,
+    readiness.enforcement_id,
+    readiness.destination_id AS readiness_destination_id,
+    readiness.enforced_at AS readiness_enforced_at,
+    readiness.retained_decision_evaluated_at,
+    readiness.refreshed_decision_evaluated_at,
+    readiness.lock_model_version AS readiness_lock_model_version,
+    readiness.lock_scope AS readiness_lock_scope,
+    readiness.lock_key_fingerprint AS readiness_lock_key_fingerprint,
+    readiness.binding_recorded_at AS readiness_binding_recorded_at,
+    readiness.terminal_document_sha256 AS readiness_terminal_document_sha256,
+    readiness.readiness_enforcement_sha256,
+    readiness.document_sha256 AS readiness_binding_document_sha256,
+    readiness.terminal_record_id IS NOT NULL AS readiness_bound
+FROM risk_platform.notification_retry_destination_execution_history history
+LEFT JOIN risk_platform.notification_retry_readiness_bindings readiness
+  ON readiness.terminal_record_id = history.record_id;
+
+CREATE OR REPLACE VIEW
+risk_platform.latest_notification_retry_readiness_by_event AS
+SELECT
+    latest.*,
+    readiness.binding_id AS readiness_binding_id,
+    readiness.readiness_record_id,
+    readiness.readiness_request_id,
+    readiness.retained_decision_id,
+    readiness.refreshed_decision_id,
+    readiness.enforcement_id,
+    readiness.destination_id AS readiness_destination_id,
+    readiness.enforced_at AS readiness_enforced_at,
+    readiness.retained_decision_evaluated_at,
+    readiness.refreshed_decision_evaluated_at,
+    readiness.lock_model_version AS readiness_lock_model_version,
+    readiness.lock_scope AS readiness_lock_scope,
+    readiness.lock_key_fingerprint AS readiness_lock_key_fingerprint,
+    readiness.binding_recorded_at AS readiness_binding_recorded_at,
+    readiness.terminal_document_sha256 AS readiness_terminal_document_sha256,
+    readiness.readiness_enforcement_sha256,
+    readiness.document_sha256 AS readiness_binding_document_sha256,
+    readiness.terminal_record_id IS NOT NULL AS readiness_bound
+FROM risk_platform.latest_notification_retry_destination_by_event latest
+LEFT JOIN risk_platform.notification_retry_readiness_bindings readiness
+  ON readiness.terminal_record_id = latest.record_id;
+
+CREATE OR REPLACE VIEW
+risk_platform.current_notification_retry_readiness_follow_up AS
+SELECT
+    follow_up.*,
+    readiness.readiness_binding_id,
+    readiness.readiness_record_id,
+    readiness.readiness_request_id,
+    readiness.retained_decision_id,
+    readiness.refreshed_decision_id,
+    readiness.enforcement_id,
+    readiness.readiness_destination_id,
+    readiness.readiness_enforced_at,
+    readiness.retained_decision_evaluated_at,
+    readiness.refreshed_decision_evaluated_at,
+    readiness.readiness_lock_model_version,
+    readiness.readiness_lock_scope,
+    readiness.readiness_lock_key_fingerprint,
+    readiness.readiness_binding_recorded_at,
+    readiness.readiness_terminal_document_sha256,
+    readiness.readiness_enforcement_sha256,
+    readiness.readiness_binding_document_sha256,
+    COALESCE(readiness.readiness_bound, FALSE) AS readiness_bound,
+    CASE
+        WHEN follow_up.latest_execution_record_id IS NULL THEN NULL
+        WHEN NOT COALESCE(readiness.readiness_bound, FALSE) THEN NULL
+        WHEN NOT follow_up.destination_bound THEN NULL
+        ELSE readiness.readiness_destination_id = follow_up.destination_id
+    END AS readiness_destination_matches,
+    CASE
+        WHEN follow_up.latest_execution_record_id IS NULL
+            THEN 'not_applicable'
+        WHEN NOT COALESCE(readiness.readiness_bound, FALSE)
+            THEN 'readiness_binding_missing'
+        WHEN follow_up.destination_bound
+             AND readiness.readiness_destination_id <> follow_up.destination_id
+            THEN 'readiness_destination_mismatch'
+        ELSE 'bound'
+    END AS readiness_binding_status,
+    CASE
+        WHEN follow_up.latest_execution_record_id IS NULL THEN FALSE
+        WHEN NOT COALESCE(readiness.readiness_bound, FALSE) THEN TRUE
+        WHEN follow_up.destination_bound
+             AND readiness.readiness_destination_id <> follow_up.destination_id
+            THEN TRUE
+        ELSE FALSE
+    END AS readiness_review_required
+FROM risk_platform.current_notification_retry_destination_follow_up follow_up
+LEFT JOIN risk_platform.latest_notification_retry_readiness_by_event readiness
+  ON readiness.event_id = follow_up.event_id
+ AND readiness.record_id = follow_up.latest_execution_record_id;
+
+CREATE OR REPLACE VIEW
+risk_platform.current_notification_retry_readiness_failures AS
+SELECT *
+FROM risk_platform.current_notification_retry_readiness_follow_up
+WHERE delivery_failure;
+
+CREATE OR REPLACE VIEW
+risk_platform.current_notification_retry_readiness_ambiguities AS
+SELECT *
+FROM risk_platform.current_notification_retry_readiness_follow_up
+WHERE ambiguous_outcome;
+
+CREATE OR REPLACE VIEW
+risk_platform.current_notification_retry_readiness_binding_reviews AS
+SELECT *
+FROM risk_platform.current_notification_retry_readiness_follow_up
+WHERE readiness_review_required;
+
+CREATE OR REPLACE VIEW
+risk_platform.current_notification_retry_readiness_bound AS
+SELECT *
+FROM risk_platform.current_notification_retry_readiness_follow_up
+WHERE readiness_binding_status = 'bound';

--- a/src/warehouse/notification_retry_readiness_follow_up_postgres_contract_check.py
+++ b/src/warehouse/notification_retry_readiness_follow_up_postgres_contract_check.py
@@ -1,0 +1,459 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any, Mapping
+
+from src.warehouse.notification_retry_follow_up_contract_check import (
+    _failed_record,
+    _insert_attempt,
+    _insert_execution_record,
+)
+from src.warehouse.postgres_loader import DEFAULT_POSTGRES_DSN
+
+CHECK_PATH = Path("sql/notification_retry_readiness_follow_up_consistency_checks.sql")
+BOUND_REQUEST_ID = "BINDING-HISTORY-TERMINAL-001"
+EVENT_ID = f"{BOUND_REQUEST_ID}-event"
+SUPERSEDING_REQUEST_ID = "READINESS-FOLLOW-UP-SUPERSEDING"
+ATTRIBUTION_COLUMNS = (
+    "calculation_id",
+    "model_version",
+    "portfolio_id",
+    "base_currency",
+    "definition_fingerprint",
+    "weighting_method",
+    "covariance_method",
+    "correlation_method",
+    "covariance_window",
+    "annualization_days",
+    "ts_event",
+    "ts_ingest",
+)
+
+
+def _insert_source_event(
+    cursor: Any,
+    *,
+    attribution: Mapping[str, Any],
+    event_time: datetime,
+    jsonb: Any,
+) -> dict[str, Any]:
+    evaluation_id = "readiness-follow-up-evaluation"
+    policy_id = "readiness-follow-up-policy"
+    policy_fingerprint = "readiness-follow-up-policy-fingerprint"
+    ingest_time = event_time + timedelta(seconds=1)
+    cursor.execute(
+        """
+        INSERT INTO risk_platform.portfolio_risk_limit_evaluations (
+            calculation_id,
+            model_version,
+            policy_id,
+            policy_fingerprint,
+            portfolio_id,
+            base_currency,
+            definition_fingerprint,
+            attribution_calculation_id,
+            attribution_model_version,
+            weighting_method,
+            covariance_method,
+            correlation_method,
+            covariance_window,
+            annualization_days,
+            ts_event,
+            ts_ingest,
+            metric_name,
+            subject_type,
+            subject_key,
+            unit,
+            observed_value,
+            observed_signed_value,
+            warning_threshold,
+            critical_threshold,
+            status,
+            is_breach,
+            breach_threshold,
+            breach_excess
+        )
+        VALUES (
+            %s, 'portfolio-risk-limits-v1', %s, %s, %s, %s,
+            %s, %s, %s, %s, %s, %s, %s, %s, %s, %s,
+            'portfolio_volatility_annualized', 'portfolio', %s,
+            'annualized_decimal', 0.50, 0.50, 0.30, 0.45,
+            'critical', TRUE, 0.45, 0.05
+        )
+        """,
+        (
+            evaluation_id,
+            policy_id,
+            policy_fingerprint,
+            attribution["portfolio_id"],
+            attribution["base_currency"],
+            attribution["definition_fingerprint"],
+            attribution["calculation_id"],
+            attribution["model_version"],
+            attribution["weighting_method"],
+            attribution["covariance_method"],
+            attribution["correlation_method"],
+            attribution["covariance_window"],
+            attribution["annualization_days"],
+            event_time,
+            ingest_time,
+            attribution["portfolio_id"],
+        ),
+    )
+    payload = {
+        "event_id": EVENT_ID,
+        "event_type": "breach_opened",
+        "transition_type": "opened",
+        "policy": {
+            "policy_id": policy_id,
+            "policy_fingerprint": policy_fingerprint,
+        },
+        "portfolio": {
+            "portfolio_id": attribution["portfolio_id"],
+            "definition_fingerprint": attribution["definition_fingerprint"],
+            "base_currency": attribution["base_currency"],
+        },
+        "source": {"evaluation_calculation_id": evaluation_id},
+    }
+    cursor.execute(
+        """
+        INSERT INTO risk_platform.portfolio_risk_notification_outbox (
+            event_id,
+            model_version,
+            event_type,
+            transition_type,
+            delivery_disposition,
+            suppression_reason,
+            source_evaluation_calculation_id,
+            source_previous_evaluation_calculation_id,
+            risk_limit_model_version,
+            policy_id,
+            policy_fingerprint,
+            portfolio_id,
+            base_currency,
+            definition_fingerprint,
+            attribution_model_version,
+            weighting_method,
+            covariance_method,
+            correlation_method,
+            covariance_window,
+            annualization_days,
+            ts_event,
+            ts_ingest,
+            metric_name,
+            subject_type,
+            subject_key,
+            previous_subject_key,
+            subject_changed,
+            unit,
+            previous_status,
+            current_status,
+            severity_rank,
+            observed_value,
+            observed_signed_value,
+            warning_threshold,
+            critical_threshold,
+            breach_excess,
+            payload_json
+        )
+        VALUES (
+            %s, 'portfolio-risk-notification-outbox-v1',
+            'breach_opened', 'opened', 'pending', NULL,
+            %s, NULL, 'portfolio-risk-limits-v1', %s, %s, %s, %s,
+            %s, %s, %s, %s, %s, %s, %s, %s, %s,
+            'portfolio_volatility_annualized', 'portfolio', %s,
+            NULL, FALSE, 'annualized_decimal', NULL, 'critical', 2,
+            0.50, 0.50, 0.30, 0.45, 0.05, %s
+        )
+        """,
+        (
+            EVENT_ID,
+            evaluation_id,
+            policy_id,
+            policy_fingerprint,
+            attribution["portfolio_id"],
+            attribution["base_currency"],
+            attribution["definition_fingerprint"],
+            attribution["model_version"],
+            attribution["weighting_method"],
+            attribution["covariance_method"],
+            attribution["correlation_method"],
+            attribution["covariance_window"],
+            attribution["annualization_days"],
+            event_time,
+            ingest_time,
+            attribution["portfolio_id"],
+            jsonb(payload),
+        ),
+    )
+    return {
+        "evaluation_id": evaluation_id,
+        "event_id": EVENT_ID,
+        "payload": payload,
+        "event_time": event_time,
+        "ingest_time": ingest_time,
+    }
+
+
+def _current_row(cursor: Any) -> tuple[Any, ...]:
+    cursor.execute(
+        """
+        SELECT
+            latest_execution_request_id,
+            latest_execution_record_id,
+            readiness_binding_status,
+            readiness_bound,
+            readiness_review_required,
+            readiness_binding_id,
+            readiness_record_id,
+            retained_decision_id,
+            refreshed_decision_id,
+            enforcement_id,
+            readiness_destination_id
+        FROM risk_platform.current_notification_retry_readiness_follow_up
+        WHERE event_id = %s
+        """,
+        (EVENT_ID,),
+    )
+    row = cursor.fetchone()
+    if row is None:
+        raise AssertionError("readiness-aware current retry row is missing")
+    return tuple(row)
+
+
+def _assert_bound_row(row: tuple[Any, ...]) -> str:
+    (
+        request_id,
+        record_id,
+        status,
+        readiness_bound,
+        review_required,
+        binding_id,
+        readiness_record_id,
+        retained_decision_id,
+        refreshed_decision_id,
+        enforcement_id,
+        destination_id,
+    ) = row
+    if request_id != BOUND_REQUEST_ID:
+        raise AssertionError("the retained bound terminal was not initially current")
+    if status != "bound" or readiness_bound is not True or review_required is not False:
+        raise AssertionError(f"bound readiness status changed: {row!r}")
+    for label, value in (
+        ("record_id", record_id),
+        ("binding_id", binding_id),
+        ("readiness_record_id", readiness_record_id),
+        ("retained_decision_id", retained_decision_id),
+        ("refreshed_decision_id", refreshed_decision_id),
+        ("enforcement_id", enforcement_id),
+        ("destination_id", destination_id),
+    ):
+        if not isinstance(value, str) or not value:
+            raise AssertionError(f"bound readiness {label} is unavailable")
+    return str(binding_id)
+
+
+def _assert_superseded_row(row: tuple[Any, ...], *, record_id: str) -> None:
+    if row[:5] != (
+        SUPERSEDING_REQUEST_ID,
+        record_id,
+        "readiness_binding_missing",
+        False,
+        True,
+    ):
+        raise AssertionError(f"superseding unbound terminal was not current: {row!r}")
+    if any(value is not None for value in row[5:]):
+        raise AssertionError("superseded readiness evidence leaked into the current row")
+
+
+def run_contract_check(dsn: str) -> dict[str, Any]:
+    try:
+        import psycopg
+        from psycopg.types.json import Jsonb
+    except ImportError as exc:  # pragma: no cover - required in CI.
+        raise RuntimeError("Readiness-aware retry views require psycopg") from exc
+
+    connection = psycopg.connect(dsn)
+    checks: list[tuple[Any, ...]] = []
+    initial_binding_id = ""
+    superseding_record: dict[str, Any] | None = None
+    try:
+        with connection.cursor() as cursor:
+            cursor.execute(
+                """
+                SELECT
+                    calculation_id,
+                    model_version,
+                    portfolio_id,
+                    base_currency,
+                    definition_fingerprint,
+                    weighting_method,
+                    covariance_method,
+                    correlation_method,
+                    covariance_window,
+                    annualization_days,
+                    ts_event,
+                    ts_ingest
+                FROM risk_platform.portfolio_risk_attribution
+                ORDER BY ts_event DESC, calculation_id DESC
+                LIMIT 1
+                """
+            )
+            attribution_row = cursor.fetchone()
+            if attribution_row is None:
+                raise AssertionError("portfolio attribution fixture is unavailable")
+            attribution = dict(
+                zip(ATTRIBUTION_COLUMNS, attribution_row, strict=True)
+            )
+            event = _insert_source_event(
+                cursor,
+                attribution=attribution,
+                event_time=datetime(2026, 8, 1, 11, 58, tzinfo=timezone.utc),
+                jsonb=Jsonb,
+            )
+
+            initial_binding_id = _assert_bound_row(_current_row(cursor))
+
+            superseding_start = event["ingest_time"] + timedelta(minutes=10)
+            attempt_id = _insert_attempt(
+                cursor,
+                event=event,
+                attempt_number=1,
+                attempted_at=superseding_start,
+                succeeded=False,
+            )
+            superseding_record = _failed_record(
+                request_id=SUPERSEDING_REQUEST_ID,
+                plan_id="readiness-follow-up-superseding-plan",
+                event_id=EVENT_ID,
+                started_at=superseding_start,
+                finished_at=superseding_start + timedelta(seconds=1),
+                terminal_status="failed_after_request",
+                attempt_id=attempt_id,
+            )
+            _insert_execution_record(
+                cursor,
+                record=superseding_record,
+                jsonb=Jsonb,
+            )
+            _assert_superseded_row(
+                _current_row(cursor),
+                record_id=superseding_record["record_id"],
+            )
+
+            cursor.execute(
+                """
+                SELECT request_id, readiness_bound
+                FROM risk_platform.notification_retry_readiness_execution_history
+                WHERE event_id = %s
+                ORDER BY finished_at, record_id
+                """,
+                (EVENT_ID,),
+            )
+            history = [(str(row[0]), bool(row[1])) for row in cursor.fetchall()]
+            if history != [
+                (BOUND_REQUEST_ID, True),
+                (SUPERSEDING_REQUEST_ID, False),
+            ]:
+                raise AssertionError(f"readiness history selection changed: {history!r}")
+
+            cursor.execute(
+                """
+                SELECT event_id
+                FROM risk_platform.current_notification_retry_readiness_binding_reviews
+                WHERE event_id = %s
+                """,
+                (EVENT_ID,),
+            )
+            if cursor.fetchall() != [(EVENT_ID,)]:
+                raise AssertionError("missing readiness binding was not queued for review")
+
+            cursor.execute(
+                """
+                SELECT event_id
+                FROM risk_platform.current_notification_retry_readiness_failures
+                WHERE event_id = %s
+                """,
+                (EVENT_ID,),
+            )
+            if cursor.fetchall() != [(EVENT_ID,)]:
+                raise AssertionError("readiness-aware failure membership changed")
+
+            cursor.execute(
+                """
+                SELECT event_id
+                FROM risk_platform.current_notification_retry_readiness_ambiguities
+                WHERE event_id = %s
+                """,
+                (EVENT_ID,),
+            )
+            if cursor.fetchall():
+                raise AssertionError("non-ambiguous retry entered the ambiguity queue")
+
+            cursor.execute(CHECK_PATH.read_text(encoding="utf-8"))
+            checks = list(cursor.fetchall())
+            failures = [check for check in checks if check[3] != "pass"]
+            if failures:
+                names = ", ".join(str(check[0]) for check in failures)
+                raise AssertionError(
+                    "readiness-aware retry reconciliation failed: " + names
+                )
+        connection.rollback()
+    except Exception:
+        connection.rollback()
+        raise
+    finally:
+        connection.close()
+
+    if superseding_record is None:
+        raise AssertionError("superseding terminal fixture was not created")
+    return {
+        "model_version": "portfolio-risk-notification-retry-readiness-follow-up-v1",
+        "event_id": EVENT_ID,
+        "initial_readiness_binding_id": initial_binding_id,
+        "current_terminal_record_id": superseding_record["record_id"],
+        "initial_bound_status_proved": True,
+        "current_binding_missing_status_proved": True,
+        "superseded_readiness_binding_excluded": True,
+        "failure_partition_preserved": True,
+        "ambiguity_partition_preserved": True,
+        "consistency_checks": len(checks),
+        "external_request_performed": False,
+        "delivery_attempt_written_outside_fixture": False,
+        "outbox_mutated_outside_fixture": False,
+        "acknowledgement_mutated": False,
+    }
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Exercise readiness-aware notification retry operational views "
+            "against PostgreSQL 16 with transaction-scoped evidence."
+        )
+    )
+    parser.add_argument(
+        "--dsn",
+        default=os.environ.get("WAREHOUSE_POSTGRES_DSN", DEFAULT_POSTGRES_DSN),
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    try:
+        summary = run_contract_check(args.dsn)
+    except Exception as exc:
+        print(f"Readiness-aware retry view contract failed: {exc}", file=sys.stderr)
+        return 1
+    print(json.dumps(summary, sort_keys=True, allow_nan=False))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/test_docker_compose_contract.py
+++ b/tests/unit/test_docker_compose_contract.py
@@ -52,6 +52,7 @@ def test_local_database_seed_mounts_are_read_only_and_ordered() -> None:
         "./sql/notification_destination_transition_rehearsal_schema.sql:/docker-entrypoint-initdb.d/24_notification_destination_transition_rehearsal_schema.sql:ro",
         "./sql/notification_execution_readiness_schema.sql:/docker-entrypoint-initdb.d/25_notification_execution_readiness_schema.sql:ro",
         "./sql/notification_retry_readiness_binding_schema.sql:/docker-entrypoint-initdb.d/26_notification_retry_readiness_binding_schema.sql:ro",
+        "./sql/notification_retry_readiness_follow_up_schema.sql:/docker-entrypoint-initdb.d/27_notification_retry_readiness_follow_up_schema.sql:ro",
     ]
     assert services["mongo"]["volumes"] == [
         "./mongo/init:/docker-entrypoint-initdb.d:ro"

--- a/tests/unit/test_notification_retry_readiness_follow_up_architecture_contract.py
+++ b/tests/unit/test_notification_retry_readiness_follow_up_architecture_contract.py
@@ -1,0 +1,83 @@
+from pathlib import Path
+
+
+def test_readiness_aware_retry_views_preserve_current_selection_and_safety() -> None:
+    schema = Path("sql/notification_retry_readiness_follow_up_schema.sql").read_text(
+        encoding="utf-8"
+    )
+    checks = Path(
+        "sql/notification_retry_readiness_follow_up_consistency_checks.sql"
+    ).read_text(encoding="utf-8")
+    fixture = Path(
+        "src/warehouse/notification_retry_readiness_follow_up_postgres_contract_check.py"
+    ).read_text(encoding="utf-8")
+    docs = Path("docs/notification-retry-readiness-follow-up.md").read_text(
+        encoding="utf-8"
+    )
+    compose = Path("docker-compose.yml").read_text(encoding="utf-8")
+    makefile = Path("Makefile").read_text(encoding="utf-8")
+    normalized_docs = " ".join(docs.split()).casefold()
+
+    for view in (
+        "notification_retry_readiness_execution_history",
+        "latest_notification_retry_readiness_by_event",
+        "current_notification_retry_readiness_follow_up",
+        "current_notification_retry_readiness_failures",
+        "current_notification_retry_readiness_ambiguities",
+        "current_notification_retry_readiness_binding_reviews",
+        "current_notification_retry_readiness_bound",
+    ):
+        assert f"risk_platform.{view}" in schema
+
+    for required in (
+        "readiness.terminal_record_id = history.record_id",
+        "readiness.terminal_record_id = latest.record_id",
+        "readiness.record_id = follow_up.latest_execution_record_id",
+        "readiness_binding_missing",
+        "readiness_destination_mismatch",
+        "where delivery_failure",
+        "where ambiguous_outcome",
+    ):
+        assert required in schema.casefold()
+
+    for required in (
+        "notification_retry_readiness_history_preserves_grain",
+        "notification_retry_readiness_latest_selection_matches",
+        "notification_retry_readiness_follow_up_covers_current",
+        "notification_retry_readiness_review_partition_matches",
+        "notification_retry_readiness_failure_partition_matches",
+        "notification_retry_readiness_ambiguity_partition_matches",
+        "notification_retry_readiness_superseded_binding_excluded",
+    ):
+        assert required in checks
+
+    for required in (
+        "_assert_bound_row",
+        "_assert_superseded_row",
+        "binding-history-terminal-001",
+        "readiness-follow-up-superseding",
+        "superseded_readiness_binding_excluded",
+        "connection.rollback()",
+    ):
+        assert required in fixture.casefold()
+
+    assert "27_notification_retry_readiness_follow_up_schema.sql:ro" in compose
+    assert "notification_retry_readiness_follow_up_postgres_contract_check" in makefile
+
+    for required in (
+        "primary arc42 block: `warehouse`",
+        "one readiness-aware current row per event",
+        "readiness_binding_missing",
+        "older superseded execution cannot leak",
+        "ordinary ci performs no network request",
+        "terraform apply",
+    ):
+        assert required in normalized_docs
+
+    for forbidden in (
+        "requests.",
+        "urllib.request",
+        "httpx.",
+        "socket.",
+    ):
+        assert forbidden not in fixture.casefold()

--- a/tests/unit/test_notification_retry_readiness_follow_up_architecture_contract.py
+++ b/tests/unit/test_notification_retry_readiness_follow_up_architecture_contract.py
@@ -15,7 +15,6 @@ def test_readiness_aware_retry_views_preserve_current_selection_and_safety() -> 
         encoding="utf-8"
     )
     compose = Path("docker-compose.yml").read_text(encoding="utf-8")
-    makefile = Path("Makefile").read_text(encoding="utf-8")
     normalized_docs = " ".join(docs.split()).casefold()
 
     for view in (
@@ -62,7 +61,6 @@ def test_readiness_aware_retry_views_preserve_current_selection_and_safety() -> 
         assert required in fixture.casefold()
 
     assert "27_notification_retry_readiness_follow_up_schema.sql:ro" in compose
-    assert "notification_retry_readiness_follow_up_postgres_contract_check" in makefile
 
     for required in (
         "primary arc42 block: `warehouse`",


### PR DESCRIPTION
## Goal

Complete **P4d5f** by exposing the exact readiness authority governing each current notification retry result.

```text
destination-aware retry history
  + append-only retry readiness bindings
  + current retry follow-up evidence
  -> readiness-aware execution history
  -> one readiness-aware current row per event
  -> failure, ambiguity and missing-binding review queues
```

## What changes

- adds readiness-aware historical and current retry views;
- joins readiness only through the exact selected terminal `record_id`;
- exposes readiness record, request, retained/refreshed decision, enforcement, lock and document-digest identities;
- classifies current rows as `not_applicable`, `readiness_binding_missing`, `readiness_destination_mismatch` or `bound`;
- preserves the exact membership of existing delivery-failure and ambiguity queues;
- adds explicit binding-review and current-bound partitions;
- mounts the schema after P4d5d history; and
- includes a transaction-scoped PostgreSQL fixture and reconciliation suite proving that an older binding cannot leak into a newer unbound current execution.

## Scope

Seven intended files, eight working commits, 1,205 additions and no deletions. Squash merge retains one coherent read-only warehouse increment. The branch is zero commits behind `main`.

## Exact-head validation

GitHub Actions run **415** (`33991260377`) passed on final head `211fc1308ffea48126f4d3585ee376304da7ebcc`:

- Security guardrails passed.
- Ruff passed.
- mypy passed across **149 source files**.
- **939 tests passed** in quality and **939 passed again** in readiness.
- Dependency integrity and the standard pipeline replay passed.
- PostgreSQL 16 initialization and contracts passed, including the new dependent view layer.
- Kubernetes rendering and Terraform format/init/validate passed without apply.
- No submitted reviews or unresolved review threads exist.

The byte-pinned Actions workflow was deliberately left unchanged. The deeper transaction-scoped fixture remains directly executable and is statically validated by the normal Python suite.

## Safety boundary

The change adds read-only serving views. No network request, webhook delivery, provider call, delivery-attempt write outside the fixture, outbox mutation, acknowledgement, deployment or `terraform apply` occurred. No endpoint value, URL, credential, payload body, response body, environment value or DSN is exposed.

Validated and ready for squash merge.