### PR TITLE
Add deterministic managed notification worker plans

### DIFF
--- a/config/notification_workers.yaml
+++ b/config/notification_workers.yaml
@@ -1,0 +1,27 @@
+model_version: portfolio-risk-notification-worker-config-v1
+workers:
+  risk-operations-managed:
+    enabled: false
+    destination_id: risk-operations-webhook
+    execution_kinds:
+      - initial
+      - retry
+    schedule:
+      mode: fixed_interval
+      interval_seconds: 300
+      jitter_seconds: 30
+      timezone: UTC
+    limits:
+      max_initial_events: 25
+      max_retry_events: 25
+      max_concurrency: 1
+      execution_timeout_seconds: 120
+    readiness:
+      required_status: allowed
+      max_age_seconds: 300
+    suspension:
+      block_on_readiness_failure: true
+      block_on_persistence_ambiguity: true
+      block_on_expired_review: true
+      max_consecutive_failures: 3
+      cooldown_seconds: 900

--- a/docs/managed-notification-worker-plan.md
+++ b/docs/managed-notification-worker-plan.md
@@ -1,0 +1,150 @@
+# Managed Notification Worker Plan
+
+Primary arc42 block: `orchestration`.
+
+## Goal
+
+Describe one bounded managed notification worker without activating a scheduler
+or executing notification delivery:
+
+```text
+reviewed worker configuration
+  + delivery and retry policy bounds
+  + reviewed destination contract
+  + deterministic planning instant
+  -> disabled | blocked | would_schedule
+  -> exact future schedule slot
+  -> no scheduler or delivery side effect
+```
+
+The configuration model is:
+
+```text
+portfolio-risk-notification-worker-config-v1
+```
+
+The plan model is:
+
+```text
+portfolio-risk-notification-worker-plan-v1
+```
+
+## Committed default
+
+The committed worker is intentionally disabled:
+
+```yaml
+workers:
+  risk-operations-managed:
+    enabled: false
+```
+
+The committed webhook delivery, retry execution and notification destination
+are also disabled. A default plan therefore reports every applicable blocking
+reason rather than implying operational activation.
+
+## Bounded worker contract
+
+Each worker binds:
+
+- one reviewed destination ID;
+- a sorted, unique subset of `initial` and `retry` work;
+- a fixed UTC interval and bounded deterministic jitter;
+- initial and retry batch limits no greater than their delivery policies;
+- one shared concurrency slot;
+- a bounded execution timeout;
+- current readiness status `allowed` with evidence no older than five minutes;
+- mandatory suspension on readiness failure;
+- mandatory suspension on unresolved persistence ambiguity;
+- mandatory suspension when destination review expires; and
+- a bounded repeated-failure threshold and cooldown.
+
+`max_concurrency` is exactly one because initial and retry execution share the
+repository-wide PostgreSQL notification-delivery advisory lock. The plan
+retains the reviewed lock model, scope and key fingerprint but does not acquire
+the lock.
+
+## Deterministic scheduling
+
+The next slot is the first fixed-interval boundary strictly after `planned_at`.
+A deterministic jitter value is derived from the worker fingerprint and slot
+boundary. The same configuration and planning instant therefore produce the
+same:
+
+```text
+worker fingerprint
+schedule boundary
+jitter
+scheduled_for
+plan ID
+```
+
+There is no random runtime state and no hidden scheduler clock.
+
+## Plan states
+
+The planner emits exactly one state:
+
+```text
+worker disabled                         -> disabled
+enabled worker with governed blockers  -> blocked
+enabled worker with no blockers        -> would_schedule
+```
+
+Blocking reasons have fixed order:
+
+```text
+worker_disabled
+delivery_disabled
+retry_execution_disabled
+destination_not_active
+endpoint_environment_mismatch
+```
+
+A disabled or blocked plan has `activation_action = none`. A valid enabled plan
+has `activation_action = would_create`; this is descriptive evidence only and
+does not create a cloud or local schedule.
+
+## Execution and suspension evidence
+
+The plan lists one bounded work item for each configured execution kind. The
+entrypoints are descriptive module identities; the planner never imports or
+invokes their execution functions.
+
+Every future worker cycle must require current retained readiness and refresh it
+under the shared delivery lock before the first request. The plan also declares
+these suspension conditions:
+
+```text
+expired_review
+persistence_ambiguity
+readiness_failure
+repeated_delivery_failure
+```
+
+P4e1 does not implement the activation, suspension or resume authority. Those
+operations belong to a separate append-only governance increment.
+
+## Operator command
+
+```bash
+.venv/bin/python \
+  -m src.orchestration.plan_notification_worker \
+  --worker-id risk-operations-managed \
+  --planned-at 2026-09-05T20:00:00Z \
+  --summary-json .demo/notification-worker-plan.json
+```
+
+There is no `--execute` option.
+
+## Safety boundary
+
+The planner reads only regular, non-symbolic-link configuration files bounded
+to 1 MB. It does not read PostgreSQL evidence, resolve an endpoint value, open a
+socket, perform DNS, send a webhook, write a delivery attempt, mutate the
+outbox, acknowledge a breach, activate local or cloud scheduling, deploy
+infrastructure or run `terraform apply`.
+
+The credential-free plan contains only environment-variable names and reviewed
+fingerprints. It does not contain an endpoint value, complete URL, credential,
+payload body, response body, environment value or PostgreSQL DSN.

--- a/src/orchestration/plan_notification_worker.py
+++ b/src/orchestration/plan_notification_worker.py
@@ -1,0 +1,821 @@
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from src.common.exceptions import StorageError, ValidationError
+from src.orchestration.portfolio_risk_notification_delivery_lock import (
+    LOCK_KEY_FINGERPRINT,
+    LOCK_MODEL_VERSION,
+    LOCK_SCOPE,
+)
+from src.orchestration.portfolio_risk_notification_destination_contract import (
+    NotificationDestination,
+    evaluate_destination_activation,
+    load_notification_destinations,
+)
+from src.orchestration.portfolio_risk_notification_retry_execution_policy import (
+    RetryExecutionPolicy,
+    aware_utc,
+    bounded_integer,
+    exact_mapping,
+    load_retry_execution_contract,
+    safe_segment,
+)
+from src.orchestration.plan_portfolio_risk_notification_retries import (
+    RetryPlanningPolicy,
+)
+from src.orchestration.deliver_portfolio_risk_notifications import (
+    WebhookDeliveryConfig,
+)
+
+CONFIG_MODEL_VERSION = "portfolio-risk-notification-worker-config-v1"
+PLAN_MODEL_VERSION = "portfolio-risk-notification-worker-plan-v1"
+MAX_CONFIG_BYTES = 1_048_576
+MAX_WORKERS = 20
+MAX_INTERVAL_SECONDS = 86_400
+MAX_JITTER_SECONDS = 3_600
+MAX_EXECUTION_TIMEOUT_SECONDS = 3_600
+MAX_READINESS_AGE_SECONDS = 300
+MAX_CONSECUTIVE_FAILURES = 20
+MAX_COOLDOWN_SECONDS = 86_400
+EXECUTION_KINDS = frozenset({"initial", "retry"})
+BLOCKING_REASON_ORDER = (
+    "worker_disabled",
+    "delivery_disabled",
+    "retry_execution_disabled",
+    "destination_not_active",
+    "endpoint_environment_mismatch",
+)
+INITIAL_ENTRYPOINT = (
+    "src.orchestration.deliver_portfolio_risk_notifications"
+)
+RETRY_ENTRYPOINT = (
+    "src.orchestration.run_recorded_readiness_enforced_"
+    "portfolio_risk_notification_retries"
+)
+
+
+@dataclass(frozen=True, slots=True)
+class WorkerSchedule:
+    mode: str
+    interval_seconds: int
+    jitter_seconds: int
+    timezone_name: str
+
+
+@dataclass(frozen=True, slots=True)
+class WorkerLimits:
+    max_initial_events: int
+    max_retry_events: int
+    max_concurrency: int
+    execution_timeout_seconds: int
+
+
+@dataclass(frozen=True, slots=True)
+class WorkerReadiness:
+    required_status: str
+    max_age_seconds: int
+
+
+@dataclass(frozen=True, slots=True)
+class WorkerSuspension:
+    block_on_readiness_failure: bool
+    block_on_persistence_ambiguity: bool
+    block_on_expired_review: bool
+    max_consecutive_failures: int
+    cooldown_seconds: int
+
+
+@dataclass(frozen=True, slots=True)
+class NotificationWorker:
+    worker_id: str
+    enabled: bool
+    destination_id: str
+    execution_kinds: tuple[str, ...]
+    schedule: WorkerSchedule
+    limits: WorkerLimits
+    readiness: WorkerReadiness
+    suspension: WorkerSuspension
+
+    @property
+    def fingerprint(self) -> str:
+        payload = _worker_document(self)
+        digest = hashlib.sha256(_canonical_bytes(payload, "worker configuration")).hexdigest()
+        return f"{CONFIG_MODEL_VERSION}-worker-{digest[:24]}"
+
+
+def _canonical_bytes(value: Mapping[str, Any], label: str) -> bytes:
+    try:
+        return json.dumps(
+            value,
+            sort_keys=True,
+            separators=(",", ":"),
+            allow_nan=False,
+        ).encode("utf-8")
+    except (TypeError, ValueError):
+        raise ValidationError(f"{label} is not canonical JSON") from None
+
+
+def _read_yaml(path: Path, label: str) -> Mapping[str, Any]:
+    if path.is_symlink():
+        raise ValidationError(f"{label} must not be a symbolic link")
+    if not path.is_file():
+        raise ValidationError(f"{label} must be a regular file")
+    try:
+        if path.stat().st_size > MAX_CONFIG_BYTES:
+            raise ValidationError(f"{label} exceeds 1 MB")
+        payload = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except ValidationError:
+        raise
+    except (OSError, UnicodeError, yaml.YAMLError):
+        raise ValidationError(f"{label} could not be loaded") from None
+    if not isinstance(payload, Mapping):
+        raise ValidationError(f"{label} must be a mapping")
+    return payload
+
+
+def _require_regular_file(path: Path, label: str) -> None:
+    if path.is_symlink():
+        raise ValidationError(f"{label} must not be a symbolic link")
+    if not path.is_file():
+        raise ValidationError(f"{label} must be a regular file")
+    try:
+        size = path.stat().st_size
+    except OSError:
+        raise ValidationError(f"{label} could not be inspected") from None
+    if size > MAX_CONFIG_BYTES:
+        raise ValidationError(f"{label} exceeds 1 MB")
+
+
+def _boolean(value: Any, label: str) -> bool:
+    if type(value) is not bool:
+        raise ValidationError(f"{label} must be boolean")
+    return bool(value)
+
+
+def _execution_kinds(value: Any) -> tuple[str, ...]:
+    if not isinstance(value, list):
+        raise ValidationError("execution_kinds must be an array")
+    parsed = tuple(safe_segment(item, "execution_kinds item") for item in value)
+    if any(item is None for item in parsed):
+        raise ValidationError("execution_kinds contains an invalid value")
+    selected = tuple(str(item) for item in parsed)
+    if not selected or not set(selected).issubset(EXECUTION_KINDS):
+        raise ValidationError("execution_kinds contains an unsupported kind")
+    if list(selected) != sorted(selected) or len(selected) != len(set(selected)):
+        raise ValidationError("execution_kinds must be sorted and unique")
+    return selected
+
+
+def _parse_schedule(value: Any) -> WorkerSchedule:
+    schedule = exact_mapping(
+        value,
+        frozenset({"mode", "interval_seconds", "jitter_seconds", "timezone"}),
+        "worker schedule",
+    )
+    if schedule["mode"] != "fixed_interval":
+        raise ValidationError("worker schedule mode must be fixed_interval")
+    if schedule["timezone"] != "UTC":
+        raise ValidationError("worker schedule timezone must be UTC")
+    interval = bounded_integer(
+        schedule["interval_seconds"],
+        "interval_seconds",
+        minimum=60,
+        maximum=MAX_INTERVAL_SECONDS,
+    )
+    jitter = bounded_integer(
+        schedule["jitter_seconds"],
+        "jitter_seconds",
+        minimum=0,
+        maximum=MAX_JITTER_SECONDS,
+    )
+    if jitter > interval // 2:
+        raise ValidationError("jitter_seconds may not exceed half the interval")
+    return WorkerSchedule(
+        mode="fixed_interval",
+        interval_seconds=interval,
+        jitter_seconds=jitter,
+        timezone_name="UTC",
+    )
+
+
+def _parse_limits(value: Any) -> WorkerLimits:
+    limits = exact_mapping(
+        value,
+        frozenset(
+            {
+                "max_initial_events",
+                "max_retry_events",
+                "max_concurrency",
+                "execution_timeout_seconds",
+            }
+        ),
+        "worker limits",
+    )
+    max_concurrency = bounded_integer(
+        limits["max_concurrency"],
+        "max_concurrency",
+        minimum=1,
+        maximum=1,
+    )
+    return WorkerLimits(
+        max_initial_events=bounded_integer(
+            limits["max_initial_events"],
+            "max_initial_events",
+            minimum=1,
+            maximum=100,
+        ),
+        max_retry_events=bounded_integer(
+            limits["max_retry_events"],
+            "max_retry_events",
+            minimum=1,
+            maximum=100,
+        ),
+        max_concurrency=max_concurrency,
+        execution_timeout_seconds=bounded_integer(
+            limits["execution_timeout_seconds"],
+            "execution_timeout_seconds",
+            minimum=1,
+            maximum=MAX_EXECUTION_TIMEOUT_SECONDS,
+        ),
+    )
+
+
+def _parse_readiness(value: Any) -> WorkerReadiness:
+    readiness = exact_mapping(
+        value,
+        frozenset({"required_status", "max_age_seconds"}),
+        "worker readiness",
+    )
+    if readiness["required_status"] != "allowed":
+        raise ValidationError("worker readiness required_status must be allowed")
+    return WorkerReadiness(
+        required_status="allowed",
+        max_age_seconds=bounded_integer(
+            readiness["max_age_seconds"],
+            "readiness max_age_seconds",
+            minimum=1,
+            maximum=MAX_READINESS_AGE_SECONDS,
+        ),
+    )
+
+
+def _parse_suspension(value: Any) -> WorkerSuspension:
+    suspension = exact_mapping(
+        value,
+        frozenset(
+            {
+                "block_on_readiness_failure",
+                "block_on_persistence_ambiguity",
+                "block_on_expired_review",
+                "max_consecutive_failures",
+                "cooldown_seconds",
+            }
+        ),
+        "worker suspension",
+    )
+    readiness = _boolean(
+        suspension["block_on_readiness_failure"],
+        "block_on_readiness_failure",
+    )
+    ambiguity = _boolean(
+        suspension["block_on_persistence_ambiguity"],
+        "block_on_persistence_ambiguity",
+    )
+    expired = _boolean(
+        suspension["block_on_expired_review"],
+        "block_on_expired_review",
+    )
+    if not readiness or not ambiguity or not expired:
+        raise ValidationError(
+            "worker suspension must block on readiness, ambiguity, and expired review"
+        )
+    return WorkerSuspension(
+        block_on_readiness_failure=True,
+        block_on_persistence_ambiguity=True,
+        block_on_expired_review=True,
+        max_consecutive_failures=bounded_integer(
+            suspension["max_consecutive_failures"],
+            "max_consecutive_failures",
+            minimum=1,
+            maximum=MAX_CONSECUTIVE_FAILURES,
+        ),
+        cooldown_seconds=bounded_integer(
+            suspension["cooldown_seconds"],
+            "cooldown_seconds",
+            minimum=0,
+            maximum=MAX_COOLDOWN_SECONDS,
+        ),
+    )
+
+
+def _parse_worker(worker_id: str, value: Any) -> NotificationWorker:
+    worker = exact_mapping(
+        value,
+        frozenset(
+            {
+                "enabled",
+                "destination_id",
+                "execution_kinds",
+                "schedule",
+                "limits",
+                "readiness",
+                "suspension",
+            }
+        ),
+        f"worker {worker_id}",
+    )
+    selected_worker_id = safe_segment(worker_id, "worker_id")
+    destination_id = safe_segment(worker["destination_id"], "destination_id")
+    assert selected_worker_id is not None and destination_id is not None
+    return NotificationWorker(
+        worker_id=selected_worker_id,
+        enabled=_boolean(worker["enabled"], "worker enabled"),
+        destination_id=destination_id,
+        execution_kinds=_execution_kinds(worker["execution_kinds"]),
+        schedule=_parse_schedule(worker["schedule"]),
+        limits=_parse_limits(worker["limits"]),
+        readiness=_parse_readiness(worker["readiness"]),
+        suspension=_parse_suspension(worker["suspension"]),
+    )
+
+
+def load_notification_workers(path: Path) -> dict[str, NotificationWorker]:
+    payload = _read_yaml(path, "notification worker configuration")
+    root = exact_mapping(
+        payload,
+        frozenset({"model_version", "workers"}),
+        "notification worker configuration",
+    )
+    if root["model_version"] != CONFIG_MODEL_VERSION:
+        raise ValidationError("notification worker model_version is unsupported")
+    workers = root["workers"]
+    if not isinstance(workers, Mapping) or not workers:
+        raise ValidationError("workers must be a non-empty mapping")
+    if len(workers) > MAX_WORKERS:
+        raise ValidationError("worker count exceeds the reviewed maximum")
+    parsed = {
+        str(worker_id): _parse_worker(str(worker_id), value)
+        for worker_id, value in workers.items()
+    }
+    if list(parsed) != sorted(parsed):
+        raise ValidationError("worker IDs must be sorted")
+    return parsed
+
+
+def _worker_document(worker: NotificationWorker) -> dict[str, Any]:
+    return {
+        "destination_id": worker.destination_id,
+        "enabled": worker.enabled,
+        "execution_kinds": list(worker.execution_kinds),
+        "limits": {
+            "execution_timeout_seconds": worker.limits.execution_timeout_seconds,
+            "max_concurrency": worker.limits.max_concurrency,
+            "max_initial_events": worker.limits.max_initial_events,
+            "max_retry_events": worker.limits.max_retry_events,
+        },
+        "model_version": CONFIG_MODEL_VERSION,
+        "readiness": {
+            "max_age_seconds": worker.readiness.max_age_seconds,
+            "required_status": worker.readiness.required_status,
+        },
+        "schedule": {
+            "interval_seconds": worker.schedule.interval_seconds,
+            "jitter_seconds": worker.schedule.jitter_seconds,
+            "mode": worker.schedule.mode,
+            "timezone": worker.schedule.timezone_name,
+        },
+        "suspension": {
+            "block_on_expired_review": (
+                worker.suspension.block_on_expired_review
+            ),
+            "block_on_persistence_ambiguity": (
+                worker.suspension.block_on_persistence_ambiguity
+            ),
+            "block_on_readiness_failure": (
+                worker.suspension.block_on_readiness_failure
+            ),
+            "cooldown_seconds": worker.suspension.cooldown_seconds,
+            "max_consecutive_failures": (
+                worker.suspension.max_consecutive_failures
+            ),
+        },
+        "worker_id": worker.worker_id,
+    }
+
+
+def _validate_limits_against_delivery(
+    worker: NotificationWorker,
+    delivery: WebhookDeliveryConfig,
+    retry_policy: RetryPlanningPolicy,
+    retry_execution: RetryExecutionPolicy,
+) -> None:
+    if worker.limits.max_initial_events > delivery.max_batch_events:
+        raise ValidationError("worker max_initial_events exceeds webhook batch limit")
+    if worker.limits.max_retry_events > delivery.max_batch_events:
+        raise ValidationError("worker max_retry_events exceeds webhook batch limit")
+    if worker.limits.max_retry_events > retry_policy.max_plan_events:
+        raise ValidationError("worker max_retry_events exceeds retry planning limit")
+    if worker.limits.max_retry_events > retry_execution.max_events:
+        raise ValidationError("worker max_retry_events exceeds retry execution limit")
+    if worker.limits.execution_timeout_seconds < delivery.timeout_seconds:
+        raise ValidationError(
+            "worker execution timeout is shorter than webhook request timeout"
+        )
+
+
+def _next_schedule(
+    worker: NotificationWorker,
+    planned_at: datetime,
+) -> tuple[datetime, int, int]:
+    epoch = int(planned_at.timestamp())
+    interval = worker.schedule.interval_seconds
+    boundary_epoch = ((epoch // interval) + 1) * interval
+    seed = hashlib.sha256(
+        f"{worker.fingerprint}:{boundary_epoch}".encode("utf-8")
+    ).digest()
+    jitter_limit = worker.schedule.jitter_seconds
+    jitter = 0 if jitter_limit == 0 else int.from_bytes(seed[:8], "big") % (
+        jitter_limit + 1
+    )
+    scheduled_for = datetime.fromtimestamp(
+        boundary_epoch + jitter,
+        tz=timezone.utc,
+    )
+    return scheduled_for, boundary_epoch, jitter
+
+
+def _work_items(worker: NotificationWorker) -> list[dict[str, Any]]:
+    items: list[dict[str, Any]] = []
+    if "initial" in worker.execution_kinds:
+        items.append(
+            {
+                "entrypoint": INITIAL_ENTRYPOINT,
+                "execution_kind": "initial",
+                "max_events": worker.limits.max_initial_events,
+            }
+        )
+    if "retry" in worker.execution_kinds:
+        items.append(
+            {
+                "entrypoint": RETRY_ENTRYPOINT,
+                "execution_kind": "retry",
+                "max_events": worker.limits.max_retry_events,
+            }
+        )
+    return items
+
+
+def _blocking_reasons(
+    *,
+    worker: NotificationWorker,
+    delivery: WebhookDeliveryConfig,
+    retry_execution: RetryExecutionPolicy,
+    activation_status: str,
+    destination: NotificationDestination,
+) -> list[str]:
+    active = {
+        "worker_disabled": not worker.enabled,
+        "delivery_disabled": not delivery.enabled,
+        "retry_execution_disabled": (
+            "retry" in worker.execution_kinds and not retry_execution.enabled
+        ),
+        "destination_not_active": activation_status != "active",
+        "endpoint_environment_mismatch": (
+            destination.endpoint_env != delivery.endpoint_env
+        ),
+    }
+    return [reason for reason in BLOCKING_REASON_ORDER if active[reason]]
+
+
+def _plan_id(identity: Mapping[str, Any]) -> str:
+    digest = hashlib.sha256(
+        _canonical_bytes(identity, "notification worker plan")
+    ).hexdigest()[:24]
+    return f"{PLAN_MODEL_VERSION}-plan-{digest}"
+
+
+def build_notification_worker_plan(
+    *,
+    worker: NotificationWorker,
+    delivery: WebhookDeliveryConfig,
+    retry_policy: RetryPlanningPolicy,
+    retry_execution: RetryExecutionPolicy,
+    destination: NotificationDestination,
+    planned_at: datetime | str,
+) -> dict[str, Any]:
+    planned = aware_utc(planned_at, "planned_at")
+    if destination.destination_id != worker.destination_id:
+        raise ValidationError("worker and destination identities differ")
+    _validate_limits_against_delivery(
+        worker,
+        delivery,
+        retry_policy,
+        retry_execution,
+    )
+    activation = evaluate_destination_activation(
+        destination,
+        evaluated_at=planned,
+    )
+    activation_status = activation["activation"]["status"]
+    scheduled_for, boundary_epoch, deterministic_jitter = _next_schedule(
+        worker,
+        planned,
+    )
+    blockers = _blocking_reasons(
+        worker=worker,
+        delivery=delivery,
+        retry_execution=retry_execution,
+        activation_status=str(activation_status),
+        destination=destination,
+    )
+    if not worker.enabled:
+        status = "disabled"
+    elif blockers:
+        status = "blocked"
+    else:
+        status = "would_schedule"
+    identity = {
+        "blocking_reasons": blockers,
+        "concurrency_control": {
+            "key_fingerprint": LOCK_KEY_FINGERPRINT,
+            "lock_acquired": False,
+            "max_concurrency": worker.limits.max_concurrency,
+            "model_version": LOCK_MODEL_VERSION,
+            "scope": LOCK_SCOPE,
+        },
+        "delivery": {
+            "delivery_fingerprint": delivery.fingerprint,
+            "max_batch_events": delivery.max_batch_events,
+            "retry_execution_enabled": retry_execution.enabled,
+            "retry_execution_policy_fingerprint": retry_execution.fingerprint,
+            "retry_planning_policy_fingerprint": retry_policy.fingerprint,
+            "webhook_enabled": delivery.enabled,
+        },
+        "destination": {
+            "activation_status": activation_status,
+            "allowed_event_types": list(destination.allowed_event_types),
+            "destination_id": destination.destination_id,
+            "endpoint_environment_variable": destination.endpoint_env,
+            "endpoint_value_recorded": False,
+            "fingerprint": destination.fingerprint,
+        },
+        "execution": {
+            "execution_timeout_seconds": worker.limits.execution_timeout_seconds,
+            "work_items": _work_items(worker),
+        },
+        "model_version": PLAN_MODEL_VERSION,
+        "planned_at": planned.isoformat(),
+        "readiness": {
+            "max_age_seconds": worker.readiness.max_age_seconds,
+            "refresh_under_shared_lock": True,
+            "required_status": worker.readiness.required_status,
+            "source_view": (
+                "risk_platform.current_notification_execution_readiness_review"
+            ),
+        },
+        "schedule": {
+            "activation_action": (
+                "would_create" if status == "would_schedule" else "none"
+            ),
+            "boundary_epoch": boundary_epoch,
+            "deterministic_jitter_seconds": deterministic_jitter,
+            "interval_seconds": worker.schedule.interval_seconds,
+            "jitter_seconds": worker.schedule.jitter_seconds,
+            "mode": worker.schedule.mode,
+            "scheduled_for": scheduled_for.isoformat(),
+            "timezone": worker.schedule.timezone_name,
+        },
+        "side_effects": {
+            "acknowledgement_mutated": False,
+            "cloud_schedule_activated": False,
+            "database_read_performed": False,
+            "delivery_attempt_written": False,
+            "external_request_performed": False,
+            "infrastructure_deployed": False,
+            "outbox_mutated": False,
+            "terraform_apply_performed": False,
+        },
+        "status": status,
+        "suspension": {
+            "conditions": [
+                "expired_review",
+                "persistence_ambiguity",
+                "readiness_failure",
+                "repeated_delivery_failure",
+            ],
+            "cooldown_seconds": worker.suspension.cooldown_seconds,
+            "max_consecutive_failures": (
+                worker.suspension.max_consecutive_failures
+            ),
+        },
+        "worker": {
+            "enabled": worker.enabled,
+            "fingerprint": worker.fingerprint,
+            "worker_id": worker.worker_id,
+        },
+    }
+    return {"plan_id": _plan_id(identity), **identity}
+
+
+def plan_notification_worker(
+    *,
+    worker_id: str,
+    planned_at: datetime | str,
+    worker_config_path: Path = Path("config/notification_workers.yaml"),
+    delivery_config_path: Path = Path("config/notification_delivery.yaml"),
+    destination_config_path: Path = Path("config/notification_destinations.yaml"),
+) -> dict[str, Any]:
+    selected_worker_id = safe_segment(worker_id, "worker_id")
+    assert selected_worker_id is not None
+    workers = load_notification_workers(worker_config_path)
+    worker = workers.get(selected_worker_id)
+    if worker is None:
+        raise ValidationError("notification worker does not exist")
+    _require_regular_file(
+        delivery_config_path,
+        "notification delivery configuration",
+    )
+    _require_regular_file(
+        destination_config_path,
+        "notification destination configuration",
+    )
+    delivery, retry_policy, retry_execution = load_retry_execution_contract(
+        delivery_config_path
+    )
+    destinations = load_notification_destinations(destination_config_path)
+    destination = destinations.get(worker.destination_id)
+    if destination is None:
+        raise ValidationError("notification worker destination does not exist")
+    return build_notification_worker_plan(
+        worker=worker,
+        delivery=delivery,
+        retry_policy=retry_policy,
+        retry_execution=retry_execution,
+        destination=destination,
+        planned_at=planned_at,
+    )
+
+
+def validate_notification_worker_plan(plan: Mapping[str, Any]) -> dict[str, Any]:
+    if not isinstance(plan, Mapping):
+        raise ValidationError("notification worker plan must be a mapping")
+    expected = {
+        "plan_id",
+        "blocking_reasons",
+        "concurrency_control",
+        "delivery",
+        "destination",
+        "execution",
+        "model_version",
+        "planned_at",
+        "readiness",
+        "schedule",
+        "side_effects",
+        "status",
+        "suspension",
+        "worker",
+    }
+    if set(plan) != expected:
+        raise ValidationError("notification worker plan fields are invalid")
+    if plan["model_version"] != PLAN_MODEL_VERSION:
+        raise ValidationError("notification worker plan model_version is unsupported")
+    if plan["status"] not in {"disabled", "blocked", "would_schedule"}:
+        raise ValidationError("notification worker plan status is invalid")
+    reasons = plan["blocking_reasons"]
+    if not isinstance(reasons, list):
+        raise ValidationError("blocking_reasons must be an array")
+    if reasons != [reason for reason in BLOCKING_REASON_ORDER if reason in reasons]:
+        raise ValidationError("blocking_reasons are not canonical")
+    if len(reasons) != len(set(reasons)):
+        raise ValidationError("blocking_reasons contain duplicates")
+    side_effects = exact_mapping(
+        plan["side_effects"],
+        frozenset(
+            {
+                "acknowledgement_mutated",
+                "cloud_schedule_activated",
+                "database_read_performed",
+                "delivery_attempt_written",
+                "external_request_performed",
+                "infrastructure_deployed",
+                "outbox_mutated",
+                "terraform_apply_performed",
+            }
+        ),
+        "worker plan side effects",
+    )
+    if any(value is not False for value in side_effects.values()):
+        raise ValidationError("notification worker plan reports a side effect")
+    planned = aware_utc(plan["planned_at"], "planned_at")
+    schedule = plan["schedule"]
+    if not isinstance(schedule, Mapping):
+        raise ValidationError("worker plan schedule must be a mapping")
+    scheduled_for = aware_utc(schedule.get("scheduled_for"), "scheduled_for")
+    if scheduled_for <= planned:
+        raise ValidationError("scheduled_for must follow planned_at")
+    worker = plan["worker"]
+    if not isinstance(worker, Mapping):
+        raise ValidationError("worker plan identity must be a mapping")
+    enabled = worker.get("enabled")
+    if type(enabled) is not bool:
+        raise ValidationError("worker plan enabled state is invalid")
+    if plan["status"] == "disabled" and enabled is not False:
+        raise ValidationError("disabled plan requires a disabled worker")
+    if plan["status"] == "would_schedule" and reasons:
+        raise ValidationError("would_schedule plan must have no blockers")
+    if plan["status"] == "blocked" and (not reasons or enabled is not True):
+        raise ValidationError("blocked plan must have an enabled worker and blockers")
+    identity = dict(plan)
+    supplied_plan_id = identity.pop("plan_id")
+    if supplied_plan_id != _plan_id(identity):
+        raise ValidationError("notification worker plan_id does not match content")
+    return dict(plan)
+
+
+def _timestamp(value: str) -> datetime:
+    try:
+        return aware_utc(value, "planned_at")
+    except ValidationError as exc:
+        raise argparse.ArgumentTypeError(str(exc)) from None
+
+
+def _write_summary(path: Path, summary: Mapping[str, Any]) -> None:
+    if path.is_symlink():
+        raise StorageError("notification worker summary must not be a symbolic link")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_suffix(path.suffix + ".tmp")
+    try:
+        temporary.write_text(
+            json.dumps(summary, indent=2, sort_keys=True, allow_nan=False) + "\n",
+            encoding="utf-8",
+        )
+        temporary.replace(path)
+    except (OSError, TypeError, ValueError):
+        temporary.unlink(missing_ok=True)
+        raise StorageError("unable to write notification worker plan") from None
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Build a deterministic plan for a managed notification worker "
+            "without activating a scheduler or executing delivery."
+        )
+    )
+    parser.add_argument("--worker-id", required=True)
+    parser.add_argument("--planned-at", required=True, type=_timestamp)
+    parser.add_argument(
+        "--config",
+        type=Path,
+        default=Path("config/notification_workers.yaml"),
+    )
+    parser.add_argument(
+        "--delivery-config",
+        type=Path,
+        default=Path("config/notification_delivery.yaml"),
+    )
+    parser.add_argument(
+        "--destination-config",
+        type=Path,
+        default=Path("config/notification_destinations.yaml"),
+    )
+    parser.add_argument("--summary-json", type=Path)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    try:
+        plan = plan_notification_worker(
+            worker_id=args.worker_id,
+            planned_at=args.planned_at,
+            worker_config_path=args.config,
+            delivery_config_path=args.delivery_config,
+            destination_config_path=args.destination_config,
+        )
+        validate_notification_worker_plan(plan)
+        if args.summary_json is not None:
+            _write_summary(args.summary_json, plan)
+    except ValidationError as exc:
+        print(f"Notification worker plan rejected: {exc}", file=sys.stderr)
+        return 1
+    except StorageError as exc:
+        print(f"Notification worker planning failed: {exc}", file=sys.stderr)
+        return 1
+    print(json.dumps(plan, sort_keys=True, allow_nan=False))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/test_notification_worker_plan.py
+++ b/tests/unit/test_notification_worker_plan.py
@@ -1,0 +1,407 @@
+from __future__ import annotations
+
+import copy
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+from src.common.exceptions import ValidationError
+from src.orchestration.plan_notification_worker import (
+    PLAN_MODEL_VERSION,
+    load_notification_workers,
+    main,
+    plan_notification_worker,
+    validate_notification_worker_plan,
+)
+
+BASE_TIME = datetime(2026, 9, 5, 20, 0, tzinfo=timezone.utc)
+WORKER_ID = "risk-operations-managed"
+
+
+def _worker_payload(*, enabled: bool = False) -> dict[str, Any]:
+    return {
+        "model_version": "portfolio-risk-notification-worker-config-v1",
+        "workers": {
+            WORKER_ID: {
+                "enabled": enabled,
+                "destination_id": "risk-operations-webhook",
+                "execution_kinds": ["initial", "retry"],
+                "schedule": {
+                    "mode": "fixed_interval",
+                    "interval_seconds": 300,
+                    "jitter_seconds": 30,
+                    "timezone": "UTC",
+                },
+                "limits": {
+                    "max_initial_events": 25,
+                    "max_retry_events": 25,
+                    "max_concurrency": 1,
+                    "execution_timeout_seconds": 120,
+                },
+                "readiness": {
+                    "required_status": "allowed",
+                    "max_age_seconds": 300,
+                },
+                "suspension": {
+                    "block_on_readiness_failure": True,
+                    "block_on_persistence_ambiguity": True,
+                    "block_on_expired_review": True,
+                    "max_consecutive_failures": 3,
+                    "cooldown_seconds": 900,
+                },
+            }
+        },
+    }
+
+
+def _delivery_payload(*, enabled: bool, retry_enabled: bool) -> dict[str, Any]:
+    return {
+        "delivery": {
+            "webhook": {
+                "enabled": enabled,
+                "endpoint_env": "RISK_NOTIFICATION_WEBHOOK_URL",
+                "timeout_seconds": 5,
+                "max_batch_events": 25,
+                "max_attempts_per_event": 3,
+                "initial_backoff_seconds": 1,
+            },
+            "retry_planning": {
+                "max_candidate_rows": 500,
+                "max_plan_events": 25,
+                "max_event_age_seconds": 604800,
+                "max_backoff_seconds": 3600,
+                "retryable_http_statuses": [408, 425, 429, 500, 502, 503, 504],
+                "retryable_error_codes": ["network_error"],
+            },
+            "retry_execution": {
+                "enabled": retry_enabled,
+                "max_plan_age_seconds": 3600,
+                "max_events": 25,
+            },
+        }
+    }
+
+
+def _destination_payload(
+    *,
+    enabled: bool,
+    endpoint_env: str = "RISK_NOTIFICATION_WEBHOOK_URL",
+) -> dict[str, Any]:
+    activation: dict[str, Any]
+    if enabled:
+        activation = {
+            "enabled": True,
+            "change_request_id": "CHG-WORKER-001",
+            "reviewed_by": ["risk-control-reviewer"],
+            "reviewed_at": "2026-09-01T00:00:00+00:00",
+            "review_expires_at": "2026-10-01T00:00:00+00:00",
+        }
+    else:
+        activation = {
+            "enabled": False,
+            "change_request_id": None,
+            "reviewed_by": [],
+            "reviewed_at": None,
+            "review_expires_at": None,
+        }
+    return {
+        "model_version": "portfolio-risk-notification-destination-v1",
+        "destinations": {
+            "risk-operations-webhook": {
+                "channel": "webhook",
+                "endpoint_env": endpoint_env,
+                "owner": {
+                    "team": "risk-operations",
+                    "contact": "risk-operations-oncall",
+                },
+                "purpose": "portfolio-risk-breach-lifecycle",
+                "recipient_scope": "risk-operations",
+                "data_classification": "internal",
+                "allowed_event_types": [
+                    "breach_escalated",
+                    "breach_opened",
+                    "breach_resolved",
+                ],
+                "activation": activation,
+            }
+        },
+    }
+
+
+def _write_yaml(path: Path, payload: dict[str, Any]) -> Path:
+    path.write_text(
+        yaml.safe_dump(payload, sort_keys=False),
+        encoding="utf-8",
+    )
+    return path
+
+
+def _paths(
+    tmp_path: Path,
+    *,
+    worker_enabled: bool,
+    delivery_enabled: bool,
+    retry_enabled: bool,
+    destination_enabled: bool,
+    endpoint_env: str = "RISK_NOTIFICATION_WEBHOOK_URL",
+) -> tuple[Path, Path, Path]:
+    worker_path = _write_yaml(
+        tmp_path / "workers.yaml",
+        _worker_payload(enabled=worker_enabled),
+    )
+    delivery_path = _write_yaml(
+        tmp_path / "delivery.yaml",
+        _delivery_payload(
+            enabled=delivery_enabled,
+            retry_enabled=retry_enabled,
+        ),
+    )
+    destination_path = _write_yaml(
+        tmp_path / "destinations.yaml",
+        _destination_payload(
+            enabled=destination_enabled,
+            endpoint_env=endpoint_env,
+        ),
+    )
+    return worker_path, delivery_path, destination_path
+
+
+def _plan(
+    tmp_path: Path,
+    *,
+    worker_enabled: bool = True,
+    delivery_enabled: bool = True,
+    retry_enabled: bool = True,
+    destination_enabled: bool = True,
+    endpoint_env: str = "RISK_NOTIFICATION_WEBHOOK_URL",
+) -> dict[str, Any]:
+    worker_path, delivery_path, destination_path = _paths(
+        tmp_path,
+        worker_enabled=worker_enabled,
+        delivery_enabled=delivery_enabled,
+        retry_enabled=retry_enabled,
+        destination_enabled=destination_enabled,
+        endpoint_env=endpoint_env,
+    )
+    return plan_notification_worker(
+        worker_id=WORKER_ID,
+        planned_at=BASE_TIME,
+        worker_config_path=worker_path,
+        delivery_config_path=delivery_path,
+        destination_config_path=destination_path,
+    )
+
+
+def test_committed_worker_is_disabled_and_plan_only() -> None:
+    plan = plan_notification_worker(
+        worker_id=WORKER_ID,
+        planned_at=BASE_TIME,
+    )
+
+    assert plan["model_version"] == PLAN_MODEL_VERSION
+    assert plan["status"] == "disabled"
+    assert plan["blocking_reasons"] == [
+        "worker_disabled",
+        "delivery_disabled",
+        "retry_execution_disabled",
+        "destination_not_active",
+    ]
+    assert plan["schedule"]["activation_action"] == "none"
+    assert plan["concurrency_control"]["max_concurrency"] == 1
+    assert plan["concurrency_control"]["lock_acquired"] is False
+    assert all(value is False for value in plan["side_effects"].values())
+    assert validate_notification_worker_plan(plan) == plan
+
+
+def test_enabled_reviewed_contract_would_schedule_deterministically(
+    tmp_path: Path,
+) -> None:
+    first = _plan(tmp_path)
+    second = _plan(tmp_path)
+
+    assert first == second
+    assert first["status"] == "would_schedule"
+    assert first["blocking_reasons"] == []
+    assert first["schedule"]["activation_action"] == "would_create"
+    assert first["schedule"]["scheduled_for"] > first["planned_at"]
+    assert first["schedule"]["deterministic_jitter_seconds"] <= 30
+    assert [item["execution_kind"] for item in first["execution"]["work_items"]] == [
+        "initial",
+        "retry",
+    ]
+    assert validate_notification_worker_plan(first) == first
+
+
+def test_changed_plan_time_changes_identity_but_remains_canonical(
+    tmp_path: Path,
+) -> None:
+    first = _plan(tmp_path)
+    worker_path, delivery_path, destination_path = _paths(
+        tmp_path,
+        worker_enabled=True,
+        delivery_enabled=True,
+        retry_enabled=True,
+        destination_enabled=True,
+    )
+    later = plan_notification_worker(
+        worker_id=WORKER_ID,
+        planned_at="2026-09-05T20:01:00+00:00",
+        worker_config_path=worker_path,
+        delivery_config_path=delivery_path,
+        destination_config_path=destination_path,
+    )
+
+    assert later["plan_id"] != first["plan_id"]
+    assert validate_notification_worker_plan(later) == later
+
+
+def test_endpoint_environment_mismatch_is_a_visible_blocker(
+    tmp_path: Path,
+) -> None:
+    plan = _plan(
+        tmp_path,
+        endpoint_env="RISK_NOTIFICATION_WEBHOOK_URL_V2",
+    )
+
+    assert plan["status"] == "blocked"
+    assert plan["blocking_reasons"] == ["endpoint_environment_mismatch"]
+    assert plan["destination"]["endpoint_value_recorded"] is False
+
+
+def test_disabled_delivery_and_retry_are_visible_for_enabled_worker(
+    tmp_path: Path,
+) -> None:
+    plan = _plan(
+        tmp_path,
+        delivery_enabled=False,
+        retry_enabled=False,
+        destination_enabled=True,
+    )
+
+    assert plan["status"] == "blocked"
+    assert plan["blocking_reasons"] == [
+        "delivery_disabled",
+        "retry_execution_disabled",
+    ]
+
+
+def test_unsafe_worker_configuration_fails_closed(tmp_path: Path) -> None:
+    cases = []
+
+    concurrency = _worker_payload(enabled=True)
+    concurrency["workers"][WORKER_ID]["limits"]["max_concurrency"] = 2
+    cases.append((concurrency, "max_concurrency"))
+
+    duplicate_kinds = _worker_payload(enabled=True)
+    duplicate_kinds["workers"][WORKER_ID]["execution_kinds"] = [
+        "initial",
+        "retry",
+        "retry",
+    ]
+    cases.append((duplicate_kinds, "sorted and unique"))
+
+    readiness = _worker_payload(enabled=True)
+    readiness["workers"][WORKER_ID]["readiness"]["max_age_seconds"] = 301
+    cases.append((readiness, "readiness max_age_seconds"))
+
+    suspension = _worker_payload(enabled=True)
+    suspension["workers"][WORKER_ID]["suspension"][
+        "block_on_persistence_ambiguity"
+    ] = False
+    cases.append((suspension, "must block on readiness"))
+
+    for index, (payload, message) in enumerate(cases):
+        path = _write_yaml(tmp_path / f"invalid-{index}.yaml", payload)
+        with pytest.raises(ValidationError, match=message):
+            load_notification_workers(path)
+
+
+def test_worker_limits_must_fit_delivery_and_retry_contract(
+    tmp_path: Path,
+) -> None:
+    worker = _worker_payload(enabled=True)
+    worker["workers"][WORKER_ID]["limits"]["max_retry_events"] = 26
+    worker_path = _write_yaml(tmp_path / "workers.yaml", worker)
+    delivery_path = _write_yaml(
+        tmp_path / "delivery.yaml",
+        _delivery_payload(enabled=True, retry_enabled=True),
+    )
+    destination_path = _write_yaml(
+        tmp_path / "destinations.yaml",
+        _destination_payload(enabled=True),
+    )
+
+    with pytest.raises(ValidationError, match="webhook batch limit"):
+        plan_notification_worker(
+            worker_id=WORKER_ID,
+            planned_at=BASE_TIME,
+            worker_config_path=worker_path,
+            delivery_config_path=delivery_path,
+            destination_config_path=destination_path,
+        )
+
+
+def test_plan_validation_rejects_identity_and_side_effect_tampering(
+    tmp_path: Path,
+) -> None:
+    plan = _plan(tmp_path)
+
+    changed_id = copy.deepcopy(plan)
+    changed_id["plan_id"] = "portfolio-risk-notification-worker-plan-v1-plan-tampered"
+    with pytest.raises(ValidationError, match="plan_id"):
+        validate_notification_worker_plan(changed_id)
+
+    changed_effect = copy.deepcopy(plan)
+    changed_effect["side_effects"]["external_request_performed"] = True
+    with pytest.raises(ValidationError, match="side effect"):
+        validate_notification_worker_plan(changed_effect)
+
+
+def test_symlinked_worker_configuration_is_rejected(tmp_path: Path) -> None:
+    target = _write_yaml(tmp_path / "workers.yaml", _worker_payload())
+    link = tmp_path / "workers-link.yaml"
+    link.symlink_to(target)
+
+    with pytest.raises(ValidationError, match="symbolic link"):
+        load_notification_workers(link)
+
+
+def test_cli_writes_credential_free_summary(tmp_path: Path, capsys: Any) -> None:
+    worker_path, delivery_path, destination_path = _paths(
+        tmp_path,
+        worker_enabled=True,
+        delivery_enabled=True,
+        retry_enabled=True,
+        destination_enabled=True,
+    )
+    summary_path = tmp_path / "summary.json"
+
+    exit_code = main(
+        [
+            "--worker-id",
+            WORKER_ID,
+            "--planned-at",
+            BASE_TIME.isoformat(),
+            "--config",
+            str(worker_path),
+            "--delivery-config",
+            str(delivery_path),
+            "--destination-config",
+            str(destination_path),
+            "--summary-json",
+            str(summary_path),
+        ]
+    )
+
+    assert exit_code == 0
+    summary = json.loads(summary_path.read_text(encoding="utf-8"))
+    assert summary["status"] == "would_schedule"
+    rendered = json.dumps(summary, sort_keys=True)
+    assert "https://" not in rendered
+    assert "postgresql://" not in rendered
+    assert "RISK_NOTIFICATION_WEBHOOK_URL=" not in rendered
+    assert json.loads(capsys.readouterr().out) == summary

--- a/tests/unit/test_notification_worker_plan_architecture_contract.py
+++ b/tests/unit/test_notification_worker_plan_architecture_contract.py
@@ -1,0 +1,65 @@
+from pathlib import Path
+
+
+def test_managed_notification_worker_is_plan_only_bounded_and_disabled() -> None:
+    source = Path("src/orchestration/plan_notification_worker.py").read_text(
+        encoding="utf-8"
+    )
+    config = Path("config/notification_workers.yaml").read_text(
+        encoding="utf-8"
+    )
+    docs = Path("docs/managed-notification-worker-plan.md").read_text(
+        encoding="utf-8"
+    )
+    normalized_docs = " ".join(docs.split()).casefold()
+
+    for required in (
+        "portfolio-risk-notification-worker-config-v1",
+        "portfolio-risk-notification-worker-plan-v1",
+        "build_notification_worker_plan",
+        "plan_notification_worker",
+        "validate_notification_worker_plan",
+        "worker_disabled",
+        "delivery_disabled",
+        "retry_execution_disabled",
+        "destination_not_active",
+        "endpoint_environment_mismatch",
+        "max_concurrency",
+        "refresh_under_shared_lock",
+        "cloud_schedule_activated",
+        "terraform_apply_performed",
+    ):
+        assert required in source
+
+    assert "risk-operations-managed:" in config
+    assert "enabled: false" in config
+    assert "max_concurrency: 1" in config
+    assert "required_status: allowed" in config
+    assert "block_on_readiness_failure: true" in config
+    assert "block_on_persistence_ambiguity: true" in config
+    assert "block_on_expired_review: true" in config
+
+    for required in (
+        "primary arc42 block: `orchestration`",
+        "there is no `--execute` option",
+        "fixed utc interval",
+        "deterministic jitter",
+        "max_concurrency` is exactly one",
+        "mandatory suspension on unresolved persistence ambiguity",
+        "does not create a cloud or local schedule",
+        "does not read postgresql evidence",
+        "does not contain an endpoint value",
+        "terraform apply",
+    ):
+        assert required in normalized_docs
+
+    for forbidden in (
+        "add_argument(\"--execute\"",
+        "requests.",
+        "urllib.request",
+        "httpx.",
+        "socket.",
+        "psycopg",
+        "subprocess",
+    ):
+        assert forbidden not in source.casefold()


### PR DESCRIPTION
## Goal

Deliver **P4e1** as a plan-only managed notification worker contract, without activating scheduling or executing delivery.

```text
reviewed worker configuration
  + delivery and retry bounds
  + reviewed destination contract
  + deterministic planning instant
  -> disabled | blocked | would_schedule
  -> exact future schedule slot
  -> no scheduler or delivery side effect
```

## Controls

- committed worker configuration is disabled;
- execution kinds are a sorted unique subset of `initial` and `retry`;
- fixed UTC interval and deterministic bounded jitter;
- initial/retry limits cannot exceed delivery and retry policies;
- concurrency is exactly one and binds the shared delivery-lock identity;
- readiness must be `allowed` and at most five minutes old;
- suspension on readiness failure, persistence ambiguity and expired review is mandatory;
- repeated-failure threshold, cooldown and execution timeout are bounded;
- endpoint-environment mismatch and disabled dependencies are visible canonical blockers;
- config and summary files are regular, non-symbolic-link and bounded to 1 MB; and
- canonical plan validation detects identity or side-effect tampering.

## Scope

Five additive files, five working commits, 1,470 additions and no deletions. Squash merge retains one coherent orchestration increment. The branch is zero commits behind `main`.

## Exact-head validation

GitHub Actions run **417** (`33991680128`) passed on final head `6c51ab26b5d6ec058445e9bbeba11c1aa70ffa9b`:

- Security guardrails passed.
- Ruff passed.
- mypy passed across **150 source files**.
- **950 tests passed** in quality and **950 passed again** in readiness.
- Dependency integrity and the standard pipeline replay passed.
- PostgreSQL 16 contracts passed.
- Kubernetes rendering and Terraform format/init/validate passed without apply.
- No submitted reviews or unresolved review threads exist.

The full contract passed on its first exact head; no repair commit or weakened control was required.

## Safety boundary

There is no `--execute` option. The planner performs no PostgreSQL read, lock acquisition, network request, DNS lookup, webhook delivery, attempt write, outbox mutation, acknowledgement, schedule activation, deployment or `terraform apply`. It stores no endpoint value, full URL, credential, payload body, response body, environment value or DSN.

Validated and ready for squash merge.