### PR TITLE
Harden managed-worker summary file writes

### DIFF
--- a/docs/managed-notification-worker-summary-safety.md
+++ b/docs/managed-notification-worker-summary-safety.md
@@ -1,0 +1,62 @@
+# Managed Worker Summary Output Safety
+
+Primary arc42 block: `orchestration`.
+
+## Decision
+
+The managed-worker planner delegates summary writes to
+`src/orchestration/notification_worker_summary.py`. The CLI and its
+`--summary-json` option are unchanged; see
+[the worker-plan walkthrough](managed-notification-worker-plan.md).
+
+The earlier writer opened a predictable `<summary>.tmp` path. Checking only the
+final destination did not protect an unrelated file targeted by a symlink at
+that temporary path. The replacement exclusively creates an unpredictable
+sibling with restrictive permissions instead. It never opens or removes the
+legacy temporary path.
+
+## Guarantees
+
+JSON is serialized with non-finite values rejected. The encoded document,
+including formatting and its final newline, must be at most 1,048,576 bytes.
+Serialization and size validation finish before directory creation or writing.
+
+Existing final destinations must be regular files, not directories or symbolic
+links, including dangling links. The destination is checked again immediately
+before replacement. The temporary file is flushed and fsynced before an atomic
+same-directory replacement publishes the complete document. On POSIX, the new
+file has owner-only permissions supplied by the temporary-file facility.
+
+A failure before replacement leaves existing destination bytes unchanged.
+Temporary-file cleanup is attempted on every exit; a filesystem failure that
+also prevents cleanup can require operator removal. Error messages do not
+include document content.
+
+## Trust Boundary And Trade-offs
+
+The parent directory must be operator-owned and trusted. This is not protection
+against another process that can replace directory entries or parent paths.
+The final rename does not follow a destination symlink, but the checks do not
+establish a hostile-filesystem sandbox.
+
+Concurrent writers publish complete documents with last-replacement-wins
+semantics. This is not compare-and-swap, a lock, an append-only ledger or a
+power-loss durability guarantee for the parent directory. The writer does not
+validate the business meaning or secrecy of arbitrary caller-supplied JSON;
+callers remain responsible for using the credential-free plan contract.
+
+## Regression Evidence
+
+```bash
+.venv/bin/python -m pytest -q tests/unit/test_notification_worker_summary.py
+make quality-check
+make security-check
+make readiness-check
+```
+
+The tests cover both the shared writer and the existing planner wrapper:
+legacy temporary symlink preservation, existing and dangling destination
+symlinks, non-regular destinations, invalid JSON, oversized output, the exact
+byte limit, successful replacement, replacement failure and directory-creation
+failure. No scheduler, external request, database write or cloud operation is
+part of this change.

--- a/src/orchestration/notification_worker_summary.py
+++ b/src/orchestration/notification_worker_summary.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import json
+import os
+import stat
+import tempfile
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+from src.common.exceptions import StorageError
+
+MAX_SUMMARY_BYTES = 1_048_576
+
+
+def _check_destination(path: Path) -> None:
+    try:
+        mode = path.lstat().st_mode
+    except FileNotFoundError:
+        return
+    if stat.S_ISLNK(mode):
+        raise StorageError("notification worker summary must not be a symbolic link")
+    if not stat.S_ISREG(mode):
+        raise StorageError("notification worker summary must be a regular file")
+
+
+def write_notification_worker_summary(
+    path: Path,
+    summary: Mapping[str, Any],
+) -> None:
+    """Atomically replace a bounded summary in an operator-owned directory.
+
+    The parent directory is trusted. This is not a sandbox against another
+    process able to replace its entries. Concurrent writers publish complete
+    documents with last-replacement-wins semantics, not compare-and-swap.
+    """
+    try:
+        payload = (
+            json.dumps(summary, indent=2, sort_keys=True, allow_nan=False) + "\n"
+        ).encode("utf-8")
+    except (TypeError, ValueError, UnicodeError, RecursionError):
+        raise StorageError("notification worker summary is not valid JSON") from None
+    if len(payload) > MAX_SUMMARY_BYTES:
+        raise StorageError("notification worker summary exceeds 1 MB")
+
+    temporary: Path | None = None
+    try:
+        _check_destination(path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        # NamedTemporaryFile exclusively creates an unpredictable sibling with
+        # restrictive permissions. Never open the old predictable .json.tmp path.
+        with tempfile.NamedTemporaryFile(
+            mode="wb",
+            prefix=f".{path.name}.",
+            suffix=".tmp",
+            dir=path.parent,
+            delete=False,
+        ) as handle:
+            temporary = Path(handle.name)
+            handle.write(payload)
+            handle.flush()
+            os.fsync(handle.fileno())
+        _check_destination(path)
+        temporary.replace(path)
+    except OSError:
+        raise StorageError("unable to write notification worker summary") from None
+    finally:
+        if temporary is not None:
+            try:
+                temporary.unlink(missing_ok=True)
+            except OSError:
+                # Do not hide the original failure. The trusted operator may
+                # need to remove a temporary file after a filesystem failure.
+                pass

--- a/src/orchestration/plan_notification_worker.py
+++ b/src/orchestration/plan_notification_worker.py
@@ -751,19 +751,11 @@ def _timestamp(value: str) -> datetime:
 
 
 def _write_summary(path: Path, summary: Mapping[str, Any]) -> None:
-    if path.is_symlink():
-        raise StorageError("notification worker summary must not be a symbolic link")
-    path.parent.mkdir(parents=True, exist_ok=True)
-    temporary = path.with_suffix(path.suffix + ".tmp")
-    try:
-        temporary.write_text(
-            json.dumps(summary, indent=2, sort_keys=True, allow_nan=False) + "\n",
-            encoding="utf-8",
-        )
-        temporary.replace(path)
-    except (OSError, TypeError, ValueError):
-        temporary.unlink(missing_ok=True)
-        raise StorageError("unable to write notification worker plan") from None
+    from src.orchestration.notification_worker_summary import (
+        write_notification_worker_summary,
+    )
+
+    write_notification_worker_summary(path, summary)
 
 
 def _build_parser() -> argparse.ArgumentParser:

--- a/tests/unit/test_notification_worker_summary.py
+++ b/tests/unit/test_notification_worker_summary.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+import json
+import os
+import stat
+from collections.abc import Callable, Mapping
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from src.common.exceptions import StorageError
+from src.orchestration.notification_worker_summary import (
+    MAX_SUMMARY_BYTES,
+    write_notification_worker_summary,
+)
+from src.orchestration.plan_notification_worker import _write_summary
+
+Writer = Callable[[Path, Mapping[str, Any]], None]
+
+
+@pytest.fixture(params=[write_notification_worker_summary, _write_summary])
+def writer(request: pytest.FixtureRequest) -> Writer:
+    return request.param
+
+
+def test_summary_replaces_complete_document(writer: Writer, tmp_path: Path) -> None:
+    target = tmp_path / "summary.json"
+    target.write_text("old evidence", encoding="utf-8")
+    writer(target, {"worker_id": "reviewed-worker"})
+    assert json.loads(target.read_text(encoding="utf-8")) == {
+        "worker_id": "reviewed-worker"
+    }
+    assert list(tmp_path.glob(".summary.json.*.tmp")) == []
+    if os.name == "posix":
+        assert stat.S_IMODE(target.stat().st_mode) == 0o600
+
+
+def test_summary_never_follows_legacy_temporary_symlink(
+    writer: Writer, tmp_path: Path
+) -> None:
+    target = tmp_path / "summary.json"
+    victim = tmp_path / "unrelated.txt"
+    victim.write_text("preserve this", encoding="utf-8")
+    legacy = target.with_suffix(target.suffix + ".tmp")
+    legacy.symlink_to(victim)
+    writer(target, {"safe": True})
+    assert victim.read_text(encoding="utf-8") == "preserve this"
+    assert legacy.is_symlink()
+    assert json.loads(target.read_text(encoding="utf-8")) == {"safe": True}
+
+
+@pytest.mark.parametrize("dangling", [False, True])
+def test_summary_rejects_destination_symlink(
+    writer: Writer, tmp_path: Path, dangling: bool
+) -> None:
+    target = tmp_path / "summary.json"
+    victim = tmp_path / "unrelated.txt"
+    if not dangling:
+        victim.write_text("preserve this", encoding="utf-8")
+    target.symlink_to(victim)
+    with pytest.raises(StorageError, match="symbolic link"):
+        writer(target, {"safe": True})
+    assert target.is_symlink()
+    assert victim.exists() is not dangling
+    if not dangling:
+        assert victim.read_text(encoding="utf-8") == "preserve this"
+
+
+def test_summary_rejects_directory(writer: Writer, tmp_path: Path) -> None:
+    target = tmp_path / "summary.json"
+    target.mkdir()
+    with pytest.raises(StorageError, match="regular file"):
+        writer(target, {"safe": True})
+    assert target.is_dir()
+
+
+@pytest.mark.parametrize("value", [float("nan"), object()])
+def test_invalid_json_has_no_filesystem_effect(
+    writer: Writer, tmp_path: Path, value: Any
+) -> None:
+    target = tmp_path / "not-created" / "summary.json"
+    with pytest.raises(StorageError, match="valid JSON"):
+        writer(target, {"value": value})
+    assert not target.parent.exists()
+
+
+def test_summary_byte_limit_precedes_filesystem_mutation(
+    writer: Writer, tmp_path: Path
+) -> None:
+    target = tmp_path / "not-created" / "summary.json"
+    with pytest.raises(StorageError, match="1 MB"):
+        writer(target, {"value": "x" * MAX_SUMMARY_BYTES})
+    assert not target.parent.exists()
+
+
+def test_summary_accepts_exact_byte_limit(writer: Writer, tmp_path: Path) -> None:
+    overhead = len((json.dumps({"value": ""}, indent=2, sort_keys=True) + "\n").encode())
+    target = tmp_path / "summary.json"
+    writer(target, {"value": "x" * (MAX_SUMMARY_BYTES - overhead)})
+    assert target.stat().st_size == MAX_SUMMARY_BYTES
+
+
+def test_failed_replacement_preserves_old_summary_and_cleans_temporary(
+    writer: Writer, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    target = tmp_path / "summary.json"
+    target.write_text("old evidence", encoding="utf-8")
+
+    def fail_replace(self: Path, destination: Path) -> Path:
+        raise OSError("injected replacement failure")
+
+    monkeypatch.setattr(Path, "replace", fail_replace)
+    with pytest.raises(StorageError, match="unable to write"):
+        writer(target, {"safe": True})
+    assert target.read_text(encoding="utf-8") == "old evidence"
+    assert sorted(path.name for path in tmp_path.iterdir()) == ["summary.json"]
+
+
+def test_parent_creation_error_is_normalized(writer: Writer, tmp_path: Path) -> None:
+    parent = tmp_path / "not-a-directory"
+    parent.write_text("preserve this", encoding="utf-8")
+    with pytest.raises(StorageError, match="unable to write"):
+        writer(parent / "summary.json", {"safe": True})
+    assert parent.read_text(encoding="utf-8") == "preserve this"


### PR DESCRIPTION
## Goal

Closes #146. First of three dependency-ordered increments under #76. Primary arc42 block: `orchestration`.

Repair the summary-output trust boundary before worker plans become lifecycle-authority inputs.

## Changes

- Add a 1 MB bounded JSON writer with an exclusively created, unpredictable temporary sibling.
- Delegate the existing planner wrapper without changing its CLI.
- Reject symbolic-link and non-regular destinations, including dangling links.
- Preserve old destination bytes on pre-replacement failure and attempt cleanup on every exit.
- Add 22 regression cases through both writer entry points.
- Document trusted-parent-directory, concurrency and crash-durability limitations.

## Validation and review evidence

Final head: `c0fc1635c85d8373203c967debd866c01d0fb93f`.

CI run **419** (`33993676969`) passed all four jobs: Security guardrails, Python readiness, PostgreSQL contract and Infrastructure validation. Python logs show Ruff passed, mypy passed across **151 source files**, **972 tests passed twice**, dependency integrity passed and the pipeline replay completed.

Actions checked the synthetic merge of this exact head into `30d8ba3e8c7a4d5698c6181b5193f8c97f9fa91e`; the branch is zero commits behind that base. Scope review confirmed exactly four intended files, 266 additions and 13 deletions. The only original-planner change is writer delegation. No submitted reviews or unresolved threads were present when checked. This is automated review evidence, not independent human approval.

## Boundary

Only optional local summary output changes. No webhook, provider request, schedule activation, deployment or Terraform apply. No configuration, workflow, schema or execution-authority changes. Committed switches remain disabled.