### PR TITLE
Add single-slot notification worker authority transitions

### DIFF
--- a/docs/notification-worker-authority.md
+++ b/docs/notification-worker-authority.md
@@ -1,0 +1,90 @@
+# Single-slot notification worker authority
+
+Primary arc42 block: `orchestration`.
+
+## Goal and boundary
+
+P4e2a adds a pure transition contract over the existing P4e1 worker plan:
+
+```text
+validated plan + explicit operator request + exact predecessor
+  -> activate | suspend | resume | disable
+  -> deterministic, credential-free transition evidence
+  -> no scheduler mutation and no delivery
+```
+
+The public API is in
+`src/orchestration/notification_worker_authority_contract.py`.
+Its model is `portfolio-risk-notification-worker-authority-transition-v1`.
+This is an evidence contract, not an authenticated approval service. Reviewer
+names and SHA-256 identifiers do not authenticate a person or sign a document.
+A future runtime must independently authenticate the operator, load current
+retained authority, and refresh notification readiness under the delivery lock.
+The existing planner remains a planning interface; authority consumers use the
+stricter `validate_authority_plan` boundary introduced here.
+
+## Why validation precedes activation
+
+A content hash is not a policy check. Recomputing a hash after changing
+`max_concurrency`, an entrypoint, a readiness limit, suspension conditions, or
+schedule fields must not make an unsafe plan acceptable. The authority boundary
+checks exact nested fields, bounded integers excluding booleans, known
+entrypoints, the shared lock identity, required suspension conditions, dependency
+blockers, and the deterministic UTC slot and jitter independently of the hash.
+
+The plan does not embed complete delivery configuration or endpoint values.
+Its configuration fingerprints remain references to evidence, not proof that
+that evidence is still current. Endpoint mismatch evidence is preserved; live
+configuration and destination review must be revalidated before execution.
+
+## State machine
+
+| Action | Permitted source states | Result |
+| --- | --- | --- |
+| activate | inactive, disabled, expired | active |
+| suspend | active | suspended |
+| resume | suspended | active |
+| disable | active, suspended, expired | disabled |
+
+Only initial activation starts a chain. Every subsequent transition references
+the exact previous transition ID, advances effective time strictly, and retains
+the worker and destination identities. A storage consumer must reconcile that
+predecessor against the current retained head, not merely validate its hash.
+
+Activation and resume require a `would_schedule` plan, sorted unique reviewer
+identities independent of the requesting operator, and an explicit expiry.
+Names differing only in case cannot bypass reviewer separation. Each grant
+covers one exact schedule slot: effective time is no later than the slot, and
+expiry is after the slot but no later than its bounded execution-timeout end.
+Expiry is exclusive. This does not grant permission for an indefinite schedule.
+
+Suspension and disablement reference the exact previously governed plan and
+need no new review or grant expiry. Canonical reasons explain the stop; disable
+requires `operator_request`. Resume requires the previous suspension cooldown
+to elapse and a new independently reviewed plan. It never automatically revives
+an expired grant.
+
+## Validation evidence
+
+The tests exercise a complete lifecycle, precise expiry boundaries, cooldown,
+wrong predecessor and scope, disabled/blocked plans, reviewer separation,
+recomputed-hash attacks, unknown fields, arbitrary entrypoints, deterministic
+identity, deep-copy isolation, and compatibility with the real P4e1 planner.
+
+Run:
+
+```bash
+.venv/bin/python -m pytest -q tests/unit/test_notification_worker_authority_contract.py
+```
+
+## Safety and remaining work
+
+No committed delivery, destination, retry, or worker setting is enabled. This
+module imports no network client and performs no database access, lock
+acquisition, scheduler activation, webhook delivery, deployment, or
+`terraform apply`. It retains neither payload bodies nor endpoint values.
+
+P4e2b must add append-only persistence, conflict-safe head selection and exact
+replay. P4e2c must combine that retained authority with current readiness and
+failure evidence. Neither transition construction nor a passing test is human
+approval to activate infrastructure.

--- a/src/orchestration/notification_worker_authority_contract.py
+++ b/src/orchestration/notification_worker_authority_contract.py
@@ -1,0 +1,350 @@
+"""Pure, single-slot worker authority evidence; never a scheduler or delivery grant."""
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from collections.abc import Mapping, Sequence
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+from src.common.exceptions import ValidationError
+
+MODEL_VERSION = "portfolio-risk-notification-worker-authority-transition-v1"
+PLAN_MODEL_VERSION = "portfolio-risk-notification-worker-plan-v1"
+LOCK_MODEL = "portfolio-risk-notification-delivery-lock-v1"
+LOCK_SCOPE = "portfolio-risk-notification-delivery"
+SAFE_ID = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,511}$")
+ENV_NAME = re.compile(r"^[A-Z][A-Z0-9_]{2,127}$")
+REASONS = (
+    "expired_review", "operator_request", "persistence_ambiguity",
+    "readiness_failure", "repeated_delivery_failure",
+)
+CONDITIONS = [reason for reason in REASONS if reason != "operator_request"]
+ENTRYPOINTS = {
+    "initial": "src.orchestration.deliver_portfolio_risk_notifications",
+    "retry": "src.orchestration.run_recorded_readiness_enforced_portfolio_risk_notification_retries",
+}
+ACTIONS = {
+    "activate": ({"inactive", "disabled", "expired"}, "active"),
+    "suspend": ({"active"}, "suspended"),
+    "resume": ({"suspended"}, "active"),
+    "disable": ({"active", "suspended", "expired"}, "disabled"),
+}
+PLAN_KEYS = frozenset({
+    "plan_id", "blocking_reasons", "concurrency_control", "delivery", "destination",
+    "execution", "model_version", "planned_at", "readiness", "schedule", "side_effects",
+    "status", "suspension", "worker",
+})
+TRANSITION_KEYS = frozenset({
+    "transition_id", "model_version", "request_id", "operator_id", "reviewed_by", "action",
+    "requested_at", "effective_at", "expires_at", "previous_transition_id", "from_state",
+    "to_state", "reason_codes", "plan", "plan_sha256", "scheduler_mutated",
+    "external_request_performed",
+})
+
+
+def canonical_bytes(value: Mapping[str, Any]) -> bytes:
+    try:
+        return json.dumps(
+            dict(value), sort_keys=True, separators=(",", ":"), allow_nan=False,
+        ).encode("utf-8")
+    except (TypeError, ValueError):
+        raise ValidationError("worker authority must be canonical JSON") from None
+
+
+def utc(value: Any, label: str) -> datetime:
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00")) if isinstance(
+            value, str
+        ) else value
+    except ValueError:
+        raise ValidationError(f"{label} must be ISO-8601") from None
+    if not isinstance(parsed, datetime) or parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise ValidationError(f"{label} must be timezone-aware")
+    return parsed.astimezone(timezone.utc)
+
+
+def identifier(value: Any, label: str) -> str:
+    if not isinstance(value, str) or not SAFE_ID.fullmatch(value):
+        raise ValidationError(f"{label} must be one bounded safe identifier")
+    return value
+
+
+def _exact(value: Any, keys: Sequence[str] | frozenset[str], label: str) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping) or set(value) != set(keys):
+        raise ValidationError(f"{label} fields are not exact")
+    return value
+
+
+def _integer(value: Any, minimum: int, maximum: int, label: str) -> int:
+    if type(value) is not int or not minimum <= value <= maximum:
+        raise ValidationError(f"{label} is outside its integer bounds")
+    return value
+
+
+def _boolean(value: Any, label: str) -> bool:
+    if type(value) is not bool:
+        raise ValidationError(f"{label} must be boolean")
+    return bool(value)
+
+
+def validate_authority_plan(value: Mapping[str, Any]) -> dict[str, Any]:
+    """Check plan semantics, not just its unkeyed content hash.
+
+    This validates a retained planning snapshot, not current configuration or
+    reviewer authentication. Execution still needs fresh under-lock readiness.
+    """
+    p = _exact(value, PLAN_KEYS, "worker plan")
+    if p["model_version"] != PLAN_MODEL_VERSION:
+        raise ValidationError("unsupported worker plan model")
+    identity = dict(p)
+    supplied_id = identity.pop("plan_id")
+    expected_id = f"{PLAN_MODEL_VERSION}-plan-{hashlib.sha256(canonical_bytes(identity)).hexdigest()[:24]}"
+    if supplied_id != expected_id:
+        raise ValidationError("worker plan_id does not match content")
+    worker = _exact(p["worker"], ("worker_id", "fingerprint", "enabled"), "worker identity")
+    identifier(worker["worker_id"], "worker_id")
+    fingerprint = identifier(worker["fingerprint"], "worker fingerprint")
+    enabled = _boolean(worker["enabled"], "worker enabled")
+    destination = _exact(p["destination"], (
+        "activation_status", "allowed_event_types", "destination_id",
+        "endpoint_environment_variable", "endpoint_value_recorded", "fingerprint",
+    ), "plan destination")
+    identifier(destination["destination_id"], "destination_id")
+    identifier(destination["fingerprint"], "destination fingerprint")
+    env = destination["endpoint_environment_variable"]
+    if not isinstance(env, str) or not ENV_NAME.fullmatch(env):
+        raise ValidationError("plan destination must name an environment variable")
+    if destination["endpoint_value_recorded"] is not False:
+        raise ValidationError("endpoint values must not be retained")
+    if destination["activation_status"] not in {
+        "active", "disabled", "not_yet_reviewed", "review_expired",
+    }:
+        raise ValidationError("invalid destination activation status")
+    events = destination["allowed_event_types"]
+    allowed_events = {"breach_opened", "breach_escalated", "breach_deescalated", "breach_resolved"}
+    if not isinstance(events, list) or not events or any(
+        not isinstance(event, str) or event not in allowed_events for event in events
+    ) or events != sorted(set(events)):
+        raise ValidationError("invalid plan event allow-list")
+    delivery = _exact(p["delivery"], (
+        "delivery_fingerprint", "max_batch_events", "retry_execution_enabled",
+        "retry_execution_policy_fingerprint", "retry_planning_policy_fingerprint", "webhook_enabled",
+    ), "plan delivery")
+    for key in ("delivery_fingerprint", "retry_execution_policy_fingerprint", "retry_planning_policy_fingerprint"):
+        identifier(delivery[key], key)
+    webhook_enabled = _boolean(delivery["webhook_enabled"], "webhook enabled")
+    retry_enabled = _boolean(delivery["retry_execution_enabled"], "retry enabled")
+    batch = _integer(delivery["max_batch_events"], 1, 100, "delivery batch")
+    execution = _exact(p["execution"], ("execution_timeout_seconds", "work_items"), "execution")
+    _integer(execution["execution_timeout_seconds"], 1, 3600, "execution timeout")
+    items = execution["work_items"]
+    if not isinstance(items, list) or not 1 <= len(items) <= 2:
+        raise ValidationError("plan must contain one or two work items")
+    kinds: list[str] = []
+    for item_value in items:
+        item = _exact(item_value, ("entrypoint", "execution_kind", "max_events"), "work item")
+        kind = identifier(item["execution_kind"], "execution kind")
+        if kind not in ENTRYPOINTS or item["entrypoint"] != ENTRYPOINTS[kind]:
+            raise ValidationError("unreviewed worker entrypoint")
+        _integer(item["max_events"], 1, batch, "work item batch")
+        kinds.append(kind)
+    if kinds != sorted(set(kinds)):
+        raise ValidationError("work items must be sorted and unique")
+    readiness = _exact(p["readiness"], (
+        "max_age_seconds", "refresh_under_shared_lock", "required_status", "source_view",
+    ), "readiness")
+    _integer(readiness["max_age_seconds"], 1, 300, "readiness age")
+    if readiness["refresh_under_shared_lock"] is not True or readiness["required_status"] != "allowed" or readiness["source_view"] != "risk_platform.current_notification_execution_readiness_review":
+        raise ValidationError("worker readiness controls cannot be weakened")
+    lock = _exact(p["concurrency_control"], (
+        "key_fingerprint", "lock_acquired", "max_concurrency", "model_version", "scope",
+    ), "concurrency control")
+    unsigned_key = int.from_bytes(hashlib.sha256(f"{LOCK_MODEL}:{LOCK_SCOPE}".encode()).digest()[:8], "big")
+    signed_key = unsigned_key if unsigned_key < 2**63 else unsigned_key - 2**64
+    key_fingerprint = hashlib.sha256(str(signed_key).encode("ascii")).hexdigest()[:24]
+    if lock["model_version"] != LOCK_MODEL or lock["scope"] != LOCK_SCOPE or lock["key_fingerprint"] != key_fingerprint or lock["lock_acquired"] is not False:
+        raise ValidationError("worker must retain the shared delivery lock identity")
+    _integer(lock["max_concurrency"], 1, 1, "max_concurrency")
+    suspension = _exact(p["suspension"], (
+        "conditions", "cooldown_seconds", "max_consecutive_failures",
+    ), "suspension")
+    if suspension["conditions"] != CONDITIONS:
+        raise ValidationError("worker suspension conditions cannot be weakened")
+    _integer(suspension["cooldown_seconds"], 0, 86400, "cooldown")
+    _integer(suspension["max_consecutive_failures"], 1, 20, "failure threshold")
+    effects = _exact(p["side_effects"], (
+        "acknowledgement_mutated", "cloud_schedule_activated", "database_read_performed",
+        "delivery_attempt_written", "external_request_performed", "infrastructure_deployed",
+        "outbox_mutated", "terraform_apply_performed",
+    ), "plan side effects")
+    if any(effect is not False for effect in effects.values()):
+        raise ValidationError("worker plan must have no side effects")
+    reasons = p["blocking_reasons"]
+    if not isinstance(reasons, list):
+        raise ValidationError("plan blocking reasons must be an array")
+    # The endpoint value is deliberately absent. Preserve the planner's mismatch
+    # evidence; current source configuration must be re-read by the execution gate.
+    expected_reasons = [reason for reason, applies in (
+        ("worker_disabled", not enabled), ("delivery_disabled", not webhook_enabled),
+        ("retry_execution_disabled", "retry" in kinds and not retry_enabled),
+        ("destination_not_active", destination["activation_status"] != "active"),
+        ("endpoint_environment_mismatch", "endpoint_environment_mismatch" in reasons),
+    ) if applies]
+    status = "disabled" if not enabled else "blocked" if expected_reasons else "would_schedule"
+    if reasons != expected_reasons or p["status"] != status:
+        raise ValidationError("plan status or blockers contradict its dependencies")
+    schedule = _exact(p["schedule"], (
+        "activation_action", "boundary_epoch", "deterministic_jitter_seconds", "interval_seconds",
+        "jitter_seconds", "mode", "scheduled_for", "timezone",
+    ), "schedule")
+    interval = _integer(schedule["interval_seconds"], 60, 86400, "interval")
+    jitter_limit = _integer(schedule["jitter_seconds"], 0, min(3600, interval - 1), "jitter")
+    planned = utc(p["planned_at"], "planned_at")
+    boundary = ((int(planned.timestamp()) // interval) + 1) * interval
+    seed = hashlib.sha256(f"{fingerprint}:{boundary}".encode()).digest()
+    jitter = int.from_bytes(seed[:8], "big") % (jitter_limit + 1)
+    _integer(schedule["boundary_epoch"], boundary, boundary, "schedule boundary")
+    _integer(schedule["deterministic_jitter_seconds"], jitter, jitter, "deterministic jitter")
+    if schedule["mode"] != "fixed_interval" or schedule["timezone"] != "UTC" or schedule["activation_action"] != ("would_create" if status == "would_schedule" else "none"):
+        raise ValidationError("schedule contradicts the worker plan")
+    if utc(schedule["scheduled_for"], "scheduled_for").timestamp() != boundary + jitter:
+        raise ValidationError("schedule slot is not deterministic")
+    return json.loads(canonical_bytes(p))
+
+
+def authority_state(transition: Mapping[str, Any] | None, *, as_of: datetime | str) -> str:
+    instant = utc(as_of, "as_of")
+    if transition is None:
+        return "inactive"
+    document = validate_worker_authority_transition(transition)
+    if instant < utc(document["effective_at"], "effective_at"):
+        return "inactive"
+    if document["to_state"] == "active" and instant >= utc(document["expires_at"], "expires_at"):
+        return "expired"
+    return str(document["to_state"])
+
+
+def _build(
+    *, plan: Mapping[str, Any], request_id: str, operator_id: str, reviewed_by: Sequence[str],
+    action: str, requested_at: datetime | str, effective_at: datetime | str,
+    expires_at: datetime | str | None, previous_transition_id: str | None,
+    from_state: str, reason_codes: Sequence[str],
+) -> dict[str, Any]:
+    p = validate_authority_plan(plan)
+    request = identifier(request_id, "request_id")
+    operator = identifier(operator_id, "operator_id")
+    if not isinstance(action, str) or action not in ACTIONS:
+        raise ValidationError("unsupported worker authority action")
+    states, target = ACTIONS[action]
+    if from_state not in states:
+        raise ValidationError("worker authority transition is not legal from current state")
+    if previous_transition_id is None:
+        if from_state != "inactive" or action != "activate":
+            raise ValidationError("only initial activation may start an authority chain")
+    else:
+        identifier(previous_transition_id, "previous_transition_id")
+        if from_state == "inactive":
+            raise ValidationError("a retained authority cannot become an inactive root")
+    requested = utc(requested_at, "requested_at")
+    effective = utc(effective_at, "effective_at")
+    if requested > effective or requested < utc(p["planned_at"], "planned_at"):
+        raise ValidationError("authority timestamps precede their request or plan")
+    if not isinstance(reviewed_by, (list, tuple)) or len(reviewed_by) > 10:
+        raise ValidationError("reviewed_by must be a bounded reviewer array")
+    reviewers = [identifier(item, "reviewer") for item in reviewed_by]
+    if reviewers != sorted(reviewers) or len({item.casefold() for item in reviewers}) != len(reviewers):
+        raise ValidationError("reviewer identities must be sorted and unique")
+    if not isinstance(reason_codes, (list, tuple)):
+        raise ValidationError("reason_codes must be an array")
+    reasons = list(reason_codes)
+    if reasons != [reason for reason in REASONS if reason in reasons]:
+        raise ValidationError("reason_codes must be canonical and unique")
+    expiry: datetime | None = None
+    if target == "active":
+        if p["status"] != "would_schedule":
+            raise ValidationError("disabled or blocked plans cannot grant worker authority")
+        if not reviewers or operator.casefold() in {item.casefold() for item in reviewers}:
+            raise ValidationError("activation requires independent reviewer identities")
+        if reasons:
+            raise ValidationError("activation cannot retain suspension reasons")
+        expiry = utc(expires_at, "expires_at")
+        slot = utc(p["schedule"]["scheduled_for"], "scheduled_for")
+        window_end = slot + timedelta(seconds=p["execution"]["execution_timeout_seconds"])
+        if not effective <= slot < expiry <= window_end:
+            raise ValidationError("active authority must cover only the exact bounded schedule slot")
+    else:
+        if expires_at is not None or reviewers or not reasons:
+            raise ValidationError("stop actions require reasons, no grant expiry, and no reviewers")
+        if action == "disable" and reasons != ["operator_request"]:
+            raise ValidationError("disable requires an explicit operator_request reason")
+    identity = {
+        "model_version": MODEL_VERSION, "request_id": request, "operator_id": operator,
+        "reviewed_by": reviewers, "action": action, "requested_at": requested.isoformat(),
+        "effective_at": effective.isoformat(), "expires_at": None if expiry is None else expiry.isoformat(),
+        "previous_transition_id": previous_transition_id, "from_state": from_state,
+        "to_state": target, "reason_codes": reasons, "plan": p,
+        "plan_sha256": hashlib.sha256(canonical_bytes(p)).hexdigest(),
+        "scheduler_mutated": False, "external_request_performed": False,
+    }
+    digest = hashlib.sha256(canonical_bytes(identity)).hexdigest()
+    return {"transition_id": f"{MODEL_VERSION}-{digest}", **identity}
+
+
+def validate_worker_authority_transition(value: Mapping[str, Any]) -> dict[str, Any]:
+    p = _exact(value, TRANSITION_KEYS, "worker authority transition")
+    rebuilt = _build(**{key: p[key] for key in (
+        "plan", "request_id", "operator_id", "reviewed_by", "action", "requested_at",
+        "effective_at", "expires_at", "previous_transition_id", "from_state", "reason_codes",
+    )})
+    if canonical_bytes(p) != canonical_bytes(rebuilt):
+        raise ValidationError("worker authority transition differs from canonical evidence")
+    return rebuilt
+
+
+def validate_worker_authority_chain(
+    transition: Mapping[str, Any], previous: Mapping[str, Any] | None,
+) -> dict[str, Any]:
+    current = validate_worker_authority_transition(transition)
+    prior = None if previous is None else validate_worker_authority_transition(previous)
+    expected_id = None if prior is None else prior["transition_id"]
+    if current["previous_transition_id"] != expected_id:
+        raise ValidationError("worker authority predecessor is not the exact current head")
+    effective = utc(current["effective_at"], "effective_at")
+    if current["from_state"] != authority_state(prior, as_of=effective):
+        raise ValidationError("worker authority from_state contradicts its predecessor")
+    if prior is not None:
+        if effective <= utc(prior["effective_at"], "previous effective_at"):
+            raise ValidationError("authority transitions must be strictly time ordered")
+        if utc(current["requested_at"], "requested_at") < utc(prior["effective_at"], "previous effective_at"):
+            raise ValidationError("authority request predates its predecessor")
+        for group, key in (("worker", "worker_id"), ("destination", "destination_id")):
+            if current["plan"][group][key] != prior["plan"][group][key]:
+                raise ValidationError("authority chain cannot change worker or destination identity")
+        if current["action"] in {"suspend", "disable"} and current["plan"] != prior["plan"]:
+            raise ValidationError("stop actions must reference the exact previously governed plan")
+        if current["action"] == "resume" and effective < (
+            utc(prior["effective_at"], "suspended_at")
+            + timedelta(seconds=prior["plan"]["suspension"]["cooldown_seconds"])
+        ):
+            raise ValidationError("resume requires the prior suspension cooldown to elapse")
+        if current["request_id"] == prior["request_id"]:
+            raise ValidationError("a new authority transition requires a new request_id")
+    return current
+
+
+def build_worker_authority_transition(
+    *, plan: Mapping[str, Any], request_id: str, operator_id: str, action: str,
+    requested_at: datetime | str, effective_at: datetime | str,
+    reviewed_by: Sequence[str] = (), expires_at: datetime | str | None = None,
+    reason_codes: Sequence[str] = (), previous: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    prior = None if previous is None else validate_worker_authority_transition(previous)
+    result = _build(
+        plan=plan, request_id=request_id, operator_id=operator_id, reviewed_by=reviewed_by,
+        action=action, requested_at=requested_at, effective_at=effective_at, expires_at=expires_at,
+        previous_transition_id=None if prior is None else prior["transition_id"],
+        from_state=authority_state(prior, as_of=effective_at), reason_codes=reason_codes,
+    )
+    return validate_worker_authority_chain(result, prior)

--- a/tests/unit/test_notification_worker_authority_contract.py
+++ b/tests/unit/test_notification_worker_authority_contract.py
@@ -1,0 +1,248 @@
+from __future__ import annotations
+
+import copy
+import hashlib
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+import pytest
+
+from src.common.exceptions import ValidationError
+from src.orchestration.notification_worker_authority_contract import (
+    CONDITIONS, ENTRYPOINTS, LOCK_MODEL, LOCK_SCOPE, PLAN_MODEL_VERSION,
+    authority_state, build_worker_authority_transition, canonical_bytes,
+    validate_authority_plan, validate_worker_authority_chain,
+    validate_worker_authority_transition,
+)
+
+NOW = datetime(2026, 9, 5, 20, 0, tzinfo=timezone.utc)
+
+
+def plan_fixture(*, planned_at: datetime = NOW, worker_id: str = "authority-worker") -> dict[str, Any]:
+    fingerprint = "portfolio-risk-notification-worker-config-v1-worker-fixture"
+    boundary = ((int(planned_at.timestamp()) // 300) + 1) * 300
+    seed = hashlib.sha256(f"{fingerprint}:{boundary}".encode()).digest()
+    jitter = int.from_bytes(seed[:8], "big") % 31
+    unsigned = int.from_bytes(hashlib.sha256(f"{LOCK_MODEL}:{LOCK_SCOPE}".encode()).digest()[:8], "big")
+    signed = unsigned if unsigned < 2**63 else unsigned - 2**64
+    p: dict[str, Any] = {
+        "model_version": PLAN_MODEL_VERSION, "planned_at": planned_at.isoformat(),
+        "worker": {"worker_id": worker_id, "fingerprint": fingerprint, "enabled": True},
+        "destination": {
+            "destination_id": "risk-operations-webhook", "fingerprint": "destination-fixture",
+            "activation_status": "active", "allowed_event_types": ["breach_opened"],
+            "endpoint_environment_variable": "RISK_NOTIFICATION_WEBHOOK_URL",
+            "endpoint_value_recorded": False,
+        },
+        "delivery": {
+            "delivery_fingerprint": "delivery-fixture", "max_batch_events": 25,
+            "retry_execution_enabled": True, "retry_execution_policy_fingerprint": "retry-execution-fixture",
+            "retry_planning_policy_fingerprint": "retry-planning-fixture", "webhook_enabled": True,
+        },
+        "execution": {
+            "execution_timeout_seconds": 120,
+            "work_items": [{"execution_kind": k, "entrypoint": v, "max_events": 25} for k, v in ENTRYPOINTS.items()],
+        },
+        "concurrency_control": {
+            "key_fingerprint": hashlib.sha256(str(signed).encode("ascii")).hexdigest()[:24],
+            "lock_acquired": False, "max_concurrency": 1, "model_version": LOCK_MODEL, "scope": LOCK_SCOPE,
+        },
+        "readiness": {
+            "max_age_seconds": 300, "refresh_under_shared_lock": True,
+            "required_status": "allowed",
+            "source_view": "risk_platform.current_notification_execution_readiness_review",
+        },
+        "schedule": {
+            "activation_action": "would_create", "boundary_epoch": boundary,
+            "deterministic_jitter_seconds": jitter, "interval_seconds": 300,
+            "jitter_seconds": 30, "mode": "fixed_interval", "timezone": "UTC",
+            "scheduled_for": datetime.fromtimestamp(boundary + jitter, tz=timezone.utc).isoformat(),
+        },
+        "suspension": {"conditions": list(CONDITIONS), "cooldown_seconds": 900, "max_consecutive_failures": 3},
+        "side_effects": {key: False for key in (
+            "acknowledgement_mutated", "cloud_schedule_activated", "database_read_performed",
+            "delivery_attempt_written", "external_request_performed", "infrastructure_deployed",
+            "outbox_mutated", "terraform_apply_performed",
+        )},
+        "status": "would_schedule", "blocking_reasons": [],
+    }
+    return rehash(p)
+
+
+def rehash(plan: dict[str, Any]) -> dict[str, Any]:
+    identity = {key: value for key, value in plan.items() if key != "plan_id"}
+    plan["plan_id"] = f"{PLAN_MODEL_VERSION}-plan-{hashlib.sha256(canonical_bytes(identity)).hexdigest()[:24]}"
+    return plan
+
+
+def grant(*, plan: dict[str, Any] | None = None, **overrides: Any) -> dict[str, Any]:
+    selected = plan if plan is not None else plan_fixture()
+    effective = datetime.fromisoformat(selected["planned_at"]) + timedelta(seconds=1)
+    args = {
+        "plan": selected, "request_id": "AUTH-001", "operator_id": "operator",
+        "reviewed_by": ["independent-reviewer"], "action": "activate",
+        "requested_at": effective, "effective_at": effective,
+        "expires_at": datetime.fromisoformat(selected["schedule"]["scheduled_for"]) + timedelta(seconds=120),
+    }
+    args.update(overrides)
+    return build_worker_authority_transition(**args)
+
+
+def stop(prior: dict[str, Any], *, action: str = "suspend", **overrides: Any) -> dict[str, Any]:
+    args = {
+        "plan": prior["plan"], "request_id": "AUTH-STOP", "operator_id": "operator",
+        "action": action, "requested_at": NOW + timedelta(seconds=2),
+        "effective_at": NOW + timedelta(seconds=2), "previous": prior,
+        "reason_codes": ["operator_request"],
+    }
+    args.update(overrides)
+    return build_worker_authority_transition(**args)
+
+
+def test_full_lifecycle_and_expiry_boundaries() -> None:
+    first = grant()
+    assert validate_worker_authority_transition(first) == first
+    assert authority_state(None, as_of=NOW) == "inactive"
+    assert authority_state(first, as_of=NOW) == "inactive"
+    assert authority_state(first, as_of=first["effective_at"]) == "active"
+    assert authority_state(first, as_of=first["expires_at"]) == "expired"
+    suspended = stop(first)
+    assert authority_state(suspended, as_of=NOW + timedelta(days=1)) == "suspended"
+    later = plan_fixture(planned_at=NOW + timedelta(minutes=20))
+    resumed = grant(plan=later, action="resume", previous=suspended, request_id="AUTH-RESUME")
+    assert resumed["from_state"] == "suspended"
+    disabled = stop(
+        resumed, action="disable", request_id="AUTH-DISABLE",
+        requested_at=NOW + timedelta(minutes=20, seconds=2),
+        effective_at=NOW + timedelta(minutes=20, seconds=2),
+    )
+    assert authority_state(disabled, as_of=NOW + timedelta(days=1)) == "disabled"
+    reactivated = grant(
+        plan=plan_fixture(planned_at=NOW + timedelta(minutes=30)),
+        previous=disabled, request_id="AUTH-REACTIVATE",
+    )
+    assert reactivated["from_state"] == "disabled"
+    assert reactivated["scheduler_mutated"] is False
+
+
+@pytest.mark.parametrize("group,key,value", [
+    ("worker", "enabled", False), ("worker", "enabled", 1),
+    ("readiness", "max_age_seconds", 301), ("readiness", "refresh_under_shared_lock", False),
+    ("readiness", "source_view", "other_view"),
+    ("concurrency_control", "max_concurrency", True),
+    ("concurrency_control", "max_concurrency", 2), ("concurrency_control", "scope", "other"),
+    ("concurrency_control", "key_fingerprint", "different-lock"),
+    ("suspension", "conditions", ["readiness_failure"]),
+    ("suspension", "max_consecutive_failures", 21),
+    ("delivery", "webhook_enabled", False), ("delivery", "retry_execution_enabled", False),
+    ("schedule", "activation_action", "none"), ("schedule", "boundary_epoch", 1),
+    ("schedule", "deterministic_jitter_seconds", 100),
+    ("schedule", "timezone", "Europe/London"), ("schedule", "jitter_seconds", 300),
+    ("destination", "endpoint_environment_variable", "https://unreviewed.test"),
+    ("destination", "endpoint_value_recorded", True),
+    ("destination", "activation_status", "disabled"),
+    ("side_effects", "cloud_schedule_activated", True),
+])
+def test_rehashed_unsafe_plan_is_rejected(group: str, key: str, value: Any) -> None:
+    p = plan_fixture()
+    p[group][key] = value
+    with pytest.raises(ValidationError):
+        grant(plan=rehash(p))
+
+
+def test_rehashed_unknown_fields_and_arbitrary_entrypoints_are_rejected() -> None:
+    p = plan_fixture()
+    p["execution"]["work_items"][0]["entrypoint"] = "os.system"
+    with pytest.raises(ValidationError, match="entrypoint"):
+        grant(plan=rehash(p))
+    p = plan_fixture()
+    p["worker"]["unknown"] = "value"
+    with pytest.raises(ValidationError, match="exact"):
+        grant(plan=rehash(p))
+
+
+@pytest.mark.parametrize("overrides", [
+    {"reviewed_by": []}, {"reviewed_by": ["operator"]}, {"reviewed_by": ["OPERATOR"]},
+    {"reviewed_by": ["A", "a"]}, {"reviewed_by": ["b", "a"]},
+    {"expires_at": None}, {"expires_at": NOW + timedelta(days=1)},
+    {"effective_at": NOW - timedelta(seconds=1)},
+    {"requested_at": datetime(2026, 9, 5)}, {"reason_codes": ["operator_request"]},
+    {"action": "execute"}, {"request_id": "bad request"},
+])
+def test_invalid_grants_fail_closed(overrides: dict[str, Any]) -> None:
+    with pytest.raises(ValidationError):
+        grant(**overrides)
+
+
+def test_disabled_and_blocked_plans_cannot_grant_authority() -> None:
+    for dependency, reason in (("worker", "worker_disabled"), ("delivery", "delivery_disabled")):
+        p = plan_fixture()
+        p[dependency]["enabled" if dependency == "worker" else "webhook_enabled"] = False
+        p["blocking_reasons"] = [reason]
+        p["status"] = "disabled" if dependency == "worker" else "blocked"
+        p["schedule"]["activation_action"] = "none"
+        validate_authority_plan(rehash(p))
+        with pytest.raises(ValidationError, match="disabled or blocked"):
+            grant(plan=p)
+
+
+def test_chain_rejects_wrong_predecessor_scope_and_cooldown() -> None:
+    first = grant()
+    suspended = stop(first)
+    with pytest.raises(ValidationError, match="predecessor"):
+        validate_worker_authority_chain(suspended, None)
+    with pytest.raises(ValidationError, match="cooldown"):
+        grant(action="resume", previous=suspended, request_id="EARLY", requested_at=NOW + timedelta(seconds=3), effective_at=NOW + timedelta(seconds=3))
+    with pytest.raises(ValidationError, match="worker or destination"):
+        grant(
+            plan=plan_fixture(planned_at=NOW + timedelta(minutes=20), worker_id="other-worker"),
+            action="resume", previous=suspended, request_id="OTHER",
+        )
+    with pytest.raises(ValidationError, match="exact previously"):
+        stop(first, plan=plan_fixture(planned_at=NOW + timedelta(seconds=1)))
+    with pytest.raises(ValidationError, match="legal"):
+        grant(previous=first, request_id="SECOND", effective_at=NOW + timedelta(seconds=3))
+
+
+def test_tamper_detection_determinism_and_input_isolation() -> None:
+    p = plan_fixture()
+    first = grant(plan=p)
+    assert first == grant(plan=p)
+    p["worker"]["enabled"] = False
+    assert first["plan"]["worker"]["enabled"] is True
+    for key, value in (("scheduler_mutated", True), ("plan_sha256", "0" * 64), ("to_state", "disabled")):
+        changed = copy.deepcopy(first)
+        changed[key] = value
+        with pytest.raises(ValidationError):
+            validate_worker_authority_transition(changed)
+
+
+def test_real_planner_output_is_accepted(tmp_path: Any) -> None:
+    from pathlib import Path
+
+    import yaml
+
+    from src.orchestration.plan_notification_worker import plan_notification_worker
+
+    documents = {}
+    for name in ("notification_workers", "notification_delivery", "notification_destinations"):
+        documents[name] = yaml.safe_load(Path(f"config/{name}.yaml").read_text())
+    documents["notification_workers"]["workers"]["risk-operations-managed"]["enabled"] = True
+    delivery = documents["notification_delivery"]["delivery"]
+    delivery["webhook"]["enabled"] = True
+    delivery["retry_execution"]["enabled"] = True
+    documents["notification_destinations"]["destinations"]["risk-operations-webhook"]["activation"] = {
+        "enabled": True, "change_request_id": "AUTH-TEST",
+        "reviewed_by": ["independent-reviewer"],
+        "reviewed_at": "2026-09-01T00:00:00Z", "review_expires_at": "2026-10-01T00:00:00Z",
+    }
+    for name, document in documents.items():
+        (tmp_path / f"{name}.yaml").write_text(yaml.safe_dump(document))
+    actual = plan_notification_worker(
+        worker_id="risk-operations-managed", planned_at=NOW,
+        worker_config_path=tmp_path / "notification_workers.yaml",
+        delivery_config_path=tmp_path / "notification_delivery.yaml",
+        destination_config_path=tmp_path / "notification_destinations.yaml",
+    )
+    assert validate_authority_plan(actual) == actual
+    assert grant(plan=actual)["plan"]["plan_id"] == actual["plan_id"]


### PR DESCRIPTION
## Goal

Deliver **P4e2a**: deterministic `activate`, `suspend`, `resume`, and `disable` evidence over one exact managed-worker plan. Primary arc42 block: `orchestration`.

## Changes

- Validate plan semantics independently of its recomputable hash: exact nested fields, dependency blockers, reviewed entrypoints, shared lock identity, mandatory suspension conditions, bounded batches/readiness, and deterministic UTC scheduling.
- Bind operator request, independent reviewer identities, exact predecessor, plan digest, effective time and exclusive expiry.
- Restrict active authority to one schedule slot and its execution-timeout window.
- Require strictly ordered transitions and suspension cooldown before resume.
- Allow stop actions without a new activation review; preserve the exact previously governed plan.
- Preserve all disabled defaults and existing plan/delivery APIs.

## Validation

GitHub Actions run **420** (`33993878881`) passed on exact head `f023ef1bded8c8919804292efe00d883eb29afbd`:

- Security guardrails passed.
- Ruff and mypy passed across **151 source files**.
- **990 tests passed twice**, including the real P4e1 planner integration.
- Dependency integrity, pipeline replay and warehouse dry-run passed.
- PostgreSQL 16 contracts passed.
- Kubernetes rendering and Terraform format/init/validate passed, without apply.

Local validation: 39 pure contract tests passed, one complete-repository integration test deselected locally but passed in CI; syntax compilation passed. Local Docker, Terraform and the complete dependency environment were unavailable.

Three additive files, 688 lines, one commit; no configuration, workflow, infrastructure or database change. Tested tree: `298e47c0859624801f0b77edea57920b7b9cab96`. No review submissions or unresolved threads were present at the merge gate; this does not represent independent human approval.

## Acceptance and safety boundaries

These are evidence records, not authenticated signatures or permission to send. Reviewer strings are not authentication, and hashes do not prove the source configuration remains current. A future runtime must authenticate callers, read retained authority and refresh readiness under the shared delivery lock.

No scheduler activation, network request, database connection, delivery, deployment, or `terraform apply` is performed by this contract. No endpoint values, secrets or payload bodies. Human operational activation remains separate.

Roadmap: #76. P4e2b persistence follows this contract.