### PR TITLE
Validate retained managed-worker plans beyond their content hash

### DIFF
--- a/docs/managed-notification-worker-plan-validation.md
+++ b/docs/managed-notification-worker-plan-validation.md
@@ -1,0 +1,73 @@
+# Retained Managed-Worker Plan Validation
+
+Primary arc42 block: `orchestration`.
+
+## Decision
+
+The existing `validate_notification_worker_plan` entry point delegates to
+`notification_worker_plan_validation.py`. A document digest detects content
+changes; it does not prove that the content obeys the worker contract. The
+validator therefore checks nested semantics before accepting the digest.
+
+All nested objects have exact field sets. Worker and delivery enablement,
+review status, execution kinds, canonical blockers, overall status and the
+schedule activation action must agree. Execution entries use only the reviewed
+initial/retry module identities. Event kinds and environment-variable names are
+validated without resolving environment values.
+
+The shared-lock identity must be exact, concurrency must be the integer one,
+and the plan must not claim to have acquired the lock. Readiness remains
+`allowed`, at most 300 seconds old, with refresh beneath that same lock.
+Mandatory suspension conditions cannot be omitted or reordered. Every declared
+side effect must be the boolean false, not an integer that compares equal.
+
+## Deterministic Scheduling
+
+The builder and validator share one integer UTC calculation for the first
+strictly future interval boundary and deterministic jitter. Integer arithmetic
+also handles a fractional instant immediately before the Unix epoch correctly;
+truncating a floating-point timestamp toward zero would skip its next boundary.
+A next slot beyond Python's datetime range is rejected as a validation error.
+
+Existing modern-date plans retain their model version and calculation. Retained
+time strings use the builder's canonical UTC ISO representation. Equivalent
+noncanonical spellings must be regenerated rather than silently rewritten.
+
+## Remaining Authority Boundary
+
+A self-consistent digest is not authentication or approval. The compact plan
+does not embed complete worker, delivery, retry and destination configurations.
+For example, it includes the destination environment-variable name but only the
+delivery fingerprint, so a retained endpoint-mismatch reason cannot be fully
+rederived from that document alone. Unused per-kind limits and all fingerprint
+preimages likewise require the source configurations.
+
+Any later lifecycle-authority constructor must independently rebuild the whole
+plan from the supplied reviewed configurations at the original planning instant
+and require exact canonical agreement. It must then evaluate review lifetimes
+at the proposed authority time. This PR validates retained evidence; it does
+not grant execution authority, read current PostgreSQL readiness or activate a
+scheduler.
+
+The returned document is a detached JSON snapshot, bounded to 1 MB, so later
+mutation of the caller's input containers cannot change the validated result.
+This is not a cryptographic signature, an immutable Python object or a durable
+append-only record.
+
+## Regression Evidence
+
+```bash
+.venv/bin/python -m pytest -q tests/unit/test_notification_worker_plan_validation.py
+make quality-check
+make security-check
+make readiness-check
+```
+
+Adversarial tests recompute the plan ID after changing nested fields. They cover
+entrypoints, lock flags, enablement, canonical blockers, events, fingerprints,
+readiness, bounds, timestamps and side effects. Positive cases preserve
+initial-only work when retry execution is disabled. Boundary cases cover
+pre-epoch fractions, exact interval edges and datetime overflow.
+
+The planner CLI and optional safe summary writer remain unchanged. Committed
+worker, delivery, retry and destination switches remain disabled.

--- a/src/orchestration/notification_worker_plan_validation.py
+++ b/src/orchestration/notification_worker_plan_validation.py
@@ -1,0 +1,285 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from collections.abc import Mapping
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+from src.common.exceptions import ValidationError
+from src.orchestration.plan_notification_worker import (
+    BLOCKING_REASON_ORDER,
+    CONFIG_MODEL_VERSION,
+    INITIAL_ENTRYPOINT,
+    MAX_CONFIG_BYTES,
+    MAX_CONSECUTIVE_FAILURES,
+    MAX_COOLDOWN_SECONDS,
+    MAX_EXECUTION_TIMEOUT_SECONDS,
+    PLAN_MODEL_VERSION,
+    RETRY_ENTRYPOINT,
+    _canonical_bytes,
+    _parse_readiness,
+    _parse_schedule,
+    _plan_id,
+)
+from src.orchestration.portfolio_risk_notification_delivery_lock import (
+    LOCK_KEY_FINGERPRINT,
+    LOCK_MODEL_VERSION,
+    LOCK_SCOPE,
+)
+from src.orchestration.portfolio_risk_notification_destination_contract import (
+    ENVIRONMENT_NAME,
+    EVENT_TYPES,
+    MODEL_VERSION as DESTINATION_MODEL_VERSION,
+)
+from src.orchestration.portfolio_risk_notification_retry_execution_policy import (
+    POLICY_MODEL_VERSION as RETRY_EXECUTION_POLICY_VERSION,
+    aware_utc,
+    bounded_integer,
+    safe_segment,
+)
+from src.orchestration.plan_portfolio_risk_notification_retries import (
+    POLICY_MODEL_VERSION as RETRY_PLANNING_POLICY_VERSION,
+)
+
+PLAN_FIELDS = frozenset({
+    "plan_id", "blocking_reasons", "concurrency_control", "delivery",
+    "destination", "execution", "model_version", "planned_at", "readiness",
+    "schedule", "side_effects", "status", "suspension", "worker",
+})
+SIDE_EFFECT_FIELDS = frozenset({
+    "acknowledgement_mutated", "cloud_schedule_activated",
+    "database_read_performed", "delivery_attempt_written",
+    "external_request_performed", "infrastructure_deployed", "outbox_mutated",
+    "terraform_apply_performed",
+})
+SUSPENSION_CONDITIONS = (
+    "expired_review", "persistence_ambiguity", "readiness_failure",
+    "repeated_delivery_failure",
+)
+READINESS_VIEW = "risk_platform.current_notification_execution_readiness_review"
+
+
+def exact_object(value: Any, fields: frozenset[str], label: str) -> dict[str, Any]:
+    if not isinstance(value, Mapping) or set(value) != fields:
+        raise ValidationError(f"{label} fields are invalid")
+    return dict(value)
+
+
+def canonical_timestamp(value: Any, label: str) -> datetime:
+    try:
+        parsed = aware_utc(value, label)
+    except (OverflowError, ValueError):
+        raise ValidationError(f"{label} is outside datetime bounds") from None
+    if not isinstance(value, str) or value != parsed.isoformat():
+        raise ValidationError(f"{label} must use canonical UTC text")
+    return parsed
+
+
+def _fingerprint(value: Any, prefix: str, label: str) -> str:
+    if not isinstance(value, str) or re.fullmatch(
+        re.escape(prefix) + r"-[0-9a-f]{24}", value
+    ) is None:
+        raise ValidationError(f"{label} fingerprint is invalid")
+    return value
+
+
+def _boolean(value: Any, label: str) -> bool:
+    if type(value) is not bool:
+        raise ValidationError(f"{label} must be boolean")
+    return bool(value)
+
+
+def deterministic_schedule(
+    worker_fingerprint: str, planned: datetime, interval: int, jitter_limit: int
+) -> tuple[datetime, int, int]:
+    """Compute the first future slot using integer UTC arithmetic."""
+    bounds = _parse_schedule({
+        "mode": "fixed_interval", "timezone": "UTC",
+        "interval_seconds": interval, "jitter_seconds": jitter_limit,
+    })
+    planned = aware_utc(planned, "planned_at")
+    epoch = datetime(1970, 1, 1, tzinfo=timezone.utc)
+    elapsed = planned - epoch
+    whole_seconds = elapsed.days * 86_400 + elapsed.seconds
+    boundary = (whole_seconds // bounds.interval_seconds + 1) * bounds.interval_seconds
+    seed = hashlib.sha256(f"{worker_fingerprint}:{boundary}".encode()).digest()
+    jitter = int.from_bytes(seed[:8], "big") % (bounds.jitter_seconds + 1)
+    try:
+        scheduled = epoch + timedelta(seconds=boundary + jitter)
+    except OverflowError:
+        raise ValidationError("next worker schedule is outside datetime bounds") from None
+    return scheduled, boundary, jitter
+
+
+def validate_retained_notification_worker_plan(plan: Mapping[str, Any]) -> dict[str, Any]:
+    """Validate internal semantics, not authenticity or current configuration."""
+    source = exact_object(plan, PLAN_FIELDS, "notification worker plan")
+    try:
+        encoded = _canonical_bytes(source, "notification worker plan")
+    except (RecursionError, UnicodeError):
+        raise ValidationError("notification worker plan is not canonical JSON") from None
+    if len(encoded) > MAX_CONFIG_BYTES:
+        raise ValidationError("notification worker plan exceeds 1 MB")
+    parsed = json.loads(encoded)
+    assert isinstance(parsed, dict)
+    # A detached JSON snapshot avoids aliasing the caller's nested containers.
+    plan = parsed
+    if plan["model_version"] != PLAN_MODEL_VERSION:
+        raise ValidationError("notification worker plan model_version is unsupported")
+    status = plan["status"]
+    if not isinstance(status, str) or status not in {"disabled", "blocked", "would_schedule"}:
+        raise ValidationError("notification worker plan status is invalid")
+    planned = canonical_timestamp(plan["planned_at"], "planned_at")
+
+    worker = exact_object(
+        plan["worker"], frozenset({"enabled", "fingerprint", "worker_id"}), "worker"
+    )
+    enabled = _boolean(worker["enabled"], "worker enabled")
+    safe_segment(worker["worker_id"], "worker_id")
+    fingerprint = _fingerprint(
+        worker["fingerprint"], f"{CONFIG_MODEL_VERSION}-worker", "worker"
+    )
+
+    lock = exact_object(plan["concurrency_control"], frozenset({
+        "key_fingerprint", "lock_acquired", "max_concurrency", "model_version", "scope"
+    }), "worker concurrency control")
+    bounded_integer(lock["max_concurrency"], "max_concurrency", minimum=1, maximum=1)
+    if (lock["lock_acquired"] is not False or lock["model_version"] != LOCK_MODEL_VERSION
+            or lock["scope"] != LOCK_SCOPE or lock["key_fingerprint"] != LOCK_KEY_FINGERPRINT):
+        raise ValidationError("worker concurrency control differs from the shared lock")
+
+    delivery = exact_object(plan["delivery"], frozenset({
+        "delivery_fingerprint", "max_batch_events", "retry_execution_enabled",
+        "retry_execution_policy_fingerprint", "retry_planning_policy_fingerprint", "webhook_enabled"
+    }), "worker delivery")
+    delivery_enabled = _boolean(delivery["webhook_enabled"], "webhook_enabled")
+    retry_enabled = _boolean(delivery["retry_execution_enabled"], "retry_execution_enabled")
+    batch_limit = bounded_integer(
+        delivery["max_batch_events"], "max_batch_events", minimum=1, maximum=100
+    )
+    _fingerprint(delivery["delivery_fingerprint"], "webhook-delivery", "delivery")
+    _fingerprint(
+        delivery["retry_execution_policy_fingerprint"],
+        f"{RETRY_EXECUTION_POLICY_VERSION}-policy", "retry execution"
+    )
+    _fingerprint(
+        delivery["retry_planning_policy_fingerprint"],
+        f"{RETRY_PLANNING_POLICY_VERSION}-policy", "retry planning"
+    )
+
+    destination = exact_object(plan["destination"], frozenset({
+        "activation_status", "allowed_event_types", "destination_id",
+        "endpoint_environment_variable", "endpoint_value_recorded", "fingerprint"
+    }), "worker destination")
+    safe_segment(destination["destination_id"], "destination_id")
+    _fingerprint(
+        destination["fingerprint"], f"{DESTINATION_MODEL_VERSION}-destination", "destination"
+    )
+    activation = destination["activation_status"]
+    if not isinstance(activation, str) or activation not in {
+        "disabled", "not_yet_reviewed", "review_expired", "active"
+    }:
+        raise ValidationError("destination activation status is invalid")
+    environment = destination["endpoint_environment_variable"]
+    if not isinstance(environment, str) or not ENVIRONMENT_NAME.fullmatch(environment):
+        raise ValidationError("destination environment-variable name is invalid")
+    if destination["endpoint_value_recorded"] is not False:
+        raise ValidationError("worker plan must not record an endpoint value")
+    events = destination["allowed_event_types"]
+    if (not isinstance(events, list) or not events
+            or any(not isinstance(item, str) for item in events)
+            or events != sorted(set(events)) or not set(events).issubset(EVENT_TYPES)):
+        raise ValidationError("destination event types are invalid")
+
+    execution = exact_object(
+        plan["execution"], frozenset({"execution_timeout_seconds", "work_items"}),
+        "worker execution"
+    )
+    bounded_integer(
+        execution["execution_timeout_seconds"], "execution timeout",
+        minimum=1, maximum=MAX_EXECUTION_TIMEOUT_SECONDS
+    )
+    items = execution["work_items"]
+    if not isinstance(items, list) or not 1 <= len(items) <= 2:
+        raise ValidationError("worker work_items must contain one or two entries")
+    kinds: list[str] = []
+    entrypoints = {"initial": INITIAL_ENTRYPOINT, "retry": RETRY_ENTRYPOINT}
+    for item in items:
+        work = exact_object(
+            item, frozenset({"entrypoint", "execution_kind", "max_events"}), "worker work item"
+        )
+        kind = work["execution_kind"]
+        if not isinstance(kind, str) or kind not in entrypoints:
+            raise ValidationError("worker execution kind is invalid")
+        if work["entrypoint"] != entrypoints[kind]:
+            raise ValidationError("worker execution entrypoint is not reviewed")
+        bounded_integer(work["max_events"], "work max_events", minimum=1, maximum=batch_limit)
+        kinds.append(kind)
+    if kinds != sorted(set(kinds)):
+        raise ValidationError("worker execution kinds must be sorted and unique")
+
+    readiness = exact_object(plan["readiness"], frozenset({
+        "max_age_seconds", "refresh_under_shared_lock", "required_status", "source_view"
+    }), "worker readiness")
+    _parse_readiness({key: readiness[key] for key in ("required_status", "max_age_seconds")})
+    if readiness["refresh_under_shared_lock"] is not True or readiness["source_view"] != READINESS_VIEW:
+        raise ValidationError("worker readiness must refresh under the shared lock")
+    suspension = exact_object(plan["suspension"], frozenset({
+        "conditions", "cooldown_seconds", "max_consecutive_failures"
+    }), "worker suspension")
+    if suspension["conditions"] != list(SUSPENSION_CONDITIONS):
+        raise ValidationError("worker suspension conditions are invalid")
+    bounded_integer(
+        suspension["cooldown_seconds"], "cooldown_seconds",
+        minimum=0, maximum=MAX_COOLDOWN_SECONDS
+    )
+    bounded_integer(
+        suspension["max_consecutive_failures"], "max_consecutive_failures",
+        minimum=1, maximum=MAX_CONSECUTIVE_FAILURES
+    )
+
+    reasons = plan["blocking_reasons"]
+    if (not isinstance(reasons, list) or any(not isinstance(item, str) for item in reasons)
+            or reasons != [reason for reason in BLOCKING_REASON_ORDER if reason in reasons]):
+        raise ValidationError("worker blocking reasons are not canonical")
+    known_blockers = {
+        "worker_disabled": not enabled,
+        "delivery_disabled": not delivery_enabled,
+        "retry_execution_disabled": "retry" in kinds and not retry_enabled,
+        "destination_not_active": activation != "active",
+    }
+    if any((reason in reasons) != required for reason, required in known_blockers.items()):
+        raise ValidationError("worker blocking reasons contradict the retained configuration")
+    expected_status = "disabled" if not enabled else "blocked" if reasons else "would_schedule"
+    if status != expected_status:
+        raise ValidationError("worker status contradicts its enabled state or blockers")
+
+    schedule = exact_object(plan["schedule"], frozenset({
+        "activation_action", "boundary_epoch", "deterministic_jitter_seconds",
+        "interval_seconds", "jitter_seconds", "mode", "scheduled_for", "timezone"
+    }), "worker schedule")
+    bounds = _parse_schedule({
+        key: schedule[key] for key in ("mode", "interval_seconds", "jitter_seconds", "timezone")
+    })
+    scheduled, boundary, jitter = deterministic_schedule(
+        fingerprint, planned, bounds.interval_seconds, bounds.jitter_seconds
+    )
+    if (type(schedule["boundary_epoch"]) is not int or schedule["boundary_epoch"] != boundary
+            or type(schedule["deterministic_jitter_seconds"]) is not int
+            or schedule["deterministic_jitter_seconds"] != jitter
+            or canonical_timestamp(schedule["scheduled_for"], "scheduled_for") != scheduled
+            or scheduled <= planned):
+        raise ValidationError("worker schedule is not the deterministic next slot")
+    expected_action = "would_create" if status == "would_schedule" else "none"
+    if schedule["activation_action"] != expected_action:
+        raise ValidationError("worker schedule activation action contradicts status")
+    side_effects = exact_object(plan["side_effects"], SIDE_EFFECT_FIELDS, "worker plan side effects")
+    if any(value is not False for value in side_effects.values()):
+        raise ValidationError("notification worker plan reports a side effect")
+    identity = dict(plan)
+    supplied_id = identity.pop("plan_id")
+    if supplied_id != _plan_id(identity):
+        raise ValidationError("notification worker plan_id does not match content")
+    return parsed

--- a/src/orchestration/plan_notification_worker.py
+++ b/src/orchestration/plan_notification_worker.py
@@ -438,21 +438,16 @@ def _next_schedule(
     worker: NotificationWorker,
     planned_at: datetime,
 ) -> tuple[datetime, int, int]:
-    epoch = int(planned_at.timestamp())
-    interval = worker.schedule.interval_seconds
-    boundary_epoch = ((epoch // interval) + 1) * interval
-    seed = hashlib.sha256(
-        f"{worker.fingerprint}:{boundary_epoch}".encode("utf-8")
-    ).digest()
-    jitter_limit = worker.schedule.jitter_seconds
-    jitter = 0 if jitter_limit == 0 else int.from_bytes(seed[:8], "big") % (
-        jitter_limit + 1
+    from src.orchestration.notification_worker_plan_validation import (
+        deterministic_schedule,
     )
-    scheduled_for = datetime.fromtimestamp(
-        boundary_epoch + jitter,
-        tz=timezone.utc,
+
+    return deterministic_schedule(
+        worker.fingerprint,
+        planned_at,
+        worker.schedule.interval_seconds,
+        worker.schedule.jitter_seconds,
     )
-    return scheduled_for, boundary_epoch, jitter
 
 
 def _work_items(worker: NotificationWorker) -> list[dict[str, Any]]:
@@ -668,79 +663,11 @@ def plan_notification_worker(
 
 
 def validate_notification_worker_plan(plan: Mapping[str, Any]) -> dict[str, Any]:
-    if not isinstance(plan, Mapping):
-        raise ValidationError("notification worker plan must be a mapping")
-    expected = {
-        "plan_id",
-        "blocking_reasons",
-        "concurrency_control",
-        "delivery",
-        "destination",
-        "execution",
-        "model_version",
-        "planned_at",
-        "readiness",
-        "schedule",
-        "side_effects",
-        "status",
-        "suspension",
-        "worker",
-    }
-    if set(plan) != expected:
-        raise ValidationError("notification worker plan fields are invalid")
-    if plan["model_version"] != PLAN_MODEL_VERSION:
-        raise ValidationError("notification worker plan model_version is unsupported")
-    if plan["status"] not in {"disabled", "blocked", "would_schedule"}:
-        raise ValidationError("notification worker plan status is invalid")
-    reasons = plan["blocking_reasons"]
-    if not isinstance(reasons, list):
-        raise ValidationError("blocking_reasons must be an array")
-    if reasons != [reason for reason in BLOCKING_REASON_ORDER if reason in reasons]:
-        raise ValidationError("blocking_reasons are not canonical")
-    if len(reasons) != len(set(reasons)):
-        raise ValidationError("blocking_reasons contain duplicates")
-    side_effects = exact_mapping(
-        plan["side_effects"],
-        frozenset(
-            {
-                "acknowledgement_mutated",
-                "cloud_schedule_activated",
-                "database_read_performed",
-                "delivery_attempt_written",
-                "external_request_performed",
-                "infrastructure_deployed",
-                "outbox_mutated",
-                "terraform_apply_performed",
-            }
-        ),
-        "worker plan side effects",
+    from src.orchestration.notification_worker_plan_validation import (
+        validate_retained_notification_worker_plan,
     )
-    if any(value is not False for value in side_effects.values()):
-        raise ValidationError("notification worker plan reports a side effect")
-    planned = aware_utc(plan["planned_at"], "planned_at")
-    schedule = plan["schedule"]
-    if not isinstance(schedule, Mapping):
-        raise ValidationError("worker plan schedule must be a mapping")
-    scheduled_for = aware_utc(schedule.get("scheduled_for"), "scheduled_for")
-    if scheduled_for <= planned:
-        raise ValidationError("scheduled_for must follow planned_at")
-    worker = plan["worker"]
-    if not isinstance(worker, Mapping):
-        raise ValidationError("worker plan identity must be a mapping")
-    enabled = worker.get("enabled")
-    if type(enabled) is not bool:
-        raise ValidationError("worker plan enabled state is invalid")
-    if plan["status"] == "disabled" and enabled is not False:
-        raise ValidationError("disabled plan requires a disabled worker")
-    if plan["status"] == "would_schedule" and reasons:
-        raise ValidationError("would_schedule plan must have no blockers")
-    if plan["status"] == "blocked" and (not reasons or enabled is not True):
-        raise ValidationError("blocked plan must have an enabled worker and blockers")
-    identity = dict(plan)
-    supplied_plan_id = identity.pop("plan_id")
-    if supplied_plan_id != _plan_id(identity):
-        raise ValidationError("notification worker plan_id does not match content")
-    return dict(plan)
+
+    return validate_retained_notification_worker_plan(plan)
 
 
 def _timestamp(value: str) -> datetime:

--- a/src/orchestration/plan_notification_worker.py
+++ b/src/orchestration/plan_notification_worker.py
@@ -6,7 +6,7 @@ import json
 import sys
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import datetime
 from pathlib import Path
 from typing import Any
 

--- a/tests/unit/test_notification_worker_plan_validation.py
+++ b/tests/unit/test_notification_worker_plan_validation.py
@@ -1,0 +1,190 @@
+from __future__ import annotations
+
+import copy
+from dataclasses import replace
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from src.common.exceptions import ValidationError
+from src.orchestration.plan_notification_worker import (
+    _plan_id,
+    build_notification_worker_plan,
+    load_notification_workers,
+    plan_notification_worker,
+    validate_notification_worker_plan,
+)
+from src.orchestration.portfolio_risk_notification_destination_contract import (
+    DestinationActivation,
+    load_notification_destinations,
+)
+from src.orchestration.portfolio_risk_notification_retry_execution_policy import (
+    load_retry_execution_contract,
+)
+
+WORKER_ID = "risk-operations-managed"
+BASE_TIME = datetime(2026, 9, 5, 20, tzinfo=timezone.utc)
+
+
+def _plan(*, initial_only: bool = False) -> dict[str, Any]:
+    worker = load_notification_workers(Path("config/notification_workers.yaml"))[WORKER_ID]
+    delivery, policy, execution = load_retry_execution_contract(
+        Path("config/notification_delivery.yaml")
+    )
+    destination = load_notification_destinations(
+        Path("config/notification_destinations.yaml")
+    )[worker.destination_id]
+    destination = replace(destination, activation=DestinationActivation(
+        enabled=True,
+        change_request_id="CHG-WORKER-VALIDATION",
+        reviewed_by=("risk-control-reviewer",),
+        reviewed_at=datetime(2026, 9, 1, tzinfo=timezone.utc),
+        review_expires_at=datetime(2026, 10, 1, tzinfo=timezone.utc),
+    ))
+    return build_notification_worker_plan(
+        worker=replace(
+            worker, enabled=True,
+            execution_kinds=("initial",) if initial_only else ("initial", "retry"),
+        ),
+        delivery=replace(delivery, enabled=True),
+        retry_policy=policy,
+        retry_execution=replace(execution, enabled=not initial_only),
+        destination=destination,
+        planned_at=BASE_TIME,
+    )
+
+
+def _rehash(plan: dict[str, Any]) -> None:
+    plan["plan_id"] = _plan_id({key: value for key, value in plan.items() if key != "plan_id"})
+
+
+@pytest.mark.parametrize(("path", "value"), [
+    ("worker.enabled", False),
+    ("worker.enabled", 1),
+    ("worker.worker_id", "../unreviewed"),
+    ("worker.fingerprint", "not-a-fingerprint"),
+    ("worker.extra", "unexpected"),
+    ("concurrency_control.lock_acquired", True),
+    ("concurrency_control.lock_acquired", 0),
+    ("concurrency_control.max_concurrency", True),
+    ("concurrency_control.max_concurrency", 2),
+    ("concurrency_control.scope", "unreviewed-scope"),
+    ("concurrency_control.key_fingerprint", "changed-lock"),
+    ("delivery.webhook_enabled", False),
+    ("delivery.retry_execution_enabled", False),
+    ("delivery.max_batch_events", 0),
+    ("delivery.max_batch_events", 101),
+    ("delivery.delivery_fingerprint", "unreviewed-delivery"),
+    ("delivery.endpoint_value", "must-not-be-retained"),
+    ("destination.activation_status", "review_expired"),
+    ("destination.endpoint_environment_variable", "not an environment name"),
+    ("destination.endpoint_value_recorded", True),
+    ("destination.allowed_event_types", ["unreviewed_event"]),
+    ("destination.allowed_event_types", ["breach_opened", "breach_opened"]),
+    ("destination.allowed_event_types", [[]]),
+    ("destination.extra", "unexpected"),
+    ("execution.execution_timeout_seconds", 0),
+    ("execution.execution_timeout_seconds", 3601),
+    ("execution.work_items", []),
+    ("execution.work_items.0.entrypoint", "unreviewed.module"),
+    ("execution.work_items.0.execution_kind", "automatic"),
+    ("execution.work_items.0.max_events", 101),
+    ("execution.work_items.0.max_events", True),
+    ("execution.work_items.0.extra", "unexpected"),
+    ("readiness.max_age_seconds", 301),
+    ("readiness.required_status", "blocked"),
+    ("readiness.refresh_under_shared_lock", False),
+    ("readiness.source_view", "unreviewed_view"),
+    ("suspension.conditions", []),
+    ("suspension.cooldown_seconds", -1),
+    ("suspension.max_consecutive_failures", 21),
+    ("schedule.mode", "cron"),
+    ("schedule.timezone", "Europe/London"),
+    ("schedule.interval_seconds", True),
+    ("schedule.jitter_seconds", 151),
+    ("schedule.boundary_epoch", 0),
+    ("schedule.deterministic_jitter_seconds", 31),
+    ("schedule.scheduled_for", "2026-09-05T20:09:00+00:00"),
+    ("schedule.activation_action", "none"),
+    ("side_effects.external_request_performed", True),
+    ("side_effects.outbox_mutated", 0),
+    ("status", "disabled"),
+    ("status", {}),
+    ("blocking_reasons", ["worker_disabled"]),
+    ("blocking_reasons", [[]]),
+    ("planned_at", "2026-09-05T20:00:00Z"),
+])
+def test_rehashed_nested_tampering_is_rejected(path: str, value: Any) -> None:
+    plan = _plan()
+    target: Any = plan
+    segments = path.split(".")
+    for segment in segments[:-1]:
+        target = target[int(segment)] if isinstance(target, list) else target[segment]
+    target[segments[-1]] = value
+    _rehash(plan)
+    with pytest.raises(ValidationError):
+        validate_notification_worker_plan(plan)
+
+
+def test_valid_initial_only_plan_does_not_require_retry_enablement() -> None:
+    plan = _plan(initial_only=True)
+    assert plan["delivery"]["retry_execution_enabled"] is False
+    assert plan["status"] == "would_schedule"
+    assert validate_notification_worker_plan(plan) == plan
+
+
+def test_duplicate_or_unsorted_work_is_rejected_after_rehash() -> None:
+    for duplicate in (False, True):
+        plan = _plan()
+        items = plan["execution"]["work_items"]
+        plan["execution"]["work_items"] = [items[0], items[0]] if duplicate else list(reversed(items))
+        _rehash(plan)
+        with pytest.raises(ValidationError, match="sorted and unique"):
+            validate_notification_worker_plan(plan)
+
+
+def test_false_worker_cannot_claim_would_schedule_with_empty_blockers() -> None:
+    plan = _plan()
+    plan["worker"]["enabled"] = False
+    _rehash(plan)
+    with pytest.raises(ValidationError, match="contradict"):
+        validate_notification_worker_plan(plan)
+
+
+def test_validation_returns_detached_snapshot() -> None:
+    plan = _plan()
+    expected = copy.deepcopy(plan)
+    retained = validate_notification_worker_plan(plan)
+    plan["worker"]["enabled"] = False
+    plan["execution"]["work_items"].clear()
+    assert retained == expected
+
+
+def test_retained_plan_size_is_bounded() -> None:
+    plan = _plan()
+    plan["worker"]["worker_id"] = "x" * 1_048_576
+    _rehash(plan)
+    with pytest.raises(ValidationError, match="1 MB"):
+        validate_notification_worker_plan(plan)
+
+
+@pytest.mark.parametrize(("instant", "boundary"), [
+    ("1969-12-31T23:59:59.500000+00:00", 0),
+    ("1970-01-01T00:00:00+00:00", 300),
+    ("1970-01-01T00:04:59.999999+00:00", 300),
+    ("1970-01-01T00:05:00+00:00", 600),
+])
+def test_next_boundary_uses_integer_utc_arithmetic(instant: str, boundary: int) -> None:
+    plan = plan_notification_worker(worker_id=WORKER_ID, planned_at=instant)
+    assert plan["schedule"]["boundary_epoch"] == boundary
+    assert validate_notification_worker_plan(plan) == plan
+
+
+def test_schedule_overflow_is_validation_error() -> None:
+    with pytest.raises(ValidationError, match="datetime bounds"):
+        plan_notification_worker(
+            worker_id=WORKER_ID,
+            planned_at=datetime.max.replace(tzinfo=timezone.utc),
+        )


### PR DESCRIPTION
## Goal

Closes #147. Second increment under #76, following merged #149. Primary arc42 block: `orchestration`.

## Changes

Strict retained-plan validation now enforces exact nested fields, strict types, reviewed entrypoints, lock identity, readiness/suspension controls, dependency blockers and deterministic UTC scheduling. The builder shares the integer scheduling implementation, including correct pre-epoch fractions and normalized datetime overflow. Validated output is a bounded detached JSON snapshot.

64 additional regression cases include rehashed nested tampering, valid initial-only operation, deep-copy isolation and timestamp boundaries.

## Validation and integration review

Final PR head: `4ca30ad1950a7e84f01e32f425779e4ef134c0c1`.

Actions run **422** (`33994162628`) passed all four jobs: Python readiness, Security guardrails, PostgreSQL contract and Infrastructure validation. Logs confirm Ruff, mypy across **153 source files**, **1,076 tests twice**, dependency integrity, pipeline replay and warehouse dry-run.

Importantly, CI checked merge commit `a68bce29cad7b2a2215730f37365263a5f29683f`, combining this exact head with current main `12a70ffa2a2615cedb77fe94f9ddd3a04f4c4a5f`, which already includes concurrently merged #150. Its lifecycle tests therefore passed alongside these changes.

Four intended files, 562 additions and 87 deletions. The existing planner diff is limited to strict-validation delegation, shared schedule calculation and removal of its unused timezone import. No review submissions or unresolved threads were present at the gate. These are automated checks and self-review, not independent human approval.

## Authority boundary

Hashes are not authentication, and compact plans cannot prove all fingerprint preimages or delivery endpoint-environment matching. The next increment binds #150's existing lifecycle contract back to reviewed configurations; it will not duplicate that state machine.

No execution, scheduling, database, cloud, workflow, dependency or committed configuration changes. All committed enablement switches remain disabled.