### PR TITLE
Persist append-only notification worker authority history

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -271,6 +271,8 @@ postgres-contract-check:
 		--dsn "$(LOCAL_POSTGRES_DSN)"
 	$(PYTHON) -m src.warehouse.notification_retry_governance_bundle_postgres_contract_check \
 		--dsn "$(LOCAL_POSTGRES_DSN)"
+	$(PYTHON) -m src.warehouse.notification_worker_authority_postgres_contract_check \
+		--dsn "$(LOCAL_POSTGRES_DSN)"
 
 local-db-up:
 	docker compose up -d postgres mongo

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,6 +36,7 @@ services:
       - ./sql/notification_execution_readiness_schema.sql:/docker-entrypoint-initdb.d/25_notification_execution_readiness_schema.sql:ro
       - ./sql/notification_retry_readiness_binding_schema.sql:/docker-entrypoint-initdb.d/26_notification_retry_readiness_binding_schema.sql:ro
       - ./sql/notification_retry_readiness_follow_up_schema.sql:/docker-entrypoint-initdb.d/27_notification_retry_readiness_follow_up_schema.sql:ro
+      - ./sql/notification_worker_authority_schema.sql:/docker-entrypoint-initdb.d/28_notification_worker_authority_schema.sql:ro
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U risk_user -d risk_platform"]
       interval: 5s

--- a/docs/notification-worker-authority-history.md
+++ b/docs/notification-worker-authority-history.md
@@ -1,0 +1,112 @@
+# Append-only notification worker authority history
+
+Primary arc42 block: `warehouse`.
+
+## Goal
+
+P4e2b retains the exact P4e2a authority transition without introducing another
+approval model or activating a scheduler:
+
+```text
+canonical transition + exact current predecessor
+  -> per-worker transaction lock
+  -> independently validated chain
+  -> append-only history
+  -> current active / suspended / expired / disabled evidence
+```
+
+Use `src/warehouse/notification_worker_authority_history.py` and
+`sql/notification_worker_authority_schema.sql`. An unknown worker is `inactive`
+in the reader; the SQL view contains only workers with retained history.
+
+## Recording and concurrency
+
+The recorder validates the entire transition before opening PostgreSQL. Within
+one READ COMMITTED transaction it sets bounded lock and statement timeouts,
+acquires a per-worker transaction advisory lock, checks exact request replay,
+reads the latest sequence, and validates the predecessor and state transition.
+A new insert and its server-assigned sequence commit together or roll back.
+
+The insert trigger independently checks the current predecessor, worker and
+destination continuity, source state, chronology, stop-plan equality and resume
+cooldown. Unique root, predecessor and worker-sequence constraints reject forks
+as a second line of defence. The complete JSON, canonical text and SHA-256 are
+retained together; SQL checks reconcile their digest and projected identities.
+Full plan semantics are enforced by the Python contract, not reimplemented in
+SQL. Direct SQL callers must not bypass that application validation boundary.
+
+```text
+same request + identical transition -> return original sequence, no insert
+same request + changed evidence    -> reject
+new request + stale predecessor    -> reject
+second root for the same worker    -> reject
+```
+
+Historical exact replay remains possible after later transitions. It never
+promotes an old grant to current authority. The trigger rejects UPDATE, DELETE
+and TRUNCATE. Database owners capable of disabling triggers or changing the
+schema remain privileged; these controls are not protection from the owner.
+
+## Time and current state
+
+The database records observation time itself and rejects future-effective
+heads. This increment retains effective transitions, not a queue of future
+approval changes. Active grants still cover exactly one bounded schedule slot.
+Expiry is exclusive; expired grants cannot silently revive.
+
+`risk_platform.current_notification_worker_authority` uses the highest sequence
+per worker and evaluates expiry using the database statement clock, not a
+long-running transaction's start time. The Python reader uses the same clock.
+Suspended and disabled states persist until a valid subsequent transition.
+
+The view and reader deliberately return `runtime_permission_granted = false`.
+An active authority is evidence, not a claim that current readiness or receiver
+health permits a request. P4e2c must check those conditions independently.
+
+## Operator usage
+
+Validate a locally constructed P4e2a document without opening a database:
+
+```bash
+.venv/bin/python -m src.warehouse.notification_worker_authority_history \
+  --transition .demo/worker-authority.json
+```
+
+Explicitly retain it using an operator-provided DSN outside source control:
+
+```bash
+.venv/bin/python -m src.warehouse.notification_worker_authority_history \
+  --transition .demo/worker-authority.json --record
+```
+
+The recording command reads `WAREHOUSE_POSTGRES_DSN` unless `--dsn` is supplied.
+The input is bounded to 1 MiB and rejects duplicate JSON keys, malformed
+contracts, symlinks and non-regular files. On POSIX, the opened final component
+is checked without following symlinks; the parent directory must be trusted.
+Driver failures are sanitized, including uncertain commit acknowledgements;
+exact request replay is the recovery mechanism, not blind reinsertion.
+
+## Database proof
+
+The existing `make postgres-contract-check` target invokes the new live fixture.
+The byte-pinned Actions workflow is unchanged. The fixture uses real planner
+output and real PostgreSQL transactions to exercise lifecycle and sequence,
+current active/expired/suspended/disabled states, inactive unknown workers,
+historical replay without promotion, changed request rejection, stale heads,
+direct SQL fork rejection, mutation rejection, future-head rejection, history
+counts, two-session lock exclusion/release, and final fixture rollback.
+The lock test is not a production concurrency stress benchmark.
+
+## Boundaries
+
+Docker initialization loads schema 28 on a fresh disposable database. Existing
+databases need an explicitly reviewed schema application; initialization mounts
+do not automatically migrate an existing data volume. No database deployment
+or production migration is performed by this PR workflow.
+
+Reviewers and content hashes are still evidence, not authenticated identities
+or signatures. Restricted database writers and authenticated operational
+approval remain future runtime responsibilities. Committed worker, destination,
+webhook and retry configuration stays disabled. No webhook, provider request,
+scheduler mutation, deployment or `terraform apply` is performed. The only
+external I/O of the recorder is the explicitly selected PostgreSQL connection.

--- a/sql/notification_worker_authority_schema.sql
+++ b/sql/notification_worker_authority_schema.sql
@@ -1,0 +1,152 @@
+-- Append-only worker authority evidence. No scheduler state is modified.
+CREATE SCHEMA IF NOT EXISTS risk_platform;
+
+CREATE TABLE IF NOT EXISTS risk_platform.notification_worker_authority_history (
+    transition_id TEXT PRIMARY KEY,
+    request_id TEXT NOT NULL UNIQUE,
+    worker_id TEXT NOT NULL,
+    destination_id TEXT NOT NULL,
+    plan_id TEXT NOT NULL,
+    previous_transition_id TEXT UNIQUE,
+    authority_sequence BIGINT NOT NULL,
+    action TEXT NOT NULL CHECK (action IN ('activate', 'suspend', 'resume', 'disable')),
+    from_state TEXT NOT NULL CHECK (
+        from_state IN ('inactive', 'active', 'suspended', 'expired', 'disabled')
+    ),
+    to_state TEXT NOT NULL CHECK (to_state IN ('active', 'suspended', 'disabled')),
+    requested_at TIMESTAMPTZ NOT NULL,
+    effective_at TIMESTAMPTZ NOT NULL,
+    expires_at TIMESTAMPTZ,
+    document_json JSONB NOT NULL,
+    canonical_document TEXT NOT NULL,
+    document_sha256 TEXT NOT NULL CHECK (document_sha256 ~ '^[0-9a-f]{64}$'),
+    recorded_at TIMESTAMPTZ NOT NULL DEFAULT clock_timestamp(),
+    UNIQUE (worker_id, authority_sequence),
+    UNIQUE (transition_id, worker_id, destination_id),
+    FOREIGN KEY (previous_transition_id, worker_id, destination_id) REFERENCES
+        risk_platform.notification_worker_authority_history
+        (transition_id, worker_id, destination_id),
+    CHECK (authority_sequence > 0),
+    CHECK (requested_at <= effective_at AND effective_at <= recorded_at),
+    CHECK ((to_state = 'active' AND expires_at IS NOT NULL AND effective_at < expires_at)
+        OR (to_state <> 'active' AND expires_at IS NULL)),
+    CHECK (jsonb_typeof(document_json) = 'object'),
+    CHECK (canonical_document::JSONB = document_json),
+    CHECK (octet_length(canonical_document) BETWEEN 1 AND 1048576),
+    CHECK (encode(sha256(convert_to(canonical_document, 'UTF8')), 'hex') = document_sha256),
+    CHECK ((document_json ->> 'model_version') IS NOT DISTINCT FROM
+        'portfolio-risk-notification-worker-authority-transition-v1'),
+    CHECK ((document_json ->> 'transition_id') IS NOT DISTINCT FROM transition_id),
+    CHECK ((document_json ->> 'request_id') IS NOT DISTINCT FROM request_id),
+    CHECK ((document_json -> 'plan' -> 'worker' ->> 'worker_id') IS NOT DISTINCT FROM worker_id),
+    CHECK ((document_json -> 'plan' -> 'destination' ->> 'destination_id') IS NOT DISTINCT FROM destination_id),
+    CHECK ((document_json -> 'plan' ->> 'plan_id') IS NOT DISTINCT FROM plan_id),
+    CHECK ((document_json ->> 'previous_transition_id') IS NOT DISTINCT FROM previous_transition_id),
+    CHECK ((document_json ->> 'action') IS NOT DISTINCT FROM action),
+    CHECK ((document_json ->> 'from_state') IS NOT DISTINCT FROM from_state),
+    CHECK ((document_json ->> 'to_state') IS NOT DISTINCT FROM to_state),
+    CHECK ((document_json ->> 'requested_at')::TIMESTAMPTZ IS NOT DISTINCT FROM requested_at),
+    CHECK ((document_json ->> 'effective_at')::TIMESTAMPTZ IS NOT DISTINCT FROM effective_at),
+    CHECK ((document_json ->> 'expires_at')::TIMESTAMPTZ IS NOT DISTINCT FROM expires_at),
+    CHECK ((document_json -> 'scheduler_mutated') IS NOT DISTINCT FROM 'false'::JSONB),
+    CHECK ((document_json -> 'external_request_performed') IS NOT DISTINCT FROM 'false'::JSONB)
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS notification_worker_authority_one_root
+ON risk_platform.notification_worker_authority_history (worker_id)
+WHERE previous_transition_id IS NULL;
+
+CREATE OR REPLACE FUNCTION risk_platform.guard_notification_worker_authority_insert()
+RETURNS TRIGGER LANGUAGE plpgsql AS $$
+DECLARE
+    prior risk_platform.notification_worker_authority_history%ROWTYPE;
+    expected_state TEXT;
+BEGIN
+    -- Same key as the application recorder; unique constraints also reject forks.
+    PERFORM pg_advisory_xact_lock(hashtextextended(
+        'notification-worker-authority:' || NEW.worker_id, 0
+    ));
+    SELECT * INTO prior
+    FROM risk_platform.notification_worker_authority_history
+    WHERE worker_id = NEW.worker_id
+    ORDER BY authority_sequence DESC LIMIT 1;
+
+    IF NOT FOUND THEN
+        IF NEW.previous_transition_id IS NOT NULL OR NEW.action <> 'activate'
+            OR NEW.from_state <> 'inactive' THEN
+            RAISE EXCEPTION 'worker authority requires initial activation' USING ERRCODE = '23514';
+        END IF;
+        NEW.authority_sequence := 1;
+    ELSE
+        IF NEW.previous_transition_id IS DISTINCT FROM prior.transition_id
+            OR NEW.destination_id <> prior.destination_id
+            OR NEW.effective_at <= prior.effective_at
+            OR NEW.requested_at < prior.effective_at THEN
+            RAISE EXCEPTION 'worker authority head or chronology conflict' USING ERRCODE = '23514';
+        END IF;
+        expected_state := CASE
+            WHEN prior.to_state = 'active' AND NEW.effective_at >= prior.expires_at
+                THEN 'expired' ELSE prior.to_state END;
+        IF NEW.from_state <> expected_state THEN
+            RAISE EXCEPTION 'worker authority source state conflict' USING ERRCODE = '23514';
+        END IF;
+        IF NEW.action IN ('suspend', 'disable') AND
+            NEW.document_json -> 'plan' IS DISTINCT FROM prior.document_json -> 'plan' THEN
+            RAISE EXCEPTION 'worker stop plan differs from retained authority' USING ERRCODE = '23514';
+        END IF;
+        IF NEW.action = 'resume' AND NEW.effective_at < prior.effective_at
+            + ((prior.document_json -> 'plan' -> 'suspension' ->> 'cooldown_seconds')::INTEGER
+                * INTERVAL '1 second') THEN
+            RAISE EXCEPTION 'worker authority suspension cooldown remains active' USING ERRCODE = '23514';
+        END IF;
+        NEW.authority_sequence := prior.authority_sequence + 1;
+    END IF;
+    IF NOT (
+        (NEW.action = 'activate' AND NEW.from_state IN ('inactive', 'disabled', 'expired') AND NEW.to_state = 'active')
+        OR (NEW.action = 'resume' AND NEW.from_state = 'suspended' AND NEW.to_state = 'active')
+        OR (NEW.action = 'suspend' AND NEW.from_state = 'active' AND NEW.to_state = 'suspended')
+        OR (NEW.action = 'disable' AND NEW.from_state IN ('active', 'suspended', 'expired') AND NEW.to_state = 'disabled')
+    ) THEN
+        RAISE EXCEPTION 'worker authority action is invalid' USING ERRCODE = '23514';
+    END IF;
+    -- Server time, not caller-supplied metadata. Future heads cannot hide current grants.
+    NEW.recorded_at := clock_timestamp();
+    RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS notification_worker_authority_insert_guard
+ON risk_platform.notification_worker_authority_history;
+CREATE TRIGGER notification_worker_authority_insert_guard
+BEFORE INSERT ON risk_platform.notification_worker_authority_history
+FOR EACH ROW EXECUTE FUNCTION risk_platform.guard_notification_worker_authority_insert();
+
+CREATE OR REPLACE FUNCTION risk_platform.reject_notification_worker_authority_mutation()
+RETURNS TRIGGER LANGUAGE plpgsql AS $$
+BEGIN
+    RAISE EXCEPTION 'notification worker authority history is append-only';
+END;
+$$;
+DROP TRIGGER IF EXISTS notification_worker_authority_reject_mutation
+ON risk_platform.notification_worker_authority_history;
+CREATE TRIGGER notification_worker_authority_reject_mutation
+BEFORE UPDATE OR DELETE ON risk_platform.notification_worker_authority_history
+FOR EACH ROW EXECUTE FUNCTION risk_platform.reject_notification_worker_authority_mutation();
+DROP TRIGGER IF EXISTS notification_worker_authority_reject_truncate
+ON risk_platform.notification_worker_authority_history;
+CREATE TRIGGER notification_worker_authority_reject_truncate
+BEFORE TRUNCATE ON risk_platform.notification_worker_authority_history
+FOR EACH STATEMENT EXECUTE FUNCTION risk_platform.reject_notification_worker_authority_mutation();
+
+CREATE OR REPLACE VIEW risk_platform.current_notification_worker_authority AS
+SELECT latest.*,
+    CASE WHEN to_state = 'active' AND statement_timestamp() >= expires_at
+        THEN 'expired' ELSE to_state END AS authority_state,
+    FALSE AS runtime_permission_granted
+FROM (
+    SELECT DISTINCT ON (worker_id)
+        worker_id, destination_id, transition_id, request_id, authority_sequence,
+        plan_id, action, to_state, effective_at, expires_at, recorded_at, document_sha256
+    FROM risk_platform.notification_worker_authority_history
+    ORDER BY worker_id, authority_sequence DESC
+) latest;

--- a/src/warehouse/notification_worker_authority_history.py
+++ b/src/warehouse/notification_worker_authority_history.py
@@ -1,0 +1,221 @@
+"""Append-only worker authority history; no delivery or scheduling side effects."""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import stat
+import sys
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+from src.common.exceptions import StorageError, ValidationError
+from src.orchestration.notification_worker_authority_contract import (
+    authority_state, canonical_bytes, identifier,
+    validate_worker_authority_chain, validate_worker_authority_transition,
+)
+
+MAX_DOCUMENT_BYTES = 1_048_576
+LOCK_SQL = "SELECT pg_advisory_xact_lock(hashtextextended(%s, 0))"
+LOCK_PREFIX = "notification-worker-authority:"
+ROW_COLUMNS = "document_json, document_sha256, authority_sequence, recorded_at"
+
+
+def _validated(value: Mapping[str, Any]) -> dict[str, Any]:
+    try:
+        result = validate_worker_authority_transition(value)
+        if len(canonical_bytes(result)) > MAX_DOCUMENT_BYTES:
+            raise ValidationError("worker authority document exceeds 1 MB")
+        return result
+    except (ValueError, TypeError, RecursionError, OverflowError, UnicodeError):
+        raise ValidationError("worker authority document is malformed") from None
+
+
+def _decode(row: Any) -> dict[str, Any]:
+    if not isinstance(row, (tuple, list)) or len(row) != 4:
+        raise StorageError("retained worker authority row is invalid")
+    try:
+        document = _validated(row[0])
+    except ValidationError:
+        raise StorageError("retained worker authority document is invalid") from None
+    digest = hashlib.sha256(canonical_bytes(document)).hexdigest()
+    if digest != row[1] or type(row[2]) is not int or row[2] < 1:
+        raise StorageError("retained worker authority integrity check failed")
+    return {
+        "transition": document, "document_sha256": digest,
+        "authority_sequence": row[2], "recorded_at": row[3],
+    }
+
+
+def _summary(retained: Mapping[str, Any], *, created: bool) -> dict[str, Any]:
+    document = retained["transition"]
+    return {
+        "transition_id": document["transition_id"], "request_id": document["request_id"],
+        "worker_id": document["plan"]["worker"]["worker_id"],
+        "destination_id": document["plan"]["destination"]["destination_id"],
+        "authority_sequence": retained["authority_sequence"],
+        "document_sha256": retained["document_sha256"], "created": created,
+        "runtime_permission_granted": False,
+    }
+
+
+def record_worker_authority_with_cursor(
+    cursor: Any, *, transition: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Append or exactly replay using the caller's transaction (READ COMMITTED)."""
+    document = _validated(transition)
+    encoded = canonical_bytes(document)
+    digest = hashlib.sha256(encoded).hexdigest()
+    worker_id = document["plan"]["worker"]["worker_id"]
+    cursor.execute("SET LOCAL lock_timeout = '5s'")
+    cursor.execute("SET LOCAL statement_timeout = '10s'")
+    cursor.execute(LOCK_SQL, (LOCK_PREFIX + worker_id,))
+    cursor.execute(
+        f"SELECT {ROW_COLUMNS} FROM risk_platform.notification_worker_authority_history "
+        "WHERE request_id = %s", (document["request_id"],),
+    )
+    row = cursor.fetchone()
+    if row is not None:
+        retained = _decode(row)
+        if retained["document_sha256"] != digest or retained["transition"] != document:
+            raise ValidationError("request_id already retains different worker authority")
+        # Historical exact replay must not promote an old grant to current head.
+        return _summary(retained, created=False)
+    cursor.execute(
+        f"SELECT {ROW_COLUMNS} FROM risk_platform.notification_worker_authority_history "
+        "WHERE worker_id = %s ORDER BY authority_sequence DESC LIMIT 1", (worker_id,),
+    )
+    prior_row = cursor.fetchone()
+    previous = None if prior_row is None else _decode(prior_row)["transition"]
+    validate_worker_authority_chain(document, previous)
+    text = encoded.decode("utf-8")
+    cursor.execute(
+        """
+        INSERT INTO risk_platform.notification_worker_authority_history (
+            transition_id, request_id, worker_id, destination_id, plan_id,
+            previous_transition_id, authority_sequence, action, from_state, to_state,
+            requested_at, effective_at, expires_at, document_json,
+            canonical_document, document_sha256
+        ) VALUES (%s, %s, %s, %s, %s, %s, 1, %s, %s, %s, %s, %s, %s, %s::JSONB, %s, %s)
+        RETURNING document_json, document_sha256, authority_sequence, recorded_at
+        """,
+        (
+            document["transition_id"], document["request_id"], worker_id,
+            document["plan"]["destination"]["destination_id"], document["plan"]["plan_id"],
+            document["previous_transition_id"], document["action"], document["from_state"],
+            document["to_state"], document["requested_at"], document["effective_at"],
+            document["expires_at"], text, text, digest,
+        ),
+    )
+    retained = _decode(cursor.fetchone())
+    if retained["transition"] != document:
+        raise StorageError("retained worker authority differs from requested evidence")
+    return _summary(retained, created=True)
+
+
+def _connect(dsn: str) -> Any:
+    if not isinstance(dsn, str) or not dsn.strip():
+        raise ValidationError("PostgreSQL DSN must be non-empty text")
+    try:
+        import psycopg
+    except ImportError:
+        raise StorageError("worker authority history requires psycopg") from None
+    return psycopg.connect(dsn, connect_timeout=5)
+
+
+def record_worker_authority(*, dsn: str, transition: Mapping[str, Any]) -> dict[str, Any]:
+    document = _validated(transition)
+    try:
+        with _connect(dsn) as connection:
+            with connection.cursor() as cursor:
+                result = record_worker_authority_with_cursor(cursor, transition=document)
+        return result
+    except (ValidationError, StorageError):
+        raise
+    except Exception:
+        # Do not expose DSNs, JSON documents or database exception details.
+        raise StorageError("worker authority transaction failed; no success is confirmed") from None
+
+
+def read_current_worker_authority_with_cursor(cursor: Any, *, worker_id: str) -> dict[str, Any]:
+    selected = identifier(worker_id, "worker_id")
+    cursor.execute("SET LOCAL statement_timeout = '10s'")
+    cursor.execute(
+        f"SELECT {ROW_COLUMNS}, statement_timestamp() "
+        "FROM risk_platform.notification_worker_authority_history "
+        "WHERE worker_id = %s ORDER BY authority_sequence DESC LIMIT 1", (selected,),
+    )
+    row = cursor.fetchone()
+    if row is None:
+        return {"worker_id": selected, "authority_state": "inactive", "transition": None,
+                "runtime_permission_granted": False}
+    if not isinstance(row, (tuple, list)) or len(row) != 5:
+        raise StorageError("current worker authority row is invalid")
+    retained = _decode(row[:4])
+    return {**_summary(retained, created=False), "transition": retained["transition"],
+            "authority_state": authority_state(retained["transition"], as_of=row[4])}
+
+
+def read_current_worker_authority(*, dsn: str, worker_id: str) -> dict[str, Any]:
+    selected = identifier(worker_id, "worker_id")
+    try:
+        with _connect(dsn) as connection:
+            with connection.cursor() as cursor:
+                return read_current_worker_authority_with_cursor(cursor, worker_id=selected)
+    except (ValidationError, StorageError):
+        raise
+    except Exception:
+        raise StorageError("unable to read current worker authority") from None
+
+
+def _unique_object(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise ValidationError("worker authority JSON contains duplicate fields")
+        result[key] = value
+    return result
+
+
+def load_worker_authority(path: Path) -> dict[str, Any]:
+    # Parent directory must be trusted. O_NOFOLLOW protects the final component;
+    # O_NONBLOCK permits rejecting a FIFO without blocking while opening it.
+    flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_NONBLOCK", 0)
+    if path.is_symlink():
+        raise ValidationError("worker authority input must not be a symbolic link")
+    try:
+        with os.fdopen(os.open(path, flags), "rb") as handle:
+            if not stat.S_ISREG(os.fstat(handle.fileno()).st_mode):
+                raise ValidationError("worker authority input must be a regular file")
+            raw = handle.read(MAX_DOCUMENT_BYTES + 1)
+        if len(raw) > MAX_DOCUMENT_BYTES:
+            raise ValidationError("worker authority input exceeds 1 MB")
+        value = json.loads(raw.decode("utf-8"), object_pairs_hook=_unique_object)
+    except (OSError, ValueError, UnicodeError, RecursionError):
+        raise ValidationError("unable to read worker authority input") from None
+    return _validated(value)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Validate or explicitly retain worker authority evidence.")
+    parser.add_argument("--transition", required=True, type=Path)
+    parser.add_argument("--record", action="store_true")
+    parser.add_argument("--dsn", default=os.environ.get("WAREHOUSE_POSTGRES_DSN"))
+    args = parser.parse_args(argv)
+    try:
+        document = load_worker_authority(args.transition)
+        result = record_worker_authority(dsn=args.dsn, transition=document) if args.record else {
+            "transition_id": document["transition_id"], "validated": True, "persisted": False,
+            "runtime_permission_granted": False,
+        }
+    except (ValidationError, StorageError) as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+    print(json.dumps(result, sort_keys=True, allow_nan=False))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/warehouse/notification_worker_authority_postgres_contract_check.py
+++ b/src/warehouse/notification_worker_authority_postgres_contract_check.py
@@ -1,0 +1,226 @@
+"""Transaction-scoped PostgreSQL proof for worker authority history."""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+from collections.abc import Callable, Mapping
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from typing import Any
+from uuid import uuid4
+
+import yaml
+
+from src.common.exceptions import ValidationError
+from src.orchestration.notification_worker_authority_contract import (
+    build_worker_authority_transition, canonical_bytes,
+)
+from src.orchestration.plan_notification_worker import plan_notification_worker
+from src.warehouse.notification_worker_authority_history import (
+    LOCK_PREFIX, LOCK_SQL, read_current_worker_authority_with_cursor,
+    record_worker_authority_with_cursor,
+)
+
+
+def _plan(directory: Path, worker_id: str, planned_at: datetime) -> dict[str, Any]:
+    configs = {
+        name: yaml.safe_load(Path(f"config/{name}.yaml").read_text(encoding="utf-8"))
+        for name in ("notification_workers", "notification_delivery", "notification_destinations")
+    }
+    worker = configs["notification_workers"]["workers"].pop("risk-operations-managed")
+    worker["enabled"] = True
+    configs["notification_workers"]["workers"] = {worker_id: worker}
+    delivery = configs["notification_delivery"]["delivery"]
+    delivery["webhook"]["enabled"] = True
+    delivery["retry_execution"]["enabled"] = True
+    activation = configs["notification_destinations"]["destinations"][worker["destination_id"]]["activation"]
+    activation.update({
+        "enabled": True, "change_request_id": "AUTHORITY-HISTORY-FIXTURE",
+        "reviewed_by": ["independent-reviewer"],
+        "reviewed_at": (planned_at - timedelta(days=1)).isoformat(),
+        "review_expires_at": (planned_at + timedelta(days=1)).isoformat(),
+    })
+    for name, config in configs.items():
+        (directory / f"{name}.yaml").write_text(yaml.safe_dump(config), encoding="utf-8")
+    return plan_notification_worker(
+        worker_id=worker_id, planned_at=planned_at,
+        worker_config_path=directory / "notification_workers.yaml",
+        delivery_config_path=directory / "notification_delivery.yaml",
+        destination_config_path=directory / "notification_destinations.yaml",
+    )
+
+
+def _grant(plan: Mapping[str, Any], request_id: str, previous: Mapping[str, Any] | None = None) -> dict[str, Any]:
+    instant = datetime.fromisoformat(plan["planned_at"]) + timedelta(seconds=1)
+    return build_worker_authority_transition(
+        plan=plan, request_id=request_id, operator_id="fixture-operator",
+        reviewed_by=["independent-reviewer"], action="activate" if previous is None else "resume",
+        requested_at=instant, effective_at=instant, previous=previous,
+        expires_at=datetime.fromisoformat(plan["schedule"]["scheduled_for"]) + timedelta(seconds=plan["execution"]["execution_timeout_seconds"]),
+    )
+
+
+def _stop(previous: Mapping[str, Any], request_id: str, action: str) -> dict[str, Any]:
+    instant = datetime.fromisoformat(previous["effective_at"]) + timedelta(seconds=1)
+    return build_worker_authority_transition(
+        plan=previous["plan"], request_id=request_id, operator_id="fixture-operator",
+        action=action, requested_at=instant, effective_at=instant,
+        reason_codes=["operator_request"], previous=previous,
+    )
+
+
+def _reject(connection: Any, operation: Callable[[], Any], message: str) -> None:
+    try:
+        with connection.transaction():
+            operation()
+    except Exception as exc:
+        if message not in str(exc):
+            raise AssertionError("rejection occurred at an unexpected contract boundary") from exc
+    else:
+        raise AssertionError("invalid authority operation was accepted")
+
+
+def _raw_insert(cursor: Any, document: Mapping[str, Any]) -> None:
+    text = canonical_bytes(document).decode("utf-8")
+    cursor.execute(
+        """
+        INSERT INTO risk_platform.notification_worker_authority_history (
+            transition_id, request_id, worker_id, destination_id, plan_id,
+            previous_transition_id, authority_sequence, action, from_state, to_state,
+            requested_at, effective_at, expires_at, document_json, canonical_document, document_sha256
+        ) VALUES (%s, %s, %s, %s, %s, %s, 1, %s, %s, %s, %s, %s, %s, %s::JSONB, %s, %s)
+        """,
+        (document["transition_id"], document["request_id"], document["plan"]["worker"]["worker_id"],
+         document["plan"]["destination"]["destination_id"], document["plan"]["plan_id"],
+         document["previous_transition_id"], document["action"], document["from_state"],
+         document["to_state"], document["requested_at"], document["effective_at"],
+         document["expires_at"], text, text, hashlib.sha256(text.encode()).hexdigest()),
+    )
+
+
+def run_contract_check(dsn: str) -> dict[str, Any]:
+    import psycopg
+
+    worker_id = "authority-contract-" + uuid4().hex
+    base = datetime(2026, 9, 1, 12, 0, tzinfo=timezone.utc)
+    results: dict[str, Any] = {}
+    with TemporaryDirectory(prefix="worker-authority-contract-") as temporary:
+        directory = Path(temporary)
+        connection = psycopg.connect(dsn, connect_timeout=5)
+        competitor = psycopg.connect(dsn, connect_timeout=5)
+        try:
+            with connection.cursor() as cursor, competitor.cursor() as second:
+                second.execute("SET LOCAL lock_timeout = '5s'")
+                first = _grant(_plan(directory, worker_id, base), worker_id + "-activate")
+                suspended = _stop(first, worker_id + "-suspend", "suspend")
+                resumed = _grant(
+                    _plan(directory, worker_id, base + timedelta(minutes=20)),
+                    worker_id + "-resume", suspended,
+                )
+                disabled = _stop(resumed, worker_id + "-disable", "disable")
+                for sequence, (document, expected) in enumerate(
+                    ((first, "expired"), (suspended, "suspended"), (resumed, "expired"), (disabled, "disabled")), 1,
+                ):
+                    retained = record_worker_authority_with_cursor(cursor, transition=document)
+                    if retained["created"] is not True or retained["authority_sequence"] != sequence:
+                        raise AssertionError("authority sequence did not advance exactly once")
+                    current = read_current_worker_authority_with_cursor(cursor, worker_id=worker_id)
+                    cursor.execute(
+                        "SELECT authority_state, runtime_permission_granted "
+                        "FROM risk_platform.current_notification_worker_authority WHERE worker_id = %s",
+                        (worker_id,),
+                    )
+                    if current["authority_state"] != expected or cursor.fetchone() != (expected, False):
+                        raise AssertionError("SQL and canonical current states differ")
+                results["lifecycle_and_sequence"] = True
+                replay = record_worker_authority_with_cursor(cursor, transition=first)
+                if replay["created"] is not False or replay["authority_sequence"] != 1:
+                    raise AssertionError("historical exact replay did not converge")
+                if read_current_worker_authority_with_cursor(cursor, worker_id=worker_id)["transition"]["transition_id"] != disabled["transition_id"]:
+                    raise AssertionError("historical replay promoted an old authority")
+                results["historical_replay_without_promotion"] = True
+                different = build_worker_authority_transition(
+                    plan=first["plan"], request_id=first["request_id"], operator_id="other-operator",
+                    action="activate", requested_at=first["requested_at"], effective_at=first["effective_at"],
+                    expires_at=first["expires_at"], reviewed_by=["independent-reviewer"],
+                )
+                _reject(connection, lambda: record_worker_authority_with_cursor(cursor, transition=different), "different worker authority")
+                fork = _stop(first, worker_id + "-fork", "disable")
+                _reject(connection, lambda: record_worker_authority_with_cursor(cursor, transition=fork), "predecessor")
+                _reject(connection, lambda: _raw_insert(cursor, fork), "head or chronology conflict")
+                results["request_conflict_and_fork_rejected"] = True
+                for operation in (
+                    "UPDATE risk_platform.notification_worker_authority_history SET plan_id = plan_id WHERE worker_id = %s",
+                    "DELETE FROM risk_platform.notification_worker_authority_history WHERE worker_id = %s",
+                ):
+                    _reject(connection, lambda sql=operation: cursor.execute(sql, (worker_id,)), "append-only")
+                _reject(connection, lambda: cursor.execute("TRUNCATE risk_platform.notification_worker_authority_history"), "append-only")
+                results["update_delete_truncate_rejected"] = True
+                cursor.execute("SELECT clock_timestamp()")
+                clock_row = cursor.fetchone()
+                if clock_row is None:
+                    raise AssertionError("database clock is unavailable")
+                now = clock_row[0]
+                active_worker = worker_id + "-active"
+                active = _grant(_plan(directory, active_worker, now - timedelta(seconds=10)), active_worker)
+                record_worker_authority_with_cursor(cursor, transition=active)
+                if read_current_worker_authority_with_cursor(cursor, worker_id=active_worker)["authority_state"] != "active":
+                    raise AssertionError("current grant was not active")
+                results["active_state"] = True
+                future = _grant(_plan(directory, worker_id + "-future", now + timedelta(days=1)), worker_id + "-future")
+                _reject(connection, lambda: record_worker_authority_with_cursor(cursor, transition=future), "check constraint")
+                results["future_head_rejected"] = True
+                if read_current_worker_authority_with_cursor(cursor, worker_id=worker_id + "-missing")["authority_state"] != "inactive":
+                    raise AssertionError("unknown worker was not inactive")
+                results["unknown_worker_inactive"] = True
+                cursor.execute(
+                    "SELECT COUNT(*), MAX(authority_sequence) FROM "
+                    "risk_platform.notification_worker_authority_history WHERE worker_id = %s", (worker_id,),
+                )
+                if cursor.fetchone() != (4, 4):
+                    raise AssertionError("rejected requests changed the authority chain")
+                results["reconciled_history_count"] = True
+                second.execute("SELECT pg_try_advisory_xact_lock(hashtextextended(%s, 0))", (LOCK_PREFIX + worker_id,))
+                if second.fetchone() != (False,):
+                    raise AssertionError("second session acquired held worker lock")
+                connection.rollback()
+                second.execute(LOCK_SQL, (LOCK_PREFIX + worker_id,))
+                competitor.rollback()
+                results["two_session_lock_exclusion_and_release"] = True
+                cursor.execute(
+                    "SELECT COUNT(*) FROM risk_platform.notification_worker_authority_history WHERE worker_id = %s OR worker_id = %s",
+                    (worker_id, active_worker),
+                )
+                if cursor.fetchone() != (0,):
+                    raise AssertionError("fixture history survived transaction rollback")
+                results["fixture_rolled_back"] = True
+        finally:
+            connection.rollback()
+            competitor.rollback()
+            connection.close()
+            competitor.close()
+    return {"model_version": "notification-worker-authority-postgres-contract-v1", "checks": results,
+            "external_request_performed": False, "scheduler_mutated": False}
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--dsn", required=True)
+    args = parser.parse_args()
+    try:
+        result = run_contract_check(args.dsn)
+    except ValidationError:
+        print("Worker authority PostgreSQL contract rejected fixture evidence", file=sys.stderr)
+        return 1
+    except Exception as exc:
+        print(f"Worker authority PostgreSQL contract failed ({type(exc).__name__})", file=sys.stderr)
+        return 1
+    print(json.dumps(result, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/warehouse/notification_worker_authority_postgres_contract_check.py
+++ b/src/warehouse/notification_worker_authority_postgres_contract_check.py
@@ -156,7 +156,9 @@ def run_contract_check(dsn: str) -> dict[str, Any]:
                     "UPDATE risk_platform.notification_worker_authority_history SET plan_id = plan_id WHERE worker_id = %s",
                     "DELETE FROM risk_platform.notification_worker_authority_history WHERE worker_id = %s",
                 ):
-                    _reject(connection, lambda sql=operation: cursor.execute(sql, (worker_id,)), "append-only")
+                    def mutate(sql: str = operation) -> None:
+                        cursor.execute(sql, (worker_id,))
+                    _reject(connection, mutate, "append-only")
                 _reject(connection, lambda: cursor.execute("TRUNCATE risk_platform.notification_worker_authority_history"), "append-only")
                 results["update_delete_truncate_rejected"] = True
                 cursor.execute("SELECT clock_timestamp()")

--- a/tests/unit/test_docker_compose_contract.py
+++ b/tests/unit/test_docker_compose_contract.py
@@ -53,6 +53,7 @@ def test_local_database_seed_mounts_are_read_only_and_ordered() -> None:
         "./sql/notification_execution_readiness_schema.sql:/docker-entrypoint-initdb.d/25_notification_execution_readiness_schema.sql:ro",
         "./sql/notification_retry_readiness_binding_schema.sql:/docker-entrypoint-initdb.d/26_notification_retry_readiness_binding_schema.sql:ro",
         "./sql/notification_retry_readiness_follow_up_schema.sql:/docker-entrypoint-initdb.d/27_notification_retry_readiness_follow_up_schema.sql:ro",
+        "./sql/notification_worker_authority_schema.sql:/docker-entrypoint-initdb.d/28_notification_worker_authority_schema.sql:ro",
     ]
     assert services["mongo"]["volumes"] == [
         "./mongo/init:/docker-entrypoint-initdb.d:ro"

--- a/tests/unit/test_notification_worker_authority_history.py
+++ b/tests/unit/test_notification_worker_authority_history.py
@@ -1,0 +1,176 @@
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+import os
+from datetime import timedelta
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from src.common.exceptions import StorageError, ValidationError
+from src.orchestration.notification_worker_authority_contract import canonical_bytes
+from src.warehouse import notification_worker_authority_history as history
+from test_notification_worker_authority_contract import NOW, grant, stop
+
+
+class Cursor:
+    def __init__(self, rows: list[Any]) -> None:
+        self.rows = iter(rows)
+        self.calls: list[tuple[str, Any]] = []
+
+    def execute(self, statement: str, params: Any = None) -> None:
+        self.calls.append((statement, params))
+
+    def fetchone(self) -> Any:
+        return next(self.rows)
+
+
+def row(document: dict[str, Any], sequence: int = 1) -> tuple[Any, ...]:
+    return document, hashlib.sha256(canonical_bytes(document)).hexdigest(), sequence, NOW
+
+
+def test_cursor_append_serializes_and_reconciles_predecessor() -> None:
+    first = grant()
+    cursor = Cursor([None, None, row(first)])
+    result = history.record_worker_authority_with_cursor(cursor, transition=first)
+    assert result['created'] is True
+    assert result['authority_sequence'] == 1
+    assert result['runtime_permission_granted'] is False
+    assert cursor.calls[2][0] == history.LOCK_SQL
+    assert cursor.calls[2][1] == ('notification-worker-authority:authority-worker',)
+    assert 'request_id = %s' in cursor.calls[3][0]
+    assert 'ORDER BY authority_sequence DESC' in cursor.calls[4][0]
+    assert cursor.calls[-1][1][-1] == result['document_sha256']
+    later = stop(first)
+    assert history.record_worker_authority_with_cursor(
+        Cursor([None, row(first), row(later, 2)]), transition=later,
+    )['authority_sequence'] == 2
+
+
+def test_exact_old_request_replay_does_not_read_or_promote_current_head() -> None:
+    first = grant()
+    cursor = Cursor([row(first)])
+    assert history.record_worker_authority_with_cursor(cursor, transition=first)['created'] is False
+    assert len(cursor.calls) == 4
+    assert not any('INSERT' in sql for sql, _ in cursor.calls)
+
+
+def test_conflicting_request_and_stale_head_fail_before_insert() -> None:
+    first = grant()
+    changed = grant(operator_id='another-operator')
+    cursor = Cursor([row(first)])
+    with pytest.raises(ValidationError, match='different worker authority'):
+        history.record_worker_authority_with_cursor(cursor, transition=changed)
+    later = stop(first)
+    cursor = Cursor([None, row(later, 2)])
+    with pytest.raises(ValidationError, match='predecessor'):
+        history.record_worker_authority_with_cursor(cursor, transition=first)
+    assert not any('INSERT' in sql for sql, _ in cursor.calls)
+
+
+def test_corrupt_retained_document_is_not_trusted() -> None:
+    first = grant()
+    with pytest.raises(StorageError, match='integrity'):
+        history.record_worker_authority_with_cursor(
+            Cursor([(first, '0' * 64, 1, NOW)]), transition=first,
+        )
+    changed = copy.deepcopy(first)
+    changed['scheduler_mutated'] = True
+    with pytest.raises(StorageError, match='document is invalid'):
+        history.record_worker_authority_with_cursor(Cursor([row(changed)]), transition=first)
+
+
+@pytest.mark.parametrize('instant,state', [
+    (NOW, 'inactive'), (NOW + timedelta(seconds=2), 'active'),
+    (NOW + timedelta(days=1), 'expired'),
+])
+def test_current_reader_uses_database_evaluation_time(instant: Any, state: str) -> None:
+    first = grant()
+    result = history.read_current_worker_authority_with_cursor(
+        Cursor([(*row(first), instant)]), worker_id='authority-worker',
+    )
+    assert result['authority_state'] == state
+    assert result['runtime_permission_granted'] is False
+
+
+def test_unknown_worker_is_inactive() -> None:
+    assert history.read_current_worker_authority_with_cursor(
+        Cursor([None]), worker_id='unknown-worker',
+    )['authority_state'] == 'inactive'
+
+
+def test_cli_defaults_to_validation_without_database_access(tmp_path: Path, monkeypatch: Any, capsys: Any) -> None:
+    path = tmp_path / 'authority.json'
+    path.write_bytes(canonical_bytes(grant()))
+    def unexpected(*args: Any, **kwargs: Any) -> Any:
+        raise AssertionError('validation must not connect')
+    monkeypatch.setattr(history, '_connect', unexpected)
+    assert history.main(['--transition', str(path)]) == 0
+    result = json.loads(capsys.readouterr().out)
+    assert result['persisted'] is False
+    assert result['runtime_permission_granted'] is False
+
+
+@pytest.mark.parametrize('content', [b'{"action":"activate","action":"disable"}', b'[]', b'{', b'NaN'])
+def test_input_rejects_invalid_json_and_duplicate_keys(tmp_path: Path, content: bytes) -> None:
+    path = tmp_path / 'input.json'
+    path.write_bytes(content)
+    with pytest.raises(ValidationError):
+        history.load_worker_authority(path)
+
+
+def test_input_rejects_symlinks_large_files_and_fifos(tmp_path: Path) -> None:
+    original = tmp_path / 'original.json'
+    original.write_bytes(canonical_bytes(grant()))
+    link = tmp_path / 'link.json'
+    link.symlink_to(original)
+    with pytest.raises(ValidationError, match='symbolic link'):
+        history.load_worker_authority(link)
+    original.write_bytes(b' ' * (history.MAX_DOCUMENT_BYTES + 1))
+    with pytest.raises(ValidationError, match='exceeds'):
+        history.load_worker_authority(original)
+    fifo = tmp_path / 'fifo'
+    if hasattr(os, 'mkfifo'):
+        os.mkfifo(fifo)
+        with pytest.raises(ValidationError, match='regular file'):
+            history.load_worker_authority(fifo)
+
+
+def test_driver_failure_is_sanitized_and_invalid_evidence_never_connects(monkeypatch: Any) -> None:
+    def broken(*args: Any, **kwargs: Any) -> Any:
+        raise RuntimeError('SECRET_DSN_AND_PAYLOAD')
+    monkeypatch.setattr(history, '_connect', broken)
+    with pytest.raises(StorageError) as exc:
+        history.record_worker_authority(dsn='secret', transition=grant())
+    assert 'SECRET' not in str(exc.value)
+    changed = grant()
+    changed['scheduler_mutated'] = True
+    with pytest.raises(ValidationError):
+        history.record_worker_authority(dsn='secret', transition=changed)
+
+
+def test_connection_context_rolls_back_on_write_failure(monkeypatch: Any) -> None:
+    entered = []
+    class BrokenCursor(Cursor):
+        def __enter__(self) -> Any:
+            return self
+        def __exit__(self, *args: Any) -> None:
+            pass
+        def execute(self, statement: str, params: Any = None) -> None:
+            if 'INSERT' in statement:
+                raise RuntimeError('simulated write failure')
+            super().execute(statement, params)
+    class Connection:
+        def __enter__(self) -> Any:
+            return self
+        def __exit__(self, exc_type: Any, *args: Any) -> None:
+            entered.append(exc_type)
+        def cursor(self) -> Any:
+            return BrokenCursor([None, None])
+    monkeypatch.setattr(history, '_connect', lambda dsn: Connection())
+    with pytest.raises(StorageError):
+        history.record_worker_authority(dsn='local', transition=grant())
+    assert entered == [RuntimeError]

--- a/tests/unit/test_notification_worker_authority_history_wiring.py
+++ b/tests/unit/test_notification_worker_authority_history_wiring.py
@@ -1,0 +1,12 @@
+from pathlib import Path
+
+
+def test_worker_authority_database_proof_is_invoked_by_standard_ci_target() -> None:
+    makefile = Path("Makefile").read_text(encoding="utf-8")
+    recipe = makefile.split("postgres-contract-check:\n", 1)[1].split("\nlocal-db-up:", 1)[0]
+    assert "-m src.warehouse.notification_worker_authority_postgres_contract_check" in recipe
+    compose = Path("docker-compose.yml").read_text(encoding="utf-8")
+    assert "28_notification_worker_authority_schema.sql:ro" in compose
+    schema = Path("sql/notification_worker_authority_schema.sql").read_text(encoding="utf-8")
+    assert "statement_timestamp() >= expires_at" in schema
+    assert "BEFORE TRUNCATE" in schema


### PR DESCRIPTION
## Goal

Deliver **P4e2b**: durable, append-only worker authority transitions with exact replay and conflict-safe current-head selection. Primary arc42 block: `warehouse`.

## Changes

- Retain the P4e2a transition format, canonical bytes and SHA-256 without a competing state machine.
- Serialize writes with a per-worker transaction advisory lock and server-assigned sequence.
- Independently validate the exact retained predecessor, chronology, scope, stop plan and resume cooldown; unique roots, successors and sequences also reject forks.
- Return historical exact request replay without promoting it to current authority; reject changed request reuse.
- Reject direct UPDATE, DELETE, TRUNCATE and future-effective heads.
- Add a current authority view and canonical reader using the database statement clock for expiry; unknown workers are inactive.
- Add a validation-only default CLI; database persistence requires explicit `--record`.
- Run the real PostgreSQL fixture through the existing `postgres-contract-check` Make target; the byte-pinned Actions workflow is unchanged.

## Scope and concurrent work

Nine files, **905 additions**, no deletions. Three branch commits: implementation, integration of concurrent main, and a typed fixture callback repair. The branch incorporates separately delivered PRs #151 and #152 unchanged, and is zero commits behind main at the merge gate. The reviewed-configuration wrapper and persistence layer share the same transition document. This recorder validates canonical evidence and retained chain identity; it does not authenticate reviewers or re-read source configuration.

## Exact-head validation

GitHub Actions run **428** (`33995065481`) passed on final head `242b4d7ccd4be5eb075d01333044141390c436e3`, tree `42428071e05a580a3af4e70bda154ddf51541689`:

- Security guardrails: passed.
- Ruff and mypy: passed across **156 source files**.
- **1,107 tests passed twice**, during quality and readiness.
- Dependency integrity, pipeline replay and warehouse dry-run: passed.
- Kubernetes rendering and Terraform format/init/validate: passed, without apply.
- PostgreSQL 16 contract: passed. Job `101384055734` actually executed the new fixture, not merely schema parsing or static checks.

All ten new PostgreSQL proof groups passed:

1. Lifecycle and server-assigned sequence.
2. Historical exact replay without head promotion.
3. Changed request rejection and application/direct-SQL fork rejection.
4. UPDATE, DELETE and TRUNCATE rejection.
5. Active current authority.
6. Future-effective head rejection.
7. Inactive unknown worker.
8. History-count reconciliation after rejected writes.
9. Two-session lock exclusion and release.
10. Full fixture transaction rollback.

Run 427 failed only on mypy's inability to infer a mutation-test lambda. Replacing it with an explicitly typed function preserved test and product behavior. Fresh run 428 passed every job.

Local validation: 55 focused tests passed; two tests needing the full repository were deselected locally and included in the passing full CI run. Syntax compilation passed. PostgreSQL/Docker and full dependency validation were performed in GitHub CI, not claimed as local runs.

At the merge gate there were no review submissions or unresolved threads. This is not independent human approval.

## Safety and acceptance boundary

No committed activation switch changes. No scheduler or delivery execution. The view returns `runtime_permission_granted = false`; active retained authority is not current notification readiness. PostgreSQL writes occur only through explicit recording or disposable CI fixtures. No provider/webhook request, deployment or `terraform apply`.

Existing databases require separately reviewed schema application; fresh Docker initialization loads schema 28. Database owners able to disable triggers remain privileged. P4e2c current-readiness/automatic-suspension decisions remain the next increment. Roadmap: #76.