### PR TITLE
Compose reviewed worker authority validation and recording

### DIFF
--- a/docs/reviewed-worker-authority-recording.md
+++ b/docs/reviewed-worker-authority-recording.md
@@ -1,0 +1,74 @@
+# Reviewed worker authority recording
+
+Primary arc42 block: `warehouse`.
+
+## Decision
+
+`src/warehouse/reviewed_notification_worker_authority_history.py` composes the
+reviewed configuration checks from PR #152 with the append-only recorder from
+PR #153. It introduces neither a new transition model nor a second ledger.
+
+`prepare_reviewed_worker_authority` validates the document size, exact supplied
+predecessor, strict plan semantics, configuration reconstruction and destination
+review lifetime without connecting to PostgreSQL. The result is a detached
+canonical transition.
+
+`record_reviewed_worker_authority` completes that preparation before calling the
+existing recorder. Inside its transaction, the recorder acquires the per-worker
+lock and reconciles the actual retained head again. A supplied predecessor does
+not replace that database check. A competing new root or stale successor still
+fails; exact historical replay still returns the original sequence without
+promoting it to current authority. Storage failures, including unconfirmed
+commit acknowledgements, are not converted into success.
+
+## Operator command
+
+Validate reviewed snapshots without any database connection:
+
+```bash
+.venv/bin/python -m src.warehouse.reviewed_notification_worker_authority_history \
+  --transition .demo/worker-authority.json \
+  --worker-config path/to/reviewed/workers.yaml \
+  --delivery-config path/to/reviewed/delivery.yaml \
+  --destination-config path/to/reviewed/destinations.yaml
+```
+
+For a successor, supply `--previous path/to/exact-predecessor.json`. Recording
+additionally requires `--record` and an operator-provided
+`WAREHOUSE_POSTGRES_DSN` environment variable. The command does not take a DSN
+argument that could be copied into shell history. It does not resolve a webhook
+endpoint. The default remains validation-only even when the environment contains
+a database DSN.
+
+## Trust and compatibility
+
+Configuration files must be immutable reviewed snapshots in trusted directories.
+This composition checks their contents, not provenance or reviewer identity.
+Historical replay requires the same reviewed configuration evidence and supplied
+historical predecessor; the storage primitive still verifies exact retained
+request identity. There is no live-readiness check or permission to deliver.
+
+The lower-level `notification_worker_authority_history` API is deliberately
+unchanged and remains a trusted persistence primitive. This new entry point is
+an opt-in configuration-checked admission path, not a database privilege change
+that makes every other writer impossible. Restricted writers, authenticated
+operators and production migration remain separate responsibilities.
+
+No schema, dependency, workflow, infrastructure or committed activation setting
+changes. Full database behavior remains covered by the existing PostgreSQL
+contract suite; the added tests use injected recorders and the existing cursor
+primitive, not a live application database.
+
+## Validation
+
+```bash
+.venv/bin/python -m pytest -q tests/unit/test_reviewed_worker_authority_recording.py
+make quality-check
+make security-check
+make readiness-check
+```
+
+Review configuration rejection before persistence, exact delegation, historical
+replay, locked head conflicts, validation-only CLI behavior and failure
+propagation. CI evidence is not independent human approval or operational
+activation.

--- a/src/warehouse/reviewed_notification_worker_authority_history.py
+++ b/src/warehouse/reviewed_notification_worker_authority_history.py
@@ -1,0 +1,96 @@
+"""Configuration-checked admission to the existing append-only worker ledger."""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+from src.common.exceptions import StorageError, ValidationError
+from src.orchestration.reviewed_notification_worker_authority import (
+    validate_reviewed_worker_authority_transition,
+)
+from src.warehouse.notification_worker_authority_history import (
+    _validated,
+    load_worker_authority,
+    record_worker_authority,
+)
+
+
+def prepare_reviewed_worker_authority(
+    *, transition: Mapping[str, Any], previous: Mapping[str, Any] | None = None,
+    worker_config_path: Path = Path("config/notification_workers.yaml"),
+    delivery_config_path: Path = Path("config/notification_delivery.yaml"),
+    destination_config_path: Path = Path("config/notification_destinations.yaml"),
+) -> dict[str, Any]:
+    """Validate immutable reviewed snapshots without connecting to PostgreSQL."""
+    document = _validated(transition)
+    prior = None if previous is None else _validated(previous)
+    return validate_reviewed_worker_authority_transition(
+        document, previous=prior, worker_config_path=worker_config_path,
+        delivery_config_path=delivery_config_path,
+        destination_config_path=destination_config_path,
+    )
+
+
+def record_reviewed_worker_authority(
+    *, dsn: str, transition: Mapping[str, Any],
+    previous: Mapping[str, Any] | None = None,
+    worker_config_path: Path = Path("config/notification_workers.yaml"),
+    delivery_config_path: Path = Path("config/notification_delivery.yaml"),
+    destination_config_path: Path = Path("config/notification_destinations.yaml"),
+) -> dict[str, Any]:
+    """Check configuration first; storage independently reconciles its locked head.
+
+    Reviewed configuration paths must be immutable trusted snapshots. This API
+    does not authenticate a caller or turn the ledger into runtime permission.
+    """
+    document = prepare_reviewed_worker_authority(
+        transition=transition, previous=previous,
+        worker_config_path=worker_config_path, delivery_config_path=delivery_config_path,
+        destination_config_path=destination_config_path,
+    )
+    return record_worker_authority(dsn=dsn, transition=document)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Validate configuration-bound authority; record only when explicitly selected."
+    )
+    parser.add_argument("--transition", required=True, type=Path)
+    parser.add_argument("--previous", type=Path)
+    parser.add_argument("--worker-config", type=Path, default=Path("config/notification_workers.yaml"))
+    parser.add_argument("--delivery-config", type=Path, default=Path("config/notification_delivery.yaml"))
+    parser.add_argument("--destination-config", type=Path, default=Path("config/notification_destinations.yaml"))
+    parser.add_argument("--record", action="store_true")
+    args = parser.parse_args(argv)
+    try:
+        document = prepare_reviewed_worker_authority(
+            transition=load_worker_authority(args.transition),
+            previous=None if args.previous is None else load_worker_authority(args.previous),
+            worker_config_path=args.worker_config, delivery_config_path=args.delivery_config,
+            destination_config_path=args.destination_config,
+        )
+        if args.record:
+            dsn = os.environ.get("WAREHOUSE_POSTGRES_DSN", "")
+            if not dsn.strip():
+                raise ValidationError("WAREHOUSE_POSTGRES_DSN is required for recording")
+            result = record_worker_authority(dsn=dsn, transition=document)
+        else:
+            result = {
+                "transition_id": document["transition_id"],
+                "configuration_validated": True, "persisted": False,
+                "runtime_permission_granted": False,
+            }
+    except (ValidationError, StorageError) as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+    print(json.dumps(result, sort_keys=True, allow_nan=False))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/test_reviewed_worker_authority_recording.py
+++ b/tests/unit/test_reviewed_worker_authority_recording.py
@@ -1,0 +1,157 @@
+from __future__ import annotations
+
+import copy
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+from src.common.exceptions import StorageError, ValidationError
+from src.warehouse import reviewed_notification_worker_authority_history as reviewed
+from src.warehouse import notification_worker_authority_history as history
+from test_notification_worker_authority_history import Cursor, row
+from test_reviewed_notification_worker_authority import (
+    _grant, _plan, configurations as configurations,
+)
+
+
+def test_preparation_is_exact_and_detached(configurations: dict[str, Path]) -> None:
+    transition = _grant(_plan(configurations), configurations)
+    result = reviewed.prepare_reviewed_worker_authority(transition=transition, **configurations)
+    assert result == transition
+    transition["plan"]["execution"]["work_items"].clear()
+    assert result["plan"]["execution"]["work_items"]
+
+
+def test_recording_passes_only_canonical_transition_to_existing_recorder(
+    configurations: dict[str, Path], monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    transition = _grant(_plan(configurations), configurations)
+    calls: list[dict[str, Any]] = []
+
+    def recorder(**kwargs: Any) -> dict[str, Any]:
+        calls.append(kwargs)
+        return {"created": True, "runtime_permission_granted": False}
+
+    monkeypatch.setattr(reviewed, "record_worker_authority", recorder)
+    result = reviewed.record_reviewed_worker_authority(
+        dsn="injected-local-dsn", transition=transition, **configurations,
+    )
+    assert result == {"created": True, "runtime_permission_granted": False}
+    assert calls == [{"dsn": "injected-local-dsn", "transition": transition}]
+
+
+def test_configuration_mismatch_never_reaches_persistence(
+    configurations: dict[str, Path], monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    transition = _grant(_plan(configurations), configurations)
+    path = configurations["worker_config_path"]
+    document = yaml.safe_load(path.read_text())
+    document["workers"]["risk-operations-managed"]["enabled"] = False
+    path.write_text(yaml.safe_dump(document), encoding="utf-8")
+
+    def forbidden(**kwargs: Any) -> dict[str, Any]:
+        raise AssertionError("persistence must not be called")
+
+    monkeypatch.setattr(reviewed, "record_worker_authority", forbidden)
+    with pytest.raises(ValidationError, match="does not match"):
+        reviewed.record_reviewed_worker_authority(
+            dsn="unused", transition=transition, **configurations,
+        )
+
+
+def test_delegation_preserves_exact_replay_and_locked_head_rejection(
+    configurations: dict[str, Path], monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    transition = _grant(_plan(configurations), configurations)
+    replay_cursor = Cursor([row(transition)])
+
+    def replay(**kwargs: Any) -> dict[str, Any]:
+        return history.record_worker_authority_with_cursor(
+            replay_cursor, transition=kwargs["transition"],
+        )
+
+    monkeypatch.setattr(reviewed, "record_worker_authority", replay)
+    assert reviewed.record_reviewed_worker_authority(
+        dsn="unused", transition=transition, **configurations,
+    )["created"] is False
+    assert not any("INSERT" in sql for sql, _ in replay_cursor.calls)
+
+    def stale(**kwargs: Any) -> dict[str, Any]:
+        return history.record_worker_authority_with_cursor(
+            Cursor([None, row(transition)]), transition=kwargs["transition"],
+        )
+
+    competing = _grant(_plan(configurations), configurations, request_id="competing-root")
+    monkeypatch.setattr(reviewed, "record_worker_authority", stale)
+    with pytest.raises(ValidationError, match="predecessor"):
+        reviewed.record_reviewed_worker_authority(
+            dsn="unused", transition=competing, **configurations,
+        )
+
+
+def test_uncertain_storage_failure_is_not_reported_as_success(
+    configurations: dict[str, Path], monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    transition = _grant(_plan(configurations), configurations)
+
+    def failed(**kwargs: Any) -> dict[str, Any]:
+        raise StorageError("worker authority transaction failed; no success is confirmed")
+
+    monkeypatch.setattr(reviewed, "record_worker_authority", failed)
+    with pytest.raises(StorageError, match="no success is confirmed"):
+        reviewed.record_reviewed_worker_authority(
+            dsn="unused", transition=transition, **configurations,
+        )
+
+
+def _arguments(configurations: dict[str, Path], target: Path) -> list[str]:
+    return [
+        "--transition", str(target),
+        "--worker-config", str(configurations["worker_config_path"]),
+        "--delivery-config", str(configurations["delivery_config_path"]),
+        "--destination-config", str(configurations["destination_config_path"]),
+    ]
+
+
+def test_cli_default_never_calls_recorder(
+    configurations: dict[str, Path], tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch, capsys: Any,
+) -> None:
+    transition = _grant(_plan(configurations), configurations)
+    target = tmp_path / "transition.json"
+    target.write_text(json.dumps(transition), encoding="utf-8")
+
+    def forbidden(**kwargs: Any) -> dict[str, Any]:
+        raise AssertionError("validation-only command must not record")
+
+    monkeypatch.setattr(reviewed, "record_worker_authority", forbidden)
+    assert reviewed.main(_arguments(configurations, target)) == 0
+    assert json.loads(capsys.readouterr().out) == {
+        "transition_id": transition["transition_id"], "configuration_validated": True,
+        "persisted": False, "runtime_permission_granted": False,
+    }
+
+
+def test_cli_record_requires_explicit_dsn_and_sanitizes_failure(
+    configurations: dict[str, Path], tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch, capsys: Any,
+) -> None:
+    transition = _grant(_plan(configurations), configurations)
+    target = tmp_path / "transition.json"
+    target.write_text(json.dumps(transition), encoding="utf-8")
+    monkeypatch.delenv("WAREHOUSE_POSTGRES_DSN", raising=False)
+    assert reviewed.main(_arguments(configurations, target) + ["--record"]) == 1
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert "WAREHOUSE_POSTGRES_DSN is required" in captured.err
+
+
+def test_retained_predecessor_cannot_be_invented(configurations: dict[str, Path]) -> None:
+    transition = _grant(_plan(configurations), configurations)
+    with pytest.raises(ValidationError, match="predecessor"):
+        reviewed.prepare_reviewed_worker_authority(
+            transition=transition, previous=copy.deepcopy(transition), **configurations,
+        )


### PR DESCRIPTION
## Goal

Closes #154. First of three bounded PRs under #76. Primary arc42 block: warehouse.

Connect #152's configuration-checked authority boundary to #153's existing locked, append-only recorder without a new schema or state machine.

## Changes

- Prepare a bounded canonical transition against its exact supplied predecessor and reviewed configuration snapshots before connecting to PostgreSQL.
- Delegate unchanged evidence to the existing recorder; actual current-head reconciliation still occurs beneath its per-worker transaction lock.
- Keep the CLI validation-only unless --record is selected; use an environment DSN only for recording.
- Add eight regression tests covering rejection before persistence, canonical delegation, historical replay, competing-root rejection, storage uncertainty, predecessor mismatch and CLI defaults.

## Validation and review

Final head: `04ee9182142b3b228de05879bde38b70f827d346`.

CI run **430** (`33998740698`) passed all four jobs: Security guardrails, Python readiness, PostgreSQL contract and Infrastructure validation. Python logs show Ruff passed, mypy across **157 source files**, **1,115 tests passed twice**, dependency integrity, pipeline replay and warehouse dry-run.

Actions checked synthetic merge `a01ade84b2d09de10dbe61880a0607e35682870c`, combining this exact head with `2133fa220bbf57ddbe8d943f5ad0a1ad1fd73b64`. Final comparison confirmed that base was still main, with no missing main commits. Self-review confirmed exactly three additive files, 327 additions and no deletions. No submitted reviews or unresolved threads were present; this is not independent human approval.

Full-repository validation ran through GitHub Actions, not a local clone. Local Docker/PostgreSQL/Terraform tools are unavailable.

## Boundaries

Existing low-level persistence remains a trusted primitive; this is an opt-in checked admission path, not a database privilege change. Snapshot provenance and caller authentication remain external responsibilities. New tests inject persistence; no application database call is made by this workflow. No enablement, delivery, scheduling, schema, dependency, workflow or infrastructure change.