### PR TITLE
Bind suspension decisions to exact worker stop transitions

### DIFF
--- a/docs/notification-worker-suspension-transition.md
+++ b/docs/notification-worker-suspension-transition.md
@@ -1,0 +1,38 @@
+# Binding suspension decisions to lifecycle transitions
+
+Primary arc42 block: `orchestration`. P4e2c, second dependency-ordered layer.
+
+`build_worker_suspension_bundle` accepts one exact authority, its canonical
+suspension decision and an operator identifier. It reconstructs both source
+contracts, permits only the `suspend` outcome and calls the existing
+`build_worker_authority_transition`. The result is an atomic-persistence input
+containing `authority`, `decision` and `transition`, not a competing state machine.
+
+The stop retains the exact governed plan and predecessor, copies the decision's
+canonical reasons and evaluation time, and has no reviewers or grant expiry.
+Its request ID is deterministically derived from the complete decision. Repeating
+the same input converges; changing the operator for that same decision retains
+the request ID but changes the transition, so persistence must reject reuse.
+Operator strings and hashes are evidence, not authentication.
+
+Healthy and inactive decisions cannot produce a transition. Expired authority
+already remains inactive and is not converted into a new suspension. Expired
+destination review does not prevent stopping an otherwise active authority.
+Evaluation at the predecessor's exact effective time cannot fabricate a later
+clock value: the existing strict chronology check rejects the stop.
+
+`validate_worker_suspension_bundle` reconstructs the decision and transition and
+compares canonical bytes. Rehashed changes to reasons, timestamps, action,
+predecessor, request identity or side-effect flags are rejected. Inputs are not
+mutated and the entire bundle is limited to 1 MiB.
+
+This layer performs no database read/write, lock acquisition, endpoint resolution,
+network request, delivery, scheduler mutation, deployment or `terraform apply`.
+No committed activation default is changed. Current retained-head selection,
+authentication and health-source provenance remain trusted-caller obligations.
+The next warehouse layer must reload the exact predecessor under its per-worker
+transaction lock and atomically retain both the stop and decision evidence.
+
+Run `python -m pytest -q tests/unit/test_notification_worker_suspension_transition.py`
+plus the full repository quality/security checks. Review the exact decision-to-stop
+binding before accepting; passing tests are not human approval.

--- a/src/orchestration/notification_worker_suspension_transition.py
+++ b/src/orchestration/notification_worker_suspension_transition.py
@@ -1,0 +1,65 @@
+"""Bind suspension decisions to the existing lifecycle, without recording or executing."""
+from __future__ import annotations
+
+import hashlib
+from collections.abc import Mapping
+from typing import Any
+
+from src.common.exceptions import ValidationError
+from src.orchestration.notification_worker_authority_contract import (
+    build_worker_authority_transition, canonical_bytes,
+    validate_worker_authority_transition,
+)
+from src.orchestration.notification_worker_suspension import (
+    MAX_DOCUMENT_BYTES, validate_worker_suspension_decision,
+)
+
+
+def build_worker_suspension_bundle(
+    *, authority: Mapping[str, Any], decision: Mapping[str, Any], operator_id: str,
+) -> dict[str, Any]:
+    """Prepare one exact stop and its evidence. This is not a new authority model.
+
+    Caller identity authentication and current retained-head selection are outside
+    this pure boundary. The recorder must recheck the predecessor transactionally.
+    """
+    try:
+        if len(canonical_bytes(authority)) + len(canonical_bytes(decision)) > MAX_DOCUMENT_BYTES:
+            raise ValidationError("worker suspension bundle exceeds 1 MB")
+        prior = validate_worker_authority_transition(authority)
+        evaluated = validate_worker_suspension_decision(decision, authority=prior)
+        if evaluated["outcome"] != "suspend":
+            raise ValidationError("only a suspend decision may create a stop transition")
+        request_id = "worker-suspension:" + hashlib.sha256(canonical_bytes(evaluated)).hexdigest()
+        transition = build_worker_authority_transition(
+            plan=prior["plan"], request_id=request_id, operator_id=operator_id, action="suspend",
+            requested_at=evaluated["evaluated_at"], effective_at=evaluated["evaluated_at"],
+            reason_codes=evaluated["reason_codes"], previous=prior,
+        )
+        result = {"authority": prior, "decision": evaluated, "transition": transition}
+        if len(canonical_bytes(result)) > MAX_DOCUMENT_BYTES:
+            raise ValidationError("worker suspension bundle exceeds 1 MB")
+        return result
+    except (ValueError, TypeError, KeyError, RecursionError, OverflowError, UnicodeError):
+        raise ValidationError("worker suspension bundle is malformed") from None
+
+
+def validate_worker_suspension_bundle(value: Mapping[str, Any]) -> dict[str, Any]:
+    """Rebuild the decision and stop, rejecting altered identities, reasons or timing."""
+    try:
+        if not isinstance(value, Mapping) or set(value) != {"authority", "decision", "transition"}:
+            raise ValidationError("worker suspension bundle fields are not exact")
+        raw = canonical_bytes(value)
+        if len(raw) > MAX_DOCUMENT_BYTES:
+            raise ValidationError("worker suspension bundle exceeds 1 MB")
+        if not isinstance(value["transition"], Mapping):
+            raise ValidationError("worker suspension transition must be an object")
+        rebuilt = build_worker_suspension_bundle(
+            authority=value["authority"], decision=value["decision"],
+            operator_id=value["transition"]["operator_id"],
+        )
+        if raw != canonical_bytes(rebuilt):
+            raise ValidationError("worker suspension bundle differs from canonical evidence")
+        return rebuilt
+    except (ValueError, TypeError, KeyError, RecursionError, OverflowError, UnicodeError):
+        raise ValidationError("worker suspension bundle is malformed") from None

--- a/tests/unit/test_notification_worker_suspension_transition.py
+++ b/tests/unit/test_notification_worker_suspension_transition.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+import copy
+import hashlib
+from datetime import timedelta
+from typing import Any
+
+import pytest
+
+from src.common.exceptions import ValidationError
+from src.orchestration.notification_worker_authority_contract import (
+    MODEL_VERSION, canonical_bytes, validate_worker_authority_chain,
+)
+from src.orchestration.notification_worker_suspension_transition import (
+    build_worker_suspension_bundle, validate_worker_suspension_bundle,
+)
+from test_notification_worker_authority_contract import NOW, grant, stop
+from test_notification_worker_suspension import AT, decision, observation
+
+
+def bundle() -> dict[str, Any]:
+    return build_worker_suspension_bundle(authority=grant(), decision=decision(), operator_id="health-observer")
+
+
+def test_bundle_reuses_exact_lifecycle_and_decision() -> None:
+    result = bundle()
+    transition = result["transition"]
+    assert validate_worker_suspension_bundle(result) == result
+    assert validate_worker_authority_chain(transition, result["authority"]) == transition
+    assert result == bundle()
+    assert transition["model_version"] == MODEL_VERSION
+    assert transition["action"] == "suspend"
+    assert transition["previous_transition_id"] == result["authority"]["transition_id"]
+    assert transition["plan"] == result["authority"]["plan"]
+    assert transition["reason_codes"] == result["decision"]["reason_codes"]
+    assert transition["effective_at"] == AT.isoformat()
+    assert transition["expires_at"] is None
+    assert transition["reviewed_by"] == []
+    assert transition["request_id"] == "worker-suspension:" + hashlib.sha256(canonical_bytes(result["decision"])).hexdigest()
+    assert transition["scheduler_mutated"] is False
+    assert transition["external_request_performed"] is False
+
+
+def test_inputs_are_not_modified_or_aliased() -> None:
+    prior, evaluated = grant(), decision()
+    expected = copy.deepcopy((prior, evaluated))
+    result = build_worker_suspension_bundle(authority=prior, decision=evaluated, operator_id="observer")
+    assert (prior, evaluated) == expected
+    prior["plan"]["worker"]["enabled"] = False
+    evaluated["reason_codes"].clear()
+    assert result["authority"]["plan"]["worker"]["enabled"] is True
+    assert result["decision"]["reason_codes"]
+
+
+@pytest.mark.parametrize("kind", ["healthy", "expired", "suspended", "disabled"])
+def test_non_suspension_results_never_materialize_a_transition(kind: str) -> None:
+    prior = grant()
+    at: Any = AT
+    if kind == "expired":
+        at = prior["expires_at"]
+    elif kind in {"suspended", "disabled"}:
+        prior = stop(prior, action="suspend" if kind == "suspended" else "disable")
+        at = NOW + timedelta(days=1)
+    evaluated = decision(observation(prior), authority=prior, evaluated_at=at)
+    with pytest.raises(ValidationError, match="only a suspend"):
+        build_worker_suspension_bundle(authority=prior, decision=evaluated, operator_id="observer")
+
+
+def test_same_effective_time_cannot_fabricate_a_later_timestamp() -> None:
+    prior = grant()
+    evaluated = decision(authority=prior, evaluated_at=prior["effective_at"])
+    with pytest.raises(ValidationError, match="strictly time ordered"):
+        build_worker_suspension_bundle(authority=prior, decision=evaluated, operator_id="observer")
+
+
+@pytest.mark.parametrize("key,value", [
+    ("previous_transition_id", "other-head"), ("request_id", "arbitrary-request"),
+    ("reason_codes", ["operator_request"]), ("effective_at", (AT + timedelta(seconds=1)).isoformat()),
+    ("scheduler_mutated", True), ("action", "disable"),
+])
+def test_rehashed_stop_cannot_change_decision_binding(key: str, value: Any) -> None:
+    result = bundle()
+    transition = result["transition"]
+    transition[key] = value
+    identity = {k: v for k, v in transition.items() if k != "transition_id"}
+    transition["transition_id"] = f"{MODEL_VERSION}-{hashlib.sha256(canonical_bytes(identity)).hexdigest()}"
+    with pytest.raises(ValidationError):
+        validate_worker_suspension_bundle(result)
+
+
+def test_exact_authority_and_exact_bundle_fields_are_required() -> None:
+    result = bundle()
+    result["authority"] = grant(request_id="OTHER-HEAD")
+    with pytest.raises(ValidationError):
+        validate_worker_suspension_bundle(result)
+    result = bundle()
+    result["unknown"] = True
+    with pytest.raises(ValidationError):
+        validate_worker_suspension_bundle(result)
+
+
+def test_operator_identity_is_required_but_is_not_authentication() -> None:
+    with pytest.raises(ValidationError):
+        build_worker_suspension_bundle(authority=grant(), decision=decision(), operator_id="")
+    other = build_worker_suspension_bundle(authority=grant(), decision=decision(), operator_id="another-observer")
+    first = bundle()
+    assert other["transition"]["request_id"] == first["transition"]["request_id"]
+    assert other["transition"]["transition_id"] != first["transition"]["transition_id"]
+
+
+def test_expired_destination_review_can_still_produce_a_stop() -> None:
+    snapshot = observation()
+    snapshot["review_expires_at"] = AT.isoformat()
+    result = build_worker_suspension_bundle(authority=grant(), decision=decision(snapshot), operator_id="observer")
+    assert result["transition"]["reason_codes"] == ["expired_review"]


### PR DESCRIPTION
## Goal

P4e2c, **2 of 3**, stacked on #158. Bind one exact suspension decision to the existing worker lifecycle stop transition. Successor: #162. Roadmap #76. Primary arc42 block: `orchestration`.

## Changes

- Revalidate the exact authority and suspension decision.
- Permit only `suspend`; healthy and inactive outcomes cannot create a stop.
- Reuse the established authority model, exact predecessor and governed plan.
- Derive a deterministic request ID from the complete decision and copy exact reasons and timing.
- Preserve strict chronology, cooldown, no grant expiry and the existing stop-review semantics.
- Supply one bounded `authority` / `decision` / `transition` bundle for atomic persistence.
- Rebuild both contracts to reject rehashed identity, reason, timing or side-effect changes.

## Exact candidate and scope

```text
Base #158: 3b262758bee8911062b2c893da5c67dd7f2438a6
Head:      df7135048c953a2540262d282dcb7805c9f886e8
Tree:      756e0c2a1c6ca5fc7f4a22427c2188d488fb977b
Scope:     3 additive files; 218 additions; 0 deletions
```

The refreshed stack incorporates accepted main `b17b1439cca98e05d28bd5722a733b583a2ca496` through non-force reconciliation. This layer's three implementation/test/documentation blobs did not change during reconciliation; complementary authority/slot preflight is preserved.

## Final validation

[GitHub Actions run 440](https://github.com/alexmarinos87/financial-risk-data-platform/actions/runs/33999552138), associated with final head `df7135048c953a2540262d282dcb7805c9f886e8`, completed successfully in all four jobs: Security guardrails, Python readiness, PostgreSQL contract and Infrastructure validation without apply.

Local source-subset validation passed **16 new focused tests plus all 46 predecessor tests: 62 passed**, compilation and whitespace checks. That local harness was not a full repository checkout; the final GitHub run supplies full-repository validation. Earlier heads/runs are superseded.

Self-review covered decision-to-stop identity, exact timing, detached inputs, inactive outcomes and operator/request conflict semantics. No submitted reviews or inline review threads were present at the final review check. Independent review and explicit human acceptance remain pending.

## Trust and side-effect boundary

Pure construction/validation only. No database read/write, lock acquisition, scheduler change, endpoint lookup, transport, notification, deployment or Terraform apply. No committed activation default changes. Caller identity and underlying health-source provenance are not authenticated by hashes. Atomic persistence and retained-head reconciliation belong to #162.

## Acceptance and merge sequence

**Draft and unmerged.** Accept and squash #158 first. Reconstruct this three-file delta on accepted current main, rerun the exact-head checks and review the resulting diff before accepting and squash-merging this layer. Do not merge into the predecessor branch as a substitute for acceptance. Verify post-merge main before reconstructing #162. No automatic merge or human approval is implied by passing CI.