### PR TITLE
Assess managed-worker readiness from explicit observations

### DIFF
--- a/docs/notification-worker-readiness.md
+++ b/docs/notification-worker-readiness.md
@@ -1,0 +1,108 @@
+# Managed-worker readiness assessment
+
+Primary arc42 block: `orchestration`.
+
+## Goal
+
+P4e2c1 adds `assess_worker_readiness` and
+`validate_worker_readiness_assessment` in
+`src/orchestration/notification_worker_readiness.py`. They combine supplied
+observations into deterministic evidence about one selected worker slot. They
+perform no I/O and do not create another authority state machine.
+
+The output is one of:
+
+| Assessment | Meaning |
+| --- | --- |
+| `may_run` | Supplied observations satisfy the assessment contract at this instant. |
+| `wait` | The authority is active and otherwise healthy, but its slot is not due. |
+| `must_suspend` | Do not run; remain stopped or request appropriate operator action. |
+
+Every output retains `runtime_permission_granted = false`. `must_suspend` is
+advice, not a command to append a suspend transition from an illegal source
+state. Neither a passing assessment nor a hash authenticates an operator,
+claims a slot, sends a notification or modifies a scheduler.
+
+## Required evidence
+
+The input has exact fields: `worker_id`, `evaluated_at`, `observed_at`,
+`scheduled_for`, `selected_authority`, `current_authority`, `configuration_plan`,
+`destination_review_expires_at`, `readiness` and `health`.
+
+Authority entries use the existing transition model, independently validated
+alongside the stricter retained-plan boundary. Either may be null, but missing
+authority cannot produce `may_run`. The selected transition must equal the
+supplied current head. A newer stop therefore invalidates a supplied older
+active grant. State and exclusive expiry use the existing authority evaluator;
+elapsed suspension cooldown never creates an implicit resume.
+
+`configuration_plan` must be reconstructed by the observation producer from its
+current reviewed configuration snapshot at the selected plan's original
+planning instant. Exact comparison detects changed configuration or a different
+plan/slot. The destination review expiry must come from that same snapshot.
+The assessment checks current review expiry and prevents active authority from
+outliving it. Disabled or blocked configuration cannot pass.
+
+`readiness` has zero to two sorted, unique rows, one required for each configured
+execution kind. Rows retain a record and decision identity, evaluation time,
+review status, allow/block decision, current-evidence match flag and exact
+configuration fingerprints. These correspond to the existing notification
+readiness review view. Missing rows, stale/future evidence, blocked/superseded
+status and configuration mismatches all prevent `may_run`. An allowed status
+contradicting its decision or match flag is malformed, not healthy.
+
+`health` likewise requires explicit observations for each configured kind.
+Each binds worker/destination, observation time, evidence identity, completeness,
+consecutive failures and persistence ambiguity. Missing or incomplete evidence
+is not inferred as zero failures. Counts are bounded integers excluding
+booleans. The configured failure threshold is inclusive, and any unresolved
+persistence ambiguity blocks. Counts are worker/destination/kind observations,
+not a newly invented derivation from individual event-attempt rows.
+
+All time text is canonical UTC. The worker's configured readiness age, at most
+300 seconds, bounds the overall observation and both per-kind evidence types.
+Evidence cannot be newer than its observation time or evaluation time. The
+aggregate input is bounded to 1 MB and snapshotted into detached JSON.
+
+## Determinism and validation
+
+Reasons have fixed evaluation order: authority, scope, configuration, observation
+age, destination review, slot, then each configured kind's readiness and health
+reasons. An otherwise valid early invocation returns only `slot_not_due`, so it
+waits rather than needlessly suspending. Early invocation plus a safety failure
+still returns `must_suspend`.
+
+The assessment retains the evidence digest, selected/current transition IDs,
+plan and slot identities and side-effect flags. Its validator rebuilds the
+entire result from supplied evidence and compares canonical bytes. Rehashing a
+changed verdict is insufficient to pass.
+
+## What this does not establish
+
+The observations are explicit inputs, not authenticated database reads. This
+increment does not prove current-head selection, consistent transaction
+snapshot, configuration provenance, health-counter derivation or lock ownership.
+A caller capable of fabricating all observations remains inside the trust
+boundary. These APIs must not be used directly as a delivery authorization
+service.
+
+A later read-only adapter must load the actual current authority, current
+readiness and complete health evidence consistently, reconstruct configuration
+from reviewed snapshots and preserve source identities. Runtime integration
+must then authenticate callers, refresh evidence under the shared delivery lock
+and enforce slot claiming/replay and concurrent-stop semantics before transport.
+No such database adapter or runtime execution is claimed here.
+
+## Validation
+
+```bash
+.venv/bin/python -m pytest -q tests/unit/test_notification_worker_readiness.py
+make quality-check
+make security-check
+make readiness-check
+```
+
+Tests use actual planner and reviewed-authority builders with temporary enabled
+configuration snapshots. Committed defaults, database schema, workflow,
+dependencies and infrastructure are unchanged. A separate no-network rehearsal
+provides an operator walkthrough with explicitly synthetic observations.

--- a/src/orchestration/notification_worker_readiness.py
+++ b/src/orchestration/notification_worker_readiness.py
@@ -1,0 +1,269 @@
+"""Pure worker assessment over supplied observations; never runtime permission."""
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Mapping
+from datetime import datetime
+from typing import Any
+
+from src.common.exceptions import ValidationError
+from src.orchestration.notification_worker_authority_contract import (
+    authority_state, canonical_bytes, identifier, validate_worker_authority_transition,
+)
+from src.orchestration.notification_worker_plan_validation import (
+    canonical_timestamp, exact_object,
+)
+from src.orchestration.plan_notification_worker import validate_notification_worker_plan
+from src.orchestration.portfolio_risk_notification_retry_execution_policy import bounded_integer
+
+MODEL_VERSION = "portfolio-risk-notification-worker-readiness-assessment-v1"
+MAX_EVIDENCE_BYTES = 1_048_576
+EVIDENCE_FIELDS = frozenset({
+    "worker_id", "evaluated_at", "observed_at", "scheduled_for",
+    "selected_authority", "current_authority", "configuration_plan",
+    "destination_review_expires_at", "readiness", "health",
+})
+READINESS_FIELDS = frozenset({
+    "execution_kind", "record_id", "decision_id", "evaluated_at", "status",
+    "decision", "matches_current_evidence", "destination_id", "destination_fingerprint",
+    "delivery_fingerprint", "retry_policy_fingerprint", "retry_execution_policy_fingerprint",
+    "endpoint_environment_variable",
+})
+HEALTH_FIELDS = frozenset({
+    "execution_kind", "worker_id", "destination_id", "observed_at", "evidence_id",
+    "evidence_complete", "consecutive_failures", "persistence_ambiguity",
+})
+READINESS_STATUSES = frozenset({"allowed", "blocked", "decision_stale", "decision_superseded"})
+
+
+def _snapshot(value: Mapping[str, Any]) -> dict[str, Any]:
+    source = exact_object(value, EVIDENCE_FIELDS, "worker evidence")
+    encoded = canonical_bytes(source)
+    if len(encoded) > MAX_EVIDENCE_BYTES:
+        raise ValidationError("worker evidence exceeds 1 MB")
+    result = json.loads(encoded)
+    assert isinstance(result, dict)
+    return result
+
+
+def _boolean(value: Any, label: str) -> bool:
+    if type(value) is not bool:
+        raise ValidationError(f"{label} must be boolean")
+    return bool(value)
+
+
+def _transition(value: Any) -> dict[str, Any] | None:
+    if value is None:
+        return None
+    if not isinstance(value, Mapping) or not isinstance(value.get("plan"), Mapping):
+        raise ValidationError("worker authority must contain a plan object")
+    validate_notification_worker_plan(value["plan"])
+    return validate_worker_authority_transition(value)
+
+
+def _rows(value: Any, fields: frozenset[str], kinds: list[str], label: str) -> dict[str, dict[str, Any]]:
+    if not isinstance(value, list) or len(value) > 2:
+        raise ValidationError(f"{label} must contain at most two observations")
+    result: dict[str, dict[str, Any]] = {}
+    order: list[str] = []
+    for item in value:
+        row = exact_object(item, fields, label)
+        kind = identifier(row["execution_kind"], "execution_kind")
+        if kind not in kinds:
+            raise ValidationError(f"{label} contains an unconfigured execution kind")
+        order.append(kind)
+        result[kind] = row
+    if order != sorted(set(order)):
+        raise ValidationError(f"{label} kinds must be sorted and unique")
+    return result
+
+
+def _age_reasons(
+    instant: datetime, *, observed: datetime, evaluated: datetime,
+    max_age: int, label: str,
+) -> list[str]:
+    reasons = []
+    if instant > observed or instant > evaluated:
+        reasons.append(f"{label}_future")
+    if (evaluated - instant).total_seconds() > max_age:
+        reasons.append(f"{label}_stale")
+    return reasons
+
+
+def _readiness_reasons(
+    row: Mapping[str, Any], *, kind: str, plan: Mapping[str, Any],
+    observed: datetime, evaluated: datetime, max_age: int,
+) -> list[str]:
+    for key in ("record_id", "decision_id", "destination_id", "destination_fingerprint",
+                "delivery_fingerprint", "retry_policy_fingerprint",
+                "retry_execution_policy_fingerprint", "endpoint_environment_variable"):
+        identifier(row[key], key)
+    status = row["status"]
+    if not isinstance(status, str) or status not in READINESS_STATUSES:
+        raise ValidationError("readiness status is invalid")
+    decision = row["decision"]
+    if not isinstance(decision, str) or decision not in {"allow", "block"}:
+        raise ValidationError("readiness decision is invalid")
+    matches = _boolean(row["matches_current_evidence"], "matches_current_evidence")
+    if (status == "allowed" and (decision != "allow" or not matches)
+            or status == "blocked" and decision != "block"):
+        raise ValidationError("readiness status contradicts its decision or current evidence")
+    reasons = _age_reasons(
+        canonical_timestamp(row["evaluated_at"], "readiness evaluated_at"),
+        observed=observed, evaluated=evaluated, max_age=max_age, label="readiness",
+    )
+    if status != "allowed":
+        reasons.append(f"readiness_{status}")
+    if not matches and status != "decision_superseded":
+        reasons.append("readiness_evidence_mismatch")
+    expected = {
+        "destination_id": plan["destination"]["destination_id"],
+        "destination_fingerprint": plan["destination"]["fingerprint"],
+        "endpoint_environment_variable": plan["destination"]["endpoint_environment_variable"],
+        "delivery_fingerprint": plan["delivery"]["delivery_fingerprint"],
+        "retry_policy_fingerprint": plan["delivery"]["retry_planning_policy_fingerprint"],
+        "retry_execution_policy_fingerprint": plan["delivery"]["retry_execution_policy_fingerprint"],
+    }
+    if any(row[key] != value for key, value in expected.items()):
+        reasons.append("readiness_configuration_mismatch")
+    return [f"{reason}:{kind}" for reason in reasons]
+
+
+def _health_reasons(
+    row: Mapping[str, Any], *, kind: str, plan: Mapping[str, Any],
+    observed: datetime, evaluated: datetime, max_age: int,
+) -> list[str]:
+    for key in ("worker_id", "destination_id", "evidence_id"):
+        identifier(row[key], key)
+    complete = _boolean(row["evidence_complete"], "health evidence_complete")
+    ambiguous = _boolean(row["persistence_ambiguity"], "health persistence_ambiguity")
+    failures = bounded_integer(
+        row["consecutive_failures"], "consecutive_failures", minimum=0, maximum=1_000_000,
+    )
+    reasons = _age_reasons(
+        canonical_timestamp(row["observed_at"], "health observed_at"),
+        observed=observed, evaluated=evaluated, max_age=max_age, label="health",
+    )
+    if (row["worker_id"] != plan["worker"]["worker_id"]
+            or row["destination_id"] != plan["destination"]["destination_id"]):
+        reasons.append("health_scope_mismatch")
+    if not complete:
+        reasons.append("health_incomplete")
+    if ambiguous:
+        reasons.append("persistence_ambiguity")
+    if failures >= plan["suspension"]["max_consecutive_failures"]:
+        reasons.append("repeated_delivery_failure")
+    return [f"{reason}:{kind}" for reason in reasons]
+
+
+def _assess(evidence: Mapping[str, Any]) -> dict[str, Any]:
+    supplied = _snapshot(evidence)
+    worker_id = identifier(supplied["worker_id"], "worker_id")
+    evaluated = canonical_timestamp(supplied["evaluated_at"], "evaluated_at")
+    observed = canonical_timestamp(supplied["observed_at"], "observed_at")
+    requested_slot = canonical_timestamp(supplied["scheduled_for"], "scheduled_for")
+    selected = _transition(supplied["selected_authority"])
+    current = _transition(supplied["current_authority"])
+    configuration = validate_notification_worker_plan(supplied["configuration_plan"])
+    plan = configuration if selected is None else selected["plan"]
+    max_age = plan["readiness"]["max_age_seconds"]
+    kinds = [item["execution_kind"] for item in plan["execution"]["work_items"]]
+    state = authority_state(current, as_of=evaluated)
+    reasons: list[str] = []
+    if selected is None:
+        reasons.append("authority_missing")
+    if selected != current:
+        reasons.append("authority_superseded")
+    if state != "active":
+        reasons.append(f"authority_{state}")
+    if (configuration["worker"]["worker_id"] != worker_id
+            or any(item is not None and item["plan"]["worker"]["worker_id"] != worker_id
+                   for item in (selected, current))):
+        reasons.append("worker_scope_mismatch")
+    if any(item is not None and canonical_timestamp(item["effective_at"], "effective_at") > observed
+           for item in (selected, current)):
+        reasons.append("authority_not_yet_observed")
+    if configuration != plan:
+        reasons.append("configuration_mismatch")
+    if configuration["status"] != "would_schedule":
+        reasons.append("configuration_blocked")
+    if canonical_timestamp(configuration["planned_at"], "planned_at") > observed:
+        reasons.append("configuration_future")
+    reasons.extend(_age_reasons(
+        observed, observed=observed, evaluated=evaluated, max_age=max_age, label="observation",
+    ))
+    review_expiry = supplied["destination_review_expires_at"]
+    if review_expiry is None:
+        reasons.append("destination_review_missing")
+    else:
+        expiry = canonical_timestamp(review_expiry, "destination_review_expires_at")
+        if evaluated >= expiry:
+            reasons.append("destination_review_expired")
+        if selected is not None and selected["expires_at"] is not None:
+            if canonical_timestamp(selected["expires_at"], "authority expires_at") > expiry:
+                reasons.append("authority_exceeds_destination_review")
+    slot = canonical_timestamp(plan["schedule"]["scheduled_for"], "plan scheduled_for")
+    if requested_slot != slot:
+        reasons.append("schedule_slot_mismatch")
+    if evaluated < slot:
+        reasons.append("slot_not_due")
+    readiness = _rows(supplied["readiness"], READINESS_FIELDS, kinds, "readiness")
+    health = _rows(supplied["health"], HEALTH_FIELDS, kinds, "health")
+    for kind in kinds:
+        if kind not in readiness:
+            reasons.append(f"readiness_missing:{kind}")
+        else:
+            reasons.extend(_readiness_reasons(
+                readiness[kind], kind=kind, plan=plan, observed=observed,
+                evaluated=evaluated, max_age=max_age,
+            ))
+        if kind not in health:
+            reasons.append(f"health_missing:{kind}")
+        else:
+            reasons.extend(_health_reasons(
+                health[kind], kind=kind, plan=plan, observed=observed,
+                evaluated=evaluated, max_age=max_age,
+            ))
+    assessment = "may_run" if not reasons else "wait" if reasons == ["slot_not_due"] else "must_suspend"
+    identity = {
+        "model_version": MODEL_VERSION, "worker_id": worker_id,
+        "evaluated_at": evaluated.isoformat(), "scheduled_for": requested_slot.isoformat(),
+        "plan_id": plan["plan_id"], "authority_state": state,
+        "selected_transition_id": None if selected is None else selected["transition_id"],
+        "current_transition_id": None if current is None else current["transition_id"],
+        "evidence_sha256": hashlib.sha256(canonical_bytes(supplied)).hexdigest(),
+        "assessment": assessment, "reasons": reasons, "read_only": True,
+        "runtime_permission_granted": False, "scheduler_mutated": False,
+        "shared_lock_acquired": False, "external_request_performed": False,
+        "database_read_performed": False,
+    }
+    digest = hashlib.sha256(canonical_bytes(identity)).hexdigest()
+    return {"assessment_id": f"{MODEL_VERSION}-{digest}", **identity}
+
+
+def assess_worker_readiness(evidence: Mapping[str, Any]) -> dict[str, Any]:
+    """Assess supplied snapshots only; the caller must establish their provenance.
+
+    No file, database, environment, transport or scheduler operation occurs here.
+    A later runtime must obtain consistent current evidence and recheck it under
+    the shared lock. Even may_run is not execution permission or a slot claim.
+    """
+    try:
+        return _assess(evidence)
+    except (TypeError, ValueError, RecursionError, OverflowError, UnicodeError):
+        raise ValidationError("worker readiness evidence is malformed") from None
+
+
+def validate_worker_readiness_assessment(
+    assessment: Mapping[str, Any], *, evidence: Mapping[str, Any],
+) -> dict[str, Any]:
+    rebuilt = assess_worker_readiness(evidence)
+    checked = exact_object(assessment, frozenset(rebuilt), "worker readiness assessment")
+    try:
+        encoded = canonical_bytes(checked)
+    except (TypeError, ValueError, RecursionError, OverflowError, UnicodeError):
+        raise ValidationError("worker readiness assessment is malformed") from None
+    if encoded != canonical_bytes(rebuilt):
+        raise ValidationError("worker readiness assessment differs from supplied evidence")
+    return rebuilt

--- a/tests/unit/test_notification_worker_readiness.py
+++ b/tests/unit/test_notification_worker_readiness.py
@@ -1,0 +1,234 @@
+from __future__ import annotations
+
+import copy
+import hashlib
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from src.common.exceptions import ValidationError
+from src.orchestration.notification_worker_authority_contract import (
+    build_worker_authority_transition, canonical_bytes,
+)
+from src.orchestration.notification_worker_readiness import (
+    MODEL_VERSION, assess_worker_readiness, validate_worker_readiness_assessment,
+)
+from src.orchestration.plan_notification_worker import _plan_id
+from test_reviewed_notification_worker_authority import (
+    NOW, _grant, _plan, configurations as configurations,
+)
+
+
+def evidence_fixture(paths: dict[str, Path]) -> dict[str, Any]:
+    plan = _plan(paths)
+    active = _grant(plan, paths)
+    slot = plan["schedule"]["scheduled_for"]
+    readiness = []
+    health = []
+    for item in plan["execution"]["work_items"]:
+        kind = item["execution_kind"]
+        readiness.append({
+            "execution_kind": kind, "record_id": f"readiness-record-{kind}",
+            "decision_id": f"readiness-decision-{kind}", "evaluated_at": slot,
+            "status": "allowed", "decision": "allow", "matches_current_evidence": True,
+            "destination_id": plan["destination"]["destination_id"],
+            "destination_fingerprint": plan["destination"]["fingerprint"],
+            "delivery_fingerprint": plan["delivery"]["delivery_fingerprint"],
+            "retry_policy_fingerprint": plan["delivery"]["retry_planning_policy_fingerprint"],
+            "retry_execution_policy_fingerprint": plan["delivery"]["retry_execution_policy_fingerprint"],
+            "endpoint_environment_variable": plan["destination"]["endpoint_environment_variable"],
+        })
+        health.append({
+            "execution_kind": kind, "worker_id": plan["worker"]["worker_id"],
+            "destination_id": plan["destination"]["destination_id"],
+            "observed_at": slot, "evidence_id": f"health-evidence-{kind}",
+            "evidence_complete": True, "consecutive_failures": 0,
+            "persistence_ambiguity": False,
+        })
+    return {
+        "worker_id": plan["worker"]["worker_id"], "evaluated_at": slot,
+        "observed_at": slot, "scheduled_for": slot,
+        "selected_authority": active, "current_authority": copy.deepcopy(active),
+        "configuration_plan": copy.deepcopy(plan),
+        "destination_review_expires_at": "2026-10-01T00:00:00+00:00",
+        "readiness": readiness, "health": health,
+    }
+
+
+def retime(evidence: dict[str, Any], instant: datetime) -> None:
+    value = instant.isoformat()
+    evidence["evaluated_at"] = value
+    evidence["observed_at"] = value
+    for row in evidence["readiness"]:
+        row["evaluated_at"] = value
+    for row in evidence["health"]:
+        row["observed_at"] = value
+
+
+def test_healthy_slot_is_deterministic_evidence_not_permission(configurations: dict[str, Path]) -> None:
+    evidence = evidence_fixture(configurations)
+    original = copy.deepcopy(evidence)
+    result = assess_worker_readiness(evidence)
+    assert result == assess_worker_readiness(evidence)
+    assert validate_worker_readiness_assessment(result, evidence=evidence) == result
+    assert result["assessment"] == "may_run"
+    assert result["reasons"] == []
+    assert result["read_only"] is True
+    for field in ("runtime_permission_granted", "scheduler_mutated", "shared_lock_acquired",
+                  "external_request_performed", "database_read_performed"):
+        assert result[field] is False
+    assert evidence == original
+
+
+def test_early_but_active_invocation_waits(configurations: dict[str, Path]) -> None:
+    evidence = evidence_fixture(configurations)
+    retime(evidence, datetime.fromisoformat(evidence["scheduled_for"]) - timedelta(seconds=1))
+    result = assess_worker_readiness(evidence)
+    assert result["assessment"] == "wait"
+    assert result["reasons"] == ["slot_not_due"]
+
+
+@pytest.mark.parametrize("action", ["suspend", "disable"])
+def test_newer_stop_cannot_be_bypassed_by_old_active_grant(
+    configurations: dict[str, Path], action: str,
+) -> None:
+    evidence = evidence_fixture(configurations)
+    prior = evidence["selected_authority"]
+    stopped = build_worker_authority_transition(
+        plan=prior["plan"], request_id=f"stop-{action}", operator_id="risk-operator",
+        action=action, requested_at=NOW + timedelta(seconds=2),
+        effective_at=NOW + timedelta(seconds=2), reason_codes=["operator_request"], previous=prior,
+    )
+    evidence["current_authority"] = stopped
+    result = assess_worker_readiness(evidence)
+    assert result["assessment"] == "must_suspend"
+    assert "authority_superseded" in result["reasons"]
+    assert f"authority_{stopped['to_state']}" in result["reasons"]
+    evidence["selected_authority"] = stopped
+    retime(evidence, NOW + timedelta(minutes=30))
+    result = assess_worker_readiness(evidence)
+    assert result["assessment"] == "must_suspend"
+    assert "authority_superseded" not in result["reasons"]
+    assert f"authority_{stopped['to_state']}" in result["reasons"]
+
+
+def test_exact_expiry_blocks_and_missing_authority_is_inactive(configurations: dict[str, Path]) -> None:
+    evidence = evidence_fixture(configurations)
+    retime(evidence, datetime.fromisoformat(evidence["selected_authority"]["expires_at"]))
+    assert "authority_expired" in assess_worker_readiness(evidence)["reasons"]
+    evidence["selected_authority"] = None
+    evidence["current_authority"] = None
+    result = assess_worker_readiness(evidence)
+    assert result["assessment"] == "must_suspend"
+    assert result["authority_state"] == "inactive"
+    assert "authority_missing" in result["reasons"]
+
+
+@pytest.mark.parametrize(("target", "key", "value", "reason"), [
+    ("root", "worker_id", "other-worker", "worker_scope_mismatch"),
+    ("root", "scheduled_for", "2026-09-05T20:06:00+00:00", "schedule_slot_mismatch"),
+    ("root", "destination_review_expires_at", None, "destination_review_missing"),
+    ("root", "destination_review_expires_at", "2026-09-05T20:03:00+00:00", "destination_review_expired"),
+    ("readiness", "status", "decision_superseded", "readiness_decision_superseded:initial"),
+    ("readiness", "status", "decision_stale", "readiness_decision_stale:initial"),
+    ("readiness", "destination_id", "other-destination", "readiness_configuration_mismatch:initial"),
+    ("readiness", "delivery_fingerprint", "changed-fingerprint", "readiness_configuration_mismatch:initial"),
+    ("health", "evidence_complete", False, "health_incomplete:initial"),
+    ("health", "worker_id", "other-worker", "health_scope_mismatch:initial"),
+    ("health", "consecutive_failures", 3, "repeated_delivery_failure:initial"),
+    ("health", "persistence_ambiguity", True, "persistence_ambiguity:initial"),
+])
+def test_explicit_blocking_evidence(
+    configurations: dict[str, Path], target: str, key: str, value: Any, reason: str,
+) -> None:
+    evidence = evidence_fixture(configurations)
+    row = evidence if target == "root" else evidence[target][0]
+    row[key] = value
+    result = assess_worker_readiness(evidence)
+    assert result["assessment"] == "must_suspend"
+    assert reason in result["reasons"]
+
+
+@pytest.mark.parametrize("group", ["readiness", "health"])
+@pytest.mark.parametrize("offset", [-301, 1])
+def test_stale_and_future_per_kind_evidence_blocks(
+    configurations: dict[str, Path], group: str, offset: int,
+) -> None:
+    evidence = evidence_fixture(configurations)
+    field = "evaluated_at" if group == "readiness" else "observed_at"
+    evidence[group][0][field] = (
+        datetime.fromisoformat(evidence["evaluated_at"]) + timedelta(seconds=offset)
+    ).isoformat()
+    result = assess_worker_readiness(evidence)
+    suffix = "stale" if offset < 0 else "future"
+    assert f"{group}_{suffix}:initial" in result["reasons"]
+    assert result["assessment"] == "must_suspend"
+
+
+@pytest.mark.parametrize("group", ["readiness", "health"])
+def test_missing_evidence_is_not_healthy_and_both_kinds_are_required(
+    configurations: dict[str, Path], group: str,
+) -> None:
+    evidence = evidence_fixture(configurations)
+    evidence[group].pop()
+    result = assess_worker_readiness(evidence)
+    assert f"{group}_missing:retry" in result["reasons"]
+    assert result["assessment"] == "must_suspend"
+
+
+def test_rehashed_configuration_alternative_does_not_match_grant(configurations: dict[str, Path]) -> None:
+    evidence = evidence_fixture(configurations)
+    plan = evidence["configuration_plan"]
+    plan["execution"]["work_items"][0]["max_events"] = 1
+    plan["plan_id"] = _plan_id({key: value for key, value in plan.items() if key != "plan_id"})
+    result = assess_worker_readiness(evidence)
+    assert "configuration_mismatch" in result["reasons"]
+    assert result["assessment"] == "must_suspend"
+
+
+def test_rehashed_changed_verdict_is_rejected_against_evidence(configurations: dict[str, Path]) -> None:
+    evidence = evidence_fixture(configurations)
+    evidence["health"][0]["persistence_ambiguity"] = True
+    result = assess_worker_readiness(evidence)
+    result["assessment"] = "may_run"
+    result["reasons"] = []
+    content = {key: value for key, value in result.items() if key != "assessment_id"}
+    result["assessment_id"] = f"{MODEL_VERSION}-{hashlib.sha256(canonical_bytes(content)).hexdigest()}"
+    with pytest.raises(ValidationError, match="differs"):
+        validate_worker_readiness_assessment(result, evidence=evidence)
+
+
+@pytest.mark.parametrize("case", ["bool_count", "unknown_field", "duplicate", "unconfigured",
+                                 "contradiction", "noncanonical_time", "oversized"])
+def test_malformed_observations_fail_closed(configurations: dict[str, Path], case: str) -> None:
+    evidence = evidence_fixture(configurations)
+    if case == "bool_count":
+        evidence["health"][0]["consecutive_failures"] = False
+    elif case == "unknown_field":
+        evidence["health"][0]["payload"] = "unexpected"
+    elif case == "duplicate":
+        evidence["readiness"] = [evidence["readiness"][0], evidence["readiness"][0]]
+    elif case == "unconfigured":
+        evidence["health"][0]["execution_kind"] = "automatic"
+    elif case == "contradiction":
+        evidence["readiness"][0]["decision"] = "block"
+    elif case == "noncanonical_time":
+        evidence["evaluated_at"] = "2026-09-05T20:05:00Z"
+    else:
+        evidence["worker_id"] = "x" * 1_048_576
+    with pytest.raises(ValidationError):
+        assess_worker_readiness(evidence)
+
+
+def test_multiple_reasons_are_stable_and_threshold_is_inclusive(configurations: dict[str, Path]) -> None:
+    evidence = evidence_fixture(configurations)
+    evidence["health"][0]["consecutive_failures"] = 2
+    assert assess_worker_readiness(evidence)["assessment"] == "may_run"
+    evidence["health"][0]["consecutive_failures"] = 3
+    evidence["health"][0]["persistence_ambiguity"] = True
+    result = assess_worker_readiness(evidence)
+    assert result["reasons"] == ["persistence_ambiguity:initial", "repeated_delivery_failure:initial"]
+    evidence["health"][0]["consecutive_failures"] = 0
+    assert result["reasons"] == ["persistence_ambiguity:initial", "repeated_delivery_failure:initial"]

--- a/tests/unit/test_notification_worker_readiness_boundaries.py
+++ b/tests/unit/test_notification_worker_readiness_boundaries.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from pathlib import Path
+
+import pytest
+import yaml
+
+from src.orchestration.notification_worker_readiness import assess_worker_readiness
+from src.orchestration.plan_notification_worker import _plan_id
+from test_notification_worker_readiness import evidence_fixture, retime
+from test_reviewed_notification_worker_authority import configurations as configurations
+
+
+@pytest.mark.parametrize("offset", [-301, 1])
+def test_overall_snapshot_must_be_fresh_and_not_future(
+    configurations: dict[str, Path], offset: int,
+) -> None:
+    evidence = evidence_fixture(configurations)
+    instant = datetime.fromisoformat(evidence["evaluated_at"]) + timedelta(seconds=offset)
+    evidence["observed_at"] = instant.isoformat()
+    result = assess_worker_readiness(evidence)
+    assert result["assessment"] == "must_suspend"
+    assert f"observation_{'stale' if offset < 0 else 'future'}" in result["reasons"]
+
+
+def test_exact_age_limit_is_allowed(configurations: dict[str, Path]) -> None:
+    evidence = evidence_fixture(configurations)
+    boundary = datetime.fromisoformat(evidence["evaluated_at"]) - timedelta(seconds=300)
+    for row in evidence["readiness"]:
+        row["evaluated_at"] = boundary.isoformat()
+    for row in evidence["health"]:
+        row["observed_at"] = boundary.isoformat()
+    assert assess_worker_readiness(evidence)["assessment"] == "may_run"
+
+
+def test_early_unhealthy_invocation_must_not_merely_wait(configurations: dict[str, Path]) -> None:
+    evidence = evidence_fixture(configurations)
+    retime(evidence, datetime.fromisoformat(evidence["scheduled_for"]) - timedelta(seconds=1))
+    evidence["health"][1]["persistence_ambiguity"] = True
+    result = assess_worker_readiness(evidence)
+    assert result["assessment"] == "must_suspend"
+    assert result["reasons"] == ["slot_not_due", "persistence_ambiguity:retry"]
+
+
+def test_review_expiry_cannot_be_shorter_than_retained_authority(configurations: dict[str, Path]) -> None:
+    evidence = evidence_fixture(configurations)
+    evidence["destination_review_expires_at"] = (
+        datetime.fromisoformat(evidence["scheduled_for"]) + timedelta(seconds=30)
+    ).isoformat()
+    result = assess_worker_readiness(evidence)
+    assert result["reasons"] == ["authority_exceeds_destination_review"]
+    assert result["assessment"] == "must_suspend"
+
+
+def test_well_formed_blocked_readiness_still_blocks(configurations: dict[str, Path]) -> None:
+    evidence = evidence_fixture(configurations)
+    evidence["readiness"][1].update(status="blocked", decision="block")
+    result = assess_worker_readiness(evidence)
+    assert result["reasons"] == ["readiness_blocked:retry"]
+    assert result["assessment"] == "must_suspend"
+
+
+def test_initial_only_configuration_requires_only_initial_observations(configurations: dict[str, Path]) -> None:
+    path = configurations["worker_config_path"]
+    document = yaml.safe_load(path.read_text(encoding="utf-8"))
+    document["workers"]["risk-operations-managed"]["execution_kinds"] = ["initial"]
+    path.write_text(yaml.safe_dump(document), encoding="utf-8")
+    evidence = evidence_fixture(configurations)
+    assert len(evidence["readiness"]) == 1
+    assert len(evidence["health"]) == 1
+    assert assess_worker_readiness(evidence)["assessment"] == "may_run"
+
+
+def test_consistent_disabled_config_cannot_pass_even_after_rehash(configurations: dict[str, Path]) -> None:
+    evidence = evidence_fixture(configurations)
+    plan = evidence["configuration_plan"]
+    plan["worker"]["enabled"] = False
+    plan["status"] = "disabled"
+    plan["blocking_reasons"] = ["worker_disabled"]
+    plan["schedule"]["activation_action"] = "none"
+    plan["plan_id"] = _plan_id({key: value for key, value in plan.items() if key != "plan_id"})
+    result = assess_worker_readiness(evidence)
+    assert "configuration_blocked" in result["reasons"]
+    assert result["assessment"] == "must_suspend"


### PR DESCRIPTION
## Superseded unmerged after concurrent-scope reconciliation

This prototype implemented a broad supplied-observation readiness assessment for #155. While it was being prepared, draft #158 introduced the per-kind health/suspension evaluator and #159 introduced its transition binding.

Closing this PR without merging to avoid shipping two competing health decision contracts. Its four additive files are not required on main. No content is being silently accepted or merged from the concurrent draft stack.

The remaining #155 scope will be narrowed to the complementary current-authority/configuration/exact-slot preflight that #158 delegates to its trusted caller. A separate bounded PR will implement that prerequisite; #156 will rehearse that preflight. Health-driven suspension and atomic stop persistence remain owned by the concurrent #158/#159 stack.

PR #157 is already independently validated and merged. No scheduler, live delivery, database or cloud activation occurred. No passing CI or independent approval is claimed for this closed prototype.