### PR TITLE
Persist worker suspension stops and decision evidence atomically

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,6 +37,7 @@ services:
       - ./sql/notification_retry_readiness_binding_schema.sql:/docker-entrypoint-initdb.d/26_notification_retry_readiness_binding_schema.sql:ro
       - ./sql/notification_retry_readiness_follow_up_schema.sql:/docker-entrypoint-initdb.d/27_notification_retry_readiness_follow_up_schema.sql:ro
       - ./sql/notification_worker_authority_schema.sql:/docker-entrypoint-initdb.d/28_notification_worker_authority_schema.sql:ro
+      - ./sql/notification_worker_suspension_schema.sql:/docker-entrypoint-initdb.d/29_notification_worker_suspension_schema.sql:ro
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U risk_user -d risk_platform"]
       interval: 5s

--- a/docs/notification-worker-suspension-history.md
+++ b/docs/notification-worker-suspension-history.md
@@ -1,0 +1,62 @@
+# Atomic worker suspension history
+
+Primary arc42 block: `warehouse`. P4e2c, third dependency-ordered layer.
+
+`record_worker_suspension` explicitly persists the exact bundle from the preceding
+orchestration layer. It commits an existing-model authority stop and its full
+suspension decision/observation in one PostgreSQL transaction. Failure of either
+write rolls both back. There is no scheduler or transport entrypoint.
+
+## Transaction and replay contract
+
+The cursor variant requires one caller-owned READ COMMITTED transaction. It
+validates before database access, acquires the existing per-worker transaction
+lock, checks retained decision replay, and reopens the current authority. New
+writes require the exact active predecessor, an evaluation no later than the
+database clock, and age within the plan's readiness limit. The established
+recorder assigns the authority sequence and revalidates chain identity.
+
+Both documents must be newly created together. A legacy stop without its decision
+is rejected instead of silently backfilled. Exact historical replay validates the
+retained bundle and both authority documents, returns the original sequence, and
+does not change current authority or refresh evidence age. Changed decision reuse
+is rejected. Any cursor-variant exception requires rolling back the caller's
+transaction; the connection-owning API enforces this automatically. Commit failure
+is reported as unconfirmed, not success; exact replay is the recovery mechanism.
+
+## SQL boundary
+
+`sql/notification_worker_suspension_schema.sql` adds append-only evidence with
+canonical bytes, SHA-256, projected identities and composite foreign keys. An
+insert trigger reconciles both retained authority documents and requires the
+new stop to be current. UPDATE, DELETE and TRUNCATE are rejected. The serving view
+joins evidence through the exact current transition, never an older suspension.
+A manual suspension may legitimately have no automated decision; the missing
+classification is an evidence distinction, not retroactive invalidation.
+
+Python remains responsible for full semantic reconstruction and no-backfill
+policy. Direct SQL callers must not bypass that boundary. Privileged owners can
+disable triggers; these controls are not authentication or protection from the
+owner. Health observations are retained adapter evidence, not independent proof
+that this recorder re-read the underlying readiness and failure-source documents.
+Authenticated callers and a reviewed live observation adapter remain required
+before any operational scheduling integration.
+
+## Validation and operation
+
+Disposable PostgreSQL proof extends the existing worker-authority fixture, reached
+through the unchanged `make postgres-contract-check` target. It exercises real
+second-write rollback, no-backfill, atomic creation, exact historical replay,
+conflicting decision reuse, stale-head rejection, current serving state and
+append-only mutation rejection. The fixture rolls all data back. The existing
+TRUNCATE rejection probe names both related tables so the new foreign key does
+not hide the append-only trigger behind an earlier PostgreSQL dependency error.
+
+Fresh Docker initialization mounts schema 29 after authority schema 28. Existing
+databases require separately reviewed schema application; initialization is not
+a migration of existing volumes. No production migration is performed here.
+
+Only an explicit call to the recording API connects to PostgreSQL. No CLI or
+scheduler is added. Committed worker/destination/delivery switches stay disabled.
+No provider request, webhook delivery, live scheduler activation, deployment or
+`terraform apply` occurs. `runtime_permission_granted` remains false in all results.

--- a/sql/notification_worker_suspension_schema.sql
+++ b/sql/notification_worker_suspension_schema.sql
@@ -1,0 +1,102 @@
+-- Atomic evidence companion to the existing worker authority history.
+CREATE TABLE IF NOT EXISTS risk_platform.notification_worker_suspension_evidence (
+    decision_id TEXT PRIMARY KEY,
+    transition_id TEXT NOT NULL UNIQUE,
+    previous_transition_id TEXT NOT NULL,
+    worker_id TEXT NOT NULL,
+    destination_id TEXT NOT NULL,
+    evaluated_at TIMESTAMPTZ NOT NULL,
+    bundle_json JSONB NOT NULL,
+    canonical_bundle TEXT NOT NULL,
+    bundle_sha256 TEXT NOT NULL CHECK (bundle_sha256 ~ '^[0-9a-f]{64}$'),
+    recorded_at TIMESTAMPTZ NOT NULL DEFAULT clock_timestamp(),
+    FOREIGN KEY (transition_id, worker_id, destination_id) REFERENCES
+        risk_platform.notification_worker_authority_history (transition_id, worker_id, destination_id),
+    FOREIGN KEY (previous_transition_id, worker_id, destination_id) REFERENCES
+        risk_platform.notification_worker_authority_history (transition_id, worker_id, destination_id),
+    CHECK (evaluated_at <= recorded_at),
+    CHECK (jsonb_typeof(bundle_json) = 'object'),
+    CHECK (canonical_bundle::JSONB = bundle_json),
+    CHECK (octet_length(canonical_bundle) BETWEEN 1 AND 1048576),
+    CHECK (encode(sha256(convert_to(canonical_bundle, 'UTF8')), 'hex') = bundle_sha256),
+    CHECK ((bundle_json -> 'decision' ->> 'model_version') IS NOT DISTINCT FROM
+        'portfolio-risk-notification-worker-suspension-decision-v1'),
+    CHECK ((bundle_json -> 'decision' ->> 'decision_id') IS NOT DISTINCT FROM decision_id),
+    CHECK ((bundle_json -> 'decision' ->> 'authority_transition_id') IS NOT DISTINCT FROM previous_transition_id),
+    CHECK ((bundle_json -> 'decision' ->> 'worker_id') IS NOT DISTINCT FROM worker_id),
+    CHECK ((bundle_json -> 'decision' ->> 'destination_id') IS NOT DISTINCT FROM destination_id),
+    CHECK ((bundle_json -> 'decision' ->> 'evaluated_at')::TIMESTAMPTZ IS NOT DISTINCT FROM evaluated_at),
+    CHECK ((bundle_json -> 'decision' ->> 'outcome') IS NOT DISTINCT FROM 'suspend'),
+    CHECK ((bundle_json -> 'decision' -> 'runtime_permission_granted') IS NOT DISTINCT FROM 'false'::JSONB),
+    CHECK ((bundle_json -> 'decision' -> 'scheduler_mutated') IS NOT DISTINCT FROM 'false'::JSONB),
+    CHECK ((bundle_json -> 'decision' -> 'external_request_performed') IS NOT DISTINCT FROM 'false'::JSONB),
+    CHECK ((bundle_json -> 'transition' ->> 'transition_id') IS NOT DISTINCT FROM transition_id),
+    CHECK ((bundle_json -> 'transition' ->> 'previous_transition_id') IS NOT DISTINCT FROM previous_transition_id),
+    CHECK ((bundle_json -> 'transition' ->> 'action') IS NOT DISTINCT FROM 'suspend'),
+    CHECK ((bundle_json -> 'transition' -> 'reason_codes') IS NOT DISTINCT FROM
+        (bundle_json -> 'decision' -> 'reason_codes')),
+    CHECK ((bundle_json -> 'transition' ->> 'effective_at')::TIMESTAMPTZ IS NOT DISTINCT FROM evaluated_at),
+    CHECK ((bundle_json -> 'authority' ->> 'transition_id') IS NOT DISTINCT FROM previous_transition_id)
+);
+
+CREATE OR REPLACE FUNCTION risk_platform.guard_notification_worker_suspension_insert()
+RETURNS TRIGGER LANGUAGE plpgsql AS $$
+DECLARE
+    prior risk_platform.notification_worker_authority_history%ROWTYPE;
+    stopped risk_platform.notification_worker_authority_history%ROWTYPE;
+    current_id TEXT;
+BEGIN
+    PERFORM pg_advisory_xact_lock(hashtextextended(
+        'notification-worker-authority:' || NEW.worker_id, 0
+    ));
+    SELECT * INTO prior FROM risk_platform.notification_worker_authority_history
+    WHERE transition_id = NEW.previous_transition_id;
+    IF NOT FOUND OR prior.document_json IS DISTINCT FROM NEW.bundle_json -> 'authority'
+        OR prior.document_sha256 IS DISTINCT FROM NEW.bundle_json -> 'decision' ->> 'authority_sha256' THEN
+        RAISE EXCEPTION 'suspension predecessor evidence differs' USING ERRCODE = '23514';
+    END IF;
+    SELECT * INTO stopped FROM risk_platform.notification_worker_authority_history
+    WHERE transition_id = NEW.transition_id;
+    IF NOT FOUND OR stopped.document_json IS DISTINCT FROM NEW.bundle_json -> 'transition'
+        OR stopped.action <> 'suspend' OR stopped.previous_transition_id <> prior.transition_id THEN
+        RAISE EXCEPTION 'suspension stop evidence differs' USING ERRCODE = '23514';
+    END IF;
+    SELECT transition_id INTO current_id FROM risk_platform.notification_worker_authority_history
+    WHERE worker_id = NEW.worker_id ORDER BY authority_sequence DESC LIMIT 1;
+    IF current_id IS DISTINCT FROM NEW.transition_id THEN
+        RAISE EXCEPTION 'suspension stop is not current authority' USING ERRCODE = '23514';
+    END IF;
+    NEW.recorded_at := clock_timestamp();
+    RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS notification_worker_suspension_insert_guard
+ON risk_platform.notification_worker_suspension_evidence;
+CREATE TRIGGER notification_worker_suspension_insert_guard
+BEFORE INSERT ON risk_platform.notification_worker_suspension_evidence
+FOR EACH ROW EXECUTE FUNCTION risk_platform.guard_notification_worker_suspension_insert();
+
+DROP TRIGGER IF EXISTS notification_worker_suspension_reject_mutation
+ON risk_platform.notification_worker_suspension_evidence;
+CREATE TRIGGER notification_worker_suspension_reject_mutation
+BEFORE UPDATE OR DELETE ON risk_platform.notification_worker_suspension_evidence
+FOR EACH ROW EXECUTE FUNCTION risk_platform.reject_notification_worker_authority_mutation();
+
+DROP TRIGGER IF EXISTS notification_worker_suspension_reject_truncate
+ON risk_platform.notification_worker_suspension_evidence;
+CREATE TRIGGER notification_worker_suspension_reject_truncate
+BEFORE TRUNCATE ON risk_platform.notification_worker_suspension_evidence
+FOR EACH STATEMENT EXECUTE FUNCTION risk_platform.reject_notification_worker_authority_mutation();
+
+CREATE OR REPLACE VIEW risk_platform.current_notification_worker_suspension_review AS
+SELECT head.worker_id, head.destination_id, head.transition_id,
+    head.authority_sequence, head.authority_state,
+    CASE WHEN head.authority_state <> 'suspended' THEN 'not_applicable'
+        WHEN evidence.decision_id IS NULL THEN 'suspension_evidence_missing'
+        ELSE 'bound' END AS suspension_evidence_status,
+    evidence.decision_id, evidence.evaluated_at, evidence.bundle_sha256,
+    FALSE AS runtime_permission_granted
+FROM risk_platform.current_notification_worker_authority head
+LEFT JOIN risk_platform.notification_worker_suspension_evidence evidence
+    ON evidence.transition_id = head.transition_id;

--- a/src/warehouse/notification_worker_authority_postgres_contract_check.py
+++ b/src/warehouse/notification_worker_authority_postgres_contract_check.py
@@ -24,6 +24,8 @@ from src.warehouse.notification_worker_authority_history import (
     record_worker_authority_with_cursor,
 )
 
+from src.warehouse.notification_worker_suspension_postgres_contract_check import check_worker_suspension_contract
+
 
 def _plan(directory: Path, worker_id: str, planned_at: datetime) -> dict[str, Any]:
     configs = {
@@ -159,7 +161,7 @@ def run_contract_check(dsn: str) -> dict[str, Any]:
                     def mutate(sql: str = operation) -> None:
                         cursor.execute(sql, (worker_id,))
                     _reject(connection, mutate, "append-only")
-                _reject(connection, lambda: cursor.execute("TRUNCATE risk_platform.notification_worker_authority_history"), "append-only")
+                _reject(connection, lambda: cursor.execute("TRUNCATE risk_platform.notification_worker_authority_history, risk_platform.notification_worker_suspension_evidence"), "append-only")
                 results["update_delete_truncate_rejected"] = True
                 cursor.execute("SELECT clock_timestamp()")
                 clock_row = cursor.fetchone()
@@ -172,6 +174,7 @@ def run_contract_check(dsn: str) -> dict[str, Any]:
                 if read_current_worker_authority_with_cursor(cursor, worker_id=active_worker)["authority_state"] != "active":
                     raise AssertionError("current grant was not active")
                 results["active_state"] = True
+                results.update(check_worker_suspension_contract(connection, cursor, active))
                 future = _grant(_plan(directory, worker_id + "-future", now + timedelta(days=1)), worker_id + "-future")
                 _reject(connection, lambda: record_worker_authority_with_cursor(cursor, transition=future), "check constraint")
                 results["future_head_rejected"] = True
@@ -199,6 +202,13 @@ def run_contract_check(dsn: str) -> dict[str, Any]:
                 if cursor.fetchone() != (0,):
                     raise AssertionError("fixture history survived transaction rollback")
                 results["fixture_rolled_back"] = True
+                cursor.execute(
+                    "SELECT COUNT(*) FROM risk_platform.notification_worker_suspension_evidence WHERE worker_id = %s",
+                    (active_worker,),
+                )
+                if cursor.fetchone() != (0,):
+                    raise AssertionError("suspension evidence survived fixture rollback")
+                results["suspension_fixture_rolled_back"] = True
         finally:
             connection.rollback()
             competitor.rollback()

--- a/src/warehouse/notification_worker_suspension_history.py
+++ b/src/warehouse/notification_worker_suspension_history.py
@@ -1,0 +1,128 @@
+"""Atomically retain a worker stop and its suspension evidence; never operate a scheduler."""
+from __future__ import annotations
+
+import hashlib
+from collections.abc import Mapping
+from typing import Any
+
+from src.common.exceptions import StorageError, ValidationError
+from src.orchestration.notification_worker_authority_contract import (
+    authority_state, canonical_bytes, utc, validate_worker_authority_transition,
+)
+from src.orchestration.notification_worker_suspension_transition import validate_worker_suspension_bundle
+from src.warehouse import notification_worker_authority_history as authority_history
+
+
+TABLE = "risk_platform.notification_worker_suspension_evidence"
+
+
+def _decode(row: Any) -> dict[str, Any]:
+    if not isinstance(row, (tuple, list)) or len(row) != 2:
+        raise StorageError("retained worker suspension row is invalid")
+    try:
+        result = validate_worker_suspension_bundle(row[0])
+    except ValidationError:
+        raise StorageError("retained worker suspension bundle is invalid") from None
+    if hashlib.sha256(canonical_bytes(result)).hexdigest() != row[1]:
+        raise StorageError("retained worker suspension digest differs")
+    return result
+
+
+def _assert_source(cursor: Any, expected: Mapping[str, Any]) -> None:
+    cursor.execute(
+        "SELECT document_json, document_sha256 FROM "
+        "risk_platform.notification_worker_authority_history WHERE transition_id = %s",
+        (expected["transition_id"],),
+    )
+    row = cursor.fetchone()
+    if not isinstance(row, (tuple, list)) or len(row) != 2:
+        raise StorageError("worker suspension retained source is missing")
+    try:
+        actual = validate_worker_authority_transition(row[0])
+    except (ValidationError, ValueError, TypeError, KeyError, RecursionError, OverflowError, UnicodeError):
+        raise StorageError("worker suspension retained source is invalid") from None
+    if actual != expected or hashlib.sha256(canonical_bytes(actual)).hexdigest() != row[1]:
+        raise StorageError("worker suspension retained source differs")
+
+
+def record_worker_suspension_with_cursor(
+    cursor: Any, *, bundle: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Use one caller-owned READ COMMITTED transaction; any exception requires rollback.
+
+    New decisions require the exact current active predecessor and a recent,
+    nonfuture evaluation on the database clock. Exact historical replay is read-only.
+    Source health provenance and operator authentication remain caller obligations.
+    """
+    document = validate_worker_suspension_bundle(bundle)
+    prior, decision, transition = (document[key] for key in ("authority", "decision", "transition"))
+    encoded = canonical_bytes(document)
+    digest = hashlib.sha256(encoded).hexdigest()
+    worker_id = decision["worker_id"]
+    cursor.execute("SET LOCAL lock_timeout = '5s'")
+    cursor.execute("SET LOCAL statement_timeout = '10s'")
+    cursor.execute(authority_history.LOCK_SQL, (authority_history.LOCK_PREFIX + worker_id,))
+    cursor.execute(
+        f"SELECT bundle_json, bundle_sha256 FROM {TABLE} WHERE decision_id = %s",
+        (decision["decision_id"],),
+    )
+    row = cursor.fetchone()
+    if row is not None:
+        if _decode(row) != document:
+            raise ValidationError("decision_id already retains different suspension evidence")
+        _assert_source(cursor, prior)
+        _assert_source(cursor, transition)
+        result = authority_history.record_worker_authority_with_cursor(cursor, transition=transition)
+        if result["created"] is not False:
+            raise StorageError("suspension replay cannot create missing authority")
+    else:
+        cursor.execute(
+            "SELECT transition_id FROM risk_platform.notification_worker_authority_history "
+            "WHERE request_id = %s", (transition["request_id"],),
+        )
+        if cursor.fetchone() is not None:
+            raise ValidationError("existing stop without decision evidence cannot be backfilled")
+        current = authority_history.read_current_worker_authority_with_cursor(cursor, worker_id=worker_id)
+        if current["transition"] != prior:
+            raise ValidationError("worker suspension predecessor is not the exact current head")
+        cursor.execute("SELECT clock_timestamp()")
+        clock = cursor.fetchone()
+        if not isinstance(clock, (tuple, list)) or len(clock) != 1:
+            raise StorageError("worker suspension database clock is unavailable")
+        now = utc(clock[0], "database clock")
+        age = (now - utc(decision["evaluated_at"], "evaluated_at")).total_seconds()
+        if not 0 <= age <= prior["plan"]["readiness"]["max_age_seconds"]:
+            raise ValidationError("worker suspension decision is stale or future-dated")
+        if authority_state(prior, as_of=now) != "active":
+            raise ValidationError("worker suspension predecessor is no longer active")
+        result = authority_history.record_worker_authority_with_cursor(cursor, transition=transition)
+        if result["created"] is not True:
+            raise ValidationError("worker suspension and authority replay states differ")
+        text = encoded.decode("utf-8")
+        cursor.execute(
+            f"INSERT INTO {TABLE} (decision_id, transition_id, previous_transition_id, "
+            "worker_id, destination_id, evaluated_at, bundle_json, canonical_bundle, bundle_sha256) "
+            "VALUES (%s, %s, %s, %s, %s, %s, %s::JSONB, %s, %s) "
+            "RETURNING bundle_json, bundle_sha256",
+            (decision["decision_id"], transition["transition_id"], prior["transition_id"],
+             worker_id, decision["destination_id"], decision["evaluated_at"], text, text, digest),
+        )
+        if _decode(cursor.fetchone()) != document:
+            raise StorageError("retained suspension evidence differs from requested bundle")
+    return {**result, "decision_id": decision["decision_id"], "bundle_sha256": digest,
+            "suspension_evidence_recorded": True, "runtime_permission_granted": False}
+
+
+def record_worker_suspension(*, dsn: str, bundle: Mapping[str, Any]) -> dict[str, Any]:
+    """Explicit database operation, with atomic commit/rollback and sanitized failure."""
+    document = validate_worker_suspension_bundle(bundle)
+    try:
+        # Reuse the established connection timeout and DSN validation policy.
+        with authority_history._connect(dsn) as connection:
+            with connection.cursor() as cursor:
+                result = record_worker_suspension_with_cursor(cursor, bundle=document)
+        return result
+    except (ValidationError, StorageError):
+        raise
+    except Exception:
+        raise StorageError("worker suspension transaction failed; no success is confirmed") from None

--- a/src/warehouse/notification_worker_suspension_postgres_contract_check.py
+++ b/src/warehouse/notification_worker_suspension_postgres_contract_check.py
@@ -1,0 +1,127 @@
+"""Disposable, transaction-scoped PostgreSQL proof of atomic suspension persistence."""
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+from typing import Any
+
+from src.orchestration.notification_worker_authority_contract import build_worker_authority_transition
+from src.orchestration.notification_worker_suspension import evaluate_worker_suspension
+from src.orchestration.notification_worker_suspension_transition import build_worker_suspension_bundle
+from src.warehouse.notification_worker_authority_history import (
+    read_current_worker_authority_with_cursor, record_worker_authority_with_cursor,
+)
+from src.warehouse.notification_worker_suspension_history import record_worker_suspension_with_cursor
+
+
+def _reject(connection: Any, operation: Callable[[], Any], expected: str) -> None:
+    try:
+        with connection.transaction():
+            operation()
+    except Exception as exc:
+        if expected not in str(exc):
+            raise AssertionError("suspension rejection occurred at an unexpected boundary") from exc
+    else:
+        raise AssertionError("invalid worker suspension operation was accepted")
+
+
+def _clock(cursor: Any) -> Any:
+    cursor.execute("SELECT clock_timestamp()")
+    row = cursor.fetchone()
+    if row is None:
+        raise AssertionError("suspension fixture requires the database clock")
+    return row[0]
+
+
+def check_worker_suspension_contract(
+    connection: Any, cursor: Any, active: Mapping[str, Any],
+) -> dict[str, bool]:
+    evaluated = evaluate_worker_suspension(authority=active, observation=None, evaluated_at=_clock(cursor))
+    bundle = build_worker_suspension_bundle(authority=active, decision=evaluated, operator_id="fixture-health-observer")
+    worker_id = evaluated["worker_id"]
+    results: dict[str, bool] = {}
+
+    def fail_second_write() -> None:
+        # DDL and both attempted writes are inside the same rejected savepoint.
+        cursor.execute("""
+            CREATE FUNCTION pg_temp.reject_worker_suspension_fixture()
+            RETURNS TRIGGER LANGUAGE plpgsql AS $$
+            BEGIN RAISE EXCEPTION 'suspension fixture second-write failure'; END;
+            $$
+        """)
+        cursor.execute("""
+            CREATE TRIGGER suspension_fixture_second_write
+            BEFORE INSERT ON risk_platform.notification_worker_suspension_evidence
+            FOR EACH ROW EXECUTE FUNCTION pg_temp.reject_worker_suspension_fixture()
+        """)
+        record_worker_suspension_with_cursor(cursor, bundle=bundle)
+
+    _reject(connection, fail_second_write, "suspension fixture second-write failure")
+    current = read_current_worker_authority_with_cursor(cursor, worker_id=worker_id)
+    cursor.execute("SELECT COUNT(*) FROM risk_platform.notification_worker_suspension_evidence WHERE worker_id = %s", (worker_id,))
+    if current["transition"] != active or current["authority_sequence"] != 1 or cursor.fetchone() != (0,):
+        raise AssertionError("second-write failure did not roll back both suspension writes")
+    results["suspension_second_write_rollback"] = True
+
+    class RollbackFixture(Exception):
+        pass
+
+    try:
+        with connection.transaction():
+            record_worker_authority_with_cursor(cursor, transition=bundle["transition"])
+            _reject(connection, lambda: record_worker_suspension_with_cursor(cursor, bundle=bundle), "cannot be backfilled")
+            raise RollbackFixture
+    except RollbackFixture:
+        pass
+    results["suspension_no_legacy_backfill"] = True
+
+    retained = record_worker_suspension_with_cursor(cursor, bundle=bundle)
+    if retained["created"] is not True or retained["authority_sequence"] != 2:
+        raise AssertionError("suspension bundle did not create exactly one authority successor")
+    cursor.execute(
+        "SELECT suspension_evidence_status, decision_id, runtime_permission_granted "
+        "FROM risk_platform.current_notification_worker_suspension_review WHERE worker_id = %s", (worker_id,),
+    )
+    if cursor.fetchone() != ("bound", evaluated["decision_id"], False):
+        raise AssertionError("current suspension evidence was not bound to its exact stop")
+    results["suspension_atomic_creation_and_bound_view"] = True
+
+    changed = build_worker_suspension_bundle(authority=active, decision=evaluated, operator_id="different-fixture-observer")
+    _reject(connection, lambda: record_worker_suspension_with_cursor(cursor, bundle=changed), "different suspension evidence")
+    stale = build_worker_suspension_bundle(
+        authority=active,
+        decision=evaluate_worker_suspension(authority=active, observation=None, evaluated_at=_clock(cursor)),
+        operator_id="fixture-health-observer",
+    )
+    _reject(connection, lambda: record_worker_suspension_with_cursor(cursor, bundle=stale), "exact current head")
+    results["suspension_conflict_and_stale_head_rejected"] = True
+
+    for sql in (
+        "UPDATE risk_platform.notification_worker_suspension_evidence SET worker_id = worker_id WHERE worker_id = %s",
+        "DELETE FROM risk_platform.notification_worker_suspension_evidence WHERE worker_id = %s",
+    ):
+        def mutate(statement: str = sql) -> None:
+            cursor.execute(statement, (worker_id,))
+        _reject(connection, mutate, "append-only")
+    _reject(connection, lambda: cursor.execute("TRUNCATE risk_platform.notification_worker_suspension_evidence"), "append-only")
+    results["suspension_update_delete_truncate_rejected"] = True
+
+    stopped = bundle["transition"]
+    now = _clock(cursor)
+    disabled = build_worker_authority_transition(
+        plan=stopped["plan"], request_id=worker_id + "-after-suspension", operator_id="fixture-operator",
+        action="disable", requested_at=now, effective_at=now, previous=stopped,
+        reason_codes=["operator_request"],
+    )
+    record_worker_authority_with_cursor(cursor, transition=disabled)
+    replay = record_worker_suspension_with_cursor(cursor, bundle=bundle)
+    if replay["created"] is not False or replay["authority_sequence"] != 2:
+        raise AssertionError("historical suspension replay did not converge")
+    current = read_current_worker_authority_with_cursor(cursor, worker_id=worker_id)
+    cursor.execute(
+        "SELECT suspension_evidence_status, decision_id FROM "
+        "risk_platform.current_notification_worker_suspension_review WHERE worker_id = %s", (worker_id,),
+    )
+    if current["transition"] != disabled or cursor.fetchone() != ("not_applicable", None):
+        raise AssertionError("historical suspension leaked into newer current authority")
+    results["suspension_historical_replay_without_promotion"] = True
+    return results

--- a/tests/unit/test_docker_compose_contract.py
+++ b/tests/unit/test_docker_compose_contract.py
@@ -54,6 +54,7 @@ def test_local_database_seed_mounts_are_read_only_and_ordered() -> None:
         "./sql/notification_retry_readiness_binding_schema.sql:/docker-entrypoint-initdb.d/26_notification_retry_readiness_binding_schema.sql:ro",
         "./sql/notification_retry_readiness_follow_up_schema.sql:/docker-entrypoint-initdb.d/27_notification_retry_readiness_follow_up_schema.sql:ro",
         "./sql/notification_worker_authority_schema.sql:/docker-entrypoint-initdb.d/28_notification_worker_authority_schema.sql:ro",
+        "./sql/notification_worker_suspension_schema.sql:/docker-entrypoint-initdb.d/29_notification_worker_suspension_schema.sql:ro",
     ]
     assert services["mongo"]["volumes"] == [
         "./mongo/init:/docker-entrypoint-initdb.d:ro"

--- a/tests/unit/test_notification_worker_suspension_history.py
+++ b/tests/unit/test_notification_worker_suspension_history.py
@@ -1,0 +1,172 @@
+from __future__ import annotations
+
+import hashlib
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from src.common.exceptions import StorageError, ValidationError
+from src.orchestration.notification_worker_authority_contract import canonical_bytes
+from src.orchestration.notification_worker_suspension_transition import build_worker_suspension_bundle
+from src.warehouse import notification_worker_suspension_history as history
+from test_notification_worker_authority_contract import grant
+from test_notification_worker_suspension import AT, decision
+from test_notification_worker_suspension_transition import bundle
+
+
+class Cursor:
+    def __init__(self, rows: list[Any], *, fail_second_write: bool = False) -> None:
+        self.rows = iter(rows)
+        self.calls: list[tuple[str, Any]] = []
+        self.fail_second_write = fail_second_write
+
+    def execute(self, statement: str, params: Any = None) -> None:
+        self.calls.append((statement, params))
+        if self.fail_second_write and statement.startswith("INSERT INTO " + history.TABLE):
+            raise RuntimeError("private-database-diagnostic")
+
+    def fetchone(self) -> Any:
+        return next(self.rows)
+
+    def __enter__(self) -> Cursor:
+        return self
+
+    def __exit__(self, *args: Any) -> None:
+        pass
+
+
+def source_row(document: dict[str, Any], sequence: int = 1) -> tuple[Any, ...]:
+    return document, hashlib.sha256(canonical_bytes(document)).hexdigest(), sequence, AT
+
+
+def evidence_row(value: dict[str, Any]) -> tuple[Any, ...]:
+    return value, hashlib.sha256(canonical_bytes(value)).hexdigest()
+
+
+def new_rows(value: dict[str, Any], now: datetime = AT) -> list[Any]:
+    return [None, None, (*source_row(value["authority"]), now), (now,), None,
+            source_row(value["authority"]), source_row(value["transition"], 2), evidence_row(value)]
+
+
+def test_atomic_append_uses_exact_worker_lock_and_retains_complete_bundle() -> None:
+    value = bundle()
+    cursor = Cursor(new_rows(value))
+    result = history.record_worker_suspension_with_cursor(cursor, bundle=value)
+    assert result["created"] is True
+    assert result["authority_sequence"] == 2
+    assert result["suspension_evidence_recorded"] is True
+    assert result["runtime_permission_granted"] is False
+    assert cursor.calls[2] == (history.authority_history.LOCK_SQL, ("notification-worker-authority:authority-worker",))
+    inserts = [(sql, params) for sql, params in cursor.calls if sql.startswith("INSERT") or "\n        INSERT" in sql]
+    assert len(inserts) == 2
+    assert "notification_worker_authority_history" in inserts[0][0]
+    assert history.TABLE in inserts[1][0]
+    assert inserts[1][1][-1] == hashlib.sha256(canonical_bytes(value)).hexdigest()
+
+
+def test_historical_replay_reopens_both_sources_without_head_read_or_write() -> None:
+    value = bundle()
+    cursor = Cursor([evidence_row(value), source_row(value["authority"])[:2],
+                     source_row(value["transition"], 2)[:2], source_row(value["transition"], 2)])
+    result = history.record_worker_suspension_with_cursor(cursor, bundle=value)
+    assert result["created"] is False
+    assert result["authority_sequence"] == 2
+    assert not any("INSERT" in sql or "ORDER BY" in sql or "clock_timestamp" in sql for sql, _ in cursor.calls)
+
+
+def test_changed_operator_cannot_reuse_decision_id() -> None:
+    first = bundle()
+    changed = build_worker_suspension_bundle(authority=grant(), decision=decision(), operator_id="other")
+    with pytest.raises(ValidationError, match="different suspension evidence"):
+        history.record_worker_suspension_with_cursor(Cursor([evidence_row(first)]), bundle=changed)
+
+
+def test_legacy_stop_is_not_silently_backfilled() -> None:
+    value = bundle()
+    cursor = Cursor([None, (value["transition"]["transition_id"],)])
+    with pytest.raises(ValidationError, match="cannot be backfilled"):
+        history.record_worker_suspension_with_cursor(cursor, bundle=value)
+    assert not any("INSERT" in sql for sql, _ in cursor.calls)
+
+
+@pytest.mark.parametrize("missing", [False, True])
+def test_stale_or_missing_current_authority_is_rejected(missing: bool) -> None:
+    value = bundle()
+    row = None if missing else (*source_row(value["transition"], 2), AT)
+    with pytest.raises(ValidationError, match="exact current head"):
+        history.record_worker_suspension_with_cursor(Cursor([None, None, row]), bundle=value)
+
+
+@pytest.mark.parametrize("offset", [-0.000001, 300.000001])
+def test_database_clock_rejects_future_or_stale_decisions(offset: float) -> None:
+    value = bundle()
+    with pytest.raises(ValidationError, match="stale or future"):
+        history.record_worker_suspension_with_cursor(Cursor(new_rows(value, AT + timedelta(seconds=offset))), bundle=value)
+
+
+def test_new_record_rejects_authority_that_expired_after_evaluation() -> None:
+    prior = grant()
+    expiry = datetime.fromisoformat(prior["expires_at"])
+    evaluated = decision(authority=prior, evaluated_at=expiry - timedelta(seconds=1))
+    value = build_worker_suspension_bundle(authority=prior, decision=evaluated, operator_id="observer")
+    with pytest.raises(ValidationError, match="no longer active"):
+        history.record_worker_suspension_with_cursor(Cursor(new_rows(value, expiry)), bundle=value)
+
+
+@pytest.mark.parametrize("index", [1, 2])
+def test_replay_rejects_missing_or_changed_retained_sources(index: int) -> None:
+    value = bundle()
+    rows: list[Any] = [evidence_row(value), source_row(value["authority"])[:2],
+                       source_row(value["transition"], 2)[:2]]
+    rows[index] = None
+    with pytest.raises(StorageError, match="source is missing"):
+        history.record_worker_suspension_with_cursor(Cursor(rows), bundle=value)
+
+
+def test_retained_bundle_digest_is_independently_checked() -> None:
+    with pytest.raises(StorageError, match="digest differs"):
+        history.record_worker_suspension_with_cursor(Cursor([(bundle(), "0" * 64)]), bundle=bundle())
+
+
+def test_second_write_failure_requires_rollback_and_diagnostics_are_sanitized(monkeypatch: Any) -> None:
+    value = bundle()
+    cursor = Cursor(new_rows(value), fail_second_write=True)
+
+    class Connection:
+        rolled_back = False
+        def __enter__(self) -> Connection:
+            return self
+        def __exit__(self, exc_type: Any, *args: Any) -> None:
+            self.rolled_back = exc_type is not None
+        def cursor(self) -> Cursor:
+            return cursor
+
+    connection = Connection()
+    monkeypatch.setattr(history.authority_history, "_connect", lambda dsn: connection)
+    with pytest.raises(StorageError, match="no success is confirmed") as caught:
+        history.record_worker_suspension(dsn="not-used", bundle=value)
+    assert connection.rolled_back is True
+    assert "private-database-diagnostic" not in str(caught.value)
+    assert any("INSERT INTO risk_platform.notification_worker_authority_history" in sql for sql, _ in cursor.calls)
+
+
+def test_malformed_bundle_is_rejected_before_connect(monkeypatch: Any) -> None:
+    def forbidden(dsn: str) -> Any:
+        raise AssertionError("must not connect")
+    monkeypatch.setattr(history.authority_history, "_connect", forbidden)
+    with pytest.raises(ValidationError):
+        history.record_worker_suspension(dsn="not-used", bundle={})
+
+
+def test_database_fixture_and_schema_are_wired_into_existing_validation() -> None:
+    schema = Path("sql/notification_worker_suspension_schema.sql").read_text()
+    assert "BEFORE UPDATE OR DELETE" in schema
+    assert "BEFORE TRUNCATE" in schema
+    assert "FOREIGN KEY (transition_id, worker_id, destination_id)" in schema
+    assert "head.transition_id" in schema
+    assert "29_notification_worker_suspension_schema.sql:ro" in Path("docker-compose.yml").read_text()
+    fixture = Path("src/warehouse/notification_worker_authority_postgres_contract_check.py").read_text()
+    assert "check_worker_suspension_contract(connection, cursor, active)" in fixture
+    assert "notification_worker_authority_postgres_contract_check" in Path("Makefile").read_text()


### PR DESCRIPTION
## Goal

P4e2c, **3 of 3**, stacked on #159 after #158. Retain an exact worker stop and its canonical suspension decision together or not at all. Roadmap #76. Primary arc42 block: `warehouse`.

## Changes

- Reuse the established authority model, per-worker transaction lock and sequence recorder.
- Require the exact current active predecessor and a recent, nonfuture decision on the database clock.
- Commit the authority stop and complete decision/observation bundle in one transaction.
- Reopen both authority documents on exact historical replay without promoting old state.
- Reject changed decision reuse, stale heads and silent backfill of legacy stops.
- Add append-only evidence with canonical bytes, SHA-256, composite foreign keys and retained-source reconciliation.
- Join serving evidence only through the exact current transition; a later authority cannot inherit an older suspension decision.
- Mount schema 29 after authority schema 28 for fresh disposable databases.
- Extend the real PostgreSQL fixture without changing the Make target or byte-pinned Actions workflow.

## Exact candidate and scope

```text
Base #159:    df7135048c953a2540262d282dcb7805c9f886e8
Final head:   3e43ff1b1668011779beae414ebb8d9ed014686a
Tested merge: 20b524e617fb6f7f50773c60602be36a6cc75a64
Scope:        8 intended paths; 604 additions; 1 deletion
```

The stack incorporates accepted main `b17b1439cca98e05d28bd5722a733b583a2ca496` without force-pushing or replacing its complementary preflight work.

The one replaced line makes the existing TRUNCATE rejection probe name both FK-related tables, so the append-only trigger remains tested rather than an earlier dependency error.

## Final exact-candidate CI

[GitHub Actions run 442](https://github.com/alexmarinos87/financial-risk-data-platform/actions/runs/33999626400) passed all four jobs for final head `3e43ff1b1668011779beae414ebb8d9ed014686a` and its tested merge checkout above:

- Security guardrails: passed.
- Python readiness: Ruff passed; mypy passed across **162 source files**; **1,215 tests passed in quality and 1,215 passed again in readiness**; dependency compatibility and standard pipeline replay passed.
- PostgreSQL contract: passed, with the actual suspension proof output inspected.
- Infrastructure validation: passed without apply.

The PostgreSQL log explicitly reports all seven suspension proof groups true: second-write rollback; no legacy backfill; atomic creation and exact bound view; conflicting decision/stale-head rejection; UPDATE/DELETE/TRUNCATE rejection; historical replay without promotion; and full fixture rollback. All ten original worker-authority proof groups also remain true.

## Repair history

The first full CI run passed Ruff, mypy, PostgreSQL, security and infrastructure but found the existing exact Docker mount-list assertion had not been extended for schema 29. The final repair adds that one read-only mount to the expected ordered list. It removes no assertion, weakens no control and changes no runtime logic. Only the final repaired run above is final acceptance evidence.

Local source-subset validation passed 76 tests with one repository-wiring test deselected because the full Makefile was absent locally. That test remained enabled and passed within final full-repository CI. Local checks are not presented as a full checkout run.

## Trust and side effects

The recording API performs explicit PostgreSQL I/O. It retains adapter observations but does not independently reload the underlying health-source records or authenticate the operator; those remain caller obligations. IDs and digests are not authentication. SQL owners remain privileged. Existing volumes require separately reviewed schema application.

No CLI, scheduler or delivery activation, configuration-default change, provider/webhook request, deployment or Terraform apply. Tests use disposable PostgreSQL and roll back fixture records. Runtime permission remains false.

## Acceptance and merge sequence

**Draft and unmerged.** No submitted reviews or inline review threads were present at the final review check. Self-review and successful CI are not independent review or human approval.

Accept predecessors in order. After their squash merges, reconstruct this eight-path delta on accepted current main, rerun all exact-head checks and obtain explicit acceptance before squash merge. Do not merge into an unaccepted predecessor branch as a shortcut. Post-merge verification remains pending because no merge has been performed.