### PR TITLE
Capture database-clocked current worker authority snapshots

### DIFF
--- a/docs/notification-worker-authority-snapshot.md
+++ b/docs/notification-worker-authority-snapshot.md
@@ -54,15 +54,21 @@ No claim of a serializable multi-source snapshot is made.
 make quality-check
 make security-check
 make readiness-check
+make postgres-contract-check
 ```
 
 Unit tests use fake cursors and connections with the real authority validators.
-They prove SQL/parameter/transaction intent, not PostgreSQL execution of the new
-SELECT. The unchanged PostgreSQL contract job remains required; a dedicated real
-snapshot-query proof is a separate acceptance item before operational use.
+The existing `notification_worker_authority_postgres_contract_check` additionally
+executes the new SELECT for every lifecycle head/sequence, an active grant and a
+missing worker. It round-trips snapshots through canonical validation and invokes
+the public read-only adapter on a separate connection to prove uncommitted
+fixture records are not visible. Four explicit `clocked_snapshot_*` proof flags
+must pass in the real PostgreSQL CI log. Existing rollback, replay and mutation
+rejection proofs remain unchanged. No workflow or Make target change is needed.
 
-No schema, workflow, dependency or committed configuration change. No application
-database access during development, notification, scheduler activation,
-deployment or Terraform apply. Exact-head CI and self-review are evidence, not
-explicit engineer acceptance. The following increments bind reviewed
-configuration and expose validation-first operator diagnostics.
+No schema, workflow, dependency or committed configuration change. Database
+operations in CI use the existing disposable fixture and roll back its records.
+No application database access during development, notification, scheduler
+activation, deployment or Terraform apply. Exact-head CI and self-review are
+evidence, not explicit engineer acceptance. The following increments bind
+reviewed configuration and expose validation-first operator diagnostics.

--- a/docs/notification-worker-authority-snapshot.md
+++ b/docs/notification-worker-authority-snapshot.md
@@ -1,0 +1,68 @@
+# Clocked current worker authority snapshots
+
+Primary arc42 block: `warehouse`. Goal #164 under roadmap #76.
+
+## Decision
+
+`src/warehouse/notification_worker_authority_snapshot.py` adds a read-only
+adapter over the existing worker authority ledger. It does not replace the
+transition model, sequence recorder or existing reader APIs.
+
+The previous reader evaluated expiry on the database clock but did not return
+that observation time. The new reader selects the highest worker sequence and
+`statement_timestamp()` together. A left lateral join returns one row even when
+no authority exists, so an empty-head observation is clocked rather than inferred.
+The worker identifier is validated before I/O and passed as a SQL parameter.
+
+`read_worker_authority_snapshot` opens a new `READ COMMITTED, READ ONLY`
+transaction, sets bounded lock/statement timeouts and returns only after the
+connection context exits successfully. Its cursor-level counterpart performs
+only timeout configuration and one SELECT; the caller owns the transaction.
+Neither path acquires an advisory lock or writes ledger records.
+
+## Evidence and checks
+
+The snapshot retains the complete canonical transition, its digest, sequence,
+recording time, database observation time and derived authority state. Unknown
+workers retain null row metadata and an inactive state. Scope, digest, strict
+positive sequence, effective/recorded/observed chronology and exclusive expiry
+are checked using the existing authority contract.
+
+`validate_worker_authority_snapshot` rebuilds the entire bounded document and
+returns a detached JSON value. Recomputing a snapshot ID cannot hide a changed
+state, contradictory digest, invalid metadata or runtime permission. A valid
+hash is not authentication: fabricated self-consistent source records are still
+inside the caller's trust boundary.
+
+## Limits
+
+A single statement is a snapshot of committed state at its database observation,
+not a lock preventing a later stop. A retained file is not proof the head remains
+current. Database and configuration files do not share an atomic snapshot.
+Health evidence, independent reviewer authentication, exact slot claims and
+under-lock revalidation remain separate gates. Runtime permission remains false.
+
+PostgreSQL READ COMMITTED takes a snapshot for each statement. READ ONLY prevents
+ordinary table modifications, not every possible disk write. See PostgreSQL's
+SET TRANSACTION reference: <https://www.postgresql.org/docs/16/sql-set-transaction.html>.
+No claim of a serializable multi-source snapshot is made.
+
+## Validation and integration
+
+```bash
+.venv/bin/python -m pytest -q tests/unit/test_notification_worker_authority_snapshot.py
+make quality-check
+make security-check
+make readiness-check
+```
+
+Unit tests use fake cursors and connections with the real authority validators.
+They prove SQL/parameter/transaction intent, not PostgreSQL execution of the new
+SELECT. The unchanged PostgreSQL contract job remains required; a dedicated real
+snapshot-query proof is a separate acceptance item before operational use.
+
+No schema, workflow, dependency or committed configuration change. No application
+database access during development, notification, scheduler activation,
+deployment or Terraform apply. Exact-head CI and self-review are evidence, not
+explicit engineer acceptance. The following increments bind reviewed
+configuration and expose validation-first operator diagnostics.

--- a/src/warehouse/notification_worker_authority_postgres_contract_check.py
+++ b/src/warehouse/notification_worker_authority_postgres_contract_check.py
@@ -23,6 +23,10 @@ from src.warehouse.notification_worker_authority_history import (
     LOCK_PREFIX, LOCK_SQL, read_current_worker_authority_with_cursor,
     record_worker_authority_with_cursor,
 )
+from src.warehouse.notification_worker_authority_snapshot import (
+    read_worker_authority_snapshot, read_worker_authority_snapshot_with_cursor,
+    validate_worker_authority_snapshot,
+)
 
 
 def _plan(directory: Path, worker_id: str, planned_at: datetime) -> dict[str, Any]:
@@ -128,6 +132,11 @@ def run_contract_check(dsn: str) -> dict[str, Any]:
                     if retained["created"] is not True or retained["authority_sequence"] != sequence:
                         raise AssertionError("authority sequence did not advance exactly once")
                     current = read_current_worker_authority_with_cursor(cursor, worker_id=worker_id)
+                    snapshot = read_worker_authority_snapshot_with_cursor(cursor, worker_id=worker_id)
+                    if (snapshot["transition"] != document or snapshot["authority_sequence"] != sequence
+                            or snapshot["authority_state"] != expected
+                            or validate_worker_authority_snapshot(snapshot) != snapshot):
+                        raise AssertionError("clocked authority snapshot differs from current head")
                     cursor.execute(
                         "SELECT authority_state, runtime_permission_granted "
                         "FROM risk_platform.current_notification_worker_authority WHERE worker_id = %s",
@@ -136,6 +145,7 @@ def run_contract_check(dsn: str) -> dict[str, Any]:
                     if current["authority_state"] != expected or cursor.fetchone() != (expected, False):
                         raise AssertionError("SQL and canonical current states differ")
                 results["lifecycle_and_sequence"] = True
+                results["clocked_snapshot_lifecycle"] = True
                 replay = record_worker_authority_with_cursor(cursor, transition=first)
                 if replay["created"] is not False or replay["authority_sequence"] != 1:
                     raise AssertionError("historical exact replay did not converge")
@@ -172,12 +182,24 @@ def run_contract_check(dsn: str) -> dict[str, Any]:
                 if read_current_worker_authority_with_cursor(cursor, worker_id=active_worker)["authority_state"] != "active":
                     raise AssertionError("current grant was not active")
                 results["active_state"] = True
+                active_snapshot = read_worker_authority_snapshot_with_cursor(cursor, worker_id=active_worker)
+                if active_snapshot["authority_state"] != "active" or active_snapshot["transition"] != active:
+                    raise AssertionError("clocked snapshot did not retain active authority")
+                results["clocked_snapshot_active"] = True
                 future = _grant(_plan(directory, worker_id + "-future", now + timedelta(days=1)), worker_id + "-future")
                 _reject(connection, lambda: record_worker_authority_with_cursor(cursor, transition=future), "check constraint")
                 results["future_head_rejected"] = True
                 if read_current_worker_authority_with_cursor(cursor, worker_id=worker_id + "-missing")["authority_state"] != "inactive":
                     raise AssertionError("unknown worker was not inactive")
                 results["unknown_worker_inactive"] = True
+                missing = read_worker_authority_snapshot_with_cursor(cursor, worker_id=worker_id + "-missing")
+                if missing["transition"] is not None or missing["authority_state"] != "inactive" or not missing["observed_at"]:
+                    raise AssertionError("missing authority did not retain its database observation clock")
+                results["clocked_snapshot_missing"] = True
+                isolated = read_worker_authority_snapshot(dsn=dsn, worker_id=worker_id)
+                if isolated["transition"] is not None or isolated["runtime_permission_granted"] is not False:
+                    raise AssertionError("read-only connection observed uncommitted fixture authority")
+                results["clocked_snapshot_read_only_isolation"] = True
                 cursor.execute(
                     "SELECT COUNT(*), MAX(authority_sequence) FROM "
                     "risk_platform.notification_worker_authority_history WHERE worker_id = %s", (worker_id,),

--- a/src/warehouse/notification_worker_authority_snapshot.py
+++ b/src/warehouse/notification_worker_authority_snapshot.py
@@ -1,0 +1,131 @@
+"""Read one clocked authority head; a snapshot never grants runtime permission."""
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Mapping
+from datetime import datetime
+from typing import Any
+
+from src.common.exceptions import StorageError, ValidationError
+from src.orchestration.notification_worker_authority_contract import (
+    authority_state, canonical_bytes, identifier, utc,
+)
+from src.warehouse.notification_worker_authority_history import _connect, _decode, _validated
+
+MODEL_VERSION = "portfolio-risk-worker-authority-snapshot-v1"
+MAX_SNAPSHOT_BYTES = 1_048_576
+SNAPSHOT_FIELDS = frozenset({
+    "snapshot_id", "model_version", "worker_id", "observed_at", "transition",
+    "document_sha256", "authority_sequence", "recorded_at", "authority_state",
+    "read_consistency", "runtime_permission_granted",
+})
+CURRENT_SNAPSHOT_SQL = """
+SELECT statement_timestamp(), head.document_json, head.document_sha256,
+       head.authority_sequence, head.recorded_at
+FROM (SELECT 1) AS observation
+LEFT JOIN LATERAL (
+    SELECT document_json, document_sha256, authority_sequence, recorded_at
+    FROM risk_platform.notification_worker_authority_history
+    WHERE worker_id = %s
+    ORDER BY authority_sequence DESC LIMIT 1
+) AS head ON TRUE
+"""
+
+
+def _build_snapshot(
+    *, worker_id: Any, observed_at: Any, transition: Any,
+    document_sha256: Any, authority_sequence: Any, recorded_at: Any,
+) -> dict[str, Any]:
+    selected = identifier(worker_id, "worker_id")
+    observed = utc(observed_at, "observed_at")
+    document = None
+    recorded = None
+    if transition is None:
+        if any(value is not None for value in (document_sha256, authority_sequence, recorded_at)):
+            raise ValidationError("missing authority cannot carry retained row metadata")
+    else:
+        document = _validated(transition)
+        if document["plan"]["worker"]["worker_id"] != selected:
+            raise ValidationError("authority snapshot worker scope differs")
+        if type(authority_sequence) is not int or not 1 <= authority_sequence < 2**63:
+            raise ValidationError("authority snapshot sequence is invalid")
+        if document_sha256 != hashlib.sha256(canonical_bytes(document)).hexdigest():
+            raise ValidationError("authority snapshot document digest differs")
+        recorded = utc(recorded_at, "recorded_at")
+        effective = utc(document["effective_at"], "effective_at")
+        if not effective <= recorded <= observed:
+            raise ValidationError("authority snapshot chronology is invalid")
+    identity = {
+        "model_version": MODEL_VERSION, "worker_id": selected,
+        "observed_at": observed.isoformat(), "transition": document,
+        "document_sha256": document_sha256, "authority_sequence": authority_sequence,
+        "recorded_at": None if recorded is None else recorded.isoformat(),
+        "authority_state": authority_state(document, as_of=observed),
+        "read_consistency": "single_statement", "runtime_permission_granted": False,
+    }
+    digest = hashlib.sha256(canonical_bytes(identity)).hexdigest()
+    result = {"snapshot_id": f"{MODEL_VERSION}-{digest}", **identity}
+    if len(canonical_bytes(result)) > MAX_SNAPSHOT_BYTES:
+        raise ValidationError("authority snapshot exceeds 1 MB")
+    return result
+
+
+def validate_worker_authority_snapshot(value: Mapping[str, Any]) -> dict[str, Any]:
+    """Recompute a bounded detached snapshot, not database provenance or freshness."""
+    try:
+        if not isinstance(value, Mapping) or set(value) != SNAPSHOT_FIELDS:
+            raise ValidationError("authority snapshot fields are not exact")
+        encoded = canonical_bytes(value)
+        if len(encoded) > MAX_SNAPSHOT_BYTES:
+            raise ValidationError("authority snapshot exceeds 1 MB")
+        snapshot = json.loads(encoded)
+        rebuilt = _build_snapshot(**{key: snapshot[key] for key in (
+            "worker_id", "observed_at", "transition", "document_sha256",
+            "authority_sequence", "recorded_at",
+        )})
+        if encoded != canonical_bytes(rebuilt):
+            raise ValidationError("authority snapshot differs from its retained evidence")
+        return rebuilt
+    except (TypeError, ValueError, RecursionError, OverflowError, UnicodeError):
+        raise ValidationError("authority snapshot is malformed") from None
+
+
+def read_worker_authority_snapshot_with_cursor(cursor: Any, *, worker_id: str) -> dict[str, Any]:
+    """SELECT only; the caller owns transaction isolation and lifecycle."""
+    selected = identifier(worker_id, "worker_id")
+    cursor.execute("SET LOCAL statement_timeout = '10s'")
+    cursor.execute(CURRENT_SNAPSHOT_SQL, (selected,))
+    row = cursor.fetchone()
+    try:
+        if not isinstance(row, (tuple, list)) or len(row) != 5:
+            raise StorageError("authority snapshot row is invalid")
+        if not isinstance(row[0], datetime):
+            raise StorageError("authority snapshot database clock is invalid")
+        if row[1] is not None:
+            _decode(row[1:])
+            if not isinstance(row[4], datetime):
+                raise StorageError("authority snapshot recording clock is invalid")
+        return _build_snapshot(
+            worker_id=selected, observed_at=row[0], transition=row[1],
+            document_sha256=row[2], authority_sequence=row[3], recorded_at=row[4],
+        )
+    except (ValidationError, StorageError, TypeError, ValueError, RecursionError, OverflowError):
+        raise StorageError("retained authority snapshot failed validation") from None
+
+
+def read_worker_authority_snapshot(*, dsn: str, worker_id: str) -> dict[str, Any]:
+    """Capture one head in a new bounded READ COMMITTED, READ ONLY transaction."""
+    selected = identifier(worker_id, "worker_id")
+    if not isinstance(dsn, str) or not dsn.strip():
+        raise ValidationError("PostgreSQL DSN must be non-empty text")
+    try:
+        with _connect(dsn) as connection:
+            with connection.cursor() as cursor:
+                cursor.execute("SET TRANSACTION ISOLATION LEVEL READ COMMITTED, READ ONLY")
+                cursor.execute("SET LOCAL lock_timeout = '5s'")
+                result = read_worker_authority_snapshot_with_cursor(cursor, worker_id=selected)
+        return result
+    except Exception:
+        # Include connection/exit failures without exposing DSNs or provider diagnostics.
+        raise StorageError("unable to read a verified worker authority snapshot") from None

--- a/tests/unit/test_notification_worker_authority_snapshot.py
+++ b/tests/unit/test_notification_worker_authority_snapshot.py
@@ -1,0 +1,193 @@
+from __future__ import annotations
+
+import copy
+import hashlib
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+import pytest
+
+from src.common.exceptions import StorageError, ValidationError
+from src.orchestration.notification_worker_authority_contract import canonical_bytes
+from src.warehouse import notification_worker_authority_snapshot as snapshots
+from test_notification_worker_authority_contract import NOW, grant, stop
+
+
+class SnapshotCursor:
+    def __init__(self, row: Any) -> None:
+        self.row = row
+        self.calls: list[tuple[str, Any]] = []
+
+    def execute(self, sql: str, params: Any = None) -> None:
+        self.calls.append((sql, params))
+
+    def fetchone(self) -> Any:
+        return self.row
+
+    def __enter__(self) -> SnapshotCursor:
+        return self
+
+    def __exit__(self, *args: Any) -> None:
+        return None
+
+
+def snapshot_row(document: dict[str, Any] | None, *, observed: datetime | None = None) -> list[Any]:
+    instant = NOW + timedelta(seconds=5) if observed is None else observed
+    if document is None:
+        return [instant, None, None, None, None]
+    return [instant, document, hashlib.sha256(canonical_bytes(document)).hexdigest(),
+            1, datetime.fromisoformat(document["effective_at"])]
+
+
+def read(document: dict[str, Any] | None, **kwargs: Any) -> dict[str, Any]:
+    return snapshots.read_worker_authority_snapshot_with_cursor(
+        SnapshotCursor(snapshot_row(document, **kwargs)), worker_id="authority-worker",
+    )
+
+
+def rehash_snapshot(value: dict[str, Any]) -> dict[str, Any]:
+    identity = {key: item for key, item in value.items() if key != "snapshot_id"}
+    value["snapshot_id"] = f"{snapshots.MODEL_VERSION}-{hashlib.sha256(canonical_bytes(identity)).hexdigest()}"
+    return value
+
+
+def test_snapshot_uses_one_parameterized_head_and_clock_select() -> None:
+    cursor = SnapshotCursor(snapshot_row(grant()))
+    result = snapshots.read_worker_authority_snapshot_with_cursor(cursor, worker_id="authority-worker")
+    assert result["authority_state"] == "active"
+    assert result["runtime_permission_granted"] is False
+    assert result["observed_at"] == (NOW + timedelta(seconds=5)).isoformat()
+    assert cursor.calls == [
+        ("SET LOCAL statement_timeout = '10s'", None),
+        (snapshots.CURRENT_SNAPSHOT_SQL, ("authority-worker",)),
+    ]
+    sql = snapshots.CURRENT_SNAPSHOT_SQL
+    assert "statement_timestamp()" in sql and "LEFT JOIN LATERAL" in sql
+    assert "ORDER BY authority_sequence DESC LIMIT 1" in sql
+    assert not any(word in sql.upper() for word in ("INSERT", "UPDATE", "DELETE", "PG_ADVISORY"))
+
+
+def test_unknown_worker_still_has_clock_and_no_invented_head() -> None:
+    result = read(None)
+    assert result["observed_at"]
+    assert result["authority_state"] == "inactive"
+    assert result["transition"] is None
+    assert result["document_sha256"] is None
+    assert result["authority_sequence"] is None
+    assert result["recorded_at"] is None
+    assert snapshots.validate_worker_authority_snapshot(result) == result
+
+
+@pytest.mark.parametrize("action", ["suspend", "disable"])
+def test_stop_head_remains_stopped_even_after_cooldown(action: str) -> None:
+    current = stop(grant(), action=action)
+    result = read(current, observed=NOW + timedelta(days=1))
+    assert result["authority_state"] == current["to_state"]
+    assert result["transition"] == current
+
+
+def test_expiry_is_exclusive_and_snapshots_are_detached() -> None:
+    document = grant()
+    expiry = datetime.fromisoformat(document["expires_at"])
+    assert read(document, observed=expiry)["authority_state"] == "expired"
+    result = read(document, observed=expiry - timedelta(microseconds=1))
+    assert result["authority_state"] == "active"
+    rebuilt = snapshots.validate_worker_authority_snapshot(result)
+    result["transition"]["reason_codes"].append("operator_request")
+    document["plan"]["execution"]["work_items"].clear()
+    assert rebuilt["transition"]["reason_codes"] == []
+    assert rebuilt["transition"]["plan"]["execution"]["work_items"]
+
+
+@pytest.mark.parametrize(("field", "value"), [
+    ("worker_id", "wrong-worker"), ("authority_state", "disabled"),
+    ("authority_sequence", True), ("authority_sequence", 0),
+    ("authority_sequence", 2**63), ("document_sha256", "0" * 64),
+    ("recorded_at", "2026-09-05T19:00:00+00:00"),
+    ("observed_at", "2026-09-05T19:00:00+00:00"),
+    ("read_consistency", "repeatable_read"), ("runtime_permission_granted", True),
+    ("runtime_permission_granted", 0), ("model_version", "other"),
+])
+def test_rehashed_contradictory_metadata_is_rejected(field: str, value: Any) -> None:
+    result = read(grant())
+    result[field] = value
+    with pytest.raises(ValidationError):
+        snapshots.validate_worker_authority_snapshot(rehash_snapshot(result))
+
+
+@pytest.mark.parametrize("field", ["authority_sequence", "recorded_at", "document_sha256"])
+def test_missing_head_cannot_carry_metadata(field: str) -> None:
+    result = read(None)
+    result[field] = 1
+    with pytest.raises(ValidationError):
+        snapshots.validate_worker_authority_snapshot(rehash_snapshot(result))
+
+
+@pytest.mark.parametrize("row", [None, (), [NOW] * 4, [NOW] * 6,
+    [NOW, None, None, 1, None], ["2026-09-05T20:00:00+00:00", None, None, None, None],
+    [NOW.replace(tzinfo=None), None, None, None, None],
+])
+def test_invalid_database_rows_fail_closed(row: Any) -> None:
+    with pytest.raises(StorageError, match="failed validation"):
+        snapshots.read_worker_authority_snapshot_with_cursor(SnapshotCursor(row), worker_id="authority-worker")
+
+
+def test_valid_timezone_is_normalized_at_the_database_boundary() -> None:
+    observed = NOW.astimezone(timezone(timedelta(hours=1)))
+    assert read(None, observed=observed)["observed_at"] == NOW.isoformat()
+
+
+def test_invalid_worker_is_rejected_before_cursor_use() -> None:
+    cursor = SnapshotCursor(None)
+    with pytest.raises(ValidationError):
+        snapshots.read_worker_authority_snapshot_with_cursor(cursor, worker_id="not a safe worker")
+    assert not cursor.calls
+
+
+def test_snapshot_size_and_extra_fields_are_bounded() -> None:
+    result = read(None)
+    result["worker_id"] = "x" * snapshots.MAX_SNAPSHOT_BYTES
+    with pytest.raises(ValidationError):
+        snapshots.validate_worker_authority_snapshot(result)
+    result = read(None)
+    result["extra"] = "not permitted"
+    with pytest.raises(ValidationError):
+        snapshots.validate_worker_authority_snapshot(result)
+
+
+def test_public_adapter_enforces_read_only_before_select(monkeypatch: pytest.MonkeyPatch) -> None:
+    cursor = SnapshotCursor(snapshot_row(grant()))
+
+    class Connection:
+        def __enter__(self) -> Connection:
+            return self
+
+        def __exit__(self, *args: Any) -> None:
+            return None
+
+        def cursor(self) -> SnapshotCursor:
+            return cursor
+
+    monkeypatch.setattr(snapshots, "_connect", lambda dsn: Connection())
+    assert snapshots.read_worker_authority_snapshot(dsn="injected", worker_id="authority-worker")["authority_state"] == "active"
+    assert cursor.calls[0] == ("SET TRANSACTION ISOLATION LEVEL READ COMMITTED, READ ONLY", None)
+    assert cursor.calls[1] == ("SET LOCAL lock_timeout = '5s'", None)
+
+
+def test_connection_errors_do_not_expose_provider_diagnostics(monkeypatch: pytest.MonkeyPatch) -> None:
+    def failed(dsn: str) -> Any:
+        raise RuntimeError("sensitive provider diagnostic " + dsn)
+
+    monkeypatch.setattr(snapshots, "_connect", failed)
+    with pytest.raises(StorageError) as caught:
+        snapshots.read_worker_authority_snapshot(dsn="secret-dsn", worker_id="authority-worker")
+    assert str(caught.value) == "unable to read a verified worker authority snapshot"
+    with pytest.raises(ValidationError):
+        snapshots.read_worker_authority_snapshot(dsn="", worker_id="authority-worker")
+
+
+def test_replay_preserves_input_bytes() -> None:
+    result = read(grant())
+    before = copy.deepcopy(result)
+    assert snapshots.validate_worker_authority_snapshot(result) == before
+    assert result == before


### PR DESCRIPTION
## Goal

Closes #164. First of three read-only preflight increments under #76. Primary arc42 block: warehouse. Followed by #168 and #169.

## Changes

- Read the highest per-worker authority sequence and PostgreSQL statement clock in one bounded parameterized SELECT, including missing workers.
- Reuse the authority contract and retained-row validation; reconcile digest, worker scope, strict sequence, effective/recorded/observed chronology and exclusive expiry.
- Return and rebuild a detached, bounded canonical snapshot; rehashed contradictory metadata fails closed.
- Use a new READ COMMITTED, READ ONLY transaction with timeouts in the public adapter; sanitize connection and context-exit failures.
- Exercise the actual SELECT and public reader through the existing disposable PostgreSQL fixture, without editing the workflow or Make target.

## Exact scope

Four paths, **420 additions, zero deletions**, three commits. Three new source/test/documentation files plus additive assertions in the existing PostgreSQL authority fixture. All pre-existing fixture checks are preserved. Existing ledger APIs, schemas, dependencies, workflows and committed configuration defaults are unchanged.

Base: `7316dd30ce5b445df0ac2c0ac019703add15aadc`.
Final head: `e875e3583904b8072a04d2fcb95424e04d45d69f`.
Tree: `61c1b5980a979bdd8e3a45f189f868ed7f17b96b`.
Tested merge: `3ffbc21d98f612896bd02a6878bb25dfcb791529`, combining that exact head and base.

## Validation evidence

[GitHub Actions run 446](https://github.com/alexmarinos87/financial-risk-data-platform/actions/runs/33999949609) passed all four jobs: Python readiness, Security guardrails, PostgreSQL contract and Infrastructure validation.

Python job `101396924847`: Ruff passed, mypy passed across **160 source files**, **1,185 tests passed twice**, dependency integrity passed, pipeline replay and warehouse dry-run passed.

PostgreSQL job `101396924927` actually executed the updated fixture. All four new proof flags passed:

- `clocked_snapshot_lifecycle`: exact head, sequence and state through activate/suspend/resume/disable.
- `clocked_snapshot_active`: active retained grant and canonical identity.
- `clocked_snapshot_missing`: missing worker retains an observation clock.
- `clocked_snapshot_read_only_isolation`: the public read-only connection cannot observe another connection's uncommitted fixture records.

All prior fixture proofs, including rollback, replay without promotion, mutation/fork rejection and two-session lock exclusion, also passed. The initial green candidate was deliberately strengthened with these real-database checks; this final run, not the superseded initial head, is the acceptance evidence.

Local syntax compilation and whitespace checks passed. Full tests, typing and PostgreSQL validation were performed by GitHub CI, not a local complete checkout. Scope and the additive fixture diff were reviewed. No submitted reviews, conversation comments or unresolved review threads were present when checked; this is not independent approval.

## Trust and safety

A snapshot is not authentication, current health or runtime permission. A later committed stop may supersede it immediately. Database and filesystem observations are not atomic across stores. Runtime permission remains false. No application database was contacted during development; CI database operations are confined to disposable fixtures. No runtime advisory lock, authority write, notification, scheduler activation, deployment or Terraform apply.

The suspension drafts #158/#159/#162 remain untouched. Concurrently merged #163 is included unchanged in the accepted base.

## Acceptance and handoff

**Draft, CI-validated, unmerged. Explicit engineer acceptance of the exact diff remains pending per AGENTS.md.** Accept this candidate first. After squash merge, reconstruct #168's isolated delta on accepted current main and rerun exact-head validation; repeat for #169. Do not merge dependent PRs into this unaccepted branch.