### PR TITLE
Bind clocked worker preflight to reviewed configuration snapshots

### DIFF
--- a/docs/reviewed-notification-worker-preflight.md
+++ b/docs/reviewed-notification-worker-preflight.md
@@ -1,0 +1,71 @@
+# Reviewed-configuration worker preflight
+
+Primary arc42 block: `orchestration`. Goal #165 follows #164 under roadmap #76.
+
+## Decision
+
+`src/orchestration/reviewed_notification_worker_preflight.py` composes the clocked
+ledger snapshot with the existing reviewed-plan binder and authority preflight.
+It does not implement a second health evaluator, lifecycle model or scheduler.
+
+`build_reviewed_worker_preflight` requires a validated snapshot and an explicit
+selected transition ID and schedule slot. It obtains the retained plan from the
+snapshot, reconstructs it at the original planning instant from the supplied
+reviewed worker/delivery/destination files, and requires exact agreement through
+`_bind_reviewed_plan`. Review expiry is obtained from that same destination
+object, not supplied independently by the caller.
+
+A changed worker switch, delivery policy, destination review or fingerprint
+raises ValidationError. A missing authority produces a blocked preflight and
+skips configuration I/O entirely. Otherwise the existing preflight determines
+whether the exact captured head/slot is eligible for separate health review,
+waiting for the slot, or blocked. A newer stop cannot be bypassed by selecting
+an old active transition ID. Expiry remains exclusive; cooldown never resumes.
+
+## Retained evidence
+
+The 1 MB bounded envelope contains the exact authority snapshot, derived
+preflight input and result. All values are detached JSON. Validation reopens the
+supplied reviewed files and rebuilds the complete envelope. A recomputed bundle
+ID cannot hide changed outcomes, evidence times, review expiry or permission.
+No configuration paths, DSN, environment values or notification bodies are
+included. The existing secret-free plan retains identifiers/fingerprints only.
+
+Evaluation is explicitly scoped to `captured_database_instant`: evaluated and
+observed time are the snapshot's database time. Reopening a retained bundle does
+not refresh the database or establish current freshness. Passing this preflight
+still means `readiness_evaluated = false` and `runtime_permission_granted = false`.
+
+## Trust and trade-offs
+
+Reviewed files must be immutable snapshots in trusted directories. Their
+contents are checked, not their provenance, authenticated reviewer identity or
+ongoing approval. Filesystem and PostgreSQL state are not an atomic cross-store
+snapshot. A concurrent stop or configuration replacement requires a new read.
+A forged internally consistent snapshot cannot be authenticated by its hash.
+Runtime integration must later reacquire current evidence under the shared
+lock, check health, authenticate the caller and enforce slot claim/replay rules.
+
+This change deliberately does not import the unaccepted suspension draft stack.
+It is independently reviewable over the first snapshot candidate, not a shortcut
+to accepting or activating any other work.
+
+## Validation
+
+```bash
+.venv/bin/python -m pytest -q tests/unit/test_reviewed_notification_worker_preflight.py
+make quality-check
+make security-check
+make readiness-check
+```
+
+Tests use real existing plan/authority builders with temporary reviewed files
+and injected database rows. They cover disabled or changed sources, missing
+heads/files, symlinks, newer stops, slot/expiry boundaries, detached replay and
+rehashed tampering. No application database or network is accessed.
+
+No schema, workflow, dependency, configuration-default or infrastructure change.
+No authority write, notification, shared lock, scheduler mutation, deployment or
+Terraform apply. Exact-head CI is evidence; explicit final-diff acceptance is
+still required. After the predecessor is accepted and squash-merged, reconstruct
+this delta on accepted main and rerun checks before accepting this candidate.

--- a/src/orchestration/reviewed_notification_worker_preflight.py
+++ b/src/orchestration/reviewed_notification_worker_preflight.py
@@ -1,0 +1,99 @@
+"""Bind captured authority preflight to reviewed immutable configuration files."""
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+from src.common.exceptions import ValidationError
+from src.orchestration.notification_worker_authority_contract import canonical_bytes, identifier, utc
+from src.orchestration.notification_worker_authority_preflight import (
+    EVIDENCE_FIELDS, evaluate_worker_authority_preflight,
+)
+from src.orchestration.reviewed_notification_worker_authority import _bind_reviewed_plan
+from src.warehouse.notification_worker_authority_snapshot import validate_worker_authority_snapshot
+
+MODEL_VERSION = "portfolio-risk-reviewed-worker-preflight-v1"
+MAX_BUNDLE_BYTES = 1_048_576
+BUNDLE_FIELDS = frozenset({
+    "bundle_id", "model_version", "snapshot", "evidence", "preflight",
+    "evaluation_scope", "configuration_validated", "runtime_permission_granted",
+})
+
+
+def build_reviewed_worker_preflight(
+    *, snapshot: Mapping[str, Any], selected_transition_id: str, scheduled_for: str,
+    worker_config_path: Path = Path("config/notification_workers.yaml"),
+    delivery_config_path: Path = Path("config/notification_delivery.yaml"),
+    destination_config_path: Path = Path("config/notification_destinations.yaml"),
+) -> dict[str, Any]:
+    """Evaluate the captured database instant; do not claim it is still current.
+
+    Files must be immutable reviewed snapshots in trusted directories. Missing
+    authority produces a blocked result without reading configuration. A changed
+    configuration raises ValidationError before producing any passing result.
+    """
+    captured = validate_worker_authority_snapshot(snapshot)
+    selected = identifier(selected_transition_id, "selected_transition_id")
+    slot = utc(scheduled_for, "scheduled_for").isoformat()
+    current = captured["transition"]
+    plan = None
+    review_expiry = None
+    if current is not None:
+        plan, destination = _bind_reviewed_plan(
+            current["plan"], worker_config_path=worker_config_path,
+            delivery_config_path=delivery_config_path,
+            destination_config_path=destination_config_path,
+        )
+        expiry = destination.activation.review_expires_at
+        review_expiry = None if expiry is None else expiry.isoformat()
+    evidence = {
+        "worker_id": captured["worker_id"], "selected_transition_id": selected,
+        "evaluated_at": captured["observed_at"], "observed_at": captured["observed_at"],
+        "scheduled_for": slot, "current_authority": current,
+        "configuration_plan": plan, "destination_review_expires_at": review_expiry,
+    }
+    identity = {
+        "model_version": MODEL_VERSION, "snapshot": captured, "evidence": evidence,
+        "preflight": evaluate_worker_authority_preflight(evidence),
+        "evaluation_scope": "captured_database_instant",
+        "configuration_validated": current is not None, "runtime_permission_granted": False,
+    }
+    digest = hashlib.sha256(canonical_bytes(identity)).hexdigest()
+    result = {"bundle_id": f"{MODEL_VERSION}-{digest}", **identity}
+    encoded = canonical_bytes(result)
+    if len(encoded) > MAX_BUNDLE_BYTES:
+        raise ValidationError("reviewed worker preflight bundle exceeds 1 MB")
+    return dict(json.loads(encoded))
+
+
+def validate_reviewed_worker_preflight(
+    value: Mapping[str, Any], *,
+    worker_config_path: Path = Path("config/notification_workers.yaml"),
+    delivery_config_path: Path = Path("config/notification_delivery.yaml"),
+    destination_config_path: Path = Path("config/notification_destinations.yaml"),
+) -> dict[str, Any]:
+    """Reopen supplied reviewed files and rebuild every retained output field."""
+    try:
+        if not isinstance(value, Mapping) or set(value) != BUNDLE_FIELDS:
+            raise ValidationError("reviewed worker preflight fields are not exact")
+        encoded = canonical_bytes(value)
+        if len(encoded) > MAX_BUNDLE_BYTES:
+            raise ValidationError("reviewed worker preflight bundle exceeds 1 MB")
+        source = json.loads(encoded)
+        evidence = source["evidence"]
+        if not isinstance(evidence, Mapping) or set(evidence) != EVIDENCE_FIELDS:
+            raise ValidationError("reviewed worker preflight evidence fields are not exact")
+        rebuilt = build_reviewed_worker_preflight(
+            snapshot=source["snapshot"], selected_transition_id=evidence["selected_transition_id"],
+            scheduled_for=evidence["scheduled_for"], worker_config_path=worker_config_path,
+            delivery_config_path=delivery_config_path,
+            destination_config_path=destination_config_path,
+        )
+        if encoded != canonical_bytes(rebuilt):
+            raise ValidationError("reviewed worker preflight differs from bound source evidence")
+        return rebuilt
+    except (KeyError, TypeError, ValueError, RecursionError, OverflowError, UnicodeError):
+        raise ValidationError("reviewed worker preflight is malformed") from None

--- a/tests/unit/test_reviewed_notification_worker_preflight.py
+++ b/tests/unit/test_reviewed_notification_worker_preflight.py
@@ -1,0 +1,160 @@
+from __future__ import annotations
+
+import copy
+import hashlib
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+from src.common.exceptions import ValidationError
+from src.orchestration.notification_worker_authority_contract import (
+    build_worker_authority_transition, canonical_bytes,
+)
+from src.orchestration import reviewed_notification_worker_preflight as reviewed
+from src.warehouse.notification_worker_authority_snapshot import read_worker_authority_snapshot_with_cursor
+from test_notification_worker_authority_snapshot import SnapshotCursor, snapshot_row
+from test_reviewed_notification_worker_authority import (
+    NOW, WORKER_ID, _grant, _plan, configurations as configurations,
+)
+
+
+def reviewed_snapshot(paths: dict[str, Path], *, observed: datetime | None = None) -> dict[str, Any]:
+    plan = _plan(paths)
+    current = _grant(plan, paths)
+    when = datetime.fromisoformat(plan["schedule"]["scheduled_for"]) if observed is None else observed
+    return read_worker_authority_snapshot_with_cursor(
+        SnapshotCursor(snapshot_row(current, observed=when)), worker_id=WORKER_ID,
+    )
+
+
+def bundle(paths: dict[str, Path], snapshot: dict[str, Any] | None = None) -> dict[str, Any]:
+    captured = reviewed_snapshot(paths) if snapshot is None else snapshot
+    current = captured["transition"]
+    return reviewed.build_reviewed_worker_preflight(
+        snapshot=captured, selected_transition_id=current["transition_id"],
+        scheduled_for=current["plan"]["schedule"]["scheduled_for"], **paths,
+    )
+
+
+def test_due_preflight_rebuilds_actual_reviewed_sources(configurations: dict[str, Path]) -> None:
+    captured = reviewed_snapshot(configurations)
+    before = copy.deepcopy(captured)
+    result = bundle(configurations, captured)
+    assert result["preflight"]["outcome"] == "eligible_for_health_review"
+    assert result["preflight"]["readiness_evaluated"] is False
+    assert result["runtime_permission_granted"] is False
+    assert result["configuration_validated"] is True
+    assert result["evidence"]["destination_review_expires_at"] == "2026-10-01T00:00:00+00:00"
+    assert result["evidence"]["evaluated_at"] == captured["observed_at"]
+    assert result["evaluation_scope"] == "captured_database_instant"
+    assert reviewed.validate_reviewed_worker_preflight(result, **configurations) == result
+    assert captured == before
+    result["snapshot"]["transition"]["reason_codes"].append("operator_request")
+    assert captured == before
+
+
+@pytest.mark.parametrize("key", ["worker_config_path", "delivery_config_path", "destination_config_path"])
+def test_changed_reviewed_configuration_rejects_retained_bundle(configurations: dict[str, Path], key: str) -> None:
+    result = bundle(configurations)
+    path = configurations[key]
+    value = yaml.safe_load(path.read_text())
+    if key == "worker_config_path":
+        value["workers"][WORKER_ID]["enabled"] = False
+    elif key == "delivery_config_path":
+        value["delivery"]["webhook"]["enabled"] = False
+    else:
+        value["destinations"]["risk-operations-webhook"]["activation"]["review_expires_at"] = "2026-09-20T00:00:00+00:00"
+    path.write_text(yaml.safe_dump(value), encoding="utf-8")
+    with pytest.raises(ValidationError):
+        reviewed.validate_reviewed_worker_preflight(result, **configurations)
+
+
+def test_missing_authority_skips_configuration_io(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured = read_worker_authority_snapshot_with_cursor(
+        SnapshotCursor(snapshot_row(None)), worker_id=WORKER_ID,
+    )
+
+    def forbidden(*args: Any, **kwargs: Any) -> Any:
+        raise AssertionError("unknown authority must not inspect configurations")
+
+    monkeypatch.setattr(reviewed, "_bind_reviewed_plan", forbidden)
+    result = reviewed.build_reviewed_worker_preflight(
+        snapshot=captured, selected_transition_id="selected-old-grant", scheduled_for=NOW.isoformat(),
+    )
+    assert result["preflight"]["outcome"] == "blocked"
+    assert "authority_missing" in result["preflight"]["reasons"]
+    assert result["configuration_validated"] is False
+    assert reviewed.validate_reviewed_worker_preflight(result) == result
+
+
+@pytest.mark.parametrize("action", ["suspend", "disable"])
+def test_newer_stop_blocks_an_old_selected_grant(configurations: dict[str, Path], action: str) -> None:
+    captured = reviewed_snapshot(configurations)
+    prior = captured["transition"]
+    current = build_worker_authority_transition(
+        plan=prior["plan"], action=action, request_id=f"reviewed-preflight-{action}",
+        operator_id="operator", previous=prior, reason_codes=["operator_request"],
+        requested_at=NOW + timedelta(seconds=2), effective_at=NOW + timedelta(seconds=2),
+    )
+    stopped = read_worker_authority_snapshot_with_cursor(
+        SnapshotCursor(snapshot_row(current, observed=datetime.fromisoformat(captured["observed_at"]))),
+        worker_id=WORKER_ID,
+    )
+    result = reviewed.build_reviewed_worker_preflight(
+        snapshot=stopped, selected_transition_id=prior["transition_id"],
+        scheduled_for=prior["plan"]["schedule"]["scheduled_for"], **configurations,
+    )
+    assert result["preflight"]["outcome"] == "blocked"
+    assert "authority_superseded" in result["preflight"]["reasons"]
+    assert f"authority_{current['to_state']}" in result["preflight"]["reasons"]
+
+
+def test_slot_and_expiry_boundaries_reuse_existing_preflight(configurations: dict[str, Path]) -> None:
+    captured = reviewed_snapshot(configurations)
+    current = captured["transition"]
+    slot = datetime.fromisoformat(current["plan"]["schedule"]["scheduled_for"])
+    early = reviewed_snapshot(configurations, observed=slot - timedelta(seconds=1))
+    assert bundle(configurations, early)["preflight"]["outcome"] == "wait"
+    expired = reviewed_snapshot(configurations, observed=datetime.fromisoformat(current["expires_at"]))
+    assert "authority_expired" in bundle(configurations, expired)["preflight"]["reasons"]
+    wrong = reviewed.build_reviewed_worker_preflight(
+        snapshot=captured, selected_transition_id=current["transition_id"],
+        scheduled_for=(slot + timedelta(seconds=1)).isoformat(), **configurations,
+    )
+    assert "schedule_slot_mismatch" in wrong["preflight"]["reasons"]
+
+
+@pytest.mark.parametrize("mutation", ["permission", "outcome", "expiry", "time", "scope", "extra"])
+def test_rehashed_bundle_tampering_is_rejected(configurations: dict[str, Path], mutation: str) -> None:
+    result = bundle(configurations)
+    if mutation == "permission":
+        result["runtime_permission_granted"] = True
+    elif mutation == "outcome":
+        result["preflight"]["outcome"] = "may_run"
+    elif mutation == "expiry":
+        result["evidence"]["destination_review_expires_at"] = "2099-01-01T00:00:00+00:00"
+    elif mutation == "time":
+        result["evidence"]["evaluated_at"] = NOW.isoformat()
+    elif mutation == "scope":
+        result["evaluation_scope"] = "current_runtime_permission"
+    else:
+        result["evidence"]["extra"] = True
+    identity = {key: value for key, value in result.items() if key != "bundle_id"}
+    result["bundle_id"] = f"{reviewed.MODEL_VERSION}-{hashlib.sha256(canonical_bytes(identity)).hexdigest()}"
+    with pytest.raises(ValidationError):
+        reviewed.validate_reviewed_worker_preflight(result, **configurations)
+
+
+def test_config_symlink_and_missing_config_fail_closed(configurations: dict[str, Path], tmp_path: Path) -> None:
+    captured = reviewed_snapshot(configurations)
+    path = configurations["worker_config_path"]
+    link = tmp_path / "linked-workers.yaml"
+    link.symlink_to(path)
+    with pytest.raises(ValidationError):
+        bundle({**configurations, "worker_config_path": link}, captured)
+    path.unlink()
+    with pytest.raises(ValidationError):
+        bundle(configurations, captured)


### PR DESCRIPTION
## Goal

Closes #165. Second of three read-only preflight increments under #76; stacked on #167 and followed by #169. Primary arc42 block: orchestration.

## Changes

- Revalidate the complete clocked authority snapshot.
- Reconstruct its retained plan through the existing reviewed-configuration binder and obtain review expiry from that same destination object, not an independent caller value.
- Reuse accepted authority/exact-slot preflight at the captured database instant, without duplicating health or suspension logic.
- Reject changed/disabled/missing reviewed files; block superseded selected IDs, newer stops, wrong slots and exclusive expiry.
- Return and revalidate a bounded detached envelope of the exact snapshot, derived preflight input and result.
- Skip configuration I/O for missing authority and retain an explicit blocked outcome.

## Exact scope and stack

Three new files, **330 additions, zero deletions**, one commit relative to #167.

Base: `e875e3583904b8072a04d2fcb95424e04d45d69f`.
Head: `6a72673e678dc5780c8924b62fee898c9523aeea`.
Tree: `f3af393c8236734a3925ef32d5ddfd6f98216fa8`.
Tested merge: `1e88b4501761963b2842254af9f1ae5c450ef3f2`, combining that exact head with the final #167 head.

## Validation evidence

[GitHub Actions run 447](https://github.com/alexmarinos87/financial-risk-data-platform/actions/runs/33999994060) passed all four jobs: Python readiness, Security guardrails, PostgreSQL contract and Infrastructure validation.

Python job `101397017967` confirms Ruff, mypy across **161 source files**, **1,200 tests passed twice**, dependency integrity, pipeline replay and warehouse dry-run. The PostgreSQL job also passed with the inherited real snapshot-query fixture from #167.

Regression tests use actual existing plan/authority builders and temporary reviewed configuration copies plus injected database rows. Coverage includes changed sources, disabled switches, missing authority/files, symlinks, newer stops, wrong slots, early/due/expired times, detached replay and rehashed evidence/result tampering.

Local syntax compilation and whitespace checks passed. Complete tests and typing were run in GitHub CI, not a local complete checkout. Scope review confirms the isolated three-file delta. No submitted reviews, conversation comments or unresolved review threads were present when checked; these checks are not independent human approval.

## Trust and side effects

Evaluation scope is explicitly `captured_database_instant`, not current runtime permission. Revalidating a retained file does not refresh its database snapshot. Reviewed files must be immutable snapshots in trusted directories; contents are checked, not provenance or authenticated approval. Filesystem and PostgreSQL observations are not atomic across stores. Runtime permission and readiness_evaluated remain false.

No schema, workflow, dependency, committed default or infrastructure change. No application database access, authority write, health evaluation, runtime advisory lock, notification, scheduler mutation, deployment or Terraform apply. Separate suspension drafts remain untouched.

## Acceptance and handoff

**Draft, CI-validated, unmerged. Explicit engineer acceptance remains pending.** Accept and squash #167 first, reconstruct this isolated delta on accepted current main and rerun exact-head checks before acceptance. Apply the same sequence to #169. Do not merge this PR into the unaccepted predecessor branch.