### PR TITLE
Expose validation-first read-only worker preflight diagnostics

### DIFF
--- a/docs/check-notification-worker-preflight.md
+++ b/docs/check-notification-worker-preflight.md
@@ -1,0 +1,99 @@
+# Read-only worker preflight operator command
+
+Primary arc42 block: `orchestration`. Goal #166 follows #164/#165 under #76.
+
+## What this demonstrates
+
+```text
+explicit worker / transition / schedule slot
+  + retained snapshot OR explicitly requested current database read
+  + reviewed immutable configuration files
+  -> configuration-bound authority preflight at the captured database instant
+  -> bounded JSON diagnostics; never execution permission
+```
+
+The module is `src.orchestration.check_notification_worker_preflight`.
+There is no execute, record, schedule, deployment or output-file flag. Output is
+stdout only, so the command introduces no file-overwrite surface. Database reads
+require `--read-current`; an environment DSN cannot turn offline mode into a read.
+Argument abbreviation is disabled.
+
+## Offline validation
+
+Provide a retained snapshot produced by the first layer, the intended worker,
+selected transition and exact slot, plus the reviewed configuration paths:
+
+```bash
+.venv/bin/python -m src.orchestration.check_notification_worker_preflight \
+  --snapshot path/to/authority-snapshot.json \
+  --worker-id risk-operations-managed \
+  --selected-transition-id "$REVIEWED_TRANSITION_ID" \
+  --scheduled-for "$REVIEWED_SCHEDULE_SLOT" \
+  --worker-config path/to/reviewed/workers.yaml \
+  --delivery-config path/to/reviewed/delivery.yaml \
+  --destination-config path/to/reviewed/destinations.yaml
+```
+
+The input must be bounded regular-file JSON with no duplicate object fields or
+symbolic-link final component. Trusted parent directories and immutable files
+remain prerequisites. The descriptor is checked before reading, including FIFO
+rejection on platforms with nonblocking file opens. The whole stdout report is
+bounded to 1 MB including its newline.
+
+Offline output explicitly says `source_mode = retained_file` and
+`database_read_performed = false`. It revalidates captured evidence only. It
+cannot prove the snapshot is still current, even when the captured result passes.
+
+## Explicit current read
+
+Use the same identity and reviewed-file arguments, replacing `--snapshot ...`
+with `--read-current`. The adapter obtains its DSN only from the operator's
+`WAREHOUSE_POSTGRES_DSN` environment variable. Do not put credentials into command
+arguments or retained evidence. A DSN argument is not supported.
+
+This invokes the first layer's new read-only transaction; it does not select an
+old grant supplied by a caller. Wrong-worker snapshots are rejected. Unknown
+workers return blocked evidence rather than an invented grant. Output identifies
+`live_database_read`, but is still evaluated at its captured database instant:
+a later stop or configuration change requires another observation.
+
+The command does not acquire the shared delivery lock, evaluate health, claim a
+slot, mutate authority or activate any delivery path. Source identifiers and
+hashes do not authenticate operators or configuration approval.
+
+## Exit status
+
+| Code | Meaning |
+| --- | --- |
+| 0 | Captured authority/slot is eligible for separate health review, not execution. |
+| 1 | Validation or I/O failed; no successful report is emitted. |
+| 2 | Invalid command usage. |
+| 3 | Captured valid authority is waiting for its slot. |
+| 4 | Captured preflight is blocked. |
+
+Validation and provider failures emit one fixed diagnostic without DSNs,
+filenames, configuration values or raw provider exceptions. This trades verbose
+operator debugging for a stable secret-free boundary. Argparse usage errors are
+not a channel for credentials: never pass secrets as unsupported arguments.
+
+## Validation and acceptance
+
+```bash
+.venv/bin/python -m pytest -q tests/unit/test_check_notification_worker_preflight.py
+make quality-check
+make security-check
+make readiness-check
+make postgres-contract-check
+```
+
+Tests inject readers and use actual source contracts with temporary enabled
+configuration copies. They cover offline/no-database behavior despite a DSN,
+explicit delegation, exit codes, missing/wrong workers, malformed/oversized/
+duplicate JSON, symlinks/FIFOs, rejected flags and redacted failures. The
+predecessor's disposable PostgreSQL fixture covers the real snapshot SELECT.
+
+No committed configuration switches, schemas, workflows, dependencies or
+infrastructure change. No application database was contacted during development.
+No external notification, scheduler activation, deployment or Terraform apply.
+The candidate remains pending explicit engineer acceptance. Accept predecessors
+in order, reconstruct each delta on accepted main and rerun exact-head CI.

--- a/src/orchestration/check_notification_worker_preflight.py
+++ b/src/orchestration/check_notification_worker_preflight.py
@@ -1,0 +1,93 @@
+"""Validation-first, read-only diagnostics for a captured worker authority slot."""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import stat
+import sys
+from collections.abc import Sequence
+from pathlib import Path
+from typing import Any
+
+from src.common.exceptions import ValidationError
+from src.orchestration.notification_worker_authority_contract import canonical_bytes, identifier, utc
+from src.orchestration.reviewed_notification_worker_preflight import (
+    MAX_BUNDLE_BYTES, build_reviewed_worker_preflight,
+)
+from src.warehouse.notification_worker_authority_history import _unique_object
+from src.warehouse.notification_worker_authority_snapshot import (
+    MAX_SNAPSHOT_BYTES, read_worker_authority_snapshot, validate_worker_authority_snapshot,
+)
+
+EXIT_CODES = {"eligible_for_health_review": 0, "wait": 3, "blocked": 4}
+
+
+def load_authority_snapshot(path: Path) -> dict[str, Any]:
+    """Read bounded regular-file JSON; parent directories must be trusted."""
+    try:
+        if path.is_symlink():
+            raise ValidationError("snapshot input must not be a symbolic link")
+        flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_NONBLOCK", 0)
+        with os.fdopen(os.open(path, flags), "rb") as handle:
+            if not stat.S_ISREG(os.fstat(handle.fileno()).st_mode):
+                raise ValidationError("snapshot input must be a regular file")
+            raw = handle.read(MAX_SNAPSHOT_BYTES + 1)
+        if len(raw) > MAX_SNAPSHOT_BYTES:
+            raise ValidationError("snapshot input exceeds 1 MB")
+        value = json.loads(raw.decode("utf-8"), object_pairs_hook=_unique_object)
+        return validate_worker_authority_snapshot(value)
+    except (OSError, TypeError, ValueError, UnicodeError, RecursionError, OverflowError):
+        raise ValidationError("unable to read a valid authority snapshot") from None
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__, allow_abbrev=False)
+    source = parser.add_mutually_exclusive_group(required=True)
+    source.add_argument("--snapshot", type=Path, help="Validate a retained snapshot without database access")
+    source.add_argument("--read-current", action="store_true", help="Explicitly read current PostgreSQL authority")
+    parser.add_argument("--worker-id", required=True)
+    parser.add_argument("--selected-transition-id", required=True)
+    parser.add_argument("--scheduled-for", required=True)
+    parser.add_argument("--worker-config", type=Path, default=Path("config/notification_workers.yaml"))
+    parser.add_argument("--delivery-config", type=Path, default=Path("config/notification_delivery.yaml"))
+    parser.add_argument("--destination-config", type=Path, default=Path("config/notification_destinations.yaml"))
+    args = parser.parse_args(argv)
+    try:
+        worker_id = identifier(args.worker_id, "worker_id")
+        selected = identifier(args.selected_transition_id, "selected_transition_id")
+        slot = utc(args.scheduled_for, "scheduled_for").isoformat()
+        if args.read_current:
+            dsn = os.environ.get("WAREHOUSE_POSTGRES_DSN", "")
+            if not dsn.strip():
+                raise ValidationError("WAREHOUSE_POSTGRES_DSN is required for explicit reading")
+            captured = read_worker_authority_snapshot(dsn=dsn, worker_id=worker_id)
+        else:
+            captured = load_authority_snapshot(args.snapshot)
+        captured = validate_worker_authority_snapshot(captured)
+        if captured["worker_id"] != worker_id:
+            raise ValidationError("snapshot does not match the selected worker")
+        result = build_reviewed_worker_preflight(
+            snapshot=captured, selected_transition_id=selected, scheduled_for=slot,
+            worker_config_path=args.worker_config, delivery_config_path=args.delivery_config,
+            destination_config_path=args.destination_config,
+        )
+        report = {
+            "source_mode": "live_database_read" if args.read_current else "retained_file",
+            "database_read_performed": args.read_current,
+            "runtime_permission_granted": False, "result": result,
+        }
+        encoded = canonical_bytes(report)
+        if len(encoded) + 1 > MAX_BUNDLE_BYTES:
+            raise ValidationError("worker preflight output exceeds 1 MB")
+        exit_code = EXIT_CODES[result["preflight"]["outcome"]]
+    except Exception:
+        # Never echo filenames, DSNs, configuration values or provider errors.
+        print("Worker preflight failed; no execution permission granted", file=sys.stderr)
+        return 1
+    print(encoded.decode("utf-8"))
+    return exit_code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/test_check_notification_worker_preflight.py
+++ b/tests/unit/test_check_notification_worker_preflight.py
@@ -1,0 +1,194 @@
+from __future__ import annotations
+
+import json
+import os
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from src.common.exceptions import ValidationError
+from src.orchestration import check_notification_worker_preflight as command
+from src.warehouse.notification_worker_authority_snapshot import read_worker_authority_snapshot_with_cursor
+from test_notification_worker_authority_snapshot import SnapshotCursor, snapshot_row
+from test_reviewed_notification_worker_authority import WORKER_ID, configurations as configurations
+from test_reviewed_notification_worker_preflight import reviewed_snapshot
+
+
+def arguments(paths: dict[str, Path], captured: dict[str, Any], source: list[str]) -> list[str]:
+    current = captured["transition"]
+    return [*source, "--worker-id", WORKER_ID,
+            "--selected-transition-id", current["transition_id"],
+            "--scheduled-for", current["plan"]["schedule"]["scheduled_for"],
+            "--worker-config", str(paths["worker_config_path"]),
+            "--delivery-config", str(paths["delivery_config_path"]),
+            "--destination-config", str(paths["destination_config_path"])]
+
+
+def write_snapshot(tmp_path: Path, captured: dict[str, Any]) -> Path:
+    path = tmp_path / "snapshot.json"
+    path.write_text(json.dumps(captured), encoding="utf-8")
+    return path
+
+
+def forbidden_reader(**kwargs: Any) -> dict[str, Any]:
+    raise AssertionError("database reader must not be called")
+
+
+def test_offline_default_never_reads_database_even_with_dsn(
+    configurations: dict[str, Path], tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: Any,
+) -> None:
+    captured = reviewed_snapshot(configurations)
+    path = write_snapshot(tmp_path, captured)
+    monkeypatch.setenv("WAREHOUSE_POSTGRES_DSN", "do-not-use")
+    monkeypatch.setattr(command, "read_worker_authority_snapshot", forbidden_reader)
+    before = {p: p.read_bytes() for p in configurations.values()}
+    assert command.main(arguments(configurations, captured, ["--snapshot", str(path)])) == 0
+    output = capsys.readouterr()
+    report = json.loads(output.out)
+    assert output.err == ""
+    assert report["source_mode"] == "retained_file"
+    assert report["database_read_performed"] is False
+    assert report["runtime_permission_granted"] is False
+    assert report["result"]["evaluation_scope"] == "captured_database_instant"
+    assert before == {p: p.read_bytes() for p in configurations.values()}
+    assert "do-not-use" not in output.out
+
+
+def test_explicit_read_delegates_only_dsn_and_worker(
+    configurations: dict[str, Path], monkeypatch: pytest.MonkeyPatch, capsys: Any,
+) -> None:
+    captured = reviewed_snapshot(configurations)
+    calls: list[dict[str, Any]] = []
+
+    def reader(**kwargs: Any) -> dict[str, Any]:
+        calls.append(kwargs)
+        return captured
+
+    monkeypatch.setenv("WAREHOUSE_POSTGRES_DSN", "injected-dsn")
+    monkeypatch.setattr(command, "read_worker_authority_snapshot", reader)
+    assert command.main(arguments(configurations, captured, ["--read-current"])) == 0
+    output = capsys.readouterr()
+    assert calls == [{"dsn": "injected-dsn", "worker_id": WORKER_ID}]
+    report = json.loads(output.out)
+    assert report["source_mode"] == "live_database_read"
+    assert report["database_read_performed"] is True
+    assert report["runtime_permission_granted"] is False
+    assert "injected-dsn" not in output.out
+
+
+def test_live_mode_requires_dsn_before_reader(
+    configurations: dict[str, Path], monkeypatch: pytest.MonkeyPatch, capsys: Any,
+) -> None:
+    captured = reviewed_snapshot(configurations)
+    monkeypatch.delenv("WAREHOUSE_POSTGRES_DSN", raising=False)
+    monkeypatch.setattr(command, "read_worker_authority_snapshot", forbidden_reader)
+    assert command.main(arguments(configurations, captured, ["--read-current"])) == 1
+    assert capsys.readouterr().out == ""
+
+
+def test_provider_failure_is_sanitized(
+    configurations: dict[str, Path], monkeypatch: pytest.MonkeyPatch, capsys: Any,
+) -> None:
+    captured = reviewed_snapshot(configurations)
+
+    def failed(**kwargs: Any) -> dict[str, Any]:
+        raise RuntimeError("credential-bearing-provider-diagnostic")
+
+    monkeypatch.setenv("WAREHOUSE_POSTGRES_DSN", "private-dsn")
+    monkeypatch.setattr(command, "read_worker_authority_snapshot", failed)
+    assert command.main(arguments(configurations, captured, ["--read-current"])) == 1
+    output = capsys.readouterr()
+    assert output.out == ""
+    assert output.err == "Worker preflight failed; no execution permission granted\n"
+
+
+@pytest.mark.parametrize(("offset", "expected"), [(-1, 3), (0, 0), (60, 4)])
+def test_wait_due_and_expiry_exit_codes(
+    configurations: dict[str, Path], tmp_path: Path, capsys: Any, offset: int, expected: int,
+) -> None:
+    baseline = reviewed_snapshot(configurations)
+    slot = datetime.fromisoformat(baseline["transition"]["plan"]["schedule"]["scheduled_for"])
+    captured = reviewed_snapshot(configurations, observed=slot + timedelta(seconds=offset))
+    path = write_snapshot(tmp_path, captured)
+    assert command.main(arguments(configurations, captured, ["--snapshot", str(path)])) == expected
+    assert json.loads(capsys.readouterr().out)["runtime_permission_granted"] is False
+
+
+def test_unknown_current_authority_is_blocked(
+    configurations: dict[str, Path], monkeypatch: pytest.MonkeyPatch, capsys: Any,
+) -> None:
+    selected = reviewed_snapshot(configurations)
+    missing = read_worker_authority_snapshot_with_cursor(
+        SnapshotCursor(snapshot_row(None)), worker_id=WORKER_ID,
+    )
+    monkeypatch.setenv("WAREHOUSE_POSTGRES_DSN", "injected")
+    monkeypatch.setattr(command, "read_worker_authority_snapshot", lambda **kwargs: missing)
+    assert command.main(arguments(configurations, selected, ["--read-current"])) == 4
+    result = json.loads(capsys.readouterr().out)["result"]
+    assert "authority_missing" in result["preflight"]["reasons"]
+    assert result["configuration_validated"] is False
+
+
+@pytest.mark.parametrize("flag", ["--execute", "--record", "--dsn", "--read"])
+def test_execution_recording_dsn_and_abbreviated_flags_are_rejected(
+    configurations: dict[str, Path], flag: str,
+) -> None:
+    captured = reviewed_snapshot(configurations)
+    with pytest.raises(SystemExit) as caught:
+        command.main(arguments(configurations, captured, ["--read-current"]) + [flag])
+    assert caught.value.code == 2
+
+
+def test_invalid_request_is_rejected_before_database(
+    configurations: dict[str, Path], monkeypatch: pytest.MonkeyPatch, capsys: Any,
+) -> None:
+    captured = reviewed_snapshot(configurations)
+    args = arguments(configurations, captured, ["--read-current"])
+    args[args.index("--worker-id") + 1] = "invalid worker"
+    monkeypatch.setenv("WAREHOUSE_POSTGRES_DSN", "injected")
+    monkeypatch.setattr(command, "read_worker_authority_snapshot", forbidden_reader)
+    assert command.main(args) == 1
+    assert capsys.readouterr().out == ""
+
+
+def test_snapshot_worker_must_match_explicit_selection(
+    configurations: dict[str, Path], tmp_path: Path, capsys: Any,
+) -> None:
+    captured = reviewed_snapshot(configurations)
+    path = write_snapshot(tmp_path, captured)
+    args = arguments(configurations, captured, ["--snapshot", str(path)])
+    args[args.index("--worker-id") + 1] = "another-worker"
+    assert command.main(args) == 1
+    assert capsys.readouterr().out == ""
+
+
+@pytest.mark.parametrize("raw", [b"{}", b"[]", b"null", b"\xff", b'{"worker_id":"a","worker_id":"b"}', b"[NaN]", b"[" * 1500])
+def test_invalid_or_duplicate_json_is_rejected(tmp_path: Path, raw: bytes) -> None:
+    path = tmp_path / "invalid.json"
+    path.write_bytes(raw)
+    with pytest.raises(ValidationError):
+        command.load_authority_snapshot(path)
+
+
+def test_oversize_input_symlink_directory_and_fifo_are_rejected(tmp_path: Path) -> None:
+    oversized = tmp_path / "oversized.json"
+    oversized.write_bytes(b" " * (command.MAX_SNAPSHOT_BYTES + 1))
+    link = tmp_path / "link.json"
+    link.symlink_to(oversized)
+    paths = [oversized, link, tmp_path]
+    if hasattr(os, "mkfifo"):
+        fifo = tmp_path / "fifo"
+        os.mkfifo(fifo)
+        paths.append(fifo)
+    for path in paths:
+        with pytest.raises(ValidationError):
+            command.load_authority_snapshot(path)
+
+
+def test_read_modes_are_mutually_exclusive_and_required() -> None:
+    for args in ([], ["--read-current", "--snapshot", "unused"]):
+        with pytest.raises(SystemExit) as caught:
+            command.main(args)
+        assert caught.value.code == 2


### PR DESCRIPTION
## Goal

Closes #166. Third of three read-only preflight increments under #76, stacked on #168 after #167. Primary arc42 block: orchestration.

## Changes

- Add mutually exclusive retained-file validation and explicit --read-current modes. An environment DSN cannot implicitly select a database read.
- Require explicit worker, selected transition and schedule slot, validating identities before database access.
- Obtain DSN only from WAREHOUSE_POSTGRES_DSN. No --dsn, --execute, --record or output-file flag; argument abbreviation is disabled.
- Load bounded regular-file JSON, rejecting duplicate fields, symlinks, FIFOs, malformed and oversized inputs.
- Reuse reviewed-configuration preflight; emit bounded stdout JSON distinguishing retained_file from live_database_read.
- Return exit 0 for eligible_for_health_review, 3 for wait, 4 for blocked, 1 for validation/I/O failure and 2 for usage errors. No outcome grants runtime permission.
- Sanitize validation and provider errors; do not retain DSNs, configuration paths or endpoint values.

## Exact scope and stack

Three new source/test/documentation files, one commit relative to #168.

Base: `6a72673e678dc5780c8924b62fee898c9523aeea`.
Head: `96300508770b28053a88344854167670a7f73a3f`.
Tree: `5c64c9079cbc4f454e75af34d7500197f6be1bac`.
Tested merge: `b24b1a5bf8743ec3ed81b34c359764d2275b4f0f`, combining this exact head with #168.

## Validation evidence

[GitHub Actions run 448](https://github.com/alexmarinos87/financial-risk-data-platform/actions/runs/34000151635) completed successfully. Python readiness, Security guardrails and Infrastructure validation passed; the run also completed its PostgreSQL contract successfully.

Python job `101397435849` confirms Ruff, mypy across **162 source files**, **1,223 tests passed twice**, dependency integrity, pipeline replay and warehouse dry-run. The inherited PostgreSQL fixture exercises the actual snapshot SELECT; the command's database delegation is tested with injected readers rather than an application database.

Tests cover offline/no-database behavior despite an available DSN, explicit read delegation, required DSN, exact selected worker, missing authority, early/due/expired exit codes, fixed redacted failures, duplicate/malformed/deep/oversized JSON, symlinks/directories/FIFOs and rejection of execution/recording/DSN/abbreviated flags. Reviewed fixture files remain unchanged.

Local syntax compilation and whitespace checks passed. Full tests and typing ran in GitHub CI, not a local complete checkout. Scope review confirms the isolated three-file delta. No submitted reviews, conversation comments or unresolved review threads were present when checked; this is not independent human approval.

## Trust and safety

Passing means eligible for separate health review at the captured database instant, not execution permission or proof retained evidence remains current. Reviewed files must be immutable snapshots in trusted directories. Filesystem and database observations are not atomic across stores. Hashes and identifiers do not authenticate operators.

No committed configuration switch, schema, workflow, dependency or infrastructure change. No application database connection during development, health evaluation, authority write, runtime advisory lock, external notification, scheduler activation, deployment or Terraform apply. Separate suspension drafts remain untouched.

## Acceptance and handoff

**Draft, CI-validated, unmerged. Explicit engineer acceptance remains pending.** Accept #167 first, then reconstruct #168's isolated delta on accepted main and rerun validation before acceptance; do the same for this candidate. Do not merge into unaccepted predecessor branches. The next runtime integration must separately refresh current authority and health under the shared delivery lock; this diagnostic is not that runtime gate.