### PR TITLE
Redact worker preflight command usage errors

### DIFF
--- a/docs/worker-preflight-usage-redaction.md
+++ b/docs/worker-preflight-usage-redaction.md
@@ -1,0 +1,42 @@
+# Worker preflight usage-error redaction
+
+Primary arc42 block: `orchestration`. Goal #170, after the #169 diagnostic.
+
+## Decision and regression
+
+`notification_worker_cli_parser.py` owns the existing argument definitions and
+uses a fixed program name and value-independent usage error. The command delegates
+argument parsing without changing its database, evidence or exit-status logic.
+Unknown options and values assigned to boolean flags previously reached normal
+argparse error rendering before the runtime redaction handler. Those messages
+can contain a mistakenly supplied credential. The focused tests demonstrate the
+original behavior with an explicitly synthetic sentinel, then reject the same
+inputs without echoing that sentinel.
+
+Invalid usage still exits 2. Help still exits 0, but does not include an invocation
+path taken from `sys.argv[0]`. Source-mode exclusivity, required identities and
+slot, configuration defaults and disabled abbreviation are preserved. No DSN
+argument is added. The runtime redaction handler remains unchanged.
+
+## Limits and verification
+
+This is output redaction, not protection against shell history, process argument
+inspection or an operator deliberately printing credentials. Credentials still
+belong only in the configured environment variable. Fixed errors trade detailed
+invalid-value diagnostics for a bounded predictable surface; `--help` retains
+ordinary option guidance.
+
+```bash
+python -m pytest -q tests/unit/test_notification_worker_cli_parser.py
+make quality-check
+make security-check
+```
+
+The parser module and its focused tests use only the standard library plus pytest;
+the existing command regression suite verifies integration in full repository CI.
+Reference: Python's documented `ArgumentParser.error` customization point,
+<https://docs.python.org/3.11/library/argparse.html#argparse.ArgumentParser.error>.
+
+No database read/write, configuration switch, schema, workflow, dependency,
+notification, scheduler activation, deployment or Terraform apply. This candidate
+remains pending explicit engineer acceptance, together with its predecessors.

--- a/src/orchestration/check_notification_worker_preflight.py
+++ b/src/orchestration/check_notification_worker_preflight.py
@@ -1,7 +1,6 @@
 """Validation-first, read-only diagnostics for a captured worker authority slot."""
 from __future__ import annotations
 
-import argparse
 import json
 import os
 import stat
@@ -11,6 +10,7 @@ from pathlib import Path
 from typing import Any
 
 from src.common.exceptions import ValidationError
+from src.orchestration.notification_worker_cli_parser import build_preflight_parser
 from src.orchestration.notification_worker_authority_contract import canonical_bytes, identifier, utc
 from src.orchestration.reviewed_notification_worker_preflight import (
     MAX_BUNDLE_BYTES, build_reviewed_worker_preflight,
@@ -42,17 +42,7 @@ def load_authority_snapshot(path: Path) -> dict[str, Any]:
 
 
 def main(argv: Sequence[str] | None = None) -> int:
-    parser = argparse.ArgumentParser(description=__doc__, allow_abbrev=False)
-    source = parser.add_mutually_exclusive_group(required=True)
-    source.add_argument("--snapshot", type=Path, help="Validate a retained snapshot without database access")
-    source.add_argument("--read-current", action="store_true", help="Explicitly read current PostgreSQL authority")
-    parser.add_argument("--worker-id", required=True)
-    parser.add_argument("--selected-transition-id", required=True)
-    parser.add_argument("--scheduled-for", required=True)
-    parser.add_argument("--worker-config", type=Path, default=Path("config/notification_workers.yaml"))
-    parser.add_argument("--delivery-config", type=Path, default=Path("config/notification_delivery.yaml"))
-    parser.add_argument("--destination-config", type=Path, default=Path("config/notification_destinations.yaml"))
-    args = parser.parse_args(argv)
+    args = build_preflight_parser().parse_args(argv)
     try:
         worker_id = identifier(args.worker_id, "worker_id")
         selected = identifier(args.selected_transition_id, "selected_transition_id")

--- a/src/orchestration/notification_worker_cli_parser.py
+++ b/src/orchestration/notification_worker_cli_parser.py
@@ -1,0 +1,32 @@
+"""Value-redacting argument parser for diagnostic worker preflight commands."""
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import NoReturn
+
+PROGRAM = "check-notification-worker-preflight"
+USAGE_ERROR = "Worker preflight usage is invalid; use --help. No execution permission granted.\n"
+
+
+class WorkerPreflightParser(argparse.ArgumentParser):
+    def error(self, message: str) -> NoReturn:
+        # The supplied argparse message may contain rejected credential values.
+        self.exit(2, USAGE_ERROR)
+
+
+def build_preflight_parser() -> argparse.ArgumentParser:
+    parser = WorkerPreflightParser(
+        prog=PROGRAM, allow_abbrev=False,
+        description="Validate captured worker authority or explicitly read current authority; never execute.",
+    )
+    source = parser.add_mutually_exclusive_group(required=True)
+    source.add_argument("--snapshot", type=Path, help="Validate retained evidence without database access")
+    source.add_argument("--read-current", action="store_true", help="Explicitly read current PostgreSQL authority")
+    parser.add_argument("--worker-id", required=True)
+    parser.add_argument("--selected-transition-id", required=True)
+    parser.add_argument("--scheduled-for", required=True)
+    parser.add_argument("--worker-config", type=Path, default=Path("config/notification_workers.yaml"))
+    parser.add_argument("--delivery-config", type=Path, default=Path("config/notification_delivery.yaml"))
+    parser.add_argument("--destination-config", type=Path, default=Path("config/notification_destinations.yaml"))
+    return parser

--- a/tests/unit/test_notification_worker_cli_parser.py
+++ b/tests/unit/test_notification_worker_cli_parser.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import argparse
+import contextlib
+import io
+import sys
+from pathlib import Path
+
+import pytest
+
+from src.orchestration.notification_worker_cli_parser import (
+    PROGRAM, USAGE_ERROR, build_preflight_parser,
+)
+
+SELECTION = ["--worker-id", "worker", "--selected-transition-id", "transition",
+             "--scheduled-for", "2026-09-06T12:00:00+00:00"]
+SENTINEL = "synthetic-sensitive-value-NOT-A-REAL-CREDENTIAL"
+
+
+@pytest.mark.parametrize("arguments", [
+    ["--read-current", *SELECTION, "--dsn", SENTINEL],
+    ["--read-current", *SELECTION, f"--dsn={SENTINEL}"],
+    ["--read-current", *SELECTION, SENTINEL],
+    [f"--read-current={SENTINEL}", *SELECTION],
+    ["--read-current", "--snapshot", SENTINEL, *SELECTION],
+    ["--read-current", *SELECTION, "--worker-config"],
+    ["--read", *SELECTION], [],
+])
+def test_usage_errors_never_echo_values(arguments: list[str]) -> None:
+    stdout, stderr = io.StringIO(), io.StringIO()
+    with contextlib.redirect_stdout(stdout), contextlib.redirect_stderr(stderr):
+        with pytest.raises(SystemExit) as caught:
+            build_preflight_parser().parse_args(arguments)
+    assert caught.value.code == 2
+    assert stdout.getvalue() == ""
+    assert stderr.getvalue() == USAGE_ERROR
+    assert SENTINEL not in stderr.getvalue()
+
+
+def test_standard_argparse_reproduces_the_original_echo() -> None:
+    parser = argparse.ArgumentParser(prog=PROGRAM)
+    parser.add_argument("--read-current", action="store_true")
+    stderr = io.StringIO()
+    with contextlib.redirect_stderr(stderr), pytest.raises(SystemExit):
+        parser.parse_args(["--read-current", "--dsn", SENTINEL])
+    assert SENTINEL in stderr.getvalue()
+
+
+@pytest.mark.parametrize("source", [["--read-current"], ["--snapshot", "captured.json"]])
+def test_valid_selection_preserves_existing_defaults(source: list[str]) -> None:
+    parsed = build_preflight_parser().parse_args([*source, *SELECTION])
+    assert parsed.worker_id == "worker"
+    assert parsed.selected_transition_id == "transition"
+    assert parsed.worker_config == Path("config/notification_workers.yaml")
+    assert parsed.delivery_config == Path("config/notification_delivery.yaml")
+    assert parsed.destination_config == Path("config/notification_destinations.yaml")
+    assert parsed.read_current is (source[0] == "--read-current")
+
+
+def test_help_is_available_and_uses_a_fixed_program_name(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(sys, "argv", [f"/private/{SENTINEL}/worker.py"])
+    stdout, stderr = io.StringIO(), io.StringIO()
+    with contextlib.redirect_stdout(stdout), contextlib.redirect_stderr(stderr):
+        with pytest.raises(SystemExit) as caught:
+            build_preflight_parser().parse_args(["--help"])
+    assert caught.value.code == 0
+    assert PROGRAM in stdout.getvalue()
+    assert "--snapshot" in stdout.getvalue() and "--read-current" in stdout.getvalue()
+    assert SENTINEL not in stdout.getvalue()
+    assert stderr.getvalue() == ""
+
+
+def test_usage_errors_ignore_dynamic_program_name(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(sys, "argv", [SENTINEL])
+    stderr = io.StringIO()
+    with contextlib.redirect_stderr(stderr), pytest.raises(SystemExit):
+        build_preflight_parser().parse_args([])
+    assert stderr.getvalue() == USAGE_ERROR

--- a/tests/unit/test_worker_preflight_usage_integration.py
+++ b/tests/unit/test_worker_preflight_usage_integration.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from src.orchestration import check_notification_worker_preflight as command
+from src.orchestration.notification_worker_cli_parser import USAGE_ERROR
+
+
+@pytest.mark.parametrize("source", [
+    ["--read-current", "--dsn", "synthetic-secret-never-real"],
+    ["--read-current=synthetic-secret-never-real"],
+    ["--read-current", "synthetic-secret-never-real"],
+    ["--read-current", "--snapshot", "synthetic-secret-never-real"],
+])
+def test_real_entrypoint_redacts_usage_before_any_io(
+    source: list[str], monkeypatch: pytest.MonkeyPatch, capsys: Any,
+) -> None:
+    calls: list[str] = []
+
+    def forbidden(*args: Any, **kwargs: Any) -> Any:
+        calls.append("unexpected I/O")
+        raise AssertionError("invalid usage must not read configuration or PostgreSQL")
+
+    for name in ("read_worker_authority_snapshot", "load_authority_snapshot", "build_reviewed_worker_preflight"):
+        monkeypatch.setattr(command, name, forbidden)
+    with pytest.raises(SystemExit) as caught:
+        command.main([*source, "--worker-id", "worker", "--selected-transition-id", "transition",
+                      "--scheduled-for", "2026-09-06T12:00:00+00:00"])
+    assert caught.value.code == 2
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert captured.err == USAGE_ERROR
+    assert calls == []


### PR DESCRIPTION
## Goal

Closes #170. First of three operator-readiness increments under #76, stacked on #169 after #167/#168. Followed by #177 and #181. Primary arc42 block: orchestration.

## Delivered repair

Normal argparse usage errors occurred before the runtime redaction handler and could echo mistakenly supplied credentials. A synthetic sentinel reproduces the original behavior. The command now delegates to one standard-library parser preserving the existing arguments, required selection, configuration defaults, source exclusivity and disabled abbreviation. Errors emit one fixed bounded diagnostic and exit 2. Help retains exit 0 and uses a fixed program label rather than invocation-path metadata.

Thirteen standalone parser tests and four actual-entrypoint tests cover rejected values, unknown options, inline values on boolean flags, mode conflicts, missing arguments, help and defaults. The entrypoint tests additionally prove no database/configuration I/O is reached by invalid usage.

## Exact scope

Five changed paths, **189 additions and 12 deletions**, two commits: new parser, two regression modules and documentation; the existing diagnostic changes only parser delegation. No execution or database logic changes.

- Base: `96300508770b28053a88344854167670a7f73a3f` (#169).
- Final head: `be7ff19b8ee6120ac8a797558278c0d78e02ae16`.
- Tree: `3d6b1bcfe239b3a4e7e38590983ff0ce20834036`.
- Tested merge: `787c09da6a43ba0a5321917de78d9bf32e6e33f7`, combining that exact head and base.
- Comparison: two commits ahead, zero behind the predecessor.

## Final-head validation

[Actions run 456](https://github.com/alexmarinos87/financial-risk-data-platform/actions/runs/34050599837) completed successfully: Python readiness, Security guardrails, PostgreSQL contract and Infrastructure validation.

Python job `101534107080` confirms Ruff, mypy across **163 source files**, **1,240 tests passed twice**, dependency integrity, pipeline replay and warehouse dry-run. The superseded initial run 449 was not used as final-head evidence. The added actual-entrypoint regressions are included in run 456 and integrated into both following candidates without force updates.

Local validation: 13 standalone parser tests, Python compilation and trailing-whitespace checks passed. The original command source was fetched and verified against Git blob `c2b96e5e1c29ab551fb091d328197f199b6d7bc8`. Full command tests, typing, infrastructure and PostgreSQL checks ran in GitHub CI, not a local complete checkout. Local GitHub DNS resolution prevented cloning and the complete tool/dependency environment was unavailable.

Scope comparison and self-review completed. No comments or unresolved review threads were present when checked. These checks are not independent engineer approval.

## Boundary and acceptance

This prevents diagnostic echo, not shell-history or process-list disclosure. Only synthetic values are used in regression tests. No schema, workflow, dependency, configuration-default or application database change; no notification, scheduler activation, deployment or Terraform apply.

**Draft, final-head CI validated, unmerged. Explicit engineer acceptance remains pending.** Accept predecessors in dependency order and reconstruct each next isolated delta on accepted main after squash merge, then rerun its exact-head checks before accepting that final diff. Do not merge into an unaccepted predecessor branch. Main and the independent health/suspension drafts are unchanged.