### PR TITLE
Replay complete worker preflight reports offline

### DIFF
--- a/docs/worker-preflight-report-replay.md
+++ b/docs/worker-preflight-report-replay.md
@@ -1,0 +1,53 @@
+# Offline replay of complete worker preflight reports
+
+Primary arc42 block: `orchestration`. Goal #171, following usage-error redaction.
+
+The diagnostic can consume its complete captured stdout document with `--report`,
+without extracting a nested snapshot by hand. This third mutually exclusive source
+mode never consults the database, even when the original report came from a live
+read and a database DSN is available in the current environment.
+
+```bash
+python -m src.orchestration.check_notification_worker_preflight \
+  --report path/to/captured-report.json \
+  --worker-id risk-operations-managed \
+  --selected-transition-id "$REVIEWED_TRANSITION_ID" \
+  --scheduled-for "$REVIEWED_SCHEDULE_SLOT" \
+  --worker-config path/to/reviewed/workers.yaml \
+  --delivery-config path/to/reviewed/delivery.yaml \
+  --destination-config path/to/reviewed/destinations.yaml
+```
+
+## Revalidation, not renewed authority
+
+The wrapper must contain exactly source mode, database-read flag, false runtime
+permission and result. Source mode and strict boolean flags must agree. The
+existing reviewed-preflight validator reconstructs the entire inner result,
+including its snapshot and configuration binding. Explicit worker, transition
+and normalized slot must match the captured selection; the command cannot silently
+replace them with values chosen by the report.
+
+Successful replay emits `source_mode = retained_report` and
+`database_read_performed = false`, preserving the original captured result and its
+database observation time. Replaying a replay is deterministic. Exit codes remain
+0/3/4 for eligible/wait/blocked at that captured instant, never permission to run.
+Changed reviewed configuration, tampered evidence and invalid wrapper metadata
+fail closed. Captured source-mode metadata is an unauthenticated claim; consistent
+metadata and hashes cannot prove that a past database read actually occurred.
+
+The existing bounded regular-file reader is shared by snapshot and report modes:
+no symlink final components, duplicate JSON fields or oversized input. Trusted
+parents and immutable reviewed configurations remain caller responsibilities.
+The command still emits only stdout and does not create or overwrite report files.
+
+```bash
+python -m pytest -q tests/unit/test_notification_worker_report_replay.py
+make quality-check
+make security-check
+make readiness-check
+```
+
+No database refresh, health evaluation, ledger write, schedule claim, live request,
+notification, configuration switch, deployment or Terraform apply. Reuse the
+existing contracts; do not interpret captured eligibility as current authority.
+Explicit engineer acceptance of this candidate and its predecessors remains pending.

--- a/src/orchestration/check_notification_worker_preflight.py
+++ b/src/orchestration/check_notification_worker_preflight.py
@@ -5,7 +5,7 @@ import json
 import os
 import stat
 import sys
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from pathlib import Path
 from typing import Any
 
@@ -13,7 +13,7 @@ from src.common.exceptions import ValidationError
 from src.orchestration.notification_worker_cli_parser import build_preflight_parser
 from src.orchestration.notification_worker_authority_contract import canonical_bytes, identifier, utc
 from src.orchestration.reviewed_notification_worker_preflight import (
-    MAX_BUNDLE_BYTES, build_reviewed_worker_preflight,
+    MAX_BUNDLE_BYTES, build_reviewed_worker_preflight, validate_reviewed_worker_preflight,
 )
 from src.warehouse.notification_worker_authority_history import _unique_object
 from src.warehouse.notification_worker_authority_snapshot import (
@@ -23,7 +23,7 @@ from src.warehouse.notification_worker_authority_snapshot import (
 EXIT_CODES = {"eligible_for_health_review": 0, "wait": 3, "blocked": 4}
 
 
-def load_authority_snapshot(path: Path) -> dict[str, Any]:
+def _load_document(path: Path, *, max_bytes: int) -> Any:
     """Read bounded regular-file JSON; parent directories must be trusted."""
     try:
         if path.is_symlink():
@@ -32,13 +32,47 @@ def load_authority_snapshot(path: Path) -> dict[str, Any]:
         with os.fdopen(os.open(path, flags), "rb") as handle:
             if not stat.S_ISREG(os.fstat(handle.fileno()).st_mode):
                 raise ValidationError("snapshot input must be a regular file")
-            raw = handle.read(MAX_SNAPSHOT_BYTES + 1)
-        if len(raw) > MAX_SNAPSHOT_BYTES:
+            raw = handle.read(max_bytes + 1)
+        if len(raw) > max_bytes:
             raise ValidationError("snapshot input exceeds 1 MB")
         value = json.loads(raw.decode("utf-8"), object_pairs_hook=_unique_object)
-        return validate_worker_authority_snapshot(value)
+        return value
     except (OSError, TypeError, ValueError, UnicodeError, RecursionError, OverflowError):
         raise ValidationError("unable to read a valid authority snapshot") from None
+
+
+def load_authority_snapshot(path: Path) -> dict[str, Any]:
+    return validate_worker_authority_snapshot(_load_document(path, max_bytes=MAX_SNAPSHOT_BYTES))
+
+
+def validate_preflight_report(
+    value: Mapping[str, Any], *, worker_id: str, selected_transition_id: str,
+    scheduled_for: str, worker_config_path: Path, delivery_config_path: Path,
+    destination_config_path: Path,
+) -> dict[str, Any]:
+    """Rebuild retained report content, never authenticate or refresh its source."""
+    fields = {"source_mode", "database_read_performed", "runtime_permission_granted", "result"}
+    if not isinstance(value, Mapping) or set(value) != fields:
+        raise ValidationError("worker preflight report fields are invalid")
+    encoded = canonical_bytes(value)
+    if len(encoded) + 1 > MAX_BUNDLE_BYTES:
+        raise ValidationError("worker preflight report exceeds 1 MB")
+    document = json.loads(encoded)
+    mode = document["source_mode"]
+    if not isinstance(mode, str) or mode not in {"live_database_read", "retained_file", "retained_report"}:
+        raise ValidationError("worker preflight report source mode is invalid")
+    if (document["database_read_performed"] is not (mode == "live_database_read")
+            or document["runtime_permission_granted"] is not False):
+        raise ValidationError("worker preflight report side effects are invalid")
+    result = validate_reviewed_worker_preflight(
+        document["result"], worker_config_path=worker_config_path,
+        delivery_config_path=delivery_config_path, destination_config_path=destination_config_path,
+    )
+    if (result["snapshot"]["worker_id"] != identifier(worker_id, "worker_id")
+            or result["evidence"]["selected_transition_id"] != identifier(selected_transition_id, "selected_transition_id")
+            or result["evidence"]["scheduled_for"] != utc(scheduled_for, "scheduled_for").isoformat()):
+        raise ValidationError("worker preflight report differs from explicit selection")
+    return result
 
 
 def main(argv: Sequence[str] | None = None) -> int:
@@ -47,23 +81,33 @@ def main(argv: Sequence[str] | None = None) -> int:
         worker_id = identifier(args.worker_id, "worker_id")
         selected = identifier(args.selected_transition_id, "selected_transition_id")
         slot = utc(args.scheduled_for, "scheduled_for").isoformat()
-        if args.read_current:
-            dsn = os.environ.get("WAREHOUSE_POSTGRES_DSN", "")
-            if not dsn.strip():
-                raise ValidationError("WAREHOUSE_POSTGRES_DSN is required for explicit reading")
-            captured = read_worker_authority_snapshot(dsn=dsn, worker_id=worker_id)
+        paths = {
+            "worker_config_path": args.worker_config, "delivery_config_path": args.delivery_config,
+            "destination_config_path": args.destination_config,
+        }
+        if args.report is not None:
+            result = validate_preflight_report(
+                _load_document(args.report, max_bytes=MAX_BUNDLE_BYTES),
+                worker_id=worker_id, selected_transition_id=selected, scheduled_for=slot, **paths,
+            )
+            source_mode = "retained_report"
         else:
-            captured = load_authority_snapshot(args.snapshot)
-        captured = validate_worker_authority_snapshot(captured)
-        if captured["worker_id"] != worker_id:
-            raise ValidationError("snapshot does not match the selected worker")
-        result = build_reviewed_worker_preflight(
-            snapshot=captured, selected_transition_id=selected, scheduled_for=slot,
-            worker_config_path=args.worker_config, delivery_config_path=args.delivery_config,
-            destination_config_path=args.destination_config,
-        )
+            if args.read_current:
+                dsn = os.environ.get("WAREHOUSE_POSTGRES_DSN", "")
+                if not dsn.strip():
+                    raise ValidationError("WAREHOUSE_POSTGRES_DSN is required for explicit reading")
+                captured = read_worker_authority_snapshot(dsn=dsn, worker_id=worker_id)
+            else:
+                captured = load_authority_snapshot(args.snapshot)
+            captured = validate_worker_authority_snapshot(captured)
+            if captured["worker_id"] != worker_id:
+                raise ValidationError("snapshot does not match the selected worker")
+            result = build_reviewed_worker_preflight(
+                snapshot=captured, selected_transition_id=selected, scheduled_for=slot, **paths,
+            )
+            source_mode = "live_database_read" if args.read_current else "retained_file"
         report = {
-            "source_mode": "live_database_read" if args.read_current else "retained_file",
+            "source_mode": source_mode,
             "database_read_performed": args.read_current,
             "runtime_permission_granted": False, "result": result,
         }

--- a/src/orchestration/notification_worker_cli_parser.py
+++ b/src/orchestration/notification_worker_cli_parser.py
@@ -22,6 +22,7 @@ def build_preflight_parser() -> argparse.ArgumentParser:
     )
     source = parser.add_mutually_exclusive_group(required=True)
     source.add_argument("--snapshot", type=Path, help="Validate retained evidence without database access")
+    source.add_argument("--report", type=Path, help="Revalidate a complete captured report offline")
     source.add_argument("--read-current", action="store_true", help="Explicitly read current PostgreSQL authority")
     parser.add_argument("--worker-id", required=True)
     parser.add_argument("--selected-transition-id", required=True)

--- a/tests/unit/test_notification_worker_report_replay.py
+++ b/tests/unit/test_notification_worker_report_replay.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+import copy
+import json
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+from src.common.exceptions import ValidationError
+from src.orchestration import check_notification_worker_preflight as command
+from test_check_notification_worker_preflight import arguments, forbidden_reader
+from test_reviewed_notification_worker_authority import WORKER_ID, configurations as configurations
+from test_reviewed_notification_worker_preflight import bundle
+
+
+def report(paths: dict[str, Path], mode: str = "live_database_read") -> dict[str, Any]:
+    return {"source_mode": mode, "database_read_performed": mode == "live_database_read",
+            "runtime_permission_granted": False, "result": bundle(paths)}
+
+
+def selection(value: dict[str, Any]) -> dict[str, str]:
+    evidence = value["result"]["evidence"]
+    return {key: evidence[key] for key in ("worker_id", "selected_transition_id", "scheduled_for")}
+
+
+@pytest.mark.parametrize("mode", ["live_database_read", "retained_file", "retained_report"])
+def test_all_capture_modes_round_trip_without_database(
+    configurations: dict[str, Path], tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    capsys: Any, mode: str,
+) -> None:
+    captured = report(configurations, mode)
+    original = copy.deepcopy(captured)
+    path = tmp_path / "report.json"
+    path.write_text(json.dumps(captured), encoding="utf-8")
+    monkeypatch.setenv("WAREHOUSE_POSTGRES_DSN", "never-use-offline")
+    monkeypatch.setattr(command, "read_worker_authority_snapshot", forbidden_reader)
+    args = arguments(configurations, captured["result"]["snapshot"], ["--report", str(path)])
+    assert command.main(args) == 0
+    output = json.loads(capsys.readouterr().out)
+    assert output["source_mode"] == "retained_report"
+    assert output["database_read_performed"] is False
+    assert output["runtime_permission_granted"] is False
+    assert output["result"] == captured["result"]
+    assert command.validate_preflight_report(output, **selection(captured), **configurations) == captured["result"]
+    assert captured == original
+
+
+@pytest.mark.parametrize(("field", "value"), [
+    ("source_mode", "unknown"), ("source_mode", []),
+    ("source_mode", "retained_file"), ("database_read_performed", False),
+    ("database_read_performed", 1), ("runtime_permission_granted", True),
+    ("runtime_permission_granted", 0), ("extra", "not permitted"),
+])
+def test_wrapper_tampering_is_rejected(configurations: dict[str, Path], field: str, value: Any) -> None:
+    captured = report(configurations)
+    wanted = selection(captured)
+    captured[field] = value
+    with pytest.raises(ValidationError):
+        command.validate_preflight_report(captured, **wanted, **configurations)
+
+
+@pytest.mark.parametrize("field", ["worker_id", "selected_transition_id", "scheduled_for"])
+def test_report_cannot_change_explicit_selection(configurations: dict[str, Path], field: str) -> None:
+    captured = report(configurations)
+    wanted = selection(captured)
+    wanted[field] = "different" if field != "scheduled_for" else "2026-01-01T00:00:00+00:00"
+    with pytest.raises(ValidationError):
+        command.validate_preflight_report(captured, **wanted, **configurations)
+
+
+def test_equivalent_selected_timezone_normalizes_and_result_is_detached(configurations: dict[str, Path]) -> None:
+    captured = report(configurations)
+    wanted = selection(captured)
+    wanted["scheduled_for"] = datetime.fromisoformat(wanted["scheduled_for"]).astimezone(
+        timezone(timedelta(hours=1))
+    ).isoformat()
+    result = command.validate_preflight_report(captured, **wanted, **configurations)
+    assert result == captured["result"]
+    result["preflight"]["reasons"].append("tampered")
+    assert captured["result"]["preflight"]["reasons"] == []
+
+
+def test_inner_outcome_and_changed_configuration_rebuild(configurations: dict[str, Path]) -> None:
+    captured = report(configurations)
+    wanted = selection(captured)
+    broken = copy.deepcopy(captured)
+    broken["result"]["preflight"]["outcome"] = "may_run"
+    with pytest.raises(ValidationError):
+        command.validate_preflight_report(broken, **wanted, **configurations)
+    path = configurations["worker_config_path"]
+    document = yaml.safe_load(path.read_text())
+    document["workers"][WORKER_ID]["enabled"] = False
+    path.write_text(yaml.safe_dump(document), encoding="utf-8")
+    with pytest.raises(ValidationError):
+        command.validate_preflight_report(captured, **wanted, **configurations)
+
+
+def test_report_input_reuses_bounded_non_symlink_duplicate_rejection(
+    configurations: dict[str, Path], tmp_path: Path, capsys: Any,
+) -> None:
+    captured = report(configurations)
+    path = tmp_path / "report.json"
+    args = arguments(configurations, captured["result"]["snapshot"], ["--report", str(path)])
+    for raw in (b'{"source_mode":"a","source_mode":"b"}', b'null',
+                b' ' * (command.MAX_BUNDLE_BYTES + 1)):
+        path.write_bytes(raw)
+        assert command.main(args) == 1
+        assert capsys.readouterr().out == ""
+    target = tmp_path / "target.json"
+    target.write_text(json.dumps(captured), encoding="utf-8")
+    path.unlink()
+    path.symlink_to(target)
+    assert command.main(args) == 1
+    assert capsys.readouterr().out == ""
+
+
+def test_report_and_live_modes_are_exclusive(configurations: dict[str, Path], tmp_path: Path) -> None:
+    captured = report(configurations)
+    args = arguments(configurations, captured["result"]["snapshot"], ["--report", "unused", "--read-current"])
+    with pytest.raises(SystemExit) as caught:
+        command.main(args)
+    assert caught.value.code == 2


### PR DESCRIPTION
## Goal

Closes #171. Second of three operator-readiness increments under #76, stacked on #176 after #167/#168/#169; followed by #181. Primary arc42 block: orchestration.

## Delivered behavior

Add mutually exclusive --report mode to revalidate the complete captured stdout report without manually extracting its snapshot. Reuse the bounded regular-file JSON reader and existing reviewed-preflight validator. Require exact wrapper fields, strict side-effect booleans, consistent source-mode metadata and exact supplied worker/transition/normalized slot. Rebuild the complete inner result against the supplied immutable reviewed configurations.

Replay always emits retained_report and database_read_performed=false, even for originally live captures. It preserves the captured observation time and result. Existing --snapshot and --read-current behavior is retained. Replay is not a database refresh or runtime permission.

## Exact scope and integration

Four changed paths, **244 additions and 21 deletions**, two commits relative to the final #176 head. The second commit integrates #176's command-level regression without changing this PR's isolated delta. No force update or acceptance merge occurred.

- Base: `be7ff19b8ee6120ac8a797558278c0d78e02ae16`.
- Final head: `0c93c9cb6254a56aef183a51d4d0557e01a42c52`.
- Tree: `8537a06acb720b1133e1660f3aec53757c8ef0fc`.
- Tested merge: `5cf216bcfe789edd79a164c656b83b24b03a2ab5`, combining that exact head and base.
- Comparison: two commits ahead, zero behind the final predecessor.

## Final-head validation

[Actions run 457](https://github.com/alexmarinos87/financial-risk-data-platform/actions/runs/34050628316) passed all four jobs: Python readiness, Security guardrails, PostgreSQL contract and Infrastructure validation.

Python job `101533472816` confirms Ruff passed, mypy passed across **163 source files**, **1,258 tests passed twice**, dependency integrity, pipeline replay and warehouse dry-run. PostgreSQL job `101533472937` passed all its fixture and consistency steps. The earlier run 450 was green too, but is not substituted for this final-head integration evidence.

Eighteen new report regression cases cover all capture modes, wrong explicit selection, strict flags, malformed wrapper fields, inner-result tampering, changed reviewed files, bounded/duplicate/symlink input, timezone normalization and detached replay. Inherited command-level redaction tests also passed.

Local validation: source/test compilation, trailing-whitespace checks and 13 standalone parser tests passed. Full report/command tests, typing and PostgreSQL ran in GitHub CI, not a local complete checkout. Scope comparison and self-review completed; no comments or unresolved review threads were present when checked. This is not independent engineer approval.

## Trust and side-effect boundary

Consistent metadata and hashes do not authenticate a claimed past database read or establish that captured authority remains current. Reviewed files require trusted immutable provenance. No schema, workflow, dependency or committed switch change. No application database contacted during development, health evaluation, authority write, notification, scheduler activation, deployment or Terraform apply.

## Acceptance

**Draft, final-head CI validated, unmerged. Explicit engineer acceptance remains pending.** Accept predecessors in dependency order; after each squash merge reconstruct the next isolated delta on accepted main and rerun its exact-head checks before accepting that final diff. Do not merge this PR into an unaccepted predecessor branch. The separate health/suspension stack is unchanged.