### PR TITLE
Verify retained notification readiness source records

### DIFF
--- a/docs/worker-readiness-source-verification.md
+++ b/docs/worker-readiness-source-verification.md
@@ -1,0 +1,37 @@
+# Reopening worker readiness source records
+
+Primary arc42 block: `warehouse`. First layer of the readiness-source adapter.
+
+`verify_worker_readiness_record` reopens the complete persisted readiness record,
+uses the existing semantic validator, verifies its retained SHA-256, and requires
+its exact selected record ID, destination and execution kind. It does not accept
+a digest or a projected status as a substitute for the source document.
+
+The observation clock is explicit. Both decision evaluation and record creation
+must be no later than observation. Age is recomputed rather than copied from a
+view or a long-running transaction timestamp. The exact configured maximum is
+accepted; older evidence is stale. Maximum age is an integer from 1 to 300,
+excluding booleans. Input serialization is bounded to 1 MiB and returned records
+are detached JSON snapshots.
+
+The result distinguishes `retained_status` from current authority. An intact
+historical allow record may have been superseded. Therefore
+`current_evidence_verified` and `runtime_permission_granted` always remain false.
+The next layer must reconcile the selected current review and governed worker
+configuration; this verifier does not authenticate a producer, select the latest
+record, inspect current failure history, or refresh notification readiness.
+
+A missing record is not passed to this verifier as an empty successful document.
+The future inventory adapter must report it as missing. Malformed, differently
+bound, oversized, future-dated and changed records raise `ValidationError`.
+Rehashing a contradictory decision cannot bypass the existing policy validator.
+
+Run `python -m pytest -q tests/unit/test_worker_readiness_source.py`, followed by
+repository quality, security and readiness checks. Tests compose the actual
+readiness record builder and gate fixtures rather than replacing the underlying
+policy validator.
+
+No existing source contract, workflow, schema, dependency or activation switch is
+changed. This is in-memory verification only: no database, network, delivery,
+scheduler, deployment or `terraform apply`. IDs and hashes are integrity evidence,
+not authenticated identities or signatures.

--- a/src/warehouse/notification_worker_readiness_source.py
+++ b/src/warehouse/notification_worker_readiness_source.py
@@ -1,0 +1,95 @@
+"""Reopen retained readiness records without confusing integrity with current authority."""
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from collections.abc import Mapping
+from datetime import datetime, timezone
+from typing import Any
+
+from src.common.exceptions import ValidationError
+
+MAX_SOURCE_BYTES = 1_048_576
+SAFE_ID = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,511}$")
+
+
+def source_identifier(value: Any) -> str:
+    if not isinstance(value, str) or SAFE_ID.fullmatch(value) is None:
+        raise ValidationError("readiness source identity must be bounded text")
+    return value
+
+
+def source_time(value: Any) -> datetime:
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00")) if isinstance(value, str) else value
+        if not isinstance(parsed, datetime) or parsed.tzinfo is None or parsed.utcoffset() is None:
+            raise ValueError
+        return parsed.astimezone(timezone.utc)
+    except (ValueError, TypeError, OverflowError):
+        raise ValidationError("readiness source time must be timezone-aware") from None
+
+
+def source_bytes(value: Mapping[str, Any]) -> bytes:
+    if not isinstance(value, Mapping):
+        raise ValidationError("readiness source must be an object")
+    try:
+        raw = json.dumps(dict(value), sort_keys=True, separators=(",", ":"), allow_nan=False).encode("utf-8")
+        if len(raw) > MAX_SOURCE_BYTES:
+            raise ValidationError("readiness source exceeds 1 MiB")
+        return raw
+    except (ValueError, TypeError, RecursionError, OverflowError, UnicodeError):
+        raise ValidationError("readiness source must be bounded canonical JSON") from None
+
+
+def verify_worker_readiness_record(
+    *, record: Mapping[str, Any], document_sha256: str, expected_record_id: str,
+    destination_id: str, execution_kind: str, observed_at: datetime | str,
+    max_age_seconds: int = 300,
+) -> dict[str, Any]:
+    """Validate the real persisted record, its digest, scope and observation-time age.
+
+    This function does not select current history or authenticate its producer.
+    Even a retained allow decision is not a current execution permission.
+    """
+    selected_id = source_identifier(expected_record_id)
+    selected_destination = source_identifier(destination_id)
+    if execution_kind not in ("initial", "retry"):
+        raise ValidationError("readiness source execution kind is unsupported")
+    if type(max_age_seconds) is not int or not 1 <= max_age_seconds <= 300:
+        raise ValidationError("readiness source maximum age must be an integer from 1 to 300")
+    if not isinstance(document_sha256, str) or re.fullmatch(r"[0-9a-f]{64}", document_sha256) is None:
+        raise ValidationError("readiness source requires a SHA-256 digest")
+    instant = source_time(observed_at)
+    detached = json.loads(source_bytes(record))
+    # Import the existing semantic validator; do not invent a second readiness policy.
+    from src.warehouse.notification_execution_readiness_history_contract import (
+        canonical_notification_execution_readiness_record_bytes,
+        validate_notification_execution_readiness_record,
+    )
+
+    try:
+        validated = validate_notification_execution_readiness_record(detached)
+        canonical = canonical_notification_execution_readiness_record_bytes(validated)
+        digest = hashlib.sha256(canonical).hexdigest()
+        if digest != document_sha256:
+            raise ValidationError("readiness source digest differs from its retained document")
+        decision = validated["decision"]
+        if (validated["record_id"] != selected_id
+                or decision["destination"]["destination_id"] != selected_destination
+                or decision["execution_kind"] != execution_kind):
+            raise ValidationError("readiness source does not match its selected identity")
+        evaluated = source_time(decision["evaluated_at"])
+        recorded = source_time(validated["recorded_at"])
+        if evaluated > instant or recorded > instant:
+            raise ValidationError("readiness source postdates its observation")
+        age = (instant - evaluated).total_seconds()
+        status = "stale" if age > max_age_seconds else "allowed" if decision["decision"] == "allow" else "blocked"
+        return {
+            "record": json.loads(canonical), "document_sha256": digest,
+            "observed_at": instant.isoformat(), "age_seconds": age,
+            "retained_status": status, "current_evidence_verified": False,
+            "runtime_permission_granted": False,
+        }
+    except (ValueError, TypeError, KeyError, RecursionError, OverflowError, UnicodeError):
+        raise ValidationError("retained readiness source is malformed") from None

--- a/tests/unit/test_worker_readiness_source.py
+++ b/tests/unit/test_worker_readiness_source.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+import copy
+import hashlib
+from datetime import timedelta
+from typing import Any
+
+import pytest
+
+from src.common.exceptions import ValidationError
+from src.warehouse.notification_execution_readiness_history_contract import (
+    MODEL_VERSION, build_notification_execution_readiness_record,
+)
+from src.warehouse.notification_worker_readiness_source import (
+    source_bytes, source_identifier, source_time, verify_worker_readiness_record,
+)
+from test_notification_execution_readiness_gate import (
+    DESTINATION_ID, EVALUATED_AT, _delivery, _evaluate,
+)
+
+
+def readiness_record(kind: str = "initial", *, blocked: bool = False) -> dict[str, Any]:
+    return build_notification_execution_readiness_record(
+        request_id="source-" + kind, recorded_at=EVALUATED_AT + timedelta(seconds=1),
+        decision=_evaluate(execution_kind=kind, delivery=_delivery(enabled=not blocked)),
+    )
+
+
+def verify(record: dict[str, Any] | None = None, **changes: Any) -> dict[str, Any]:
+    selected = readiness_record() if record is None else record
+    args = {
+        "record": selected, "document_sha256": hashlib.sha256(source_bytes(selected)).hexdigest(),
+        "expected_record_id": selected["record_id"], "destination_id": DESTINATION_ID,
+        "execution_kind": selected["decision"]["execution_kind"] if isinstance(selected["decision"], dict) else "initial",
+        "observed_at": EVALUATED_AT + timedelta(seconds=2),
+    }
+    args.update(changes)
+    return verify_worker_readiness_record(**args)
+
+
+@pytest.mark.parametrize("kind", ["initial", "retry"])
+def test_reopens_real_canonical_record_but_never_grants_current_permission(kind: str) -> None:
+    source = readiness_record(kind)
+    result = verify(source)
+    assert result["record"] == source
+    assert result["retained_status"] == "allowed"
+    assert result["age_seconds"] == 2
+    assert result["current_evidence_verified"] is False
+    assert result["runtime_permission_granted"] is False
+    assert result == verify(source)
+    source["decision"]["blocking_reasons"].append("changed")
+    assert result["record"]["decision"]["blocking_reasons"] == []
+
+
+def test_retained_block_cannot_be_presented_as_allow() -> None:
+    assert verify(readiness_record(blocked=True))["retained_status"] == "blocked"
+
+
+@pytest.mark.parametrize("age,status", [(300, "allowed"), (300.000001, "stale")])
+def test_recomputes_age_at_explicit_observation_instant(age: float, status: str) -> None:
+    assert verify(observed_at=EVALUATED_AT + timedelta(seconds=age))["retained_status"] == status
+
+
+@pytest.mark.parametrize("field,value", [
+    ("expected_record_id", "wrong"), ("destination_id", "other-destination"),
+    ("execution_kind", "retry"), ("document_sha256", "0" * 64),
+    ("document_sha256", "not-a-digest"), ("execution_kind", "execute"),
+])
+def test_wrong_selected_identity_or_digest_is_rejected(field: str, value: Any) -> None:
+    with pytest.raises(ValidationError):
+        verify(**{field: value})
+
+
+@pytest.mark.parametrize("age", [-1, 0, 0.999999])
+def test_recording_time_cannot_postdate_observation(age: float) -> None:
+    with pytest.raises(ValidationError, match="postdates"):
+        verify(observed_at=EVALUATED_AT + timedelta(seconds=age))
+
+
+@pytest.mark.parametrize("maximum", [True, False, 0, 301, 1.5, "300"])
+def test_age_limit_is_strictly_typed_and_bounded(maximum: Any) -> None:
+    with pytest.raises(ValidationError):
+        verify(max_age_seconds=maximum)
+
+
+def test_rehashed_record_still_requires_original_semantic_validator() -> None:
+    record = readiness_record(blocked=True)
+    record["decision"]["decision"] = "allow"
+    identity = {key: value for key, value in record.items() if key != "record_id"}
+    record["record_id"] = f"{MODEL_VERSION}-record-{hashlib.sha256(source_bytes(identity)).hexdigest()[:24]}"
+    with pytest.raises(ValidationError):
+        verify(record)
+
+
+@pytest.mark.parametrize("change", ["unknown", "bad_time", "wrong_model", "not_object"])
+def test_malformed_retained_document_is_rejected(change: str) -> None:
+    record = readiness_record()
+    if change == "unknown":
+        record["endpoint_value"] = "not-permitted"
+    elif change == "bad_time":
+        record["recorded_at"] = "2026-06-01T12:00:01"
+    elif change == "wrong_model":
+        record["model_version"] = "other"
+    else:
+        record["decision"] = []
+    with pytest.raises(ValidationError):
+        verify(record, execution_kind="initial")
+
+
+def test_helpers_reject_unbounded_noncanonical_or_naive_inputs() -> None:
+    for value in ({"x": "a" * 1_048_576}, {"x": float("nan")}, {"x": object()}, []):
+        with pytest.raises(ValidationError):
+            source_bytes(value)  # type: ignore[arg-type]
+    for value in ("", "https://not-an-identifier", "a" * 513, None):
+        with pytest.raises(ValidationError):
+            source_identifier(value)
+    with pytest.raises(ValidationError):
+        source_time("2026-06-01T12:00:00")
+    assert source_time("2026-06-01T13:00:00+01:00") == EVALUATED_AT
+
+
+def test_validation_preserves_caller_owned_input() -> None:
+    record = readiness_record()
+    previous = copy.deepcopy(record)
+    verify(record)
+    assert record == previous


### PR DESCRIPTION
## Goal

Readiness-source adapter, **1 of 3**, under roadmap #76. Primary arc42 block: `warehouse`.

Dependency order: **#178 → #180 → #183**. Reopen actual retained readiness documents before consumers trust projected identities, digests or status. This stack imports no unaccepted suspension or preflight-diagnostics implementation.

## Changes

- Reuse the existing readiness-record and decision semantic validators.
- Verify exact record, destination and execution-kind identity plus stored SHA-256.
- Recompute age at an explicit observation instant; reject future evaluation or recording times.
- Enforce a 1 MiB serialized source bound and strictly typed maximum age of 1–300 seconds.
- Return detached evidence and distinguish retained status from current readiness.
- Keep current-evidence verification and runtime permission false: an intact historical allow decision is not current authority.

## Exact candidate

```text
Base main: 7316dd30ce5b445df0ac2c0ac019703add15aadc
Head:      a4421b133e659f25bdf0c4eea7716afa8ab667cf
Tree:      01a2c7719073b78b6fe1cd7c85757ba402a430fc
Scope:     3 additive files; 258 additions; 0 deletions
```

The 27 new parametrized test cases compose the real readiness record builder and gate fixtures. They cover exact identity/digest binding, semantic reconstruction after rehashing, age boundaries, future recording time, malformed documents, strict limits and detached inputs.

## Validation and review

[CI run 451](https://github.com/alexmarinos87/financial-risk-data-platform/actions/runs/34050132918), associated with this exact head, passed all four jobs: Security guardrails, Python readiness, PostgreSQL contract and Infrastructure validation without apply. No source repair was required.

Local syntax compilation, five dependency-free malformed-input checks and UTC conversion passed. Full repository acquisition failed locally, so Ruff, mypy, the canonical integration tests and complete repository validation are evidenced by GitHub CI, not claimed as local runs.

Self-review covered preserved semantic validation, exact source identity, freshness and retained-vs-current semantics. Conversation comments, submitted reviews and inline review threads were empty at inspection. Self-review and CI are not independent human approval.

## Boundary and acceptance

No application database I/O, live provider request, endpoint resolution, notification delivery, scheduler activation, schema/config/workflow/dependency change, deployment or Terraform apply. IDs and hashes are not authentication.

**Draft and unmerged; exact-diff acceptance pending.** After explicit acceptance, squash with the expected head pinned and verify resulting main CI. Reconstruct each successor's isolated delta on accepted main and repeat exact-candidate validation and acceptance. Do not merge successors into unaccepted predecessor branches as a shortcut.