### PR TITLE
Reconcile current readiness sources with governed worker plans

### DIFF
--- a/docs/worker-readiness-source-snapshot.md
+++ b/docs/worker-readiness-source-snapshot.md
@@ -1,0 +1,45 @@
+# Reconciling worker readiness sources
+
+Primary arc42 block: `warehouse`. Second readiness-source adapter layer.
+
+`build_worker_readiness_snapshot` combines one canonical worker authority with
+at most two source entries. Each selected execution kind requires the complete
+persisted readiness record, its stored SHA-256, and a narrow current-review
+projection. It reuses the preceding verifier and the existing authority contract.
+No alternate readiness or lifecycle policy is introduced.
+
+The current projection names the selected record and current destination,
+activation authority/checklist, activation status, transition record/rehearsal,
+transition status and endpoint environment-variable identity. The adapter compares
+these to the reopened source, not to an unverified `allowed` label. It also checks
+delivery, retry-planning and retry-execution fingerprints and enablement against
+the governed worker plan. Changed evidence becomes `superseded`, stale evidence
+remains stale, retained blocks remain blocked, and every missing kind blocks.
+
+The bounded aggregate input is detached JSON. Inventory order does not affect
+the result; duplicate or unselected kinds and inconsistent record/view joins are
+rejected. Output binds authority and complete source digests, exposes the exact
+per-kind record references, and can be reconstructed by its validator. Unknown
+projection fields, including a caller-supplied status label, are rejected.
+
+`ready_sources` describes only the supplied readiness sources. It is not a claim
+that the producer actually selected current database state, that reviewed
+configuration is still current, that a schedule slot is due or claimed, or that
+failure history is healthy. Accordingly `current_authority_verified`,
+`failure_history_verified` and `runtime_permission_granted` stay false. The next
+read-only database adapter establishes source selection; the separately reviewed
+preflight still owns current configuration and exact-slot checks.
+
+Initial-delivery attempts do not currently retain worker and execution-kind
+identities. This layer does not guess those identities, infer zero failures from
+missing rows, or fabricate the failure summaries required by the suspension
+contract. A provenance-aware history adapter remains separate work.
+
+Tests use real readiness records and the existing worker authority builder. They
+cover independent kinds, missing rows, review replacement, policy drift, freshness,
+malformed joins, deterministic ordering, immutable inputs and rehashed verdicts.
+Run `python -m pytest -q tests/unit/test_worker_readiness_snapshot.py` and the full
+repository quality/security/readiness checks.
+
+No I/O, schema change, configuration activation, scheduler mutation, delivery,
+deployment or `terraform apply`. Source IDs and hashes are not authentication.

--- a/src/warehouse/notification_worker_readiness_snapshot.py
+++ b/src/warehouse/notification_worker_readiness_snapshot.py
@@ -1,0 +1,180 @@
+"""Reconcile verified readiness records with a worker plan and current review evidence."""
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from collections.abc import Mapping
+from datetime import datetime
+from typing import Any
+
+from src.common.exceptions import ValidationError
+from src.orchestration.notification_worker_authority_contract import (
+    authority_state, validate_worker_authority_transition,
+)
+from src.warehouse.notification_worker_readiness_source import (
+    source_bytes, source_identifier, source_time, verify_worker_readiness_record,
+)
+
+MODEL_VERSION = "portfolio-risk-worker-readiness-snapshot-v1"
+REVIEW_FIELDS = (
+    "destination_id", "execution_kind", "readiness_record_id",
+    "current_destination_fingerprint", "current_authority_id", "current_checklist_id",
+    "activation_review_status", "operational_activation_ready",
+    "current_transition_record_id", "current_transition_rehearsal_id",
+    "current_transition_review_status", "current_transition_ready",
+    "current_endpoint_environment_variable",
+)
+SOURCE_FIELDS = {"execution_kind", "record", "document_sha256", "review"}
+
+
+def _review(value: Any, *, destination_id: str, kind: str) -> dict[str, Any]:
+    if not isinstance(value, Mapping) or set(value) != set(REVIEW_FIELDS):
+        raise ValidationError("worker readiness review fields are not exact")
+    result = dict(value)
+    if result["destination_id"] != destination_id or result["execution_kind"] != kind:
+        raise ValidationError("worker readiness review scope differs from selected source")
+    for field in REVIEW_FIELDS:
+        if field in {"operational_activation_ready", "current_transition_ready"}:
+            if type(result[field]) is not bool:
+                raise ValidationError("worker readiness review flags must be boolean")
+        elif result[field] is not None:
+            source_identifier(result[field])
+    env = result["current_endpoint_environment_variable"]
+    if env is not None and re.fullmatch(r"[A-Z][A-Z0-9_]{2,127}", env) is None:
+        raise ValidationError("worker readiness review must name an environment variable")
+    return result
+
+
+def _matches_current(decision: Mapping[str, Any], review: Mapping[str, Any]) -> bool:
+    activation = decision["activation_review"] or {}
+    transition = decision["transition_review"] or {}
+    comparisons = (
+        (review["current_destination_fingerprint"], decision["destination"]["fingerprint"]),
+        (review["current_authority_id"], activation.get("authority_id")),
+        (review["current_checklist_id"], activation.get("checklist_id")),
+        (review["activation_review_status"], activation.get("review_status")),
+        (review["operational_activation_ready"], activation.get("operational_activation_ready")),
+        (review["current_transition_record_id"], transition.get("transition_record_id")),
+        (review["current_transition_rehearsal_id"], transition.get("transition_rehearsal_id")),
+        (review["current_transition_review_status"], transition.get("transition_review_status")),
+        (review["current_transition_ready"], transition.get("transition_ready")),
+        (review["current_endpoint_environment_variable"], transition.get("rollback_endpoint_environment_variable")),
+    )
+    return all(actual == expected for actual, expected in comparisons)
+
+
+def _matches_plan(decision: Mapping[str, Any], plan: Mapping[str, Any]) -> bool:
+    configuration = decision["configuration"]
+    destination = decision["destination"]
+    comparisons = (
+        (destination["fingerprint"], plan["destination"]["fingerprint"]),
+        (destination["endpoint_environment_variable"], plan["destination"]["endpoint_environment_variable"]),
+        (configuration["endpoint_environment_variable"], plan["destination"]["endpoint_environment_variable"]),
+        (configuration["delivery_fingerprint"], plan["delivery"]["delivery_fingerprint"]),
+        (configuration["retry_policy_fingerprint"], plan["delivery"]["retry_planning_policy_fingerprint"]),
+        (configuration["retry_execution_policy_fingerprint"], plan["delivery"]["retry_execution_policy_fingerprint"]),
+        (configuration["delivery_enabled"], plan["delivery"]["webhook_enabled"]),
+        (configuration["retry_execution_enabled"], plan["delivery"]["retry_execution_enabled"]),
+    )
+    return all(actual == expected for actual, expected in comparisons)
+
+
+def build_worker_readiness_snapshot(
+    *, authority: Mapping[str, Any], sources: list[Mapping[str, Any]],
+    observed_at: datetime | str,
+) -> dict[str, Any]:
+    """Reconcile supplied sources; database selection and failure verification are separate.
+
+    Missing selected kinds block. Current-view labels are not accepted as proof:
+    source records are reopened and review/configuration agreement is recomputed.
+    """
+    try:
+        if not isinstance(sources, list) or len(sources) > 2:
+            raise ValidationError("worker readiness source inventory must contain at most two rows")
+        detached = json.loads(source_bytes({"authority": authority, "sources": sources}))
+        prior = validate_worker_authority_transition(detached["authority"])
+        plan = prior["plan"]
+        instant = source_time(observed_at)
+        kinds = [item["execution_kind"] for item in plan["execution"]["work_items"]]
+        inventory: dict[str, dict[str, Any]] = {}
+        for source in detached["sources"]:
+            if not isinstance(source, dict) or set(source) != SOURCE_FIELDS:
+                raise ValidationError("worker readiness source fields are not exact")
+            kind = source["execution_kind"]
+            if not isinstance(kind, str) or kind not in kinds or kind in inventory:
+                raise ValidationError("worker readiness source kind is unselected or duplicated")
+            inventory[kind] = source
+        destination_id = plan["destination"]["destination_id"]
+        missing: list[str] = []
+        reasons: list[str] = []
+        rows: list[dict[str, Any]] = []
+        if authority_state(prior, as_of=instant) != "active":
+            reasons.append("worker_authority_not_active")
+        for kind in kinds:
+            source = inventory.get(kind)
+            if source is None:
+                missing.append(kind)
+                reasons.append(f"readiness_missing:{kind}")
+                continue
+            review_value = source["review"]
+            review = None if review_value is None else _review(review_value, destination_id=destination_id, kind=kind)
+            selected_id = None if review is None else review["readiness_record_id"]
+            if selected_id is None:
+                if source["record"] is not None or source["document_sha256"] is not None:
+                    raise ValidationError("worker readiness document has no current selected record")
+                missing.append(kind)
+                reasons.append(f"readiness_missing:{kind}")
+                continue
+            verified = verify_worker_readiness_record(
+                record=source["record"], document_sha256=source["document_sha256"],
+                expected_record_id=selected_id, destination_id=destination_id, execution_kind=kind,
+                observed_at=instant, max_age_seconds=plan["readiness"]["max_age_seconds"],
+            )
+            decision = verified["record"]["decision"]
+            assert review is not None
+            status = verified["retained_status"]
+            if not _matches_current(decision, review):
+                status = "superseded"
+                reasons.append(f"readiness_review_changed:{kind}")
+            if not _matches_plan(decision, plan):
+                status = "superseded"
+                reasons.append(f"readiness_plan_mismatch:{kind}")
+            if status != "allowed":
+                reasons.append(f"readiness_not_allowed:{kind}")
+            rows.append({
+                "execution_kind": kind, "record_id": selected_id,
+                "document_sha256": verified["document_sha256"],
+                "destination_id": destination_id,
+                "destination_fingerprint": decision["destination"]["fingerprint"],
+                "delivery_fingerprint": decision["configuration"]["delivery_fingerprint"],
+                "evaluated_at": decision["evaluated_at"], "status": status,
+            })
+        ordered_sources = [inventory[kind] for kind in kinds if kind in inventory]
+        identity = {
+            "model_version": MODEL_VERSION, "worker_id": plan["worker"]["worker_id"],
+            "destination_id": destination_id, "authority_transition_id": prior["transition_id"],
+            "authority_sha256": hashlib.sha256(source_bytes(prior)).hexdigest(),
+            "sources_sha256": hashlib.sha256(source_bytes({"sources": ordered_sources})).hexdigest(),
+            "observed_at": instant.isoformat(), "readiness": rows,
+            "missing_execution_kinds": missing, "blocking_reasons": sorted(reasons),
+            "outcome": "blocked" if reasons else "ready_sources",
+            "current_authority_verified": False, "failure_history_verified": False,
+            "runtime_permission_granted": False,
+        }
+        return {"snapshot_id": f"{MODEL_VERSION}-{hashlib.sha256(source_bytes(identity)).hexdigest()}", **identity}
+    except (ValueError, TypeError, KeyError, RecursionError, OverflowError, UnicodeError):
+        raise ValidationError("worker readiness source snapshot is malformed") from None
+
+
+def validate_worker_readiness_snapshot(
+    value: Mapping[str, Any], *, authority: Mapping[str, Any], sources: list[Mapping[str, Any]],
+) -> dict[str, Any]:
+    try:
+        raw = source_bytes(value)
+        rebuilt = build_worker_readiness_snapshot(authority=authority, sources=sources, observed_at=value["observed_at"])
+        if raw != source_bytes(rebuilt):
+            raise ValidationError("worker readiness snapshot differs from its source evidence")
+        return rebuilt
+    except (ValueError, TypeError, KeyError, RecursionError, OverflowError, UnicodeError):
+        raise ValidationError("worker readiness snapshot is malformed") from None

--- a/tests/unit/test_worker_readiness_snapshot.py
+++ b/tests/unit/test_worker_readiness_snapshot.py
@@ -1,0 +1,169 @@
+from __future__ import annotations
+
+import copy
+import hashlib
+from datetime import timedelta
+from typing import Any
+
+import pytest
+
+from src.common.exceptions import ValidationError
+from src.warehouse.notification_worker_readiness_source import source_bytes
+from src.warehouse.notification_worker_readiness_snapshot import (
+    MODEL_VERSION, build_worker_readiness_snapshot, validate_worker_readiness_snapshot,
+)
+from test_notification_execution_readiness_gate import EVALUATED_AT
+from test_notification_worker_authority_contract import grant, plan_fixture, rehash, stop
+from test_worker_readiness_source import readiness_record
+
+OBSERVED = EVALUATED_AT + timedelta(seconds=2)
+
+
+def source_entry(kind: str) -> dict[str, Any]:
+    record = readiness_record(kind)
+    decision = record["decision"]
+    activation, transition = decision["activation_review"], decision["transition_review"]
+    return {"execution_kind": kind, "record": record,
+            "document_sha256": hashlib.sha256(source_bytes(record)).hexdigest(), "review": {
+        "destination_id": decision["destination"]["destination_id"], "execution_kind": kind,
+        "readiness_record_id": record["record_id"],
+        "current_destination_fingerprint": decision["destination"]["fingerprint"],
+        "current_authority_id": activation["authority_id"], "current_checklist_id": activation["checklist_id"],
+        "activation_review_status": activation["review_status"],
+        "operational_activation_ready": activation["operational_activation_ready"],
+        "current_transition_record_id": transition["transition_record_id"],
+        "current_transition_rehearsal_id": transition["transition_rehearsal_id"],
+        "current_transition_review_status": transition["transition_review_status"],
+        "current_transition_ready": transition["transition_ready"],
+        "current_endpoint_environment_variable": transition["rollback_endpoint_environment_variable"],
+    }}
+
+
+def readiness_authority() -> dict[str, Any]:
+    p = plan_fixture(planned_at=EVALUATED_AT - timedelta(seconds=60))
+    decision = readiness_record()["decision"]
+    p["destination"]["fingerprint"] = decision["destination"]["fingerprint"]
+    configuration = decision["configuration"]
+    for target, source in (("delivery_fingerprint", "delivery_fingerprint"),
+                           ("retry_planning_policy_fingerprint", "retry_policy_fingerprint"),
+                           ("retry_execution_policy_fingerprint", "retry_execution_policy_fingerprint")):
+        p["delivery"][target] = configuration[source]
+    return grant(plan=rehash(p))
+
+
+def snapshot(sources: Any = None, **changes: Any) -> dict[str, Any]:
+    args = {"authority": readiness_authority(), "sources": [source_entry("initial"), source_entry("retry")] if sources is None else sources,
+            "observed_at": OBSERVED}
+    args.update(changes)
+    return build_worker_readiness_snapshot(**args)
+
+
+def test_verified_sources_do_not_claim_failure_health_or_runtime_permission() -> None:
+    result = snapshot()
+    assert result["outcome"] == "ready_sources"
+    assert result["missing_execution_kinds"] == []
+    assert [row["status"] for row in result["readiness"]] == ["allowed", "allowed"]
+    assert result["failure_history_verified"] is False
+    assert result["current_authority_verified"] is False
+    assert result["runtime_permission_granted"] is False
+    assert validate_worker_readiness_snapshot(result, authority=readiness_authority(), sources=[source_entry("initial"), source_entry("retry")]) == result
+    assert snapshot([source_entry("retry"), source_entry("initial")]) == result
+
+
+@pytest.mark.parametrize("kind", ["initial", "retry"])
+def test_missing_kind_blocks_without_fabricating_zero_failures(kind: str) -> None:
+    result = snapshot([source_entry(kind)])
+    missing = "retry" if kind == "initial" else "initial"
+    assert result["outcome"] == "blocked"
+    assert result["missing_execution_kinds"] == [missing]
+    assert "failures" not in result
+
+
+@pytest.mark.parametrize("field", [
+    "current_destination_fingerprint", "current_authority_id", "current_checklist_id",
+    "activation_review_status", "current_transition_record_id", "current_transition_rehearsal_id",
+    "current_transition_review_status", "current_endpoint_environment_variable",
+])
+def test_changed_current_review_supersedes_an_intact_old_allow(field: str) -> None:
+    entries = [source_entry("initial"), source_entry("retry")]
+    entries[1]["review"][field] = "OTHER_ENV" if field.endswith("variable") else "changed"
+    result = snapshot(entries)
+    assert result["outcome"] == "blocked"
+    assert result["readiness"][0]["status"] == "allowed"
+    assert result["readiness"][1]["status"] == "superseded"
+
+
+@pytest.mark.parametrize("field", ["operational_activation_ready", "current_transition_ready"])
+def test_changed_current_review_boolean_is_not_ignored(field: str) -> None:
+    entry = source_entry("initial")
+    entry["review"][field] = False
+    assert snapshot([entry])["readiness"][0]["status"] == "superseded"
+    entry["review"][field] = 0
+    with pytest.raises(ValidationError):
+        snapshot([entry])
+
+
+@pytest.mark.parametrize("field", ["delivery_fingerprint", "retry_planning_policy_fingerprint", "retry_execution_policy_fingerprint"])
+def test_governed_policy_drift_cannot_pass_on_destination_identity_alone(field: str) -> None:
+    prior = readiness_authority()
+    p = copy.deepcopy(prior["plan"])
+    p["delivery"][field] = "changed-policy"
+    result = snapshot(authority=grant(plan=rehash(p)))
+    assert result["outcome"] == "blocked"
+    assert all(row["status"] == "superseded" for row in result["readiness"])
+
+
+def test_age_is_recomputed_not_accepted_from_current_view() -> None:
+    result = snapshot(observed_at=EVALUATED_AT + timedelta(seconds=301))
+    assert all(row["status"] == "stale" for row in result["readiness"])
+    assert result["outcome"] == "blocked"
+
+
+@pytest.mark.parametrize("variant", ["duplicate", "unselected", "extra", "orphan", "wrong_record", "missing_digest", "nonobject"])
+def test_inconsistent_source_inventory_is_rejected(variant: str) -> None:
+    entry = source_entry("initial")
+    entries: Any = [entry]
+    if variant == "duplicate":
+        entries.append(copy.deepcopy(entry))
+    elif variant == "unselected":
+        entry["execution_kind"] = "other"
+    elif variant == "extra":
+        entry["review"]["readiness_review_status"] = "allowed"
+    elif variant == "orphan":
+        entry["review"] = None
+    elif variant == "wrong_record":
+        entry["review"]["readiness_record_id"] = "different-record"
+    elif variant == "missing_digest":
+        entry["document_sha256"] = None
+    else:
+        entries = [None]
+    with pytest.raises(ValidationError):
+        snapshot(entries)
+
+
+def test_missing_current_view_is_explicit_and_stopped_authority_never_passes() -> None:
+    entries = [{"execution_kind": "initial", "record": None, "document_sha256": None, "review": None}]
+    assert snapshot(entries)["missing_execution_kinds"] == ["initial", "retry"]
+    prior = readiness_authority()
+    stopped = stop(prior, requested_at=EVALUATED_AT, effective_at=EVALUATED_AT)
+    result = snapshot(authority=stopped)
+    assert "worker_authority_not_active" in result["blocking_reasons"]
+
+
+def test_rehashed_summary_cannot_drop_missing_source_blockers() -> None:
+    result = snapshot([])
+    result["outcome"] = "ready_sources"
+    result["blocking_reasons"] = []
+    identity = {key: value for key, value in result.items() if key != "snapshot_id"}
+    result["snapshot_id"] = f"{MODEL_VERSION}-{hashlib.sha256(source_bytes(identity)).hexdigest()}"
+    with pytest.raises(ValidationError):
+        validate_worker_readiness_snapshot(result, authority=readiness_authority(), sources=[])
+
+
+def test_input_evidence_is_detached_and_not_modified() -> None:
+    entries = [source_entry("initial"), source_entry("retry")]
+    before = copy.deepcopy(entries)
+    result = snapshot(entries)
+    assert entries == before
+    entries[0]["record"]["decision"]["destination"]["fingerprint"] = "mutated"
+    assert result["readiness"][0]["destination_fingerprint"] != "mutated"


### PR DESCRIPTION
## Goal

Readiness-source adapter, **2 of 3**, stacked on #178; successor #183. Roadmap #76; primary arc42 block: `warehouse`.

Reconcile complete readiness documents against narrowly selected current activation/transition evidence and the governed worker plan. Do not trust a projected `allowed` label.

## Changes

- Reopen every selected kind through #178's canonical source verifier.
- Reconcile current destination, activation authority/checklist, transition/rehearsal and endpoint-variable identities.
- Compare delivery and both retry-policy fingerprints and enablement to the worker's governed plan.
- Classify changed evidence as superseded, old evidence as stale and missing kinds as missing/blocked.
- Reject duplicate/unselected kinds, malformed projections and inconsistent record/view joins.
- Bind full source and authority digests into deterministic detached snapshots and reconstruct summaries to reject rehashed tampering.
- Keep current-authority verification, failure-history verification and runtime permission explicitly false in this pure layer.

## Exact candidate

```text
Base #178: a4421b133e659f25bdf0c4eea7716afa8ab667cf
Head:      6e46a3bb9796985b3d153edcd077f74b172ca402
Tree:      e503f891e81ae158b262a6849296b513a7403123
Scope:     3 additive files; 394 additions; 0 deletions
```

27 new parametrized tests cover both kinds, review replacement, policy drift, freshness, missing evidence, malformed joins, deterministic ordering, detached inputs and rehashed summaries. They use real readiness records and the existing authority builder. No unaccepted suspension or preflight-diagnostics modules are imported.

## Validation and review

[CI run 453](https://github.com/alexmarinos87/financial-risk-data-platform/actions/runs/34050335779), associated with this exact head, passed all four jobs: Security guardrails, Python readiness, PostgreSQL contract and Infrastructure validation without apply. No source repair was required.

Local syntax compilation passed. Full tests, Ruff, mypy and repository checks ran in GitHub CI; no complete local checkout or PostgreSQL execution is claimed.

Self-review covered source-to-view identity, independent-kind checks, missing-vs-malformed distinctions, current-state limitations and immutable inputs. Conversation comments, submitted reviews and inline review threads were empty at inspection. Independent review and exact-diff human acceptance remain pending.

## Limits and safety

This pure reconciliation layer does not select database rows or authenticate producers. #183 provides actual read-only source selection. Current reviewed configuration/slot preflight and complete failure histories remain separate responsibilities. Initial-delivery attempt rows lack worker/execution-kind identities; no such identity or zero-failure evidence is invented here.

No I/O, schema/workflow/configuration-default change, scheduler mutation, delivery, deployment or Terraform apply. `ready_sources` never grants runtime permission.

## Acceptance sequence

**Draft and unmerged.** After #178 is explicitly accepted and squash-merged, reconstruct this isolated delta on accepted main, rerun exact-candidate checks, review and obtain acceptance before this layer's squash merge. Verify resulting main before reconstructing #183. Do not merge into an unaccepted predecessor branch as a shortcut.