### PR TITLE
Prove committed worker preflight through isolated PostgreSQL

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -273,6 +273,9 @@ postgres-contract-check:
 		--dsn "$(LOCAL_POSTGRES_DSN)"
 	$(PYTHON) -m src.warehouse.notification_worker_authority_postgres_contract_check \
 		--dsn "$(LOCAL_POSTGRES_DSN)"
+	@WAREHOUSE_POSTGRES_DSN="$(LOCAL_POSTGRES_DSN)" \
+		$(PYTHON) -m src.warehouse.notification_worker_preflight_postgres_contract_check \
+		--allow-disposable-database
 
 local-db-up:
 	docker compose up -d postgres mongo

--- a/docs/worker-preflight-postgres-operator-proof.md
+++ b/docs/worker-preflight-postgres-operator-proof.md
@@ -1,0 +1,80 @@
+# Committed-state PostgreSQL operator proof
+
+Primary arc42 block: `warehouse`. Goal #172 follows #170/#171.
+
+## Why this proof is separate
+
+The earlier transaction-scoped fixture validates snapshots on its writing cursor
+and proves that a separate reader cannot see uncommitted rows. This proof adds the
+missing committed-state path: the actual public read-only adapter and complete
+operator command observe committed active and stopped authority on new connections.
+It also proves an old captured report can still be replayed offline after a stop,
+without presenting that replay as current authority or permission to execute.
+
+## Isolation and explicit invocation
+
+```bash
+# Only against the disposable local PostgreSQL service, never a production tunnel.
+# WAREHOUSE_POSTGRES_DSN is supplied by the operator environment, not an argument.
+python -m src.warehouse.notification_worker_preflight_postgres_contract_check \
+  --allow-disposable-database
+```
+
+The existing `make postgres-contract-check` target invokes this proof with the
+acknowledgement and its LOCAL_POSTGRES_DSN through the environment. The Actions
+workflow is unchanged. This target already destroys/recreates disposable local
+volumes; it is not an application-database validation command.
+
+The proof requires an explicit loopback host and rejects service indirection,
+remote host addresses and host lists. That is a mistake-prevention boundary, not
+proof that a loopback port is not a production tunnel. The operator must choose
+the disposable service. The role needs CREATEDB or equivalent privileges.
+
+The administration connection creates a uniquely generated database from
+template0 in autocommit mode. Only that database receives the existing authority
+schema and synthetic committed records. The fixture never modifies application
+tables in the administration database. Child connections close before DROP; no
+FORCE or session-termination command is used. A failed CREATE is never followed
+by a DROP. Body failures still attempt exact-name cleanup, and successful cleanup
+is verified against pg_database before reporting success. Process termination or
+connection loss can leave a fixture database; absence of a success report must
+not be interpreted as confirmed cleanup.
+
+## Real checks
+
+The fixture temporarily copies reviewed configurations and uses the existing
+planner/authority builders. Its one-minute, zero-jitter plan is already due and
+has a bounded five-minute authority window; repository configuration bytes are
+unchanged.
+
+The proof verifies the public reader sees the committed active grant, actually
+uses READ COMMITTED/READ ONLY, and PostgreSQL rejects a table write with SQLSTATE
+25006. It runs the complete live-read command, commits a newer disable transition,
+then proves the same old selected grant is blocked. Exact historical replay does
+not promote it. Offline replay retains the prior captured result and performs no
+database read. Missing-worker observations remain clocked and exactly two intended
+authority records exist before the disposable database is dropped.
+
+The test-time cursor audit calls the real reader, inspects real transaction
+settings and rolls back the intentionally rejected write using a savepoint. It
+does not replace database results with mocks. Separate unit tests use injected
+drivers only to prove acknowledgement, name generation and cleanup control flow.
+
+```bash
+python -m pytest -q tests/unit/test_worker_preflight_postgres_proof_safety.py
+make quality-check
+make security-check
+make postgres-contract-check
+```
+
+References: PostgreSQL 16 CREATE DATABASE and DROP DATABASE require execution
+outside a transaction block; DROP cannot run while connected to its target.
+<https://www.postgresql.org/docs/16/sql-createdatabase.html>
+<https://www.postgresql.org/docs/16/sql-dropdatabase.html>
+
+No application database is contacted during development. CI uses only its
+explicit disposable PostgreSQL service. No new schema design, committed worker
+switch, dependency, workflow, notification, live provider request, scheduler
+activation, cloud deployment or Terraform apply. Explicit engineer acceptance is
+still pending, and this proof does not integrate the independent health stack or
+make the preflight diagnostic an execution gate.

--- a/src/warehouse/notification_worker_preflight_postgres_contract_check.py
+++ b/src/warehouse/notification_worker_preflight_postgres_contract_check.py
@@ -19,9 +19,12 @@ DATABASE_PREFIX = "worker_preflight_contract_"
 LOCAL_HOSTS = frozenset({"localhost", "127.0.0.1", "::1"})
 
 
-def _check_local_parameters(parameters: Mapping[str, str]) -> None:
-    if (parameters.get("host") not in LOCAL_HOSTS or "service" in parameters
-            or ("hostaddr" in parameters and parameters["hostaddr"] not in LOCAL_HOSTS - {"localhost"})):
+def _check_local_parameters(parameters: Mapping[str, object]) -> None:
+    host = parameters.get("host")
+    hostaddr = parameters.get("hostaddr")
+    if (not isinstance(host, str) or host not in LOCAL_HOSTS or "service" in parameters
+            or ("hostaddr" in parameters and (not isinstance(hostaddr, str)
+                or hostaddr not in LOCAL_HOSTS - {"localhost"}))):
         raise ValueError("disposable preflight proof requires an explicit loopback database host")
 
 

--- a/src/warehouse/notification_worker_preflight_postgres_contract_check.py
+++ b/src/warehouse/notification_worker_preflight_postgres_contract_check.py
@@ -1,0 +1,214 @@
+"""Explicit disposable PostgreSQL proof for the complete worker preflight path."""
+from __future__ import annotations
+
+import contextlib
+import io
+import json
+import os
+import re
+import sys
+from collections.abc import Iterator, Mapping
+from datetime import timedelta
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from typing import Any
+from unittest.mock import patch
+from uuid import uuid4
+
+DATABASE_PREFIX = "worker_preflight_contract_"
+LOCAL_HOSTS = frozenset({"localhost", "127.0.0.1", "::1"})
+
+
+def _check_local_parameters(parameters: Mapping[str, str]) -> None:
+    if (parameters.get("host") not in LOCAL_HOSTS or "service" in parameters
+            or ("hostaddr" in parameters and parameters["hostaddr"] not in LOCAL_HOSTS - {"localhost"})):
+        raise ValueError("disposable preflight proof requires an explicit loopback database host")
+
+
+def _owned_database_name(token: str) -> str:
+    if not isinstance(token, str) or re.fullmatch(r"[0-9a-f]{32}", token) is None:
+        raise ValueError("invalid generated fixture database identity")
+    return DATABASE_PREFIX + token
+
+
+@contextlib.contextmanager
+def disposable_database(dsn: str, *, allow_disposable_database: bool = False) -> Iterator[str]:
+    if allow_disposable_database is not True:
+        raise ValueError("explicit disposable database acknowledgement is required")
+    if not isinstance(dsn, str) or not dsn.strip():
+        raise ValueError("a local administration DSN is required")
+    import psycopg
+    from psycopg import sql
+    from psycopg.conninfo import conninfo_to_dict, make_conninfo
+
+    _check_local_parameters(conninfo_to_dict(dsn))
+    name = _owned_database_name(uuid4().hex)
+    with psycopg.connect(dsn, autocommit=True, connect_timeout=5) as admin:
+        with admin.cursor() as cursor:
+            cursor.execute("SET statement_timeout = '15s'")
+            cursor.execute("SET lock_timeout = '5s'")
+            created = False
+            try:
+                cursor.execute(sql.SQL("CREATE DATABASE {} TEMPLATE template0").format(sql.Identifier(name)))
+                created = True
+                yield make_conninfo(
+                    dsn, dbname=name, connect_timeout=5,
+                    options="-c statement_timeout=10000 -c lock_timeout=5000",
+                )
+            finally:
+                # Never drop a caller-selected name or a database whose creation failed.
+                if created:
+                    cursor.execute(sql.SQL("DROP DATABASE {}").format(sql.Identifier(name)))
+                    cursor.execute("SELECT 1 FROM pg_database WHERE datname = %s", (name,))
+                    if cursor.fetchone() is not None:
+                        raise AssertionError("fixture database cleanup was not confirmed")
+
+
+def _run_command(dsn: str, arguments: list[str]) -> tuple[int, dict[str, Any]]:
+    from src.orchestration.check_notification_worker_preflight import main
+
+    stdout, stderr = io.StringIO(), io.StringIO()
+    with patch.dict(os.environ, {"WAREHOUSE_POSTGRES_DSN": dsn}):
+        with contextlib.redirect_stdout(stdout), contextlib.redirect_stderr(stderr):
+            code = main(arguments)
+    if stderr.getvalue():
+        raise AssertionError("worker preflight command rejected integration fixture")
+    report = json.loads(stdout.getvalue())
+    if report["runtime_permission_granted"] is not False:
+        raise AssertionError("operator report granted runtime permission")
+    return code, report
+
+
+def _exercise(dsn: str, directory: Path) -> dict[str, bool]:
+    import psycopg
+    import yaml
+
+    from src.orchestration import check_notification_worker_preflight as command
+    from src.orchestration.plan_notification_worker import plan_notification_worker
+    from src.warehouse import notification_worker_authority_snapshot as snapshots
+    from src.warehouse.notification_worker_authority_history import record_worker_authority
+    from src.warehouse.notification_worker_authority_postgres_contract_check import _grant, _plan, _stop
+
+    checks: dict[str, bool] = {}
+    with psycopg.connect(dsn) as connection, connection.cursor() as cursor:
+        cursor.execute(Path("sql/notification_worker_authority_schema.sql").read_text(encoding="utf-8"))
+        cursor.execute("SELECT clock_timestamp()")
+        clock = cursor.fetchone()
+        if clock is None:
+            raise AssertionError("fixture database clock is unavailable")
+        planned = clock[0] - timedelta(seconds=61)
+    worker_id = "preflight-integration-worker"
+    _plan(directory, worker_id, planned)
+    worker_path = directory / "notification_workers.yaml"
+    configuration = yaml.safe_load(worker_path.read_text(encoding="utf-8"))
+    worker = configuration["workers"][worker_id]
+    worker["schedule"].update(interval_seconds=60, jitter_seconds=0)
+    worker["limits"]["execution_timeout_seconds"] = 300
+    worker_path.write_text(yaml.safe_dump(configuration), encoding="utf-8")
+    paths = {
+        "worker_config_path": worker_path,
+        "delivery_config_path": directory / "notification_delivery.yaml",
+        "destination_config_path": directory / "notification_destinations.yaml",
+    }
+    plan = plan_notification_worker(worker_id=worker_id, planned_at=planned, **paths)
+    active = _grant(plan, "PREFLIGHT-INTEGRATION-ACTIVATE")
+    record_worker_authority(dsn=dsn, transition=active)
+    original_reader = snapshots.read_worker_authority_snapshot_with_cursor
+
+    def audited_read(cursor: Any, *, worker_id: str) -> dict[str, Any]:
+        captured = original_reader(cursor, worker_id=worker_id)
+        cursor.execute("SHOW transaction_read_only")
+        if cursor.fetchone() != ("on",):
+            raise AssertionError("public snapshot transaction was not read-only")
+        cursor.execute("SHOW transaction_isolation")
+        if cursor.fetchone() != ("read committed",):
+            raise AssertionError("public snapshot isolation was not READ COMMITTED")
+        try:
+            with cursor.connection.transaction():
+                cursor.execute("UPDATE risk_platform.notification_worker_authority_history SET plan_id = plan_id WHERE FALSE")
+        except psycopg.errors.ReadOnlySqlTransaction:
+            checks["public_reader_write_rejected"] = True
+        else:
+            raise AssertionError("read-only transaction accepted a table write")
+        return captured
+
+    with patch.object(snapshots, "read_worker_authority_snapshot_with_cursor", audited_read):
+        captured = snapshots.read_worker_authority_snapshot(dsn=dsn, worker_id=worker_id)
+    if captured["transition"] != active or captured["authority_state"] != "active":
+        raise AssertionError("separate public reader did not observe committed active authority")
+    checks["committed_active_public_read"] = True
+    selection = [
+        "--worker-id", worker_id, "--selected-transition-id", active["transition_id"],
+        "--scheduled-for", plan["schedule"]["scheduled_for"],
+        "--worker-config", str(paths["worker_config_path"]),
+        "--delivery-config", str(paths["delivery_config_path"]),
+        "--destination-config", str(paths["destination_config_path"]),
+    ]
+    code, live_report = _run_command(dsn, ["--read-current", *selection])
+    if (code != 0 or live_report["source_mode"] != "live_database_read"
+            or live_report["result"]["preflight"]["outcome"] != "eligible_for_health_review"):
+        raise AssertionError("committed due slot did not pass the real operator preflight")
+    checks["live_due_operator_path"] = True
+    stopped = _stop(active, "PREFLIGHT-INTEGRATION-DISABLE", "disable")
+    record_worker_authority(dsn=dsn, transition=stopped)
+    code, stop_report = _run_command(dsn, ["--read-current", *selection])
+    reasons = stop_report["result"]["preflight"]["reasons"]
+    if code != 4 or not {"authority_superseded", "authority_disabled"}.issubset(reasons):
+        raise AssertionError("new committed stop did not block the selected old grant")
+    checks["committed_stop_blocks_old_selection"] = True
+    replay = record_worker_authority(dsn=dsn, transition=active)
+    current = snapshots.read_worker_authority_snapshot(dsn=dsn, worker_id=worker_id)
+    if replay["created"] is not False or current["transition"] != stopped:
+        raise AssertionError("historical replay promoted an old grant")
+    checks["historical_replay_does_not_promote"] = True
+    report_path = directory / "captured-report.json"
+    report_path.write_text(json.dumps(live_report), encoding="utf-8")
+    with patch.object(command, "read_worker_authority_snapshot", side_effect=AssertionError("offline read")):
+        code, replayed_report = _run_command(dsn, ["--report", str(report_path), *selection])
+    if (code != 0 or replayed_report["result"] != live_report["result"]
+            or replayed_report["source_mode"] != "retained_report"
+            or replayed_report["database_read_performed"] is not False):
+        raise AssertionError("offline replay changed capture or implied a fresh database read")
+    checks["offline_capture_is_not_current_authority"] = True
+    missing = snapshots.read_worker_authority_snapshot(dsn=dsn, worker_id="missing-worker")
+    if missing["transition"] is not None or not missing["observed_at"]:
+        raise AssertionError("missing worker was not observed on the database clock")
+    checks["missing_worker_clock"] = True
+    with psycopg.connect(dsn) as connection, connection.cursor() as cursor:
+        cursor.execute("SELECT COUNT(*) FROM risk_platform.notification_worker_authority_history")
+        if cursor.fetchone() != (2,):
+            raise AssertionError("diagnostic checks changed committed authority history")
+    checks["only_two_intended_authority_records"] = True
+    return checks
+
+
+def run_contract_check(dsn: str, *, allow_disposable_database: bool = False) -> dict[str, Any]:
+    with disposable_database(dsn, allow_disposable_database=allow_disposable_database) as fixture_dsn:
+        with TemporaryDirectory(prefix="worker-preflight-integration-") as temporary:
+            checks = _exercise(fixture_dsn, Path(temporary))
+    checks["owned_fixture_database_dropped"] = True
+    return {"model_version": "worker-preflight-operator-postgres-contract-v1", "checks": checks,
+            "runtime_permission_granted": False, "external_request_performed": False,
+            "scheduler_mutated": False}
+
+
+def main() -> int:
+    from src.orchestration.notification_worker_cli_parser import WorkerPreflightParser
+
+    parser = WorkerPreflightParser(prog="worker-preflight-postgres-contract", allow_abbrev=False)
+    parser.add_argument("--allow-disposable-database", action="store_true")
+    arguments = parser.parse_args()
+    try:
+        result = run_contract_check(
+            os.environ.get("WAREHOUSE_POSTGRES_DSN", ""),
+            allow_disposable_database=arguments.allow_disposable_database,
+        )
+    except Exception:
+        print("Worker preflight disposable PostgreSQL proof failed; inspect fixture cleanup", file=sys.stderr)
+        return 1
+    print(json.dumps(result, sort_keys=True, allow_nan=False))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/test_worker_preflight_postgres_proof_safety.py
+++ b/tests/unit/test_worker_preflight_postgres_proof_safety.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from src.warehouse.notification_worker_preflight_postgres_contract_check import (
+    DATABASE_PREFIX, _check_local_parameters, _owned_database_name, disposable_database,
+)
+
+
+@pytest.mark.parametrize("acknowledgement", [False, None, 0, 1, "true"])
+def test_database_creation_requires_strict_explicit_ack_before_driver_import(
+    monkeypatch: pytest.MonkeyPatch, acknowledgement: Any,
+) -> None:
+    monkeypatch.setitem(sys.modules, "psycopg", None)
+    with pytest.raises(ValueError, match="acknowledgement"):
+        with disposable_database("unused", allow_disposable_database=acknowledgement):
+            raise AssertionError("database context must not be entered")
+
+
+@pytest.mark.parametrize("dsn", [None, "", "  ", 1])
+def test_dsn_must_exist_before_driver_import(monkeypatch: pytest.MonkeyPatch, dsn: Any) -> None:
+    monkeypatch.setitem(sys.modules, "psycopg", None)
+    with pytest.raises(ValueError, match="DSN"):
+        with disposable_database(dsn, allow_disposable_database=True):
+            raise AssertionError("database context must not be entered")
+
+
+@pytest.mark.parametrize("parameters", [
+    {}, {"host": "production.example"}, {"host": "/tmp"},
+    {"host": "localhost,production.example"}, {"host": "localhost", "service": "hidden"},
+    {"host": "localhost", "hostaddr": "192.0.2.1"},
+])
+def test_nonlocal_or_indirect_administration_hosts_are_rejected(parameters: dict[str, str]) -> None:
+    with pytest.raises(ValueError, match="loopback"):
+        _check_local_parameters(parameters)
+
+
+@pytest.mark.parametrize("host", ["localhost", "127.0.0.1", "::1"])
+def test_explicit_loopback_hosts_are_allowed(host: str) -> None:
+    _check_local_parameters({"host": host})
+
+
+@pytest.mark.parametrize("token", ["risk_platform", "", "a" * 31, "A" * 32, "'; DROP DATABASE postgres", None])
+def test_fixture_database_name_cannot_be_supplied_or_injected(token: Any) -> None:
+    with pytest.raises(ValueError):
+        _owned_database_name(token)
+
+
+def test_generated_name_is_bounded_and_distinct_from_application_databases() -> None:
+    name = _owned_database_name("a" * 32)
+    assert name == DATABASE_PREFIX + "a" * 32
+    assert len(name) < 64
+    assert name not in {"postgres", "template0", "template1", "risk_platform"}
+
+
+def test_disposable_proof_is_wired_into_existing_ci_target() -> None:
+    makefile = Path("Makefile").read_text(encoding="utf-8")
+    target = makefile.split("\npostgres-contract-check:\n", 1)[1].split("\nlocal-db-up:", 1)[0]
+    assert "src.warehouse.notification_worker_preflight_postgres_contract_check" in target
+    assert "--allow-disposable-database" in target
+    assert 'WAREHOUSE_POSTGRES_DSN="$(LOCAL_POSTGRES_DSN)"' in target
+
+
+@pytest.mark.parametrize("fail_at", [None, "create", "body"])
+def test_only_successfully_created_database_is_dropped(
+    monkeypatch: pytest.MonkeyPatch, fail_at: str | None,
+) -> None:
+    from types import ModuleType, SimpleNamespace
+
+    calls: list[str] = []
+
+    class Cursor:
+        def __enter__(self) -> Cursor:
+            return self
+
+        def __exit__(self, *args: Any) -> None:
+            return None
+
+        def execute(self, statement: str, params: Any = None) -> None:
+            calls.append(statement)
+            if fail_at == "create" and statement.startswith("CREATE DATABASE"):
+                raise RuntimeError("injected creation failure")
+
+        def fetchone(self) -> None:
+            return None
+
+    class Connection:
+        def __enter__(self) -> Connection:
+            return self
+
+        def __exit__(self, *args: Any) -> None:
+            return None
+
+        def cursor(self) -> Cursor:
+            return Cursor()
+
+    driver = ModuleType("psycopg")
+    monkeypatch.setattr(driver, "connect", lambda *args, **kwargs: Connection(), raising=False)
+    monkeypatch.setattr(driver, "sql", SimpleNamespace(SQL=str, Identifier=lambda name: f'"{name}"'), raising=False)
+    conninfo = ModuleType("psycopg.conninfo")
+    monkeypatch.setattr(conninfo, "conninfo_to_dict", lambda dsn: {"host": "localhost"}, raising=False)
+    monkeypatch.setattr(conninfo, "make_conninfo", lambda dsn, **kwargs: kwargs["dbname"], raising=False)
+    monkeypatch.setitem(sys.modules, "psycopg", driver)
+    monkeypatch.setitem(sys.modules, "psycopg.conninfo", conninfo)
+    try:
+        with disposable_database("synthetic-administration-dsn", allow_disposable_database=True) as name:
+            assert name.startswith(DATABASE_PREFIX)
+            if fail_at == "body":
+                raise RuntimeError("injected body failure")
+    except RuntimeError:
+        assert fail_at is not None
+    else:
+        assert fail_at is None
+    creates = [sql for sql in calls if sql.startswith("CREATE DATABASE")]
+    drops = [sql for sql in calls if sql.startswith("DROP DATABASE")]
+    assert len(creates) == 1
+    if fail_at == "create":
+        assert not drops
+    else:
+        assert len(drops) == 1
+        assert creates[0].split('"')[1] == drops[0].split('"')[1]

--- a/tests/unit/test_worker_preflight_postgres_proof_safety.py
+++ b/tests/unit/test_worker_preflight_postgres_proof_safety.py
@@ -123,3 +123,18 @@ def test_only_successfully_created_database_is_dropped(
     else:
         assert len(drops) == 1
         assert creates[0].split('"')[1] == drops[0].split('"')[1]
+
+
+@pytest.mark.parametrize("parameters", [
+    {"host": None}, {"host": 1}, {"host": []},
+    {"host": "localhost", "hostaddr": None},
+    {"host": "localhost", "hostaddr": 1},
+    {"host": "localhost", "hostaddr": []},
+])
+def test_non_text_host_values_fail_closed(parameters: dict[str, Any]) -> None:
+    with pytest.raises(ValueError, match="loopback"):
+        _check_local_parameters(parameters)
+
+
+def test_non_host_driver_values_do_not_weaken_or_break_host_checks() -> None:
+    _check_local_parameters({"host": "localhost", "port": 5433, "connect_timeout": None})


### PR DESCRIPTION
## Goal

Closes #172. Third operator-readiness increment under #76, stacked on #177 after #176 and the preceding #167/#168/#169 stack. Primary arc42 block: warehouse.

## Delivered proof

An explicitly acknowledged, loopback-only disposable database fixture now exercises committed authority through the real public reader and complete operator command. It creates an internally generated unique database from template0, applies the existing authority schema there, closes child connections and drops only that exact successfully created database. It never modifies application tables in the supplied administration database. No caller-selected drop name, FORCE or session-termination operation exists.

The existing disposable postgres-contract-check target gains exactly three lines invoking the fixture with environment DSN and --allow-disposable-database. The pinned Actions workflow, schema source, dependencies and configuration defaults are unchanged.

## Exact scope and integration

Four paths, **440 additions and zero deletions**, three commits relative to final #177. This includes integration of #176's entrypoint regression through #177 and a narrow connection-parameter typing repair.

- Base: `0c93c9cb6254a56aef183a51d4d0557e01a42c52`.
- Final head: `a9c4391c4dee85125bf019c2f8cc1fc40cbc5697`.
- Tree: `e8885dcbcc1f6bae3b2425c584e29fe983abf423`.
- Tested merge: `e898faae2fe2e8f838949797840cc1d0e5e8bec8`, combining that exact head and base.
- Comparison: three commits ahead, zero behind the predecessor. No force update or acceptance merge.

## Final-head validation

[Actions run 460](https://github.com/alexmarinos87/financial-risk-data-platform/actions/runs/34050880213) passed all four jobs: Python readiness, Security guardrails, PostgreSQL contract and Infrastructure validation.

Python job `101534161263` confirms Ruff, mypy across **164 source files**, **1,294 tests passed twice**, dependency integrity, pipeline replay and warehouse dry-run.

PostgreSQL job `101534161296` actually ran the new fixture and reported all nine proof groups true:

1. `committed_active_public_read` — new connection sees the committed grant.
2. `public_reader_write_rejected` — real READ COMMITTED/READ ONLY settings and PostgreSQL rejection of a table write.
3. `live_due_operator_path` — complete live-read command accepts the captured due slot for separate health review only.
4. `committed_stop_blocks_old_selection` — newly committed disable blocks the old selected grant.
5. `historical_replay_does_not_promote` — exact old request replay leaves current authority stopped.
6. `offline_capture_is_not_current_authority` — prior capture replays offline unchanged without database reading or permission.
7. `missing_worker_clock` — missing authority still has a database observation clock.
8. `only_two_intended_authority_records` — diagnostics and replay did not add records.
9. `owned_fixture_database_dropped` — exact generated database cleanup was confirmed.

All inherited PostgreSQL checks also passed. The test-time cursor audit calls the real reader, inspects actual transaction settings and catches the real read-only SQLSTATE inside a savepoint; it does not mock database results.

## Repair and local evidence

Pre-repair CI rejected a too-narrow Mapping[str, str] annotation because Psycopg connection dictionaries may contain string, integer or null values. The repair accepts Mapping[str, object] and explicitly narrows host fields before membership checks. Seven added regressions reject non-text hosts while allowing unrelated driver parameter types; no loopback restriction or validation gate was removed.

Local result: **35 fixture-safety tests passed, one Makefile-wiring test deselected** because the full checkout was unavailable. That wiring test remained enabled and passed in full CI. Thirteen parser tests, source/test compilation and whitespace checks passed locally. Full repository tests, typing and real PostgreSQL execution ran in GitHub CI, not locally. Scope and Makefile diffs were reviewed; no comments or unresolved threads were present when checked. This is not independent engineer approval.

## Safety and acceptance

The fixture requires a disposable local service and database-creation privilege. Loopback checks prevent common mistakes but do not prove a port is not a production tunnel. Process interruption or connection loss can leave a generated fixture database; no cleanup success is claimed on failure. Only CI's disposable PostgreSQL service was used for real database execution in this increment.

No application database contacted during development, live provider/webhook request, scheduler activation, cloud deployment or Terraform apply. Runtime permission stays false. Existing health/suspension drafts are unchanged.

**Draft, final-head CI validated, unmerged; explicit engineer acceptance remains pending.** Accept predecessors in order, reconstruct isolated deltas on accepted main after squash merges and rerun exact-head validation before accepting each final diff. This proof is not an operational activation or a runtime health gate.