### PR TITLE
Capture verified worker readiness sources in one database statement

### DIFF
--- a/docs/worker-readiness-source-reader.md
+++ b/docs/worker-readiness-source-reader.md
@@ -1,0 +1,70 @@
+# Clocked, read-only worker readiness sources
+
+Primary arc42 block: `warehouse`. Goal #174 follows #173 under roadmap #76.
+
+## Decision
+
+`notification_worker_readiness_sources_reader.py` selects the configured initial
+and retry readiness sources in one PostgreSQL statement. It retains the serving
+row, complete canonical source document, stored digest and a shared database
+statement clock, then delegates verification to the source contract from #173.
+
+The exact worker plan is validated before database access. Destination and
+selected kinds are SQL parameters, never interpolated identifiers or filters.
+A left join from the selected kinds preserves missing views and missing records.
+The query returns at most three rows: a maximum of two kinds plus one duplicate
+sentinel. Wrong cardinality or duplicate kind fails instead of being discarded.
+
+A serving row referencing a missing retained document is corruption, not a
+healthy source or an ordinary absent decision. The SELECT withholds a JSONB
+source larger than 262,144 PostgreSQL text bytes and returns its size instead;
+the reader rejects that row. This bound is conservative relative to compact
+canonical JSON, whose independent bound is enforced by the source verifier.
+The complete returned snapshot is bounded to 1,048,576 canonical bytes.
+
+## Transaction and clock
+
+The public reader opens a new `READ COMMITTED, READ ONLY` transaction with a
+five-second lock timeout and ten-second statement timeout. The cursor helper
+performs one source SELECT; its caller owns transaction configuration and
+lifecycle. Neither path acquires an advisory lock, refreshes a decision, writes
+a record, reads worker authority or invokes transport.
+
+Both kinds come from the same statement snapshot and observation clock. The
+verifier recomputes freshness against that clock and the worker's maximum age,
+never upgrading a more restrictive serving status. The public function returns
+only after the connection context exits successfully. Query, decoding,
+connection and context-exit failures produce a fixed diagnostic without DSNs,
+source contents or driver diagnostics.
+
+PostgreSQL READ COMMITTED gives each statement its own snapshot; READ ONLY
+rejects ordinary table modifications, not every possible disk write. Reference:
+https://www.postgresql.org/docs/16/sql-set-transaction.html
+
+## Deliberate boundaries
+
+This is a readiness-source capture, not an atomic capture of worker authority,
+configuration files and all health history. Callers must not combine independently
+captured snapshots and label them a runtime lock or execution permission. A
+newer stop or source change can occur immediately after the SELECT.
+
+`worker_authority_verified`, `failure_history_verified` and
+`runtime_permission_granted` remain false. No healthy failure count is inferred
+from a missing or unbound history. Source provenance and authenticated operator
+approval remain separate. There is no CLI, scheduling or execution option.
+
+## Validation
+
+```bash
+.venv/bin/python -m pytest -q tests/unit/test_worker_readiness_sources_reader.py
+make quality-check
+make security-check
+make readiness-check
+```
+
+Tests use actual accepted plan/readiness contracts with fake cursors to verify
+SQL parameters, bounded fetch, shared clocks, missing/duplicate/broken joins,
+oversized and malformed records, pre-I/O input rejection and transaction exits.
+The following independently reviewable PR adds real PostgreSQL query proof.
+No schema, dependency, workflow, configuration default or existing API changes.
+Exact-head CI and self-review are not independent review or final acceptance.

--- a/src/warehouse/notification_worker_readiness_sources_reader.py
+++ b/src/warehouse/notification_worker_readiness_sources_reader.py
@@ -1,0 +1,107 @@
+"""Read bounded readiness records together, without operating worker authority."""
+from __future__ import annotations
+
+from collections.abc import Mapping
+from datetime import datetime
+from typing import Any
+
+from src.common.exceptions import StorageError, ValidationError
+from src.orchestration.plan_notification_worker import validate_notification_worker_plan
+from src.warehouse.notification_worker_authority_history import _connect
+from src.warehouse.notification_worker_readiness_sources import (
+    MAX_SOURCE_BYTES, build_worker_readiness_sources,
+)
+
+READINESS_SOURCES_SQL = """
+WITH selected_kinds AS (SELECT unnest(%s::text[]) AS execution_kind)
+SELECT statement_timestamp(), selected.execution_kind, review.destination_id,
+       review.readiness_record_id, review.readiness_review_status,
+       review.execution_ready, review.decision_matches_current_evidence,
+       CASE WHEN octet_length(retained.record_json::text) <= %s
+            THEN retained.record_json ELSE NULL END AS record_json,
+       retained.document_sha256,
+       octet_length(retained.record_json::text) AS source_bytes
+FROM selected_kinds selected
+LEFT JOIN risk_platform.current_notification_execution_readiness_review review
+  ON review.destination_id = %s AND review.execution_kind = selected.execution_kind
+LEFT JOIN risk_platform.notification_execution_readiness_decisions retained
+  ON retained.record_id = review.readiness_record_id
+ORDER BY selected.execution_kind, review.readiness_record_id
+LIMIT 3
+"""
+
+
+def read_worker_readiness_sources_with_cursor(
+    cursor: Any, *, plan: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Read one source statement; the caller owns its transaction and lifetime."""
+    selected = validate_notification_worker_plan(plan)
+    kinds = [item["execution_kind"] for item in selected["execution"]["work_items"]]
+    destination_id = selected["destination"]["destination_id"]
+    try:
+        cursor.execute("SET LOCAL statement_timeout = '10s'")
+        cursor.execute(READINESS_SOURCES_SQL, (kinds, MAX_SOURCE_BYTES, destination_id))
+        rows = cursor.fetchmany(3)
+        if not isinstance(rows, (list, tuple)) or len(rows) != len(kinds):
+            raise StorageError("readiness source grain is not unique or complete")
+        observed = None
+        sources = []
+        for row in rows:
+            if not isinstance(row, (list, tuple)) or len(row) != 10:
+                raise StorageError("readiness source row is invalid")
+            if not isinstance(row[0], datetime):
+                raise StorageError("readiness source database clock is invalid")
+            if observed is None:
+                observed = row[0]
+            elif row[0] != observed:
+                raise StorageError("readiness sources do not share an observation clock")
+            if row[2] is None:
+                if any(value is not None for value in row[3:]):
+                    raise StorageError("missing readiness view has retained metadata")
+                sources.append({
+                    "destination_id": destination_id, "execution_kind": row[1],
+                    "readiness_record_id": None, "readiness_review_status": "decision_missing",
+                    "execution_ready": False, "decision_matches_current_evidence": False,
+                    "record_json": None, "document_sha256": None,
+                })
+                continue
+            if row[3] is not None:
+                if type(row[9]) is not int or not 1 <= row[9] <= MAX_SOURCE_BYTES:
+                    raise StorageError("readiness source record is missing or oversized")
+                if row[7] is None:
+                    raise StorageError("readiness serving row has no retained document")
+            elif row[9] is not None:
+                raise StorageError("missing readiness record carries document metadata")
+            sources.append({
+                "destination_id": row[2], "execution_kind": row[1],
+                "readiness_record_id": row[3], "readiness_review_status": row[4],
+                "execution_ready": row[5], "decision_matches_current_evidence": row[6],
+                "record_json": row[7], "document_sha256": row[8],
+            })
+        if observed is None:
+            raise StorageError("readiness observation clock is missing")
+        return build_worker_readiness_sources(plan=selected, sources=sources, observed_at=observed)
+    except Exception:
+        # No provider diagnostics, document contents or credential-bearing strings.
+        raise StorageError("unable to capture verified worker readiness sources") from None
+
+
+def read_worker_readiness_sources(*, dsn: str, plan: Mapping[str, Any]) -> dict[str, Any]:
+    """Open a bounded READ ONLY transaction; return only after successful exit.
+
+    This reads readiness, not current worker authority or complete failure
+    history. Callers must not combine independent snapshots as an atomic runtime
+    permission. No advisory lock, source refresh, transition or transport runs.
+    """
+    selected = validate_notification_worker_plan(plan)
+    if not isinstance(dsn, str) or not dsn.strip():
+        raise ValidationError("PostgreSQL DSN must be non-empty text")
+    try:
+        with _connect(dsn) as connection:
+            with connection.cursor() as cursor:
+                cursor.execute("SET TRANSACTION ISOLATION LEVEL READ COMMITTED, READ ONLY")
+                cursor.execute("SET LOCAL lock_timeout = '5s'")
+                result = read_worker_readiness_sources_with_cursor(cursor, plan=selected)
+        return result
+    except Exception:
+        raise StorageError("unable to capture verified worker readiness sources") from None

--- a/tests/unit/test_worker_readiness_sources_reader.py
+++ b/tests/unit/test_worker_readiness_sources_reader.py
@@ -1,0 +1,170 @@
+from __future__ import annotations
+
+import copy
+from datetime import timedelta
+from typing import Any
+
+import pytest
+
+from src.common.exceptions import StorageError, ValidationError
+from src.orchestration.notification_worker_authority_contract import canonical_bytes
+from src.warehouse import notification_worker_readiness_sources_reader as reader
+from src.warehouse.notification_worker_readiness_sources import validate_worker_readiness_sources
+from test_worker_readiness_sources import BASE_TIME, source_fixture
+
+
+class Cursor:
+    def __init__(self, rows: list[Any]) -> None:
+        self.rows = rows
+        self.calls: list[tuple[str, Any]] = []
+        self.fetch_sizes: list[int] = []
+
+    def execute(self, sql: str, params: Any = None) -> None:
+        self.calls.append((sql, params))
+
+    def fetchmany(self, size: int) -> list[Any]:
+        self.fetch_sizes.append(size)
+        return self.rows
+
+    def __enter__(self) -> Cursor:
+        return self
+
+    def __exit__(self, *args: Any) -> None:
+        return None
+
+
+def database_rows(sources: list[dict[str, Any]]) -> list[list[Any]]:
+    return [[BASE_TIME + timedelta(seconds=5), source["execution_kind"], source["destination_id"],
+             source["readiness_record_id"], source["readiness_review_status"], source["execution_ready"],
+             source["decision_matches_current_evidence"], source["record_json"], source["document_sha256"],
+             len(canonical_bytes(source["record_json"]))] for source in sources]
+
+
+@pytest.mark.parametrize("initial_only", [False, True])
+def test_one_bounded_source_statement_binds_only_selected_kinds(initial_only: bool) -> None:
+    plan, sources = source_fixture(initial_only=initial_only)
+    cursor = Cursor(database_rows(sources))
+    result = reader.read_worker_readiness_sources_with_cursor(cursor, plan=plan)
+    assert result["all_sources_allowed"] is True
+    assert result == validate_worker_readiness_sources(result)
+    kinds = [row["execution_kind"] for row in sources]
+    assert cursor.calls == [("SET LOCAL statement_timeout = '10s'", None),
+                            (reader.READINESS_SOURCES_SQL,
+                             (kinds, reader.MAX_SOURCE_BYTES, plan["destination"]["destination_id"]))]
+    assert cursor.fetch_sizes == [3]
+    assert "LIMIT 3" in reader.READINESS_SOURCES_SQL
+    assert "statement_timestamp()" in reader.READINESS_SOURCES_SQL
+    assert "CASE WHEN octet_length" in reader.READINESS_SOURCES_SQL
+
+
+def test_missing_view_rows_have_clocked_missing_outcomes() -> None:
+    plan, _ = source_fixture()
+    rows = [[BASE_TIME, kind, *([None] * 8)] for kind in ("initial", "retry")]
+    result = reader.read_worker_readiness_sources_with_cursor(Cursor(rows), plan=plan)
+    assert result["observed_at"] == BASE_TIME.isoformat()
+    assert [row["status"] for row in result["readiness"]] == ["missing", "missing"]
+    assert result["all_sources_allowed"] is False
+
+
+@pytest.mark.parametrize("variant", ["empty", "duplicate", "too_many", "bad_clock", "mixed_clock",
+                                      "missing_join", "oversize", "bool_size", "digest", "shape"])
+def test_invalid_database_results_fail_closed(variant: str) -> None:
+    plan, sources = source_fixture()
+    rows = database_rows(sources)
+    if variant == "empty":
+        rows = []
+    elif variant == "duplicate":
+        rows[1] = copy.deepcopy(rows[0])
+    elif variant == "too_many":
+        rows.append(copy.deepcopy(rows[0]))
+    elif variant == "bad_clock":
+        rows[0][0] = BASE_TIME.isoformat()
+    elif variant == "mixed_clock":
+        rows[1][0] += timedelta(seconds=1)
+    elif variant == "missing_join":
+        rows[0][7] = None
+    elif variant == "oversize":
+        rows[0][7], rows[0][9] = None, reader.MAX_SOURCE_BYTES + 1
+    elif variant == "bool_size":
+        rows[0][9] = True
+    elif variant == "digest":
+        rows[0][8] = "0" * 64
+    else:
+        rows[0].pop()
+    with pytest.raises(StorageError, match="unable to capture verified"):
+        reader.read_worker_readiness_sources_with_cursor(Cursor(rows), plan=plan)
+
+
+class Connection:
+    def __init__(self, cursor: Cursor, *, exit_failure: bool = False) -> None:
+        self.selected_cursor = cursor
+        self.exit_failure = exit_failure
+        self.exited = False
+
+    def __enter__(self) -> Connection:
+        return self
+
+    def __exit__(self, *args: Any) -> None:
+        self.exited = True
+        if self.exit_failure:
+            raise RuntimeError("private-provider-details")
+
+    def cursor(self) -> Cursor:
+        return self.selected_cursor
+
+
+def test_public_reader_uses_read_only_transaction_and_waits_for_exit(monkeypatch: pytest.MonkeyPatch) -> None:
+    plan, sources = source_fixture()
+    cursor = Cursor(database_rows(sources))
+    connection = Connection(cursor)
+    calls = []
+
+    def connect(dsn: str) -> Connection:
+        calls.append(dsn)
+        return connection
+
+    monkeypatch.setattr(reader, "_connect", connect)
+    result = reader.read_worker_readiness_sources(dsn="injected-dsn", plan=plan)
+    assert connection.exited is True
+    assert calls == ["injected-dsn"]
+    assert cursor.calls[0][0] == "SET TRANSACTION ISOLATION LEVEL READ COMMITTED, READ ONLY"
+    assert cursor.calls[1][0] == "SET LOCAL lock_timeout = '5s'"
+    assert result["runtime_permission_granted"] is False
+
+
+def test_context_exit_failure_is_redacted_not_success(monkeypatch: pytest.MonkeyPatch) -> None:
+    plan, sources = source_fixture()
+    connection = Connection(Cursor(database_rows(sources)), exit_failure=True)
+    monkeypatch.setattr(reader, "_connect", lambda dsn: connection)
+    with pytest.raises(StorageError) as error:
+        reader.read_worker_readiness_sources(dsn="secret-dsn", plan=plan)
+    assert str(error.value) == "unable to capture verified worker readiness sources"
+
+
+@pytest.mark.parametrize("variant", ["plan", "empty_dsn", "invalid_dsn"])
+def test_bad_request_never_opens_database(variant: str, monkeypatch: pytest.MonkeyPatch) -> None:
+    plan, _ = source_fixture()
+    dsn: Any = "unused"
+    if variant == "plan":
+        plan["status"] = "not-a-status"
+    else:
+        dsn = "" if variant == "empty_dsn" else None
+
+    def forbidden(*args: Any) -> Any:
+        raise AssertionError("connection should not be attempted")
+
+    monkeypatch.setattr(reader, "_connect", forbidden)
+    with pytest.raises(ValidationError):
+        reader.read_worker_readiness_sources(dsn=dsn, plan=plan)
+
+
+def test_provider_error_is_redacted_at_cursor_boundary() -> None:
+    plan, _ = source_fixture()
+
+    class FailedCursor(Cursor):
+        def execute(self, sql: str, params: Any = None) -> None:
+            raise RuntimeError("credential-bearing-provider-details")
+
+    with pytest.raises(StorageError) as error:
+        reader.read_worker_readiness_sources_with_cursor(FailedCursor([]), plan=plan)
+    assert "credential" not in str(error.value)


### PR DESCRIPTION
## Goal

Closes #174. Second of three source-verification review units under #76, stacked on #179. Primary arc42 block: warehouse.

## Changes

Collect selected execution kinds, serving flags, full retained records, stored digests and the statement clock in one parameterized SELECT. Preserve missing rows, reject duplicate grains and broken joins, and withhold then reject oversized JSON before decoding. Reuse #179's canonical verifier. The public adapter opens READ COMMITTED, READ ONLY with bounded timeouts and returns only after successful context exit. Provider failures use a fixed redacted diagnostic.

Three additive files, 347 additions, no deletions relative to #179. No new health policy, authority model, schema, configuration default, dependency, workflow, CLI or existing execution API change. Independent concurrent stacks remain untouched.

## Exact-head validation

Final head `032908a7dadb70555604c6017b3b6f0845013927` passed GitHub Actions run **455** (`34050577876`): Security guardrails, Python readiness, PostgreSQL contract and Infrastructure validation.

Python job `101533336978` confirms Ruff, mypy across **161 source files**, **1,202 tests passed twice**, dependency integrity, pipeline replay and warehouse dry-run. This layer adds **19 regression cases**. Checkout log: synthetic merge `3c0019bc6f5b29f2a51335f1cff34a5b8ed26041`, combining this exact head with predecessor `a08ed964ac3d5d586f8a1adf88f36371df024e50`.

Local syntax compilation and staged whitespace checks passed in a source-subset staging directory. Full tests and infrastructure/database checks ran in GitHub Actions, not a complete local checkout. The added cursor tests exercise actual source contracts. The following PR supplies real PostgreSQL query proof; the passing existing database suite alone does not establish that new query proof.

## Review and acceptance

Self-review covered exact selected kinds, one-statement clocking, incomplete source handling, bounded transfer, SQL parameters, no writes and context-exit errors. This remains self-review, not independent review or engineer acceptance.

**Draft and unmerged.** Accept #179 first, reconstruct this isolated delta on accepted main and rerun exact-head checks; do not merge into an unaccepted predecessor branch.

## Boundary

Readiness capture does not establish current worker authority, complete failure history or runtime permission. Separate snapshots are not an atomic runtime gate. No application database, notification, scheduler, advisory lock, deployment or Terraform apply was performed.