### PR TITLE
Read current worker readiness sources in one read-only statement

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -274,6 +274,9 @@ postgres-contract-check:
 	$(PYTHON) -m src.warehouse.notification_worker_authority_postgres_contract_check \
 		--dsn "$(LOCAL_POSTGRES_DSN)"
 
+	$(PYTHON) -m src.warehouse.worker_readiness_postgres_contract_check \
+		--dsn "$(LOCAL_POSTGRES_DSN)"
+
 local-db-up:
 	docker compose up -d postgres mongo
 

--- a/docs/worker-readiness-source-reader.md
+++ b/docs/worker-readiness-source-reader.md
@@ -13,21 +13,27 @@ retained readiness record. Record JSON is size-checked server-side before transf
 A third row is retained as an ambiguity sentinel and rejected instead of silently
 truncating an unexpected inventory. The aggregate Python boundary remains 1 MiB.
 The reader independently verifies authority identity/digest and reopens each
-source through the preceding semantic and current-review reconciliation layers.
+source through semantic and current-review reconciliation.
 
 ## Clock and transaction contract
 
-A single statement supplies both data and observation time. Existing review views
-use CURRENT_TIMESTAMP, which is transaction-start time. The reader therefore
-requires transaction and statement clocks to agree and verifies read-only READ
-COMMITTED mode. Its dedicated autocommit SELECT has a fresh transaction clock;
-a cursor borrowed from an older explicit transaction is rejected, not silently
-reported as current. The cursor variant never changes caller transaction settings.
+The original timestamp-equality guard rejected a fresh parameterized query in CI
+run 463 before the unknown-worker scenario could complete. Transaction freshness
+is now checked from connection state **before** the data statement: the connection
+must be open, explicitly autocommit, IDLE, outside pipeline mode, and exclusively
+owned for the operation. Existing, failed, active and unknown transactions are
+rejected without sending SQL. Neither a clock tolerance nor equal timestamps can
+bypass this check. The cursor variant never changes caller transaction settings.
 
-PostgreSQL documents transaction_timestamp and statement_timestamp under Date/Time
-Functions, section Current Date/Time; they agree for the first command of a
-transaction. Psycopg autocommit avoids implicitly keeping a transaction open across
-unrelated commands. This adapter uses only session-local settings and SELECT.
+The SELECT verifies read-only READ COMMITTED mode and returns both timestamps.
+`observed_at` uses the new transaction's timestamp, matching CURRENT_TIMESTAMP in
+the existing views. Statement time is parsed but is not compared for equality;
+protocol preparation may produce distinct timestamps in a fresh operation. The
+owning function closes its dedicated connection on both success and failure.
+Concurrent use of a supplied cursor/connection is outside this API's contract.
+
+References: Psycopg, "Transactions management" and `ConnectionInfo.transaction_status`;
+PostgreSQL, "Message Flow", extended query protocol and timestamp behaviour.
 
 ## Meaning and limitations
 
@@ -46,20 +52,23 @@ and no unaccepted suspension or preflight-diagnostics code is imported.
 
 ## Executable evidence
 
-The existing `make postgres-contract-check` runs the new source-reader proof after
-its established readiness and authority fixtures. It uses actual retained records
-and a replaced activation review to prove supersession, exact selected IDs,
-unknown-worker blocking, no read-side authority writes, replacement by a newer stop,
-and rejection of an older transaction clock. Unit tests additionally exercise
-matching ready sources, malformed rows, bounds, wrong modes, digest tampering,
-parameterization, sanitized failure and connection cleanup.
+`make postgres-contract-check` invokes the source-reader proof after its established
+readiness and authority fixtures. It reopens actual retained records, detects
+superseded activation reviews, reconciles exact selected IDs, checks unknown-worker
+blocking and repeated read-side immutability, observes a newer stop, and rejects
+an existing explicit transaction. Unit tests also cover matching ready sources,
+malformed rows, bounds, wrong modes, tampered digests and connection cleanup.
 
-The proof explicitly commits two synthetic authority records so dedicated read-only
-sessions can see them. They remain only in the disposable contract database until
-normal CI teardown. This is not a rollback-only fixture and must not run against
-production. The test target already creates and tears down that disposable database.
-No schema, application configuration, workflow or dependency change is required.
+The session regression tests cover IDLE/autocommit, all four non-IDLE states,
+pipeline mode, missing state evidence and strict booleans. Reader tests check that
+unequal clocks in an idle session are accepted and that equal clocks cannot hide
+an existing transaction. All original source-integrity assertions remain enabled.
 
-The reader performs PostgreSQL I/O only. No notification, provider request, delivery
-lock, scheduler activation, deployment or `terraform apply` occurs. Source validation
-and passing CI do not authorize runtime execution or replace exact-diff acceptance.
+The proof commits two synthetic authority records so dedicated read-only sessions
+can see them. They remain only in the disposable contract database until CI
+teardown. This is not a rollback-only fixture and must not run against production.
+No schema, application configuration, workflow or dependency is changed.
+
+The application reader performs PostgreSQL reads only. No notification, provider
+request, delivery lock, scheduler activation, deployment or Terraform apply occurs.
+Passing CI does not authorize execution or replace exact-diff human acceptance.

--- a/docs/worker-readiness-source-reader.md
+++ b/docs/worker-readiness-source-reader.md
@@ -1,0 +1,65 @@
+# Read-only PostgreSQL worker readiness sources
+
+Primary arc42 block: `warehouse`. Third readiness-source adapter layer.
+
+`read_current_worker_readiness(dsn=..., worker_id=...)` opens a dedicated
+connection in autocommit mode, sets read-only READ COMMITTED defaults and a
+10-second statement timeout, then selects all data in one parameterized statement.
+The DSN must be explicitly supplied; no credential value is retained or printed.
+
+The statement selects the actual highest-sequence worker authority, expands only
+its selected execution kinds, and joins the current readiness view to each exact
+retained readiness record. Record JSON is size-checked server-side before transfer.
+A third row is retained as an ambiguity sentinel and rejected instead of silently
+truncating an unexpected inventory. The aggregate Python boundary remains 1 MiB.
+The reader independently verifies authority identity/digest and reopens each
+source through the preceding semantic and current-review reconciliation layers.
+
+## Clock and transaction contract
+
+A single statement supplies both data and observation time. Existing review views
+use CURRENT_TIMESTAMP, which is transaction-start time. The reader therefore
+requires transaction and statement clocks to agree and verifies read-only READ
+COMMITTED mode. Its dedicated autocommit SELECT has a fresh transaction clock;
+a cursor borrowed from an older explicit transaction is rejected, not silently
+reported as current. The cursor variant never changes caller transaction settings.
+
+PostgreSQL documents transaction_timestamp and statement_timestamp under Date/Time
+Functions, section Current Date/Time; they agree for the first command of a
+transaction. Psycopg autocommit avoids implicitly keeping a transaction open across
+unrelated commands. This adapter uses only session-local settings and SELECT.
+
+## Meaning and limitations
+
+An unknown worker returns `authority_missing`, not health. Missing records block;
+newer stops replace old active heads. A `ready_sources` result still does not verify
+current reviewed configuration, due-slot/replay ownership, health-history
+completeness, operator authentication or live under-lock readiness. Failure-history
+verification and runtime permission always remain false. The inner pure snapshot
+retains its own unverified-provenance flags; the outer result separately records
+that actual single-statement database source selection was performed.
+
+The adapter trusts the configured database and its schema owners. A compromised
+owner or fabricated cursor remains inside that trust boundary. It reads current
+view projections, not cryptographic approvals. No scheduler consumes this output
+and no unaccepted suspension or preflight-diagnostics code is imported.
+
+## Executable evidence
+
+The existing `make postgres-contract-check` runs the new source-reader proof after
+its established readiness and authority fixtures. It uses actual retained records
+and a replaced activation review to prove supersession, exact selected IDs,
+unknown-worker blocking, no read-side authority writes, replacement by a newer stop,
+and rejection of an older transaction clock. Unit tests additionally exercise
+matching ready sources, malformed rows, bounds, wrong modes, digest tampering,
+parameterization, sanitized failure and connection cleanup.
+
+The proof explicitly commits two synthetic authority records so dedicated read-only
+sessions can see them. They remain only in the disposable contract database until
+normal CI teardown. This is not a rollback-only fixture and must not run against
+production. The test target already creates and tears down that disposable database.
+No schema, application configuration, workflow or dependency change is required.
+
+The reader performs PostgreSQL I/O only. No notification, provider request, delivery
+lock, scheduler activation, deployment or `terraform apply` occurs. Source validation
+and passing CI do not authorize runtime execution or replace exact-diff acceptance.

--- a/src/warehouse/notification_worker_readiness_reader.py
+++ b/src/warehouse/notification_worker_readiness_reader.py
@@ -1,0 +1,135 @@
+"""Bounded, single-statement PostgreSQL readiness-source selection; never delivery."""
+from __future__ import annotations
+
+import hashlib
+from typing import Any
+
+from src.common.exceptions import StorageError, ValidationError
+from src.orchestration.notification_worker_authority_contract import validate_worker_authority_transition
+from src.warehouse.notification_worker_readiness_snapshot import REVIEW_FIELDS, build_worker_readiness_snapshot
+from src.warehouse.notification_worker_readiness_source import source_bytes, source_identifier, source_time
+
+# Only reviewed constant column names enter SQL. Worker identity remains a parameter.
+_REVIEW_JSON = ", ".join(f"'{field}', v.{field}" for field in REVIEW_FIELDS)
+READINESS_SOURCE_SQL = f"""
+WITH selected_authority AS MATERIALIZED (
+    SELECT CASE WHEN octet_length(document_json::TEXT) <= 1048576
+                THEN document_json ELSE NULL END AS document,
+           document_sha256, authority_sequence,
+           octet_length(document_json::TEXT) > 1048576 AS oversized
+    FROM risk_platform.notification_worker_authority_history
+    WHERE worker_id = %s
+    ORDER BY authority_sequence DESC LIMIT 1
+), selected_sources AS (
+    SELECT work.item ->> 'execution_kind' AS execution_kind,
+           CASE WHEN octet_length(r.record_json::TEXT) <= 1048576
+                THEN r.record_json ELSE NULL END AS record,
+           r.document_sha256,
+           CASE WHEN v.destination_id IS NULL THEN NULL
+                ELSE jsonb_build_object({_REVIEW_JSON}) END AS review,
+           COALESCE(octet_length(r.record_json::TEXT) > 1048576, FALSE) AS oversized
+    FROM selected_authority a
+    CROSS JOIN LATERAL jsonb_array_elements(
+        CASE WHEN jsonb_typeof(a.document -> 'plan' -> 'execution' -> 'work_items') = 'array'
+             THEN a.document -> 'plan' -> 'execution' -> 'work_items'
+             ELSE '[]'::JSONB END
+    ) work(item)
+    LEFT JOIN risk_platform.current_notification_execution_readiness_review v
+      ON v.destination_id = a.document -> 'plan' -> 'destination' ->> 'destination_id'
+     AND v.execution_kind = work.item ->> 'execution_kind'
+    LEFT JOIN risk_platform.notification_execution_readiness_decisions r
+      ON r.record_id = v.readiness_record_id
+    ORDER BY work.item ->> 'execution_kind'
+    LIMIT 3
+)
+SELECT statement_timestamp(), transaction_timestamp(),
+       current_setting('transaction_isolation'), current_setting('transaction_read_only'),
+       (SELECT jsonb_build_object('document', document, 'document_sha256', document_sha256,
+                                 'authority_sequence', authority_sequence, 'oversized', oversized)
+        FROM selected_authority),
+       COALESCE((SELECT jsonb_agg(to_jsonb(s) ORDER BY s.execution_kind)
+                 FROM selected_sources s), '[]'::JSONB)
+"""
+
+
+def read_worker_readiness_with_cursor(cursor: Any, *, worker_id: str) -> dict[str, Any]:
+    """Require a fresh read-only READ COMMITTED statement, not an older transaction.
+
+    The owning API supplies an autocommit connection. This variant does not change
+    caller transaction settings, acquire locks, or silently accept stale clocks.
+    """
+    selected = source_identifier(worker_id)
+    try:
+        cursor.execute(READINESS_SOURCE_SQL, (selected,))
+        row = cursor.fetchone()
+        if not isinstance(row, (tuple, list)) or len(row) != 6:
+            raise StorageError("worker readiness source query returned an invalid envelope")
+        instant = source_time(row[0])
+        if source_time(row[1]) != instant or row[2] != "read committed" or row[3] != "on":
+            raise StorageError("worker readiness sources require a fresh read-only statement")
+        retained, entries = row[4], row[5]
+        if not isinstance(entries, list) or len(entries) > 2:
+            raise StorageError("worker readiness source inventory is oversized or ambiguous")
+        result: dict[str, Any] = {
+            "model_version": "portfolio-risk-worker-readiness-read-v1",
+            "worker_id": selected, "observed_at": instant.isoformat(),
+            "database_read_performed": True, "single_statement_read_only": True,
+            "failure_history_verified": False, "runtime_permission_granted": False,
+            "notification_delivery_performed": False, "scheduler_mutated": False,
+        }
+        if retained is None:
+            if entries:
+                raise StorageError("worker readiness sources exist without selected authority")
+            return {**result, "status": "authority_missing", "authority_sequence": None,
+                    "authority_transition_id": None, "snapshot": None}
+        if not isinstance(retained, dict) or set(retained) != {
+            "document", "document_sha256", "authority_sequence", "oversized",
+        } or retained["oversized"] is not False:
+            raise StorageError("worker readiness authority source is invalid or oversized")
+        document = validate_worker_authority_transition(retained["document"])
+        digest = hashlib.sha256(source_bytes(document)).hexdigest()
+        sequence = retained["authority_sequence"]
+        if (retained["document_sha256"] != digest or type(sequence) is not int or sequence < 1
+                or document["plan"]["worker"]["worker_id"] != selected
+                or source_time(document["effective_at"]) > instant):
+            raise StorageError("worker readiness authority integrity or selected identity differs")
+        sources = []
+        for entry in entries:
+            if not isinstance(entry, dict) or set(entry) != {
+                "execution_kind", "record", "document_sha256", "review", "oversized",
+            } or entry["oversized"] is not False:
+                raise StorageError("worker readiness retained source is invalid or oversized")
+            sources.append({key: value for key, value in entry.items() if key != "oversized"})
+        snapshot = build_worker_readiness_snapshot(authority=document, sources=sources, observed_at=instant)
+        return {**result, "status": snapshot["outcome"], "authority_sequence": sequence,
+                "authority_transition_id": document["transition_id"], "snapshot": snapshot}
+    except (ValidationError, StorageError):
+        raise
+    except Exception:
+        raise StorageError("worker readiness source lookup failed") from None
+
+
+def _connect(dsn: str) -> Any:
+    if not isinstance(dsn, str) or not dsn.strip():
+        raise ValidationError("worker readiness reader requires an explicit PostgreSQL DSN")
+    try:
+        import psycopg
+    except ImportError:
+        raise StorageError("worker readiness reader requires psycopg") from None
+    return psycopg.connect(dsn, connect_timeout=5, autocommit=True)
+
+
+def read_current_worker_readiness(*, dsn: str, worker_id: str) -> dict[str, Any]:
+    """Open a dedicated read-only session, select once, validate and close it."""
+    selected = source_identifier(worker_id)
+    try:
+        with _connect(dsn) as connection:
+            with connection.cursor() as cursor:
+                cursor.execute("SET default_transaction_read_only = on")
+                cursor.execute("SET default_transaction_isolation = 'read committed'")
+                cursor.execute("SET statement_timeout = '10s'")
+                return read_worker_readiness_with_cursor(cursor, worker_id=selected)
+    except (ValidationError, StorageError):
+        raise
+    except Exception:
+        raise StorageError("worker readiness read-only session failed") from None

--- a/src/warehouse/notification_worker_readiness_reader.py
+++ b/src/warehouse/notification_worker_readiness_reader.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import hashlib
+from collections.abc import Mapping
 from typing import Any
 
 from src.common.exceptions import StorageError, ValidationError
@@ -93,7 +94,7 @@ def read_worker_readiness_with_cursor(cursor: Any, *, worker_id: str) -> dict[st
                 or document["plan"]["worker"]["worker_id"] != selected
                 or source_time(document["effective_at"]) > instant):
             raise StorageError("worker readiness authority integrity or selected identity differs")
-        sources = []
+        sources: list[Mapping[str, Any]] = []
         for entry in entries:
             if not isinstance(entry, dict) or set(entry) != {
                 "execution_kind", "record", "document_sha256", "review", "oversized",

--- a/src/warehouse/notification_worker_readiness_reader.py
+++ b/src/warehouse/notification_worker_readiness_reader.py
@@ -7,6 +7,7 @@ from typing import Any
 
 from src.common.exceptions import StorageError, ValidationError
 from src.orchestration.notification_worker_authority_contract import validate_worker_authority_transition
+from src.warehouse.notification_worker_readiness_session import require_fresh_readiness_session
 from src.warehouse.notification_worker_readiness_snapshot import REVIEW_FIELDS, build_worker_readiness_snapshot
 from src.warehouse.notification_worker_readiness_source import source_bytes, source_identifier, source_time
 
@@ -57,16 +58,20 @@ def read_worker_readiness_with_cursor(cursor: Any, *, worker_id: str) -> dict[st
     """Require a fresh read-only READ COMMITTED statement, not an older transaction.
 
     The owning API supplies an autocommit connection. This variant does not change
-    caller transaction settings, acquire locks, or silently accept stale clocks.
+    caller transaction settings or acquire locks. The connection must be exclusive.
     """
     selected = source_identifier(worker_id)
     try:
+        require_fresh_readiness_session(cursor)
         cursor.execute(READINESS_SOURCE_SQL, (selected,))
         row = cursor.fetchone()
         if not isinstance(row, (tuple, list)) or len(row) != 6:
             raise StorageError("worker readiness source query returned an invalid envelope")
-        instant = source_time(row[0])
-        if source_time(row[1]) != instant or row[2] != "read committed" or row[3] != "on":
+        # Readiness views use transaction time. Freshness is established above
+        # from real session state, not equality of protocol-dependent clocks.
+        source_time(row[0])
+        instant = source_time(row[1])
+        if row[2] != "read committed" or row[3] != "on":
             raise StorageError("worker readiness sources require a fresh read-only statement")
         retained, entries = row[4], row[5]
         if not isinstance(entries, list) or len(entries) > 2:

--- a/src/warehouse/notification_worker_readiness_session.py
+++ b/src/warehouse/notification_worker_readiness_session.py
@@ -1,0 +1,28 @@
+"""Check session state before reading transaction-time readiness views."""
+from __future__ import annotations
+
+from typing import Any
+
+from src.common.exceptions import StorageError
+
+
+def require_fresh_readiness_session(cursor: Any) -> None:
+    """Require an exclusively owned, idle autocommit connection outside pipelines.
+
+    Timestamp equality is not a transaction-state test. In particular, protocol
+    preparation can give a fresh parameterized statement distinct timestamps.
+    No query or caller transaction mutation is performed by this guard.
+    """
+    connection = getattr(cursor, "connection", None)
+    info = getattr(connection, "info", None)
+    transaction = getattr(info, "transaction_status", None)
+    pipeline = getattr(info, "pipeline_status", None)
+    if (
+        getattr(connection, "closed", None) is not False
+        or getattr(connection, "autocommit", None) is not True
+        or getattr(transaction, "name", None) != "IDLE"
+        or getattr(pipeline, "name", None) != "OFF"
+    ):
+        raise StorageError(
+            "worker readiness sources require a fresh read-only statement"
+        )

--- a/src/warehouse/worker_readiness_postgres_contract_check.py
+++ b/src/warehouse/worker_readiness_postgres_contract_check.py
@@ -1,0 +1,123 @@
+"""Read-only adapter proof against the disposable database seeded by the existing CI target."""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from typing import Any
+from uuid import uuid4
+
+from src.common.exceptions import StorageError
+from src.orchestration.notification_worker_authority_contract import (
+    PLAN_MODEL_VERSION, build_worker_authority_transition, canonical_bytes,
+)
+from src.warehouse.notification_execution_readiness_postgres_contract_check import DESTINATION_ID
+from src.warehouse.notification_worker_authority_history import record_worker_authority
+from src.warehouse.notification_worker_authority_postgres_contract_check import _grant, _plan
+from src.warehouse.notification_worker_readiness_reader import (
+    read_current_worker_readiness, read_worker_readiness_with_cursor,
+)
+
+
+def run_contract_check(dsn: str) -> dict[str, Any]:
+    import psycopg
+
+    worker_id = "readiness-source-proof-" + uuid4().hex
+    checks: dict[str, bool] = {}
+    if read_current_worker_readiness(dsn=dsn, worker_id=worker_id)["status"] != "authority_missing":
+        raise AssertionError("unknown worker produced readiness")
+    checks["unknown_worker_blocks"] = True
+    with psycopg.connect(dsn, autocommit=True) as connection:
+        with connection.cursor() as cursor:
+            cursor.execute(
+                "SELECT r.record_json FROM risk_platform.current_notification_execution_readiness_review v "
+                "JOIN risk_platform.notification_execution_readiness_decisions r ON r.record_id = v.readiness_record_id "
+                "WHERE v.destination_id = %s AND v.execution_kind = 'initial'", (DESTINATION_ID,),
+            )
+            source = cursor.fetchone()
+            if source is None:
+                raise AssertionError("existing readiness fixture must run before source-reader proof")
+            decision = source[0]["decision"]
+            with TemporaryDirectory(prefix="worker-readiness-source-proof-") as temporary:
+                p = _plan(Path(temporary), worker_id, datetime.now(timezone.utc) - timedelta(seconds=10))
+            p["destination"]["destination_id"] = decision["destination"]["destination_id"]
+            p["destination"]["fingerprint"] = decision["destination"]["fingerprint"]
+            p["destination"]["endpoint_environment_variable"] = decision["destination"]["endpoint_environment_variable"]
+            configuration = decision["configuration"]
+            for target, field in (("delivery_fingerprint", "delivery_fingerprint"),
+                                  ("retry_planning_policy_fingerprint", "retry_policy_fingerprint"),
+                                  ("retry_execution_policy_fingerprint", "retry_execution_policy_fingerprint")):
+                p["delivery"][target] = configuration[field]
+            identity = {key: value for key, value in p.items() if key != "plan_id"}
+            p["plan_id"] = f"{PLAN_MODEL_VERSION}-plan-{hashlib.sha256(canonical_bytes(identity)).hexdigest()[:24]}"
+            active = _grant(p, worker_id)
+            record_worker_authority(dsn=dsn, transition=active)
+            first = read_current_worker_readiness(dsn=dsn, worker_id=worker_id)
+            if first["status"] != "blocked" or first["authority_sequence"] != 1:
+                raise AssertionError("superseded readiness sources did not block")
+            observed_rows = first["snapshot"]["readiness"]
+            if len(observed_rows) != 2 or any(row["status"] != "superseded" for row in observed_rows):
+                raise AssertionError("actual current-review replacement was not independently detected")
+            cursor.execute(
+                "SELECT readiness_record_id FROM risk_platform.current_notification_execution_readiness_review "
+                "WHERE destination_id = %s ORDER BY execution_kind", (DESTINATION_ID,),
+            )
+            if [row["record_id"] for row in observed_rows] != [row[0] for row in cursor.fetchall()]:
+                raise AssertionError("reader selected different retained readiness sources")
+            checks["real_records_reopened_and_supersession_detected"] = True
+            cursor.execute("SELECT COUNT(*) FROM risk_platform.notification_worker_authority_history")
+            before = cursor.fetchone()
+            read_current_worker_readiness(dsn=dsn, worker_id=worker_id)
+            cursor.execute("SELECT COUNT(*) FROM risk_platform.notification_worker_authority_history")
+            if cursor.fetchone() != before:
+                raise AssertionError("readiness reader wrote authority history")
+            checks["read_only_repeat_does_not_write"] = True
+            now = datetime.now(timezone.utc)
+            stopped = build_worker_authority_transition(
+                plan=p, request_id=worker_id + "-stop", operator_id="fixture-operator",
+                action="suspend", requested_at=now, effective_at=now, previous=active,
+                reason_codes=["operator_request"],
+            )
+            record_worker_authority(dsn=dsn, transition=stopped)
+            latest = read_current_worker_readiness(dsn=dsn, worker_id=worker_id)
+            if latest["authority_transition_id"] != stopped["transition_id"] or latest["authority_sequence"] != 2:
+                raise AssertionError("reader reused an older active worker head")
+            if "worker_authority_not_active" not in latest["snapshot"]["blocking_reasons"]:
+                raise AssertionError("stopped authority was not blocked")
+            checks["newer_stop_replaces_old_active_head"] = True
+            cursor.execute("BEGIN READ ONLY")
+            cursor.execute("SELECT 1")
+            try:
+                read_worker_readiness_with_cursor(cursor, worker_id=worker_id)
+            except StorageError as exc:
+                if "fresh read-only statement" not in str(exc):
+                    raise
+            else:
+                raise AssertionError("older caller transaction was accepted")
+            finally:
+                cursor.execute("ROLLBACK")
+            checks["older_transaction_clock_rejected"] = True
+    return {"checks": checks, "fixture_authority_records": 2,
+            "fixture_cleanup": "disposable_database_teardown", "runtime_permission_granted": False,
+            "notification_delivery_performed": False, "scheduler_mutated": False}
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--dsn", required=True)
+    args = parser.parse_args()
+    try:
+        result = run_contract_check(args.dsn)
+    except Exception:
+        print("Worker readiness PostgreSQL source proof failed", file=sys.stderr)
+        return 1
+    print(json.dumps(result, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/warehouse/worker_readiness_postgres_contract_check.py
+++ b/src/warehouse/worker_readiness_postgres_contract_check.py
@@ -112,8 +112,19 @@ def main() -> int:
     args = parser.parse_args()
     try:
         result = run_contract_check(args.dsn)
-    except Exception:
-        print("Worker readiness PostgreSQL source proof failed", file=sys.stderr)
+    except Exception as exc:
+        # Fixed categories only: no DSN, source document or raw exception diagnostic.
+        category = "contract_failure"
+        if isinstance(exc, StorageError) and str(exc) == "worker readiness sources require a fresh read-only statement":
+            category = "fresh_statement_required"
+        trace = exc.__traceback__
+        source_line = 0
+        while trace is not None:
+            if Path(trace.tb_frame.f_code.co_filename).name == "worker_readiness_postgres_contract_check.py":
+                source_line = trace.tb_lineno
+            trace = trace.tb_next
+        print(json.dumps({"status": "failed", "category": category,
+                          "fixture_line": source_line}), file=sys.stderr)
         return 1
     print(json.dumps(result, sort_keys=True))
     return 0

--- a/tests/unit/test_worker_readiness_reader.py
+++ b/tests/unit/test_worker_readiness_reader.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+import hashlib
+from datetime import timedelta
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from src.common.exceptions import StorageError, ValidationError
+from src.warehouse import notification_worker_readiness_reader as reader
+from src.warehouse.notification_worker_readiness_source import source_bytes
+from test_worker_readiness_snapshot import OBSERVED, readiness_authority, source_entry
+
+
+class Cursor:
+    def __init__(self, row: Any) -> None:
+        self.row = row
+        self.calls: list[tuple[str, Any]] = []
+    def execute(self, sql: str, params: Any = None) -> None:
+        self.calls.append((sql, params))
+    def fetchone(self) -> Any:
+        return self.row
+    def __enter__(self) -> Cursor:
+        return self
+    def __exit__(self, *args: Any) -> None:
+        pass
+
+
+def envelope() -> list[Any]:
+    document = readiness_authority()
+    return [OBSERVED, OBSERVED, "read committed", "on", {
+        "document": document, "document_sha256": hashlib.sha256(source_bytes(document)).hexdigest(),
+        "authority_sequence": 1, "oversized": False,
+    }, [{**source_entry(kind), "oversized": False} for kind in ("initial", "retry")]]
+
+
+def test_single_parameterized_statement_reopens_current_sources() -> None:
+    cursor = Cursor(envelope())
+    result = reader.read_worker_readiness_with_cursor(cursor, worker_id="authority-worker")
+    assert cursor.calls == [(reader.READINESS_SOURCE_SQL, ("authority-worker",))]
+    assert result["status"] == "ready_sources"
+    assert result["single_statement_read_only"] is True
+    assert result["authority_transition_id"] == readiness_authority()["transition_id"]
+    assert result["failure_history_verified"] is False
+    assert result["runtime_permission_granted"] is False
+    assert len(result["snapshot"]["readiness"]) == 2
+
+
+def test_unknown_worker_is_not_healthy() -> None:
+    result = reader.read_worker_readiness_with_cursor(Cursor([OBSERVED, OBSERVED, "read committed", "on", None, []]), worker_id="unknown")
+    assert result["status"] == "authority_missing"
+    assert result["snapshot"] is None
+
+
+@pytest.mark.parametrize("index,value", [(1, OBSERVED - timedelta(microseconds=1)), (2, "repeatable read"), (3, "off")])
+def test_old_transaction_or_wrong_session_mode_cannot_supply_current_evidence(index: int, value: Any) -> None:
+    row = envelope()
+    row[index] = value
+    with pytest.raises(StorageError, match="fresh read-only"):
+        reader.read_worker_readiness_with_cursor(Cursor(row), worker_id="authority-worker")
+
+
+@pytest.mark.parametrize("variant", ["oversize_authority", "oversize_record", "three_rows", "wrong_worker", "digest", "bool_sequence", "orphan", "bad_envelope"])
+def test_invalid_or_ambiguous_database_sources_fail_closed(variant: str) -> None:
+    row: Any = envelope()
+    worker_id = "authority-worker"
+    if variant == "oversize_authority":
+        row[4]["oversized"] = True
+    elif variant == "oversize_record":
+        row[5][0]["oversized"] = True
+    elif variant == "three_rows":
+        row[5].append(row[5][0])
+    elif variant == "wrong_worker":
+        worker_id = "other-worker"
+    elif variant == "digest":
+        row[4]["document_sha256"] = "0" * 64
+    elif variant == "bool_sequence":
+        row[4]["authority_sequence"] = True
+    elif variant == "orphan":
+        row[4] = None
+    else:
+        row = None
+    with pytest.raises(StorageError):
+        reader.read_worker_readiness_with_cursor(Cursor(row), worker_id=worker_id)
+
+
+def test_database_failure_does_not_expose_provider_diagnostics() -> None:
+    class FailureCursor(Cursor):
+        def execute(self, sql: str, params: Any = None) -> None:
+            raise RuntimeError("private-dsn-and-provider-detail")
+    with pytest.raises(StorageError, match="source lookup failed") as caught:
+        reader.read_worker_readiness_with_cursor(FailureCursor(None), worker_id="worker")
+    assert "private-dsn" not in str(caught.value)
+
+
+def test_owning_reader_sets_only_bounded_session_options_and_closes(monkeypatch: Any) -> None:
+    cursor = Cursor(envelope())
+    class Connection:
+        closed = False
+        def __enter__(self) -> Connection:
+            return self
+        def __exit__(self, *args: Any) -> None:
+            self.closed = True
+        def cursor(self) -> Cursor:
+            return cursor
+    connection = Connection()
+    monkeypatch.setattr(reader, "_connect", lambda dsn: connection)
+    result = reader.read_current_worker_readiness(dsn="not-used", worker_id="authority-worker")
+    assert connection.closed is True
+    assert [sql for sql, _ in cursor.calls[:3]] == [
+        "SET default_transaction_read_only = on", "SET default_transaction_isolation = 'read committed'",
+        "SET statement_timeout = '10s'",
+    ]
+    assert result["runtime_permission_granted"] is False
+
+
+def test_invalid_selection_fails_before_database_access(monkeypatch: Any) -> None:
+    def forbidden(dsn: str) -> Any:
+        raise AssertionError("connection was not permitted")
+    monkeypatch.setattr(reader, "_connect", forbidden)
+    with pytest.raises(ValidationError):
+        reader.read_current_worker_readiness(dsn="not-used", worker_id="not valid")
+
+
+def test_query_and_real_postgres_proof_remain_bounded_and_wired() -> None:
+    sql = reader.READINESS_SOURCE_SQL
+    assert "LIMIT 1" in sql and "LIMIT 3" in sql
+    assert "r.record_id = v.readiness_record_id" in sql
+    assert "ORDER BY authority_sequence DESC" in sql
+    assert "octet_length(r.record_json::TEXT) <= 1048576" in sql
+    assert "pg_advisory" not in sql
+    assert "worker_readiness_postgres_contract_check" in Path("Makefile").read_text()

--- a/tests/unit/test_worker_readiness_reader.py
+++ b/tests/unit/test_worker_readiness_reader.py
@@ -10,12 +10,14 @@ import pytest
 from src.common.exceptions import StorageError, ValidationError
 from src.warehouse import notification_worker_readiness_reader as reader
 from src.warehouse.notification_worker_readiness_source import source_bytes
+from test_worker_readiness_session import session_cursor
 from test_worker_readiness_snapshot import OBSERVED, readiness_authority, source_entry
 
 
 class Cursor:
     def __init__(self, row: Any) -> None:
         self.row = row
+        self.connection = session_cursor().connection
         self.calls: list[tuple[str, Any]] = []
     def execute(self, sql: str, params: Any = None) -> None:
         self.calls.append((sql, params))
@@ -53,12 +55,29 @@ def test_unknown_worker_is_not_healthy() -> None:
     assert result["snapshot"] is None
 
 
-@pytest.mark.parametrize("index,value", [(1, OBSERVED - timedelta(microseconds=1)), (2, "repeatable read"), (3, "off")])
-def test_old_transaction_or_wrong_session_mode_cannot_supply_current_evidence(index: int, value: Any) -> None:
+@pytest.mark.parametrize("index,value", [(2, "repeatable read"), (3, "off")])
+def test_wrong_session_mode_cannot_supply_current_evidence(index: int, value: Any) -> None:
     row = envelope()
     row[index] = value
     with pytest.raises(StorageError, match="fresh read-only"):
         reader.read_worker_readiness_with_cursor(Cursor(row), worker_id="authority-worker")
+
+
+@pytest.mark.parametrize("offset", [-1, 0, 1])
+def test_fresh_session_does_not_require_equal_protocol_clocks(offset: int) -> None:
+    row = envelope()
+    row[0] = OBSERVED + timedelta(microseconds=offset)
+    result = reader.read_worker_readiness_with_cursor(Cursor(row), worker_id="authority-worker")
+    assert result["status"] == "ready_sources"
+    assert result["observed_at"] == OBSERVED.isoformat()
+
+
+def test_equal_clocks_cannot_hide_an_existing_transaction() -> None:
+    cursor = Cursor(envelope())
+    cursor.connection.info.transaction_status.name = "INTRANS"
+    with pytest.raises(StorageError, match="fresh read-only"):
+        reader.read_worker_readiness_with_cursor(cursor, worker_id="authority-worker")
+    assert cursor.calls == []
 
 
 @pytest.mark.parametrize("variant", ["oversize_authority", "oversize_record", "three_rows", "wrong_worker", "digest", "bool_sequence", "orphan", "bad_envelope"])

--- a/tests/unit/test_worker_readiness_session.py
+++ b/tests/unit/test_worker_readiness_session.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from src.common.exceptions import StorageError
+from src.warehouse.notification_worker_readiness_session import (
+    require_fresh_readiness_session,
+)
+
+
+def session_cursor() -> SimpleNamespace:
+    return SimpleNamespace(connection=SimpleNamespace(
+        closed=False, autocommit=True,
+        info=SimpleNamespace(
+            transaction_status=SimpleNamespace(name="IDLE"),
+            pipeline_status=SimpleNamespace(name="OFF"),
+        ),
+    ))
+
+
+def test_idle_autocommit_session_is_accepted_without_io() -> None:
+    # Deliberately no execute method: state validation cannot send SQL.
+    require_fresh_readiness_session(session_cursor())
+
+
+@pytest.mark.parametrize("state", ["ACTIVE", "INTRANS", "INERROR", "UNKNOWN"])
+def test_nonidle_sessions_are_rejected_before_io(state: str) -> None:
+    cursor = session_cursor()
+    cursor.connection.info.transaction_status.name = state
+    with pytest.raises(StorageError, match="fresh read-only statement"):
+        require_fresh_readiness_session(cursor)
+
+
+@pytest.mark.parametrize("state", ["ON", "ABORTED"])
+def test_pipeline_sessions_are_rejected(state: str) -> None:
+    cursor = session_cursor()
+    cursor.connection.info.pipeline_status.name = state
+    with pytest.raises(StorageError):
+        require_fresh_readiness_session(cursor)
+
+
+@pytest.mark.parametrize("value", [False, None, 1, "true"])
+def test_autocommit_must_be_explicitly_true(value: object) -> None:
+    cursor = session_cursor()
+    cursor.connection.autocommit = value
+    with pytest.raises(StorageError):
+        require_fresh_readiness_session(cursor)
+
+
+@pytest.mark.parametrize("value", [True, None, 0, "false"])
+def test_connection_must_be_explicitly_open(value: object) -> None:
+    cursor = session_cursor()
+    cursor.connection.closed = value
+    with pytest.raises(StorageError):
+        require_fresh_readiness_session(cursor)
+
+
+@pytest.mark.parametrize("cursor", [None, SimpleNamespace(), SimpleNamespace(connection=None)])
+def test_missing_session_evidence_is_rejected(cursor: object) -> None:
+    with pytest.raises(StorageError):
+        require_fresh_readiness_session(cursor)


### PR DESCRIPTION
## Goal and dependency

Readiness-source adapter, layer 3, stacked on #180 after #178. Roadmap #76; primary arc42 block: `warehouse`. Successors: #202 (pre-encoding JSON bounds) and #206 (opt-in inspection command).

Select actual current worker authority and its readiness source records in one bounded read-only PostgreSQL statement, then apply the existing canonical and current-review verifiers.

## Implementation

- Select the highest-sequence authority and only its governed execution kinds.
- Join each current review to the exact retained readiness record; reject oversized or ambiguous inventories.
- Use a dedicated autocommit connection, read-only READ COMMITTED defaults, 5-second connection timeout and 10-second statement timeout.
- Before SQL, require an open, idle autocommit session outside pipeline mode. The connection must be exclusively owned for this operation.
- Use the fresh transaction timestamp as observed_at, matching CURRENT_TIMESTAMP in existing views; do not use timestamp equality as proof of transaction freshness.
- Reopen complete records and verify scope/digests; keep failure-history verification and runtime permission false.
- Exercise the actual reader against the established disposable PostgreSQL fixtures.

## Repaired validation failure

Earlier run 463 failed at the very first unknown-worker read with `fresh_statement_required` (fixture line 31). The original equality check between transaction and statement clocks was too strict for the fresh parameterized operation. The repair checks actual session state before the query instead. It still rejects existing/failed/active transactions and pipeline mode; equal clocks cannot hide an existing transaction. No tolerance or bypass was added.

Repair commit: `c0fd216fc4bd23d68836efc1d0784c12bd929078`, appended without force update. Repair-only scope: five paths, 155 additions / 31 deletions. It adds 18 session cases and a net three reader regression cases.

## Exact final candidate and evidence

```text
Base #180:    6e46a3bb9796985b3d153edcd077f74b172ca402
Head:         c0fd216fc4bd23d68836efc1d0784c12bd929078
Tree:         7a97773ccc0ea61a3046ac3c168c29ca33865975
CI checkout:  52c1e735805ec9d171836bdf364eb685f7ee1597
Whole PR:     7 paths; 595 additions; 0 deletions; 4 commits
```

[CI run 474](https://github.com/alexmarinos87/financial-risk-data-platform/actions/runs/34063070132) passed all four jobs: Python readiness, PostgreSQL contract, Security guardrails and Infrastructure validation. The Python log confirms **1,244 tests passed twice**, Ruff, mypy across **164 source files**, dependency integrity, pipeline demo and warehouse dry-run. Its checkout explicitly combines the stated head with the intended #180 base. GitGuardian check **101566952179** also passed.

Locally, **18 session tests passed** and the repaired files passed compilation/whitespace inspection. The original reader bytes were verified against blob `15569ab1de2f226b541574d832dd58cf2703e389`. A complete repository checkout was unavailable locally; full tests, typing, infrastructure and real PostgreSQL execution ran in GitHub CI, not locally.

Self-review covered selected source identity, parameterization, bounded retrieval, transaction state, current-time consistency and safe diagnostics. Independent review and exact-diff human acceptance are still pending.

## Boundaries and acceptance

The reader performs PostgreSQL reads and connection-local settings only. The proof explicitly commits two synthetic authority records inside CI's disposable database for separate sessions to observe; normal teardown removes that database. It is not a rollback-only proof and must not run against production.

No schema, activation-default, workflow or dependency change. No authenticated-operator claim, slot/replay ownership, verified per-worker failure history, live under-lock authority refresh, delivery, scheduling, deployment or Terraform apply. No code is imported from the separate unaccepted suspension or preflight-diagnostics stacks.

**Draft and unmerged.** Accept/integrate #178, reconstruct and accept #180, then reconstruct this isolated delta on accepted main and rerun its full checks before acceptance. Passing CI is evidence, not permission to merge or execute. Apply the same process to #202 and #206 afterward.