### PR TITLE
Use bounded strict file intake for readiness records

### DIFF
--- a/docs/readiness-record-file-intake.md
+++ b/docs/readiness-record-file-intake.md
@@ -1,0 +1,63 @@
+# Readiness record file-intake hardening
+
+Primary arc42 block: `warehouse`. Goal #187, following the common reader in #186.
+
+## Decision and scope
+
+The readiness recorder's `_read_record` delegates to
+`src.common.bounded_json.load_bounded_json_object` with the existing
+1,048,576-byte ceiling. Its old path-size check followed by unbounded `read_text`
+could exceed the checked size when a file grew. Plain JSON decoding also lost
+conflicting earlier duplicate fields before record validation could see them.
+
+This change replaces only the local-file loader. Canonical record validation,
+decision reconstruction, request idempotency, SQL, transaction handling,
+result formatting and public CLI options are unchanged. Parsing success still
+does not authorize a record: the existing semantic validator runs before the
+recorder connects to PostgreSQL.
+
+## Compatibility
+
+Ordinary valid readiness files round-trip unchanged, including formatting
+whitespace within the byte limit. Duplicate keys at any depth are rejected,
+even when the last occurrence would have formed a valid canonical record.
+Non-finite numbers, invalid UTF-8, non-object roots and more than 64 nested
+containers are rejected. Exact one-megabyte files remain accepted; one byte
+more is rejected on actual descriptor reads.
+
+The shared reader now supplies fixed intake diagnostics, so consumers should
+not rely on the old exact error text. Existing negative tests retain the same
+rejection assertions with updated diagnostic matches. The command's validation
+failure exit remains one; no new execution or recording mode is introduced.
+
+The separate existing DSN option and argparse behavior are not changed by this
+file-intake patch. Do not pass credentials as unsupported command arguments.
+This PR does not claim to solve process-list or shell-history confidentiality.
+
+## Trust and validation
+
+See [the shared intake contract](bounded-json-evidence.md) for platform flags,
+trusted-parent-directory assumptions, descriptor cleanup and the absence of a
+regular-file read deadline or immutable-file guarantee. Inputs must still come
+from immutable reviewed snapshots. A parsed object or hash is not proof of
+reviewer authentication, current source state or execution permission.
+
+```bash
+python -m pytest -q tests/unit/test_bounded_json.py \
+  tests/unit/test_notification_execution_readiness_recorder.py \
+  tests/unit/test_readiness_record_file_intake.py
+make quality-check
+make security-check
+make readiness-check
+```
+
+New tests use the existing real readiness builder and validator. They demonstrate
+a valid last duplicate occurrence being accepted by plain decoding but rejected
+at intake, exact byte boundaries, symlinks/FIFOs/directories, unchanged delegation,
+no recorder call on malformed input and no database connection on semantically
+invalid records. Database-facing calls are injected in positive CLI tests.
+
+No application database is accessed during implementation or unit testing. No
+schema, workflow, dependency, configuration enablement, scheduler, transport,
+notification or deployment change. Independent review and explicit final-diff
+engineer acceptance remain required before merge.

--- a/src/warehouse/notification_execution_readiness_recorder.py
+++ b/src/warehouse/notification_execution_readiness_recorder.py
@@ -208,19 +208,9 @@ def record_notification_execution_readiness(
 
 
 def _read_record(path: Path) -> dict[str, Any]:
-    if path.is_symlink():
-        raise ValidationError("notification readiness record must not be a symbolic link")
-    if not path.is_file():
-        raise ValidationError("notification readiness record must be a regular file")
-    if path.stat().st_size > MAX_RECORD_BYTES:
-        raise ValidationError("notification readiness record exceeds 1 MB")
-    try:
-        value = json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, UnicodeError, ValueError):
-        raise ValidationError("notification readiness record could not be read") from None
-    if not isinstance(value, Mapping):
-        raise ValidationError("notification readiness record must be a JSON object")
-    return dict(value)
+    from src.common.bounded_json import load_bounded_json_object
+
+    return load_bounded_json_object(path, max_bytes=MAX_RECORD_BYTES)
 
 
 def _build_parser() -> argparse.ArgumentParser:

--- a/tests/unit/test_notification_execution_readiness_recorder.py
+++ b/tests/unit/test_notification_execution_readiness_recorder.py
@@ -27,12 +27,12 @@ def test_record_reader_rejects_non_object_and_oversized_files(
 ) -> None:
     array = tmp_path / "array.json"
     array.write_text("[]", encoding="utf-8")
-    with pytest.raises(ValidationError, match="JSON object"):
+    with pytest.raises(ValidationError, match="must be an object"):
         _read_record(array)
 
     oversized = tmp_path / "oversized.json"
     oversized.write_bytes(b" " * (MAX_RECORD_BYTES + 1))
-    with pytest.raises(ValidationError, match="exceeds 1 MB"):
+    with pytest.raises(ValidationError, match="byte limit"):
         _read_record(oversized)
 
 

--- a/tests/unit/test_readiness_record_file_intake.py
+++ b/tests/unit/test_readiness_record_file_intake.py
@@ -1,0 +1,159 @@
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from src.common import bounded_json
+from src.common.exceptions import ValidationError
+from src.warehouse import notification_execution_readiness_recorder as recorder
+from src.warehouse.notification_execution_readiness_history_contract import (
+    validate_notification_execution_readiness_record,
+)
+from test_notification_execution_readiness_enforcement import _record
+
+
+def test_real_canonical_record_round_trips_unchanged(tmp_path: Path) -> None:
+    record = _record()
+    raw = json.dumps(record, ensure_ascii=False).encode()
+    path = tmp_path / "record.json"
+    path.write_bytes(raw)
+    loaded = recorder._read_record(path)
+    assert loaded == record
+    assert validate_notification_execution_readiness_record(loaded) == record
+    assert path.read_bytes() == raw
+
+
+@pytest.mark.parametrize("nested", [False, True])
+def test_duplicate_field_cannot_hide_behind_valid_last_occurrence(tmp_path: Path, nested: bool) -> None:
+    record = _record()
+    text = json.dumps(record)
+    if nested:
+        text = text.replace('"decision": {', '"decision": {"decision":"discarded",', 1)
+    else:
+        text = '{"record_id":"discarded",' + text[1:]
+    # Demonstrate that the old parser loses the conflicting earlier value.
+    assert json.loads(text) == record
+    path = tmp_path / "duplicate.json"
+    path.write_text(text, encoding="utf-8")
+    with pytest.raises(ValidationError, match="duplicate fields"):
+        recorder._read_record(path)
+
+
+@pytest.mark.parametrize("extra", [0, 1])
+def test_record_file_keeps_exact_one_megabyte_limit(tmp_path: Path, extra: int) -> None:
+    record = _record()
+    raw = json.dumps(record).encode()
+    raw += b" " * (recorder.MAX_RECORD_BYTES + extra - len(raw))
+    path = tmp_path / "bounded.json"
+    path.write_bytes(raw)
+    if extra:
+        with pytest.raises(ValidationError, match="byte limit"):
+            recorder._read_record(path)
+    else:
+        assert recorder._read_record(path) == record
+
+
+@pytest.mark.parametrize("raw", [
+    b'{"value":NaN}', b'{"value":Infinity}', b'{"value":1e9999}',
+    b'{"private":"\xff"}', b'{"key":1,"key":2}', b'[]', b'null',
+    b'{"private":', b'{"v":' * 65 + b'0' + b'}' * 65,
+])
+def test_cli_rejects_bad_intake_before_recording(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str], raw: bytes,
+) -> None:
+    path = tmp_path / "private-record-path.json"
+    path.write_bytes(raw)
+    calls: list[dict[str, Any]] = []
+
+    def forbidden(**kwargs: Any) -> dict[str, Any]:
+        calls.append(kwargs)
+        raise AssertionError("invalid file must not reach recording")
+
+    monkeypatch.setattr(recorder, "record_notification_execution_readiness", forbidden)
+    assert recorder.main(["--record", str(path), "--dsn", "unused-test-dsn"]) == 1
+    captured = capsys.readouterr()
+    assert calls == []
+    assert captured.out == ""
+    assert captured.err.startswith("Notification readiness record rejected:")
+    assert "private" not in captured.err
+    assert "unused-test-dsn" not in captured.err
+
+
+@pytest.mark.parametrize("dangling", [False, True])
+def test_record_input_symlink_is_rejected(tmp_path: Path, dangling: bool) -> None:
+    target = tmp_path / "record.json"
+    if not dangling:
+        target.write_text(json.dumps(_record()))
+    link = tmp_path / "link.json"
+    link.symlink_to(target)
+    with pytest.raises(ValidationError, match="symbolic link"):
+        recorder._read_record(link)
+    assert link.is_symlink()
+
+
+def test_record_input_directory_is_rejected(tmp_path: Path) -> None:
+    with pytest.raises(ValidationError, match="regular file"):
+        recorder._read_record(tmp_path)
+
+
+@pytest.mark.skipif(not hasattr(os, "mkfifo"), reason="FIFO support is unavailable")
+def test_record_input_fifo_is_rejected_without_waiting(tmp_path: Path) -> None:
+    path = tmp_path / "fifo"
+    os.mkfifo(path)
+    with pytest.raises(ValidationError, match="regular file"):
+        recorder._read_record(path)
+
+
+def test_loader_delegates_the_existing_byte_limit(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    record = _record()
+    calls: list[tuple[Path, int]] = []
+
+    def load(path: Path, *, max_bytes: int) -> dict[str, Any]:
+        calls.append((path, max_bytes))
+        return record
+
+    path = tmp_path / "not-read.json"
+    monkeypatch.setattr(bounded_json, "load_bounded_json_object", load)
+    assert recorder._read_record(path) == record
+    assert calls == [(path, 1_048_576)]
+
+
+def test_cli_valid_input_delegates_unchanged_record(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str],
+) -> None:
+    record = _record()
+    path = tmp_path / "record.json"
+    path.write_text(json.dumps(record), encoding="utf-8")
+    calls: list[dict[str, Any]] = []
+
+    def record_once(**kwargs: Any) -> dict[str, Any]:
+        calls.append(kwargs)
+        assert validate_notification_execution_readiness_record(kwargs["record"]) == record
+        return {"record_id": record["record_id"], "created": False}
+
+    monkeypatch.setattr(recorder, "record_notification_execution_readiness", record_once)
+    assert recorder.main(["--record", str(path), "--dsn", "injected-dsn"]) == 0
+    assert calls == [{"dsn": "injected-dsn", "record": record}]
+    assert json.loads(capsys.readouterr().out) == {"record_id": record["record_id"], "created": False}
+
+
+def test_valid_json_does_not_replace_semantic_validation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str],
+) -> None:
+    import psycopg
+
+    record = _record()
+    record["record_id"] = "not-the-canonical-identity"
+    path = tmp_path / "record.json"
+    path.write_text(json.dumps(record), encoding="utf-8")
+
+    def forbidden(*args: Any, **kwargs: Any) -> Any:
+        raise AssertionError("invalid semantic evidence must not connect")
+
+    monkeypatch.setattr(psycopg, "connect", forbidden)
+    assert recorder.main(["--record", str(path), "--dsn", "unused-dsn"]) == 1
+    assert capsys.readouterr().out == ""


### PR DESCRIPTION
## Goal

Closes #187. Second of two file-intake review units under #76, stacked on #192. Primary arc42 block: warehouse.

## Change and compatibility

Replace only notification_execution_readiness_recorder._read_record with delegation to the common bounded JSON reader, retaining the existing 1,048,576-byte ceiling. Canonical record/decision validation, SQL, transaction handling, request idempotency, result formatting and CLI options remain unchanged.

Add **21 regression cases** using the real existing readiness builder: valid round-trip, exact byte limit, duplicate root/nested fields whose final occurrences would otherwise be canonical, malformed/non-finite JSON, symlink/nonregular files, pre-recording rejection and preserved semantic validation before connection. Existing negative tests retain their rejection assertions with two diagnostic-text matches updated to the common reader.

Four intended paths: recorder loader, its existing diagnostic expectations, dedicated integration tests and documentation; **227 additions and 15 deletions**. Head `7f8449d847f91322a7594b345d3031ae4eaa8fe3`; tree `31190cbc4b02c70fc580e339c9ea13ac9b9b37c1`.

## Exact-head validation

GitHub Actions run **473** (`34052333990`) passed Python readiness, Security guardrails, PostgreSQL contract and Infrastructure validation. Python job `101538050279` confirms Ruff passed, mypy passed across **160 source files**, **1,220 tests passed twice**, dependency integrity, pipeline replay and warehouse dry-run.

Checkout log identifies synthetic merge `0039b0be0ab9b9980a7d4bd5030a95fdb51679b9`, combining this exact head with predecessor `1dc74d4d44898b02644b3b2689b8c690aadc5c27`. Final comparison found the full two-commit chain contained every current main commit, with main still `7316dd30ce5b445df0ac2c0ac019703add15aadc`. Across both PRs there are seven intended paths and **68 new regression cases**.

The copied baseline recorder matches accepted Git blob `96899825d7f3b7847b35a2946f7efb06d08f6ae7`. Local AST comparison confirms `_read_record` is the only changed function/top-level node. Compilation passed. The common reader's 47 focused tests passed locally in a source-subset directory. The new integration cases and complete repository checks ran in GitHub Actions, not a full local checkout.

## Review and acceptance

Reviewed the published recorder patch: one loader-only hunk, no SQL/transaction/CLI changes. Self-review covered parsing before side effects, valid-file compatibility, redacted intake errors and preservation of semantic validation. Submitted reviews and review threads were empty when checked. Independent correctness/production review and explicit final-diff engineer acceptance remain pending.

**Validated draft, unmerged.** Accept #192 first, reconstruct this isolated delta on accepted main and rerun final-head checks before acceptance. Do not merge into the unaccepted predecessor as a shortcut.

## Boundary

No schema, workflow, dependency, configuration switch, application database access, notification, scheduler, transport or deployment change. Existing DSN/argparse options are deliberately not redesigned. Parent-directory trust and immutable-file provenance remain caller responsibilities; parsing is not authenticated approval. Database test effects are confined to the existing disposable CI service.