### PR TITLE
Reconcile all exact-head pull request checks for review

### DIFF
--- a/docs/pr-check-evidence.md
+++ b/docs/pr-check-evidence.md
@@ -1,0 +1,63 @@
+# Exact-head pull-request check evidence
+
+Primary arc42 block: `engineering-controls`. Goal #195 under #76.
+
+## Decision
+
+A green Actions workflow is not the full check inventory. PR #191 demonstrated
+this: four workflow jobs passed while a separate GitGuardian check failed.
+`scripts/pr_check_evidence.py` summarizes both check runs and commit statuses
+without assigning engineer acceptance, dismissing a finding, or merging a PR.
+This complements the local Git/overnight package in `scripts/morning_review.py`;
+it does not replace it or change any branch rule.
+
+Call `summarize_checks` with the exact full head SHA, every page from the check
+runs endpoint using `filter=latest`, and every page from the combined commit
+status endpoint for that same SHA. Each page's total must reconcile with the
+collected distinct IDs. Check heads and status-page heads must match exactly.
+An incomplete or changing page inventory is an error, never a partial success.
+The bound is ten pages / 1,000 rows per source; unsupported names or API states
+fail closed. No network or filesystem I/O occurs in this module.
+
+## Repository-specific diagnostic policy
+
+The policy expects Python readiness, PostgreSQL contract, Security guardrails
+and Infrastructure validation from GitHub Actions App 15368, plus GitGuardian
+Security Checks from App 46505. These identities were observed on this repository;
+they are not a universal GitHub policy or a substitute for reading branch rules.
+Same-named checks from another app do not satisfy the expectation. Every
+additional observed failure still counts, including legacy commit statuses.
+
+Only `success` counts as passed. Missing, queued, neutral and skipped evidence
+remain incomplete. This is deliberately more conservative than GitHub's possible
+branch-rule semantics. Repeated latest app/name or context identities remain
+ambiguous: the tool does not guess which result to discard. Provider-reported
+failures are not waived by prose describing a suspected false positive.
+
+Output contains selected IDs, names and result fields only, not API output
+bodies, descriptions or arbitrary provider URLs. Results are detached and ordered.
+`engineer_acceptance` is always `pending`, `branch_rules_verified` is false and
+`merge_authorized` is false, even when all reported checks passed.
+
+## Validation and limits
+
+```bash
+python -m pytest -q tests/unit/test_pr_check_evidence.py
+make quality-check
+make security-check
+```
+
+Tests reproduce a workflow-green/scanner-red inventory, missing/spoofed app
+checks, additional failing statuses, pagination gaps, stale SHA evidence,
+ambiguous reruns, strict types and provider-content exclusion.
+
+The input remains captured evidence, not authenticated offline provenance.
+This does not prove a workflow tested the latest base/merge tree, that GitHub has
+already created every future check, or that a reviewer accepted the diff. The
+successor collects current PR/compare evidence with read-only API calls. GitHub
+also limits reference-level check listing to recent suites; this tool does not
+claim an unlimited historical audit. Existing scanner incidents stay untouched.
+
+Primary API contracts:
+- <https://docs.github.com/en/rest/checks/runs#list-check-runs-for-a-git-reference>
+- <https://docs.github.com/en/rest/commits/statuses#get-the-combined-status-for-a-specific-reference>

--- a/scripts/pr_check_evidence.py
+++ b/scripts/pr_check_evidence.py
@@ -1,0 +1,133 @@
+"""Conservative exact-head check inventory; never a merge/approval decision."""
+from __future__ import annotations
+
+import re
+from collections import Counter
+from collections.abc import Mapping
+from typing import Any
+
+MAX_ROWS = 1000
+MAX_PAGES = 10
+REQUIRED_CHECKS = frozenset({
+    (15368, "Python readiness"), (15368, "PostgreSQL contract"),
+    (15368, "Security guardrails"), (15368, "Infrastructure validation"),
+    (46505, "GitGuardian Security Checks"),
+})
+FAILURES = frozenset({"failure", "cancelled", "timed_out", "action_required", "startup_failure", "stale"})
+CONCLUSIONS = FAILURES | {"success", "neutral", "skipped"}
+
+
+class EvidenceError(ValueError):
+    """Invalid or incomplete evidence; diagnostics never include provider content."""
+
+
+def full_sha(value: Any) -> str:
+    if not isinstance(value, str) or re.fullmatch(r"[0-9a-f]{40}", value) is None:
+        raise EvidenceError("a full lowercase commit SHA is required")
+    return value
+
+
+def positive_id(value: Any) -> int:
+    if type(value) is not int or value <= 0:
+        raise EvidenceError("invalid evidence identifier")
+    return value
+
+
+def display_name(value: Any) -> str:
+    if (not isinstance(value, str) or not 1 <= len(value) <= 128
+            or value != value.strip() or any(not 32 <= ord(char) <= 126 for char in value)):
+        raise EvidenceError("unsupported evidence name")
+    return value
+
+
+def complete_rows(pages: Any, key: str, *, head_sha: str | None = None) -> list[Mapping[str, Any]]:
+    """Reconcile all page totals and IDs, rather than accepting a partial first page."""
+    if not isinstance(pages, list) or not 1 <= len(pages) <= MAX_PAGES:
+        raise EvidenceError("missing or excessive evidence pages")
+    rows: list[Mapping[str, Any]] = []
+    total = None
+    seen: set[int] = set()
+    for page in pages:
+        if not isinstance(page, Mapping):
+            raise EvidenceError("invalid evidence page")
+        count = page.get("total_count")
+        items = page.get(key)
+        if (type(count) is not int or not 0 <= count <= MAX_ROWS
+                or not isinstance(items, list) or len(items) > 100):
+            raise EvidenceError("invalid evidence page inventory")
+        if total is not None and count != total:
+            raise EvidenceError("evidence inventory changed during pagination")
+        total = count
+        if head_sha is not None and page.get("sha") != head_sha:
+            raise EvidenceError("commit-status page belongs to another head")
+        for row in items:
+            if not isinstance(row, Mapping):
+                raise EvidenceError("invalid evidence row")
+            row_id = positive_id(row.get("id"))
+            if row_id in seen:
+                raise EvidenceError("duplicate evidence row")
+            seen.add(row_id)
+            rows.append(row)
+    if len(rows) != total:
+        raise EvidenceError("incomplete evidence pagination")
+    return rows
+
+
+def summarize_checks(*, head_sha: str, check_pages: Any, status_pages: Any) -> dict[str, Any]:
+    """Summarize latest check runs and combined latest-per-context commit statuses.
+
+    The caller must obtain filter=latest check pages and combined status pages
+    for this exact SHA. API totals cannot authenticate offline captures or prove
+    the absence of checks GitHub has not yet created. Duplicate latest identities
+    remain ambiguous instead of guessing which rerun to discard.
+    """
+    head = full_sha(head_sha)
+    checks = complete_rows(check_pages, "check_runs")
+    statuses = complete_rows(status_pages, "statuses", head_sha=head)
+    entries: list[dict[str, Any]] = []
+    identities: Counter[tuple[int, str]] = Counter()
+    for row in checks:
+        if row.get("head_sha") != head:
+            raise EvidenceError("check run belongs to another head")
+        app = row.get("app")
+        if not isinstance(app, Mapping):
+            raise EvidenceError("check run has no app identity")
+        app_id = positive_id(app.get("id"))
+        name = display_name(row.get("name"))
+        state, conclusion = row.get("status"), row.get("conclusion")
+        if not isinstance(state, str) or state not in {"queued", "in_progress", "completed", "pending", "waiting", "requested"}:
+            raise EvidenceError("unknown check-run state")
+        if state == "completed":
+            if not isinstance(conclusion, str) or conclusion not in CONCLUSIONS:
+                raise EvidenceError("unknown completed check conclusion")
+            outcome = "passed" if conclusion == "success" else "failed" if conclusion in FAILURES else "incomplete"
+        else:
+            if conclusion is not None:
+                raise EvidenceError("unfinished check has a conclusion")
+            outcome = "incomplete"
+        identities[(app_id, name)] += 1
+        entries.append({"kind": "check_run", "id": row["id"], "app_id": app_id,
+                        "name": name, "state": state, "conclusion": conclusion, "outcome": outcome})
+    contexts: Counter[str] = Counter()
+    for row in statuses:
+        name = display_name(row.get("context"))
+        state = row.get("state")
+        if not isinstance(state, str) or state not in {"success", "failure", "error", "pending"}:
+            raise EvidenceError("unknown commit-status state")
+        contexts[name] += 1
+        entries.append({"kind": "commit_status", "id": row["id"], "app_id": None,
+                        "name": name, "state": state, "conclusion": None,
+                        "outcome": "passed" if state == "success" else "incomplete" if state == "pending" else "failed"})
+    missing = [{"app_id": app_id, "name": name}
+               for app_id, name in sorted(REQUIRED_CHECKS - identities.keys())]
+    ambiguous = any(count > 1 for count in identities.values()) or any(count > 1 for count in contexts.values())
+    failed = any(row["outcome"] == "failed" for row in entries)
+    incomplete = bool(missing) or ambiguous or any(row["outcome"] == "incomplete" for row in entries)
+    outcome = "failed" if failed else "incomplete" if incomplete else "passed"
+    return {
+        "head_sha": head, "outcome": outcome, "all_reported_checks_passed": outcome == "passed",
+        "entries": sorted(entries, key=lambda row: (row["kind"], row["app_id"] or 0, row["name"], row["id"])),
+        "missing_required_checks": missing, "ambiguous_latest_identities": ambiguous,
+        "evidence_scope": "captured_exact_head", "branch_rules_verified": False,
+        "engineer_acceptance": "pending", "merge_authorized": False,
+    }

--- a/tests/unit/test_pr_check_evidence.py
+++ b/tests/unit/test_pr_check_evidence.py
@@ -1,0 +1,157 @@
+from __future__ import annotations
+
+import copy
+import json
+from typing import Any
+
+import pytest
+
+from scripts import pr_check_evidence as evidence
+
+HEAD = "a" * 40
+
+
+def pages() -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    checks = [{"id": i, "name": name, "app": {"id": app}, "head_sha": HEAD,
+               "status": "completed", "conclusion": "success"}
+              for i, (app, name) in enumerate(sorted(evidence.REQUIRED_CHECKS), 1)]
+    return [{"total_count": len(checks), "check_runs": checks}], [{"sha": HEAD, "total_count": 0, "statuses": []}]
+
+
+def summarize(checks: Any, statuses: Any) -> dict[str, Any]:
+    return evidence.summarize_checks(head_sha=HEAD, check_pages=checks, status_pages=statuses)
+
+
+def test_green_inventory_is_not_engineer_acceptance_and_drops_provider_content() -> None:
+    checks, statuses = pages()
+    checks[0]["check_runs"][0]["output"] = {"text": "private-provider-content"}
+    checks[0]["check_runs"][0]["details_url"] = "https://untrusted.invalid/private"
+    before = copy.deepcopy((checks, statuses))
+    result = summarize(checks, statuses)
+    assert result["outcome"] == "passed" and result["all_reported_checks_passed"] is True
+    assert result["merge_authorized"] is False and result["engineer_acceptance"] == "pending"
+    assert result["branch_rules_verified"] is False
+    assert "private" not in json.dumps(result)
+    result["entries"][0]["name"] = "changed"
+    assert (checks, statuses) == before
+
+
+def test_four_green_workflow_jobs_cannot_hide_gitguardian_failure() -> None:
+    checks, statuses = pages()
+    scanner = next(row for row in checks[0]["check_runs"] if row["app"]["id"] == 46505)
+    scanner["conclusion"] = "failure"
+    result = summarize(checks, statuses)
+    assert result["outcome"] == "failed" and result["all_reported_checks_passed"] is False
+    assert [row["name"] for row in result["entries"] if row["outcome"] == "failed"] == ["GitGuardian Security Checks"]
+
+
+@pytest.mark.parametrize("conclusion", ["neutral", "skipped", "cancelled", "timed_out", "action_required", "startup_failure", "stale"])
+def test_non_success_conclusions_never_pass(conclusion: str) -> None:
+    checks, statuses = pages()
+    checks[0]["check_runs"][0]["conclusion"] = conclusion
+    assert summarize(checks, statuses)["all_reported_checks_passed"] is False
+
+
+@pytest.mark.parametrize("state", ["queued", "in_progress", "pending", "waiting", "requested"])
+def test_unfinished_checks_are_incomplete(state: str) -> None:
+    checks, statuses = pages()
+    checks[0]["check_runs"][0].update(status=state, conclusion=None)
+    assert summarize(checks, statuses)["outcome"] == "incomplete"
+
+
+def test_same_named_other_app_cannot_satisfy_requirement() -> None:
+    checks, statuses = pages()
+    checks[0]["check_runs"][0]["app"]["id"] = 999
+    result = summarize(checks, statuses)
+    assert result["outcome"] == "incomplete"
+    assert len(result["missing_required_checks"]) == 1
+
+
+def test_extra_failing_app_is_not_ignored() -> None:
+    checks, statuses = pages()
+    extra = {**checks[0]["check_runs"][0], "id": 99, "app": {"id": 999}, "conclusion": "failure"}
+    checks[0]["check_runs"].append(extra)
+    checks[0]["total_count"] += 1
+    assert summarize(checks, statuses)["outcome"] == "failed"
+
+
+@pytest.mark.parametrize("state", ["success", "failure", "error", "pending"])
+def test_commit_statuses_are_reconciled_separately(state: str) -> None:
+    checks, statuses = pages()
+    statuses[0].update(total_count=1, statuses=[{"id": 91, "context": "external-audit", "state": state}])
+    result = summarize(checks, statuses)
+    assert result["outcome"] == ("passed" if state == "success" else "incomplete" if state == "pending" else "failed")
+
+
+def test_full_pagination_and_order_independence() -> None:
+    checks, statuses = pages()
+    baseline = summarize(checks, statuses)
+    rows = checks[0]["check_runs"]
+    split = [{"total_count": 5, "check_runs": rows[:2]}, {"total_count": 5, "check_runs": list(reversed(rows[2:]))}]
+    assert summarize(split, statuses) == baseline
+
+
+@pytest.mark.parametrize("mutation", ["missing_page", "changed_total", "duplicate_id", "wrong_head", "wrong_status_head",
+                                      "boolean_total", "boolean_id", "bad_app", "bad_name", "bad_state", "bad_conclusion", "unfinished_conclusion"])
+def test_malformed_or_partial_evidence_fails_closed(mutation: str) -> None:
+    checks, statuses = pages()
+    row = checks[0]["check_runs"][0]
+    if mutation == "missing_page":
+        checks[0]["total_count"] = 6
+    elif mutation == "changed_total":
+        checks.append({"total_count": 6, "check_runs": []})
+    elif mutation == "duplicate_id":
+        checks[0]["check_runs"][1]["id"] = row["id"]
+    elif mutation == "wrong_head":
+        row["head_sha"] = "b" * 40
+    elif mutation == "wrong_status_head":
+        statuses[0]["sha"] = "b" * 40
+    elif mutation == "boolean_total":
+        checks[0]["total_count"] = True
+    elif mutation == "boolean_id":
+        row["id"] = True
+    elif mutation == "bad_app":
+        row["app"] = None
+    elif mutation == "bad_name":
+        row["name"] = "control\ncharacter"
+    elif mutation == "bad_state":
+        row["status"] = []
+    elif mutation == "bad_conclusion":
+        row["conclusion"] = "new-unknown-result"
+    else:
+        row["status"] = "queued"
+    with pytest.raises(evidence.EvidenceError):
+        summarize(checks, statuses)
+
+
+@pytest.mark.parametrize("kind", ["check", "status"])
+def test_duplicate_latest_identities_are_ambiguous_not_guessed(kind: str) -> None:
+    checks, statuses = pages()
+    if kind == "check":
+        checks[0]["check_runs"].append({**checks[0]["check_runs"][0], "id": 99})
+        checks[0]["total_count"] += 1
+    else:
+        statuses[0].update(total_count=2, statuses=[{"id": i, "context": "same", "state": "success"} for i in (98, 99)])
+    result = summarize(checks, statuses)
+    assert result["ambiguous_latest_identities"] is True
+    assert result["outcome"] == "incomplete"
+
+
+@pytest.mark.parametrize("value", [None, "main", "a" * 39, "A" * 40, 1])
+def test_explicit_full_head_is_required(value: Any) -> None:
+    with pytest.raises(evidence.EvidenceError):
+        evidence.summarize_checks(head_sha=value, check_pages=[], status_pages=[])
+
+
+@pytest.mark.parametrize("value", [None, [], [{}], [{"total_count": 1001, "check_runs": []}]])
+def test_missing_or_unbounded_pages_are_rejected(value: Any) -> None:
+    _, statuses = pages()
+    with pytest.raises(evidence.EvidenceError):
+        summarize(value, statuses)
+
+
+def test_empty_inventory_is_missing_not_green() -> None:
+    _, statuses = pages()
+    result = summarize([{"total_count": 0, "check_runs": []}], statuses)
+    assert result["outcome"] == "incomplete"
+    assert len(result["missing_required_checks"]) == 5


### PR DESCRIPTION
## Goal and status

Closes #195 after acceptance and merge. First of two acceptance-backlog increments under #76; followed by #203. Primary arc42 block: engineering-controls.

**Implemented, final-head CI and separate GitGuardian scan passed; draft and unmerged. Independent review and explicit final-diff engineer acceptance remain pending.** This stack starts directly from accepted main and imports none of the pending notification/fixture/source/suspension implementations.

## Delivered behavior

A pure standard-library reconciler for fully paginated latest check runs and combined commit-status pages. Every source is bound to the exact full SHA; totals and distinct row IDs must reconcile. The diagnostic policy expects the four repository Actions jobs plus GitGuardian from their observed App IDs. Same-named checks from another App cannot satisfy a requirement. Additional failed checks and legacy statuses are not ignored. Missing, queued, skipped/neutral or ambiguous latest evidence never becomes all-checks-passed.

Output excludes provider bodies, descriptions and arbitrary URLs. Engineer acceptance remains pending, branch rules remain unverified and merge authorization remains false on every successful output path. The motivating #191 case—four passing workflow jobs plus a failed separate scanner check—is reported as failed. No scanner finding is adjudicated or dismissed.

## Exact candidate

- Base main: `7316dd30ce5b445df0ac2c0ac019703add15aadc`.
- Final head: `4cf5602041d53be89f52344265740c0edbec70af`.
- Tree: `65331ce2f63f390ceebaef43ae0367f0627583c4`.
- Tested synthetic merge: `3c11a7901c27bc69bd8f23c79890ae9bdb98ee66`, combining that exact head and base.
- Scope: **three additive files, 353 additions, zero deletions, one commit**: reconciler, focused regression suite and operating document. Changed-file inventory was verified. No source changes after the successful CI run.

## Final-head validation

[Actions run 475](https://github.com/alexmarinos87/financial-risk-data-platform/actions/runs/34063104219) passed all four jobs: Python readiness, PostgreSQL contract, Security guardrails and Infrastructure validation.

Python job `101567053866` confirms Ruff passed, **1,197 tests passed twice**, dependency integrity, pipeline replay and warehouse dry-run. The repository's mypy command passed across 159 `src` files; that existing command does not directly type-check these new `scripts` modules. PostgreSQL job `101567053912` completed its existing disposable contract and consistency checks. Separate GitGuardian check **101567052252** passed for this exact head.

All **45 new tests passed locally**; compilation and staged whitespace checks passed in a source-subset worktree. The combined successor suite was also rerun locally: 110 passed, none skipped or deselected. Full clone failed on GitHub DNS and the complete local toolchain was unavailable. Full-repository checks, typing and real PostgreSQL/infrastructure validation ran in GitHub CI, not locally.

## Review and limits

Self-review covered stale SHA and pagination rejection, strict IDs, App-scoped requirements, extra failures, ambiguous latest identities, detached deterministic output and exclusion of provider bodies. Conversation, submitted-review and inline-comment inventory was empty when inspected. This is not independent correctness/production review or engineer approval.

The expected-check policy is a conservative repository-specific review aid, not GitHub branch-rule evaluation. Historical captures are not authenticated; checks not yet created cannot be observed. Passing check inventory does not verify the current merge/base tree tested by CI. No I/O in this pure layer, scanner suppression, workflow/settings change, status override, merge, database operation or deployment.

## Acceptance sequence

Accept this exact delta first. After its accepted squash merge, reconstruct #203's isolated three-file delta on accepted main and rerun its exact-head checks before acceptance. Do not merge the successor into an unaccepted predecessor. Existing pending PRs, including #191's failed scanner disposition, remain unchanged.