### PR TITLE
Bound controlled-receiver rehearsal file intake

### DIFF
--- a/docs/receiver-record-file-intake.md
+++ b/docs/receiver-record-file-intake.md
@@ -1,0 +1,63 @@
+# Controlled-receiver rehearsal file intake
+
+Primary arc42 block: `warehouse`. Goal #197; prerequisite #186 / PR #192.
+
+## Decision and runtime boundary
+
+The existing receiver history recorder delegates `_read_record` to the shared
+bounded JSON reader with its unchanged 1,048,576-byte ceiling. This removes a
+path-size check followed by an unbounded text read. The recorder's checklist
+and rehearsal validators, SQL, transactions, identities, idempotency and CLI
+functions are unchanged.
+
+The sequence is local file intake, then semantic record validation, then the
+existing explicit PostgreSQL recording operation. The file parser does not
+run the receiver or send a notification. Ordinary JSON decoding can discard
+earlier duplicate names; the strict reader rejects them before they disappear.
+Tests demonstrate both root and nested conflicts whose last occurrences form
+an otherwise valid canonical record, including an escaped equivalent field.
+
+## Compatibility and limits
+
+Completed and rejected canonical records retain their exact decoded contents.
+Valid JSON formatting and trailing whitespace remain allowed within the byte
+ceiling. Duplicate fields, non-finite numbers/float overflow, malformed UTF-8,
+non-object roots and more than 64 nested containers now fail at intake. The
+shared reader supplies fixed diagnostics; exact old message text is not an API.
+The CLI flags, rejection exit 1 and usage exit 2 remain unchanged.
+
+See [bounded JSON evidence](bounded-json-evidence.md) for descriptor ownership,
+platform-dependent flags and short-read handling. Parent directories and the
+filesystem remain trusted. Concurrent in-place modification is not prevented;
+this is not an immutable snapshot or I/O deadline. Parsing and hashes do not
+authenticate a reviewer or grant runtime permission. Use immutable reviewed
+inputs. Existing DSN options, shell-history exposure and argument parsing are
+not redesigned in this loader-only patch.
+
+## Validation and review
+
+```bash
+python -m pytest -q tests/unit/test_receiver_record_file_intake.py
+make quality-check
+make security-check
+make readiness-check
+```
+
+The tests reuse the existing real rehearsal builders/validators, exercise the
+actual local loader, and guard CLI persistence calls on malformed, missing,
+nonregular or growing inputs. They count actual bytes when a file grows after
+inspection. Semantic tampering must not reach a database connection; the test
+records attempted calls rather than relying on an exception that could be
+caught by the recorder. Positive CLI tests inject persistence and do not claim
+live database recording. Existing disposable PostgreSQL CI remains a separate
+regression gate, not proof of local-file behavior by itself.
+
+This candidate is independent of readiness-recorder integration #194 and the
+sibling transition-intake goal #198. Accept the common reader first, then
+reconstruct each isolated consumer delta on accepted main and rerun exact-head
+checks. Independent correctness/production review and explicit final-diff
+engineer acceptance are still required. No schema, workflow, dependency,
+configuration activation, scheduling or deployment changes are included.
+
+Reference for decoder behavior: Python 3.11 JSON documentation,
+https://docs.python.org/3.11/library/json.html#repeated-names-within-an-object

--- a/src/warehouse/controlled_receiver_rehearsal_recorder.py
+++ b/src/warehouse/controlled_receiver_rehearsal_recorder.py
@@ -263,19 +263,9 @@ def record_controlled_receiver_rehearsal(
 
 
 def _read_record(path: Path) -> dict[str, Any]:
-    if path.is_symlink():
-        raise ValidationError("controlled receiver record must not be a symbolic link")
-    if not path.is_file():
-        raise ValidationError("controlled receiver record must be a regular file")
-    if path.stat().st_size > 1_048_576:
-        raise ValidationError("controlled receiver record exceeds 1 MB")
-    try:
-        value = json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, UnicodeError, ValueError):
-        raise ValidationError("controlled receiver record could not be read") from None
-    if not isinstance(value, Mapping):
-        raise ValidationError("controlled receiver record must be a JSON object")
-    return dict(value)
+    from src.common.bounded_json import load_bounded_json_object
+
+    return load_bounded_json_object(path, max_bytes=1_048_576)
 
 
 def _build_parser() -> Any:

--- a/tests/unit/test_receiver_record_file_intake.py
+++ b/tests/unit/test_receiver_record_file_intake.py
@@ -1,0 +1,223 @@
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from src.common import bounded_json
+from src.common.exceptions import ValidationError
+from src.warehouse import controlled_receiver_rehearsal_recorder as recorder
+from src.warehouse.controlled_receiver_rehearsal_contract import (
+    validate_controlled_receiver_rehearsal_record,
+)
+from test_controlled_receiver_rehearsal_contract import build
+
+LIMIT = 1_048_576
+
+
+def _reject_before_recording(
+    path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str],
+) -> None:
+    calls: list[dict[str, Any]] = []
+
+    def forbidden(**kwargs: Any) -> dict[str, Any]:
+        calls.append(kwargs)
+        pytest.fail("intake failure reached persistence")
+
+    monkeypatch.setattr(recorder, "record_controlled_receiver_rehearsal", forbidden)
+    assert recorder.main(["--record", str(path), "--dsn", "private-unused-dsn"]) == 1
+    captured = capsys.readouterr()
+    assert calls == []
+    assert captured.out == ""
+    assert captured.err.startswith("Controlled receiver rehearsal rejected:")
+    assert "private" not in captured.err
+    assert str(path) not in captured.err
+
+
+@pytest.mark.parametrize("rejected", [False, True])
+def test_canonical_receiver_record_round_trips(tmp_path: Path, rejected: bool) -> None:
+    record = build(
+        terminal_status="rejected_before_request", failure_code="validation_error",
+        attempted_request_count=0, receiver_summary=None,
+    ) if rejected else build()
+    path = tmp_path / "record.json"
+    raw = json.dumps(record, indent=2).encode("utf-8") + b"\n"
+    path.write_bytes(raw)
+    loaded = recorder._read_record(path)
+    assert loaded == record
+    assert validate_controlled_receiver_rehearsal_record(loaded) == record
+    assert path.read_bytes() == raw
+
+
+@pytest.mark.parametrize("target", ["root", "checklist", "escaped_root"])
+def test_duplicate_cannot_hide_behind_canonical_last_value(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str], target: str,
+) -> None:
+    record = build()
+    text = json.dumps(record)
+    if target == "checklist":
+        marker = '"activation_checklist": {'
+        assert marker in text
+        text = text.replace(marker, marker + '"authority_id":"private-shadow",', 1)
+    else:
+        key = 'record_id' if target == "root" else r'\u0072ecord_id'
+        text = '{"' + key + '":"private-shadow",' + text[1:]
+    # The legacy decoder loses the conflicting first field, even though the
+    # remaining last-value document satisfies the real semantic validator.
+    assert json.loads(text) == record
+    assert validate_controlled_receiver_rehearsal_record(json.loads(text)) == record
+    path = tmp_path / "private-duplicate.json"
+    path.write_text(text, encoding="utf-8")
+    with pytest.raises(ValidationError, match="duplicate fields"):
+        recorder._read_record(path)
+    _reject_before_recording(path, monkeypatch, capsys)
+
+
+@pytest.mark.parametrize("extra", [0, 1])
+def test_exact_byte_ceiling(tmp_path: Path, extra: int) -> None:
+    record = build()
+    raw = json.dumps(record).encode("utf-8")
+    assert len(raw) < LIMIT
+    raw += b" " * (LIMIT + extra - len(raw))
+    path = tmp_path / "record.json"
+    path.write_bytes(raw)
+    if extra:
+        with pytest.raises(ValidationError, match="byte limit"):
+            recorder._read_record(path)
+    else:
+        assert recorder._read_record(path) == record
+
+
+@pytest.mark.parametrize("raw", [
+    b'{"v":NaN}', b'{"v":Infinity}', b'{"v":-Infinity}', b'{"v":1e9999}',
+    b'{"private":"\xff"}', b'[]', b'null', b'{"private":',
+    b'{"v":' * 65 + b'0' + b'}' * 65,
+])
+def test_malformed_intake_never_records(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str], raw: bytes,
+) -> None:
+    path = tmp_path / "private-input.json"
+    path.write_bytes(raw)
+    _reject_before_recording(path, monkeypatch, capsys)
+
+
+@pytest.mark.parametrize("kind", ["directory", "missing", "symlink", "dangling", "fifo"])
+def test_unsafe_file_never_records(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str], kind: str,
+) -> None:
+    path = tmp_path / "private-input"
+    if kind == "directory":
+        path.mkdir()
+    elif kind in {"symlink", "dangling"}:
+        target = tmp_path / "target"
+        if kind == "symlink":
+            target.write_text("{}", encoding="utf-8")
+        path.symlink_to(target)
+    elif kind == "fifo":
+        if not hasattr(os, "mkfifo"):
+            pytest.skip("FIFO support is unavailable")
+        os.mkfifo(path)
+    _reject_before_recording(path, monkeypatch, capsys)
+
+
+def test_file_growth_is_bounded_before_recording(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str],
+) -> None:
+    path = tmp_path / "private-growing.json"
+    path.write_text("{}", encoding="utf-8")
+    real_open, real_read = os.open, os.read
+    consumed: list[int] = []
+
+    def growing(file: Any, flags: int, *args: Any, **kwargs: Any) -> int:
+        path.write_bytes(b" " * (LIMIT + 100))
+        return real_open(file, flags, *args, **kwargs)
+
+    def measured(fd: int, count: int) -> bytes:
+        chunk = real_read(fd, count)
+        consumed.append(len(chunk))
+        return chunk
+
+    monkeypatch.setattr(bounded_json.os, "open", growing)
+    monkeypatch.setattr(bounded_json.os, "read", measured)
+    _reject_before_recording(path, monkeypatch, capsys)
+    assert sum(consumed) == LIMIT + 1
+
+
+def test_exact_loader_delegation(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    result = {"only_intake": True}
+    calls: list[tuple[Path, int]] = []
+
+    def load(path: Path, *, max_bytes: int) -> dict[str, Any]:
+        calls.append((path, max_bytes))
+        return result
+
+    monkeypatch.setattr(bounded_json, "load_bounded_json_object", load)
+    path = tmp_path / "not-read"
+    assert recorder._read_record(path) is result
+    assert calls == [(path, LIMIT)]
+
+
+def test_valid_cli_delegates_without_altering_record(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str],
+) -> None:
+    record = build()
+    path = tmp_path / "record.json"
+    path.write_text(json.dumps(record), encoding="utf-8")
+    calls: list[dict[str, Any]] = []
+
+    def capture(**kwargs: Any) -> dict[str, Any]:
+        calls.append(kwargs)
+        return {"record_id": kwargs["record"]["record_id"], "created": False}
+
+    monkeypatch.setattr(recorder, "record_controlled_receiver_rehearsal", capture)
+    assert recorder.main(["--record", str(path), "--dsn", "injected-dsn"]) == 0
+    assert calls == [{"dsn": "injected-dsn", "record": record}]
+    output = capsys.readouterr()
+    assert json.loads(output.out) == {"record_id": record["record_id"], "created": False}
+    assert output.err == ""
+
+
+def test_semantic_validation_still_precedes_connection(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str],
+) -> None:
+    import psycopg
+
+    record = build()
+    record["record_id"] = "tampered-identity"
+    path = tmp_path / "record.json"
+    path.write_text(json.dumps(record), encoding="utf-8")
+    calls: list[tuple[Any, ...]] = []
+
+    def forbidden(*args: Any, **kwargs: Any) -> Any:
+        calls.append(args)
+        pytest.fail("semantic rejection reached database connection")
+
+    monkeypatch.setattr(psycopg, "connect", forbidden)
+    assert recorder.main(["--record", str(path), "--dsn", "unused-dsn"]) == 1
+    assert calls == []
+    assert capsys.readouterr().out == ""
+
+
+def test_io_error_is_redacted_before_recording(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str],
+) -> None:
+    path = tmp_path / "private-input.json"
+    path.write_text("{}", encoding="utf-8")
+
+    def fail(*args: Any, **kwargs: Any) -> Any:
+        raise OSError("private filesystem diagnostic")
+
+    monkeypatch.setattr(bounded_json.os, "open", fail)
+    _reject_before_recording(path, monkeypatch, capsys)
+
+
+def test_cli_still_has_no_execute_flag() -> None:
+    with pytest.raises(SystemExit) as error:
+        recorder._build_parser().parse_args(["--record", "unused.json", "--execute"])
+    assert error.value.code == 2


### PR DESCRIPTION
## Goal and dependency

Closes #197 after explicit acceptance and merge. Roadmap #76; primary arc42 block: warehouse. Depends only on common-reader #192/#186 at `1dc74d4d44898b02644b3b2689b8c690aadc5c27`. Independent sibling of #205 and #194, not a successor to either. Prerequisite and other pending branches are unchanged.

## Delivered change and exact scope

Replace only `controlled_receiver_rehearsal_recorder._read_record` with the shared bounded JSON reader, retaining the 1,048,576-byte ceiling. The published source diff has exactly one loader-only hunk. Existing semantic validators, checklist/record identities, SQL, transaction and idempotency behavior, CLI functions and exit codes are unchanged.

Three intended paths, **289 additions and 13 deletions**: the recorder loader; `tests/unit/test_receiver_record_file_intake.py`; `docs/receiver-record-file-intake.md`. The two new files add tests and a focused walkthrough; no existing test assertion is removed.

**27 new regression cases** use real existing builders to cover completed/rejected canonical round-trip, root/nested/escaped duplicate fields whose last occurrences form valid canonical evidence, exact byte boundaries, malformed/non-finite/over-depth inputs, missing and unsafe files, growth after inspection, fixed redacted I/O diagnostics and unchanged CLI delegation. Tests count actual consumed bytes on growth. Persistence/connection guards record attempted calls, avoiding a false pass if a broad recorder handler swallows an injected exception. Positive CLI tests inject persistence.

## Exact-candidate validation

- Final head: `317b025fff4b9373b7d700cbe7b0fb33b77081a0`.
- Tree: `9173f04b3282fb8c339ab5f54caf9f4ad5bdb823`.
- GitHub Actions **run 476 / 34063186265: success**.
- Python readiness, Security guardrails, PostgreSQL contract and Infrastructure validation all passed.
- Python job `101567270482` confirms Ruff, mypy across **160 source files**, **1,226 tests passing twice**, dependency integrity, pipeline replay and warehouse dry-run.
- Tested synthetic merge: `e1e5edddaf633d9b5fb43adad2b1e3a04bb32066`, combining this exact head with #192's exact prerequisite.

This run tests this sibling and its prerequisite, not a combined branch containing #194/#205 or the worker-health stacks. The existing disposable PostgreSQL job is persistence regression evidence; the new unit/CLI tests establish the file-intake behavior.

## Local evidence and review limitations

Copied baseline recorder/common helper matched fetched Git blobs `0f32d51bd6b7ef022cffab45b2ac1f23760697d6` and `b3f842bcf6ee37291c9ca5ec8f8b0cc74684a891`. AST comparison found `_read_record` as the sole changed product node. Compilation and staged whitespace checks passed. Fifteen extracted-loader checks and 18 extracted-CLI cases passed locally. Those source-subset harnesses execute the actual loader/CLI bodies but are not full-module semantic integration; complete canonical-record and repository validation ran in CI.

Local cloning failed GitHub DNS resolution. Docker and Terraform are absent; no full local PostgreSQL/infrastructure run or `make morning-review` package is claimed. Published scope and failure cases were self-reviewed. Submitted reviews and review threads were empty at the final check. **Independent correctness/production review and explicit final-diff engineer acceptance remain pending.**

## Acceptance and safety

**Validated draft, unmerged; #197 remains open.** Accept #192 first, then reconstruct this isolated consumer delta on accepted current main and rerun final-head checks. Do not merge into an unaccepted prerequisite as a shortcut. Main was still `7316dd30ce5b445df0ac2c0ac019703add15aadc` at final reconciliation.

No schema, workflow, dependency, configuration enablement, application database access, live notification, scheduling or deployment. CI database effects are confined to the existing disposable service. The shared reader's trusted-directory, mutable-file and no-I/O-deadline limitations remain. Parsing is not authenticated approval or runtime permission.