### PR TITLE
Bound readiness JSON before canonical document encoding

### DIFF
--- a/docs/worker-readiness-json-bounds.md
+++ b/docs/worker-readiness-json-bounds.md
@@ -1,0 +1,49 @@
+# Readiness JSON bounds before serialization
+
+Primary arc42 block: `warehouse`. Goal: #199, under roadmap #76.
+
+`source_bytes` now delegates to `bounded_source_bytes`. Previously it allocated
+`json.dumps(value)` in full before checking the 1 MiB result. The new helper
+checks plain JSON types, traversal depth, visited nodes and exact encoded size
+before invoking the document encoder. Existing record and decision semantic
+validators remain unchanged.
+
+## Contract
+
+The maximum encoded document is 1,048,576 bytes, inclusive. Keys, punctuation,
+quotes and ASCII escapes count toward that limit. Non-ASCII BMP characters and
+control characters use JSON escaping; supplementary characters require two
+six-byte escapes. The returned sorted, compact, ASCII-escaped bytes match the
+previous encoder for supported values, including finite floats and negative zero.
+Consequently ordinary retained record digests and model versions do not change.
+
+The root can be a mapping and is copied. Nested values must be built-in JSON
+objects, arrays, strings, finite numbers, booleans or null. String keys are
+mandatory: integer-key coercion and tuple-to-array conversion are rejected.
+Depth is at most 64 edges from the root; at most 100,000 nodes are visited,
+including keys and repeated references. Integers have at most 4,096 magnitude
+bits. Cycles are rejected; shared acyclic values are permitted and counted for
+every occurrence. Diagnostics never interpolate keys or input values.
+
+These are explicit input and work budgets, not a promise that total process
+memory is 1 MiB. The caller's input is already allocated, and copying, sorting and
+encoding require additional memory. Callers must not mutate inputs concurrently.
+Custom mapping code is inside the caller trust boundary, not sandboxed by this
+helper. Output is an integrity encoding, not a signature or runtime permission.
+
+## Evidence
+
+Run `python -m pytest -q tests/unit/test_worker_readiness_json.py` and the existing
+source/snapshot/reader suites. Tests compare old and new bytes and SHA-256, cover
+exact byte, depth and node boundaries, and prove oversized or unsupported inputs
+fail before the document encoder is called. Escaping tests include ASCII,
+controls, DEL, BMP, surrogate escapes and supplementary Unicode characters.
+
+The source verifier itself is exercised with oversized evidence to show that the
+shared boundary is reached before semantic processing. Normal semantic validation
+is still covered by the existing real-record tests in repository CI.
+
+This change performs no I/O, adds no dependency, and changes no schema, delivery
+configuration, workflow or activation default. No scheduler, notification,
+deployment or Terraform apply is introduced. Human acceptance remains separate
+from automated validation.

--- a/src/warehouse/notification_worker_readiness_json.py
+++ b/src/warehouse/notification_worker_readiness_json.py
@@ -1,0 +1,104 @@
+"""Bound JSON work before allocating the canonical readiness document."""
+from __future__ import annotations
+
+import json
+import math
+from collections.abc import Mapping
+from typing import Any
+
+from src.common.exceptions import ValidationError
+
+MAX_SOURCE_BYTES = 1_048_576
+MAX_SOURCE_DEPTH = 64
+MAX_SOURCE_NODES = 100_000
+MAX_INTEGER_BITS = 4096
+
+
+def bounded_source_bytes(value: Mapping[str, Any]) -> bytes:
+    """Preserve compact sorted ASCII JSON, with a bounded pre-encoding traversal.
+
+    Root mappings are copied; nested values must be plain JSON types. The caller
+    must not mutate the input during validation. Bounds cover encoded size and
+    traversal work, not the caller's existing allocation or total process memory.
+    """
+    if not isinstance(value, Mapping):
+        raise ValidationError("readiness source must be an object")
+    if len(value) > MAX_SOURCE_NODES:
+        raise ValidationError("readiness source exceeds the node limit")
+    size = 0
+    nodes = 0
+    ancestors: set[int] = set()
+
+    def add(amount: int) -> None:
+        nonlocal size
+        size += amount
+        if size > MAX_SOURCE_BYTES:
+            raise ValidationError("readiness source exceeds 1 MiB")
+
+    def visit(item: Any, depth: int) -> None:
+        nonlocal nodes
+        nodes += 1
+        if nodes > MAX_SOURCE_NODES or depth > MAX_SOURCE_DEPTH:
+            raise ValidationError("readiness source exceeds structural limits")
+        kind = type(item)
+        if item is None:
+            add(4)
+        elif kind is bool:
+            add(4 if item else 5)
+        elif kind is str:
+            # Every character takes at least one byte, before ASCII escaping.
+            if len(item) + 2 > MAX_SOURCE_BYTES - size:
+                raise ValidationError("readiness source exceeds 1 MiB")
+            add(2)
+            for character in item:
+                code = ord(character)
+                if character in '"\\\b\f\n\r\t':
+                    add(2)
+                elif 32 <= code <= 126:
+                    add(1)
+                else:
+                    add(6 if code <= 0xFFFF else 12)
+        elif kind is int:
+            if item.bit_length() > MAX_INTEGER_BITS:
+                raise ValidationError("readiness source integer exceeds the bit limit")
+            add(len(str(item)))
+        elif kind is float:
+            if not math.isfinite(item):
+                raise ValidationError("readiness source numbers must be finite")
+            add(len(repr(item)))
+        elif kind is dict or kind is list:
+            if len(item) > MAX_SOURCE_NODES - nodes:
+                raise ValidationError("readiness source exceeds the node limit")
+            identity = id(item)
+            if identity in ancestors:
+                raise ValidationError("readiness source must not contain cycles")
+            ancestors.add(identity)
+            try:
+                add(2 + max(0, len(item) - 1))
+                if kind is dict:
+                    add(len(item))  # One colon per key/value pair.
+                    for key, child in item.items():
+                        if type(key) is not str:
+                            raise ValidationError("readiness source keys must be strings")
+                        visit(key, depth + 1)
+                        visit(child, depth + 1)
+                else:
+                    for child in item:
+                        visit(child, depth + 1)
+            finally:
+                ancestors.remove(identity)
+        else:
+            raise ValidationError("readiness source contains a non-JSON value")
+
+    try:
+        document = dict(value)
+        visit(document, 0)
+        raw = json.dumps(
+            document, sort_keys=True, separators=(",", ":"),
+            ensure_ascii=True, allow_nan=False,
+        ).encode("ascii")
+        if len(raw) != size or len(raw) > MAX_SOURCE_BYTES:
+            raise ValidationError("readiness source changed during serialization")
+        return raw
+    except (ValueError, TypeError, RecursionError, OverflowError, UnicodeError):
+        raise ValidationError("readiness source must be bounded canonical JSON") from None

--- a/src/warehouse/notification_worker_readiness_source.py
+++ b/src/warehouse/notification_worker_readiness_source.py
@@ -9,8 +9,11 @@ from datetime import datetime, timezone
 from typing import Any
 
 from src.common.exceptions import ValidationError
+from src.warehouse.notification_worker_readiness_json import (
+    MAX_SOURCE_BYTES as MAX_SOURCE_BYTES,
+    bounded_source_bytes,
+)
 
-MAX_SOURCE_BYTES = 1_048_576
 SAFE_ID = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,511}$")
 
 
@@ -31,15 +34,7 @@ def source_time(value: Any) -> datetime:
 
 
 def source_bytes(value: Mapping[str, Any]) -> bytes:
-    if not isinstance(value, Mapping):
-        raise ValidationError("readiness source must be an object")
-    try:
-        raw = json.dumps(dict(value), sort_keys=True, separators=(",", ":"), allow_nan=False).encode("utf-8")
-        if len(raw) > MAX_SOURCE_BYTES:
-            raise ValidationError("readiness source exceeds 1 MiB")
-        return raw
-    except (ValueError, TypeError, RecursionError, OverflowError, UnicodeError):
-        raise ValidationError("readiness source must be bounded canonical JSON") from None
+    return bounded_source_bytes(value)
 
 
 def verify_worker_readiness_record(

--- a/tests/unit/test_worker_readiness_json.py
+++ b/tests/unit/test_worker_readiness_json.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from types import MappingProxyType
+from typing import Any
+
+import pytest
+
+from src.common.exceptions import ValidationError
+from src.warehouse import notification_worker_readiness_json as bounded
+from src.warehouse.notification_worker_readiness_source import source_bytes
+
+
+def original_bytes(value: Any) -> bytes:
+    return json.dumps(
+        value, sort_keys=True, separators=(",", ":"), allow_nan=False,
+    ).encode("utf-8")
+
+
+@pytest.mark.parametrize("value", [
+    {}, {"items": []}, {"flags": [None, True, False]},
+    {"ints": [0, -1, 10**100, -(2**4095)]},
+    {"floats": [-0.0, 1.0, 1e-100, 1.23456789012345, 1e300]},
+    {"z": {"b": 2, "a": 1}, "a": [{"x": "value"}]},
+    {"text": ''.join(chr(code) for code in range(256))},
+    {"text": '\u2028\ud800\udfff\uffff\U00010000\U0010ffff'},
+])
+def test_plain_json_preserves_original_bytes_and_digest(value: Any) -> None:
+    expected = original_bytes(value)
+    actual = source_bytes(value)
+    assert actual == expected
+    assert hashlib.sha256(actual).digest() == hashlib.sha256(expected).digest()
+
+
+def test_root_mapping_is_copied_without_coercing_nested_values() -> None:
+    assert source_bytes(MappingProxyType({"b": 2, "a": 1})) == b'{"a":1,"b":2}'
+    with pytest.raises(ValidationError):
+        source_bytes({"nested": MappingProxyType({"a": 1})})
+
+
+@pytest.mark.parametrize("character", ['x', '\n', '\\', '"', '\x00', '\x7f', '\u00e9', '\U0001f600'])
+def test_exact_encoded_size_boundary_includes_ascii_escaping(character: str) -> None:
+    unit = len(original_bytes(character)) - 2
+    count, remaining = divmod(bounded.MAX_SOURCE_BYTES - 8, unit)
+    value = {"x": character * count + 'a' * remaining}
+    raw = source_bytes(value)
+    assert raw == original_bytes(value)
+    assert len(raw) == bounded.MAX_SOURCE_BYTES
+    value["x"] += 'a'
+    with pytest.raises(ValidationError, match="1 MiB"):
+        source_bytes(value)
+
+
+@pytest.mark.parametrize("value", [
+    {1: "coerced-key"}, {"tuple": (1, 2)}, {"number": float("nan")},
+    {"number": float("inf")}, {"number": -float("inf")}, {"object": object()},
+    {"bytes": b"value"}, {"set": {1, 2}}, {"int": 1 << 4096},
+    {"int": -(1 << 4096)}, [], None,
+])
+def test_non_json_or_unbounded_values_fail_before_encoding(value: Any, monkeypatch: Any) -> None:
+    def forbidden(*args: Any, **kwargs: Any) -> Any:
+        raise AssertionError("encoder must not see invalid input")
+    monkeypatch.setattr(bounded.json, "dumps", forbidden)
+    with pytest.raises(ValidationError):
+        source_bytes(value)
+
+
+def test_oversized_string_fails_before_encoding(monkeypatch: Any) -> None:
+    def forbidden(*args: Any, **kwargs: Any) -> Any:
+        raise AssertionError("encoder must not allocate the oversized document")
+    monkeypatch.setattr(bounded.json, "dumps", forbidden)
+    with pytest.raises(ValidationError, match="1 MiB"):
+        source_bytes({"x": "a" * bounded.MAX_SOURCE_BYTES})
+
+
+@pytest.mark.parametrize("container_type", [list, dict])
+def test_cycles_are_rejected_but_shared_acyclic_values_are_valid(container_type: Any) -> None:
+    cyclic = container_type()
+    if isinstance(cyclic, list):
+        cyclic.append(cyclic)
+    else:
+        cyclic["self"] = cyclic
+    with pytest.raises(ValidationError, match="cycles"):
+        source_bytes({"x": cyclic})
+    shared = [1, {"a": True}]
+    assert source_bytes({"a": shared, "b": shared}) == original_bytes({"a": shared, "b": shared})
+
+
+def nested(depth: int) -> dict[str, Any]:
+    child: Any = 0
+    for _ in range(depth - 1):
+        child = [child]
+    return {"x": child}
+
+
+def test_depth_boundary_is_explicit() -> None:
+    value = nested(bounded.MAX_SOURCE_DEPTH)
+    assert source_bytes(value) == original_bytes(value)
+    with pytest.raises(ValidationError, match="structural"):
+        source_bytes(nested(bounded.MAX_SOURCE_DEPTH + 1))
+
+
+def test_node_boundary_counts_keys_and_repeated_values() -> None:
+    value = {"x": [None] * (bounded.MAX_SOURCE_NODES - 3)}
+    assert source_bytes(value) == original_bytes(value)
+    value["x"].append(None)
+    with pytest.raises(ValidationError, match="node"):
+        source_bytes(value)
+
+
+def test_success_does_not_mutate_input() -> None:
+    value = {"b": [3, 2, 1], "a": {"z": True}}
+    before = original_bytes(value)
+    source_bytes(value)
+    assert original_bytes(value) == before
+    assert list(value) == ["b", "a"]
+
+
+def test_source_validator_inherits_guard_before_loading_semantic_dependencies(monkeypatch: Any) -> None:
+    from src.warehouse.notification_worker_readiness_source import verify_worker_readiness_record
+    def forbidden(*args: Any, **kwargs: Any) -> Any:
+        raise AssertionError("encoder must not see oversized readiness evidence")
+    monkeypatch.setattr(bounded.json, "dumps", forbidden)
+    with pytest.raises(ValidationError, match="1 MiB"):
+        verify_worker_readiness_record(
+            record={"x": "a" * bounded.MAX_SOURCE_BYTES}, document_sha256="0" * 64,
+            expected_record_id="record", destination_id="destination", execution_kind="initial",
+            observed_at="2026-06-01T12:00:00+00:00",
+        )


### PR DESCRIPTION
## Goal and dependency

Refs #199; roadmap #76. Primary arc42 block: `warehouse`.

One bounded hardening delta on the repaired readiness-source stack: **#178 → #180 → #183 → #202 → #206**. The previous size check allocated the entire encoded document before enforcing 1 MiB. This change bounds encoded size and traversal before document encoding.

## Changes

- Preserve existing sorted, compact ASCII JSON bytes and digests for supported values.
- Count escaped string, key, scalar and punctuation bytes before invoking the document encoder.
- Enforce inclusive limits of 1,048,576 encoded bytes, depth 64, 100,000 visited nodes and 4,096 integer magnitude bits.
- Reject cycles, non-finite numbers, unsupported nested types, non-string keys and implicit tuple/key coercions. Shared acyclic values remain valid and count at each occurrence.
- Route the existing source_bytes boundary through the helper so source verification, snapshots and readers inherit the guard. Keep the established semantic readiness validators and model versions.
- Document the actual contract: this is not a total-process-memory cap, a sandbox for custom mappings or protection against concurrent input mutation.

## Exact final candidate

```text
Base #183:    c0fd216fc4bd23d68836efc1d0784c12bd929078
Head:         aa8dbdf3f13ca52f6975f324a07ab71f99e7e531
Tree:         66f75694338d75fcf78722ba9ee6e0685b42cbc2
CI checkout:  7964e2e3cf686dae2dd5df7736c2953bcd51bc57
Scope:        4 paths; 288 additions; 10 deletions; 1 commit
```

Paths: bounded encoder, source_bytes integration, focused tests and operating document. The original source file was checked against Git blob `73a14b54b01f90cb258ea88284975476b191c473` before editing. Successor #206 adds the opt-in inspection command separately.

## Validation

[CI run 477](https://github.com/alexmarinos87/financial-risk-data-platform/actions/runs/34063371496) passed all four jobs: **Python readiness, PostgreSQL contract, Security guardrails and Infrastructure validation**. The Python log confirms **1,280 tests passed twice**, Ruff, mypy across **165 source files**, dependency integrity, pipeline demo and warehouse dry-run. Its checkout explicitly combines this head with the stated #183 base.

**GitGuardian check 101567765204 passed** with no secrets detected in the candidate commit.

Locally, **36 focused JSON cases passed**, and the combined JSON/session subset passed **54 cases**. Exact byte/depth/node boundaries, Unicode escaping, canonical-byte and digest compatibility, immutability and rejection before document encoding are covered. The real source verifier is challenged with oversized evidence before semantic processing. Existing semantic-record tests remain enabled and passed in full CI.

A complete repository checkout was unavailable locally. Full repository tests, Ruff, mypy, infrastructure validation and real PostgreSQL execution are evidenced by CI, not claimed as local runs. No test was disabled to obtain the green result.

## Review and acceptance

Self-review covered compatibility, strict scalar types, cycle handling, exact boundary arithmetic and safe diagnostics. No discussion/review comments were returned at inspection. **Independent review and exact-diff human acceptance remain pending.** Automated checks do not constitute approval.

**Draft and unmerged.** Goal #199 remains open pending acceptance and integration. After predecessors are explicitly accepted and squash-merged, reconstruct this isolated delta on accepted main, rerun complete validation and obtain acceptance. Do not merge into an unaccepted predecessor branch as a shortcut.

## Safety

No database I/O, schema/configuration/workflow/dependency change, source request, notification, scheduler activation, deployment or Terraform apply. No code is imported from the separate suspension or preflight-diagnostics stacks. Source integrity never grants runtime permission.