### PR TITLE
Collect read-only pull request stack review evidence

### DIFF
--- a/docs/pr-stack-review.md
+++ b/docs/pr-stack-review.md
@@ -1,0 +1,103 @@
+# Read-only pull-request stack review
+
+Primary arc42 block: `engineering-controls`. Goal #196 follows #195 / PR #200.
+
+## Decision and operator path
+
+The notification diagnostic chain has several unmerged predecessors. A passing
+child PR must not hide a parent's failed scanner check or imply that the parent
+was accepted. This command collects evidence for review; it has no merge,
+approve, dismiss, write-status, branch-update, database or deployment operation.
+
+From a checkout containing this candidate:
+
+```bash
+python -m scripts.pr_stack_review --read-github \
+  --repository alexmarinos87/financial-risk-data-platform \
+  --pr 167 --pr 168 --pr 169 --pr 176 --pr 177 --pr 181 --pr 191 --pr 193
+```
+
+Public repositories can be read without a token. Private repositories require
+an existing `GH_TOKEN` environment value with read access to pull requests,
+contents, checks and commit statuses. There is no token argument. Do not paste
+credentials into command history. No write scope is needed by this command.
+It does not use cloud credentials, invoke Git, inspect worktree files or modify
+the existing local `morning-review` package.
+
+The command emits one JSON report to stdout only. Exit 0 means the reported
+technical checks and base comparisons are clear, **not approval to merge**.
+Exit 3 means technical blockers were captured. Exit 1 means collection failed
+and no successful report was emitted; exit 2 is invalid usage. Usage and runtime
+errors use fixed diagnostics without raw arguments, tokens or provider bodies.
+
+## Collection contract
+
+For each explicitly selected PR, read exact head/base identities, the complete
+latest check-run and combined-status inventories, and the comparison of those
+exact commits. The preceding reconciler checks App identity, SHA binding,
+pagination completeness, missing evidence and every reported failure.
+
+After every candidate has been collected, re-read all PR identities and `main`.
+A changed head, base, draft/open state or main reference invalidates collection.
+The comparison records how many base commits the candidate lacks. Dependency
+order follows matching base-branch/head-branch identities within the selected
+same-repository candidates. Missing predecessors, conflicting head identities,
+cycles, head/base mismatches and inherited technical failures are explicit or
+fail collection; no relationship is invented from PR body prose.
+
+The report separates check outcomes, technical blockers, draft status, pending
+predecessor merge and pending engineer acceptance. All candidates retain
+`merge_authorized = false`. Independent review, branch-rule enforcement and the
+actual merge tree tested by CI are not verified by this command. Use CI checkout
+logs, the final diff and independent review alongside it before acceptance.
+Logical dependencies not expressed by base branches need separate review.
+
+## Transport and bounds
+
+The standard-library transport permits only an internal allowlist of GET paths
+at `https://api.github.com`. It rejects redirects and does not follow any URLs
+inside responses. TLS certificate verification stays enabled. Environment proxy
+routing is disabled; environments requiring a corporate proxy need a separately
+reviewed adapter rather than silently redirecting authenticated requests.
+
+Select at most 25 unique positive PR numbers. Each API read is limited to 1 MiB,
+with a 15-second socket timeout. Pagination is capped at ten pages / 1,000 rows
+per source; limits, missing data and unsupported fork PRs fail closed. The
+socket timeout is not a whole-command deadline. The final stdout report is also
+bounded. API bodies, descriptions and arbitrary provider URLs are not retained;
+review output includes only selected PR and check identities and diagnostics.
+
+## Validation and important limits
+
+```bash
+python -m pytest -q tests/unit/test_pr_check_evidence.py tests/unit/test_pr_stack_review.py
+make quality-check
+make security-check
+make readiness-check
+```
+
+Tests exercise the actual collector and entry point using injected API responses,
+including scanner failure propagation, exact refs moving mid-collection,
+pagination, missing/cyclic dependencies, behind-base comparisons, strict
+selection, safe transport construction and redacted errors. Transport tests
+inspect actual Request methods/headers and bounded reads; they do not contact
+GitHub or use real credentials. Full CI runs the unchanged repository suite.
+
+Ref-stable collection is **not an atomic GitHub snapshot**. Check results can
+change between requests or new checks may be created immediately afterward.
+Re-run at the final review point. The fixed expected-check policy belongs to this
+repository; it is not an inferred universal or branch-protection policy. Neither
+this tool nor a passing successor dismisses #191's existing GitGuardian finding.
+
+This independent two-PR engineering-control stack starts at accepted main. It
+imports none of the unaccepted notification/source/suspension implementations.
+Accept #200 before this candidate, reconstruct the isolated successor delta on
+accepted main and rerun exact-head CI. Independent review and explicit engineer
+acceptance remain separate; no changes to CI settings or existing PR stacks are
+made by running the command.
+
+Primary API references:
+- <https://docs.github.com/en/rest/pulls/pulls#get-a-pull-request>
+- <https://docs.github.com/en/rest/commits/commits#compare-two-commits>
+- <https://docs.github.com/en/rest/checks/runs#list-check-runs-for-a-git-reference>
+- <https://docs.github.com/en/rest/commits/statuses#get-the-combined-status-for-a-specific-reference>

--- a/scripts/pr_stack_review.py
+++ b/scripts/pr_stack_review.py
@@ -1,0 +1,237 @@
+"""Read-only, bounded GitHub PR stack diagnostics; never accepts or merges code."""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from collections.abc import Callable, Mapping, Sequence
+from datetime import datetime, timezone
+from typing import Any
+from urllib.request import HTTPRedirectHandler, ProxyHandler, Request, build_opener
+
+from scripts.pr_check_evidence import (
+    MAX_PAGES, MAX_ROWS, EvidenceError, display_name, full_sha, summarize_checks,
+)
+
+MAX_PRS = 25
+MAX_RESPONSE_BYTES = 1_048_576
+ReadJSON = Callable[[str], Mapping[str, Any]]
+SAFE_SUFFIX = re.compile(
+    r"(?:git/ref/heads/main|pulls/[1-9][0-9]*|"
+    r"compare/[0-9a-f]{40}\.\.\.[0-9a-f]{40}\?per_page=1|"
+    r"commits/[0-9a-f]{40}/(?:check-runs\?filter=latest&|status\?)"
+    r"per_page=100&page=(?:[1-9]|10))"
+)
+
+
+def repository_name(value: Any) -> str:
+    if (not isinstance(value, str) or len(value) > 200
+            or re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9_-]*/[A-Za-z0-9][A-Za-z0-9_.-]*", value) is None):
+        raise EvidenceError("invalid repository identity")
+    return value
+
+
+class NoRedirects(HTTPRedirectHandler):
+    def redirect_request(self, *args: Any, **kwargs: Any) -> None:
+        raise EvidenceError("GitHub redirects are not accepted")
+
+
+def _unique_object(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    value: dict[str, Any] = {}
+    for key, item in pairs:
+        if key in value:
+            raise EvidenceError("duplicate API field")
+        value[key] = item
+    return value
+
+
+def _reject_constant(value: str) -> Any:
+    raise EvidenceError("non-finite API value")
+
+
+class GitHubReadOnly:
+    def __init__(self, repository: str, *, token: str | None = None) -> None:
+        self.repository = repository_name(repository)
+        if token is not None and (not isinstance(token, str) or not 1 <= len(token) <= 2048
+                                  or re.fullmatch(r"[A-Za-z0-9_]+", token) is None):
+            raise EvidenceError("invalid environment authentication value")
+        self._token = token
+
+    def __call__(self, suffix: str) -> Mapping[str, Any]:
+        if not isinstance(suffix, str) or SAFE_SUFFIX.fullmatch(suffix) is None:
+            raise EvidenceError("unsupported read-only GitHub endpoint")
+        headers = {"Accept": "application/vnd.github+json", "User-Agent": "pr-stack-review",
+                   "X-GitHub-Api-Version": "2022-11-28"}
+        if self._token is not None:
+            headers["Authorization"] = "Bearer " + self._token
+        request = Request(f"https://api.github.com/repos/{self.repository}/{suffix}", headers=headers, method="GET")
+        try:
+            # Fixed TLS origin; do not follow provider URLs or inherited proxies.
+            opener = build_opener(NoRedirects(), ProxyHandler({}))
+            with opener.open(request, timeout=15) as response:
+                if response.status != 200:
+                    raise EvidenceError("unexpected GitHub response")
+                raw = response.read(MAX_RESPONSE_BYTES + 1)
+            if len(raw) > MAX_RESPONSE_BYTES:
+                raise EvidenceError("GitHub response exceeded the size limit")
+            value = json.loads(raw.decode("utf-8"), object_pairs_hook=_unique_object, parse_constant=_reject_constant)
+            if not isinstance(value, dict):
+                raise EvidenceError("GitHub response is not an object")
+            return value
+        except Exception:
+            raise EvidenceError("unable to obtain bounded GitHub evidence") from None
+
+
+def _pages(read: ReadJSON, endpoint: str, key: str) -> list[Mapping[str, Any]]:
+    pages: list[Mapping[str, Any]] = []
+    collected = 0
+    for number in range(1, MAX_PAGES + 1):
+        separator = "&" if "?" in endpoint else "?"
+        page = read(f"{endpoint}{separator}per_page=100&page={number}")
+        count, rows = page.get("total_count"), page.get(key)
+        if (type(count) is not int or not 0 <= count <= MAX_ROWS
+                or not isinstance(rows, list) or len(rows) > 100):
+            raise EvidenceError("invalid paginated GitHub inventory")
+        pages.append(page)
+        collected += len(rows)
+        if collected >= count:
+            return pages  # The pure verifier checks exact totals/IDs on all pages.
+        if not rows:
+            raise EvidenceError("GitHub pagination ended before its total")
+    raise EvidenceError("GitHub pagination exceeded the page limit")
+
+
+def _pr_identity(raw: Mapping[str, Any], repository: str, number: int) -> dict[str, Any]:
+    try:
+        if (raw["number"] != number or type(raw["number"]) is not int
+                or raw["state"] != "open" or raw["merged"] is not False
+                or type(raw["draft"]) is not bool):
+            raise EvidenceError("selection is not an open unmerged PR")
+        if raw["base"]["repo"]["full_name"] != repository or raw["head"]["repo"]["full_name"] != repository:
+            raise EvidenceError("fork or cross-repository PR is unsupported")
+        return {"number": number, "head_sha": full_sha(raw["head"]["sha"]),
+                "base_sha": full_sha(raw["base"]["sha"]),
+                "head_ref": display_name(raw["head"]["ref"]),
+                "base_ref": display_name(raw["base"]["ref"]), "draft": raw["draft"]}
+    except (KeyError, TypeError):
+        raise EvidenceError("PR identity is incomplete") from None
+
+
+def _main_sha(read: ReadJSON) -> str:
+    raw = read("git/ref/heads/main")
+    try:
+        if raw["ref"] != "refs/heads/main" or raw["object"]["type"] != "commit":
+            raise EvidenceError("main reference is not a commit")
+        return full_sha(raw["object"]["sha"])
+    except (KeyError, TypeError):
+        raise EvidenceError("main identity is incomplete") from None
+
+
+def collect_stack(repository: str, numbers: Sequence[int], read: ReadJSON) -> dict[str, Any]:
+    repository = repository_name(repository)
+    if (not isinstance(numbers, (list, tuple)) or not 1 <= len(numbers) <= MAX_PRS
+            or any(type(n) is not int or n <= 0 for n in numbers)
+            or len(set(numbers)) != len(numbers)):
+        raise EvidenceError("select one to twenty-five distinct PR numbers")
+    started = datetime.now(timezone.utc).isoformat()
+    main_sha = _main_sha(read)
+    candidates: dict[int, dict[str, Any]] = {}
+    for number in sorted(numbers):
+        identity = _pr_identity(read(f"pulls/{number}"), repository, number)
+        head, base = identity["head_sha"], identity["base_sha"]
+        checks = summarize_checks(
+            head_sha=head, check_pages=_pages(read, f"commits/{head}/check-runs?filter=latest", "check_runs"),
+            status_pages=_pages(read, f"commits/{head}/status", "statuses"),
+        )
+        comparison = read(f"compare/{base}...{head}?per_page=1")
+        try:
+            behind = comparison["behind_by"]
+            merge_base = full_sha(comparison["merge_base_commit"]["sha"])
+            if (comparison["base_commit"]["sha"] != base or type(behind) is not int or behind < 0
+                    or (behind == 0 and merge_base != base)):
+                raise EvidenceError("comparison does not reconcile the selected base")
+        except (KeyError, TypeError):
+            raise EvidenceError("comparison evidence is incomplete") from None
+        candidates[number] = {**identity, "checks": checks, "behind_base_by": behind}
+    # Re-read every PR after all collection, not just immediately after its checks.
+    for number, candidate in candidates.items():
+        final = _pr_identity(read(f"pulls/{number}"), repository, number)
+        if any(final[key] != candidate[key] for key in final):
+            raise EvidenceError("PR references changed during collection")
+    if _main_sha(read) != main_sha:
+        raise EvidenceError("main changed during collection")
+    heads = {row["head_ref"]: n for n, row in candidates.items()}
+    if len(heads) != len(candidates) or "main" in heads:
+        raise EvidenceError("selected PR heads are ambiguous")
+    order: list[int] = []
+    visiting: set[int] = set()
+
+    def visit(number: int) -> None:
+        if number in visiting:
+            raise EvidenceError("PR dependency cycle detected")
+        if number in order:
+            return
+        visiting.add(number)
+        row = candidates[number]
+        parent = heads.get(row["base_ref"]) if row["base_ref"] != "main" else None
+        blockers: list[str] = []
+        if row["checks"]["outcome"] != "passed":
+            blockers.append("checks_" + row["checks"]["outcome"])
+        if row["behind_base_by"]:
+            blockers.append("head_behind_base")
+        if row["base_ref"] == "main":
+            if row["base_sha"] != main_sha:
+                blockers.append("base_main_mismatch")
+        elif parent is None:
+            blockers.append("predecessor_not_selected")
+        else:
+            visit(parent)
+            if row["base_sha"] != candidates[parent]["head_sha"]:
+                blockers.append("predecessor_head_mismatch")
+            if candidates[parent]["technical_blockers"]:
+                blockers.append("predecessor_technical_blocked")
+        row.update(predecessor_pr=parent, technical_blockers=sorted(blockers),
+                   engineer_acceptance="pending", predecessor_merge_pending=parent is not None,
+                   merge_authorized=False)
+        visiting.remove(number)
+        order.append(number)
+
+    for number in sorted(candidates):
+        visit(number)
+    return {"model_version": "pr-stack-review-v1", "repository": repository, "main_sha": main_sha,
+            "collection_started_at": started, "collection_finished_at": datetime.now(timezone.utc).isoformat(),
+            "collection_consistency": "ref_stable_non_atomic", "review_order": order,
+            "candidates": [candidates[n] for n in order],
+            "all_technical_checks_passed": all(not row["technical_blockers"] for row in candidates.values()),
+            "independent_review_verified": False, "tested_merge_tree_verified": False,
+            "engineer_acceptance": "pending", "merge_authorized": False}
+
+
+class ReviewParser(argparse.ArgumentParser):
+    def error(self, message: str) -> Any:
+        self.exit(2, "PR stack review usage is invalid; no changes made\n")
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = ReviewParser(prog="pr-stack-review", description=__doc__, allow_abbrev=False)
+    parser.add_argument("--read-github", action="store_true", required=True)
+    parser.add_argument("--repository", required=True)
+    parser.add_argument("--pr", type=int, action="append", required=True)
+    arguments = parser.parse_args(argv)
+    try:
+        reader = GitHubReadOnly(arguments.repository, token=os.environ.get("GH_TOKEN") or None)
+        result = collect_stack(arguments.repository, arguments.pr, reader)
+        encoded = json.dumps(result, sort_keys=True, allow_nan=False)
+        if len(encoded.encode("utf-8")) > MAX_RESPONSE_BYTES:
+            raise EvidenceError("review report exceeds size limit")
+    except Exception:
+        print("PR stack review failed; no changes made", file=sys.stderr)
+        return 1
+    print(encoded)
+    return 0 if result["all_technical_checks_passed"] else 3
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/test_pr_stack_review.py
+++ b/tests/unit/test_pr_stack_review.py
@@ -1,0 +1,315 @@
+from __future__ import annotations
+
+import copy
+import io
+import json
+from typing import Any
+
+import pytest
+
+from scripts import pr_stack_review as review
+from scripts.pr_check_evidence import EvidenceError, REQUIRED_CHECKS
+
+REPO = "owner/repository"
+MAIN = "a" * 40
+
+
+def pr(number: int, *, base: str = "main", base_sha: str = MAIN) -> dict[str, Any]:
+    head = f"{number:040x}"
+    return {"number": number, "state": "open", "merged": False, "draft": True,
+            "head": {"ref": f"feature/{number}", "sha": head, "repo": {"full_name": REPO}},
+            "base": {"ref": base, "sha": base_sha, "repo": {"full_name": REPO}},
+            "body": "not-evidence-and-must-not-be-output"}
+
+
+class Reader:
+    def __init__(self, rows: list[dict[str, Any]]) -> None:
+        self.rows = {row["number"]: row for row in rows}
+        self.calls: list[str] = []
+        self.failure: int | None = None
+        self.behind = 0
+        self.change: str | None = None
+        self.reads: dict[int, int] = {}
+
+    def __call__(self, suffix: str) -> dict[str, Any]:
+        self.calls.append(suffix)
+        assert review.SAFE_SUFFIX.fullmatch(suffix), suffix
+        if suffix == "git/ref/heads/main":
+            sha = "e" * 40 if self.change == "main" and self.calls.count(suffix) > 1 else MAIN
+            return {"ref": "refs/heads/main", "object": {"type": "commit", "sha": sha}}
+        if suffix.startswith("pulls/"):
+            number = int(suffix.split("/")[1])
+            self.reads[number] = self.reads.get(number, 0) + 1
+            row = copy.deepcopy(self.rows[number])
+            if self.change == "head" and self.reads[number] > 1:
+                row["head"]["sha"] = "f" * 40
+            if self.change == "draft" and self.reads[number] > 1:
+                row["draft"] = False
+            return row
+        if suffix.startswith("compare/"):
+            base = suffix.split("/")[1].split("...")[0]
+            return {"base_commit": {"sha": base}, "merge_base_commit": {"sha": "b" * 40 if self.behind else base},
+                    "behind_by": self.behind}
+        sha = suffix.split("/")[1]
+        if "/status?" in suffix:
+            return {"sha": sha, "total_count": 0, "statuses": []}
+        rows = [{"id": i, "head_sha": sha, "name": name, "app": {"id": app},
+                 "status": "completed", "conclusion": "failure" if self.failure == int(sha, 16) and app == 46505 else "success"}
+                for i, (app, name) in enumerate(sorted(REQUIRED_CHECKS), 1)]
+        return {"total_count": len(rows), "check_runs": rows}
+
+
+def test_collector_propagates_scanner_failure_through_actual_dependency_chain() -> None:
+    parent = pr(191)
+    child = pr(193, base="feature/191", base_sha=parent["head"]["sha"])
+    reader = Reader([parent, child])
+    reader.failure = 191
+    result = review.collect_stack(REPO, [193, 191], reader)
+    assert result["review_order"] == [191, 193]
+    assert result["all_technical_checks_passed"] is False
+    first, second = result["candidates"]
+    assert first["technical_blockers"] == ["checks_failed"]
+    assert second["checks"]["outcome"] == "passed"
+    assert second["technical_blockers"] == ["predecessor_technical_blocked"]
+    assert second["predecessor_merge_pending"] is True
+    assert all(row["merge_authorized"] is False for row in result["candidates"])
+    assert result["merge_authorized"] is False
+    assert reader.reads == {191: 2, 193: 2}
+    assert reader.calls[-1] == "git/ref/heads/main"
+    assert "not-evidence" not in json.dumps(result)
+
+
+def test_green_stack_still_requires_acceptance_and_predecessor_merge() -> None:
+    first = pr(3)
+    reader = Reader([first, pr(1, base="feature/3", base_sha=first["head"]["sha"])])
+    result = review.collect_stack(REPO, [1, 3], reader)
+    assert result["review_order"] == [3, 1]
+    assert result["all_technical_checks_passed"] is True
+    assert result["engineer_acceptance"] == "pending" and result["merge_authorized"] is False
+    assert result["candidates"][1]["predecessor_merge_pending"] is True
+    assert result["independent_review_verified"] is False
+    assert result["collection_consistency"] == "ref_stable_non_atomic"
+
+
+@pytest.mark.parametrize("change", ["main", "head", "draft"])
+def test_moving_refs_or_candidate_state_invalidate_collection(change: str) -> None:
+    reader = Reader([pr(1)])
+    reader.change = change
+    with pytest.raises(EvidenceError, match="changed"):
+        review.collect_stack(REPO, [1], reader)
+
+
+def test_missing_predecessor_is_not_assumed_to_be_main() -> None:
+    result = review.collect_stack(REPO, [2], Reader([pr(2, base="feature/absent")]))
+    assert result["candidates"][0]["technical_blockers"] == ["predecessor_not_selected"]
+
+
+def test_behind_base_is_explicit_even_with_passing_checks() -> None:
+    reader = Reader([pr(1)])
+    reader.behind = 2
+    result = review.collect_stack(REPO, [1], reader)
+    assert result["candidates"][0]["behind_base_by"] == 2
+    assert result["candidates"][0]["technical_blockers"] == ["head_behind_base"]
+
+
+def test_cycle_is_rejected() -> None:
+    first, second = pr(1), pr(2)
+    first["base"].update(ref="feature/2", sha=second["head"]["sha"])
+    second["base"].update(ref="feature/1", sha=first["head"]["sha"])
+    with pytest.raises(EvidenceError, match="cycle"):
+        review.collect_stack(REPO, [1, 2], Reader([first, second]))
+
+
+@pytest.mark.parametrize("mutation", ["fork", "closed", "merged", "bad_draft", "bad_sha", "wrong_number", "missing_repo"])
+def test_unsupported_or_malformed_prs_fail_closed(mutation: str) -> None:
+    row = pr(1)
+    if mutation == "fork":
+        row["head"]["repo"]["full_name"] = "other/repository"
+    elif mutation == "closed":
+        row["state"] = "closed"
+    elif mutation == "merged":
+        row["merged"] = True
+    elif mutation == "bad_draft":
+        row["draft"] = 1
+    elif mutation == "bad_sha":
+        row["head"]["sha"] = "short"
+    elif mutation == "wrong_number":
+        row["number"] = 2
+    else:
+        row["head"]["repo"] = None
+    with pytest.raises(EvidenceError):
+        review._pr_identity(row, REPO, 1)
+
+
+@pytest.mark.parametrize("numbers", [[], [1, 1], [0], [True], list(range(1, 27)), "1"])
+def test_invalid_selection_never_reaches_io(numbers: Any) -> None:
+    reader = Reader([pr(1)])
+    with pytest.raises(EvidenceError):
+        review.collect_stack(REPO, numbers, reader)
+    assert reader.calls == []
+
+
+@pytest.mark.parametrize("repository", ["../x", "a/b?token=x", "https://github.com/a/b", "a/b/c", "a/..", "a/b\n", None])
+def test_invalid_repository_never_reaches_io(repository: Any) -> None:
+    reader = Reader([pr(1)])
+    with pytest.raises(EvidenceError):
+        review.collect_stack(repository, [1], reader)
+    assert reader.calls == []
+
+
+def test_pagination_visits_every_page_and_uses_explicit_latest_filter() -> None:
+    calls: list[str] = []
+
+    def read(suffix: str) -> dict[str, Any]:
+        calls.append(suffix)
+        page = int(suffix.rsplit("=", 1)[1])
+        return {"total_count": 101, "check_runs": [{"id": n} for n in (range(1, 101) if page == 1 else [101])]}
+
+    result = review._pages(read, "commits/" + "a" * 40 + "/check-runs?filter=latest", "check_runs")
+    assert len(result) == 2 and calls[-1].endswith("&per_page=100&page=2")
+
+
+@pytest.mark.parametrize("page", [{"total_count": 1, "check_runs": []}, {"total_count": 1001, "check_runs": []},
+                                  {"total_count": True, "check_runs": []}, {"total_count": 1, "check_runs": None}])
+def test_incomplete_or_excessive_api_pages_fail(page: dict[str, Any]) -> None:
+    with pytest.raises(EvidenceError):
+        review._pages(lambda path: page, "unused", "check_runs")
+
+
+@pytest.mark.parametrize("suffix", ["https://evil.invalid", "../issues", "issues/1", "pulls/1/merge",
+                                    "pulls/1?token=x", "git/ref/heads/main#fragment", "pulls/01"])
+def test_transport_rejects_every_non_read_endpoint_before_opener(monkeypatch: pytest.MonkeyPatch, suffix: str) -> None:
+    def forbidden(*args: Any) -> Any:
+        raise AssertionError("opener must not be reached")
+    monkeypatch.setattr(review, "build_opener", forbidden)
+    with pytest.raises(EvidenceError, match="endpoint"):
+        review.GitHubReadOnly(REPO)(suffix)
+
+
+def test_transport_uses_fixed_origin_get_bounds_and_environment_token_only(monkeypatch: pytest.MonkeyPatch) -> None:
+    observed: dict[str, Any] = {}
+
+    class Response(io.BytesIO):
+        status = 200
+        def read(self, size: int = -1) -> bytes:
+            observed["read_limit"] = size
+            return super().read(size)
+
+    class Opener:
+        def open(self, request: Any, timeout: int) -> Response:
+            observed.update(url=request.full_url, method=request.method, headers=dict(request.headers), timeout=timeout)
+            return Response(b'{"total_count":0,"check_runs":[]}')
+
+    def build(*handlers: Any) -> Opener:
+        assert any(isinstance(h, review.NoRedirects) for h in handlers)
+        assert next(h for h in handlers if isinstance(h, review.ProxyHandler)).proxies == {}
+        return Opener()
+
+    monkeypatch.setattr(review, "build_opener", build)
+    reader = review.GitHubReadOnly(REPO, token="TEST_ONLY_VALUE")
+    assert reader("pulls/1")["total_count"] == 0
+    assert observed["url"] == "https://api.github.com/repos/owner/repository/pulls/1"
+    assert observed["method"] == "GET" and observed["timeout"] == 15
+    assert observed["read_limit"] == review.MAX_RESPONSE_BYTES + 1
+    assert observed["headers"]["Authorization"] == "Bearer TEST_ONLY_VALUE"
+    with pytest.raises(EvidenceError):
+        review.NoRedirects().redirect_request(None)
+
+
+@pytest.mark.parametrize("payload", [b"[]", b'{"x":1,"x":2}', b'{"x":NaN}', b"\xff", b"[" * 1500,
+                                     b" " * (review.MAX_RESPONSE_BYTES + 1)])
+def test_transport_rejects_bad_response_without_echo(monkeypatch: pytest.MonkeyPatch, payload: bytes) -> None:
+    class Response(io.BytesIO):
+        status = 200
+    class Opener:
+        def open(self, *args: Any, **kwargs: Any) -> Response:
+            return Response(payload)
+    monkeypatch.setattr(review, "build_opener", lambda *args: Opener())
+    with pytest.raises(EvidenceError) as caught:
+        review.GitHubReadOnly(REPO)("pulls/1")
+    assert str(caught.value) == "unable to obtain bounded GitHub evidence"
+
+
+@pytest.mark.parametrize("token", ["", "bad\nheader", "bad value", "x" * 2049, 42])
+def test_invalid_environment_token_is_not_echoed(token: Any) -> None:
+    with pytest.raises(EvidenceError) as caught:
+        review.GitHubReadOnly(REPO, token=token)
+    assert str(caught.value) == "invalid environment authentication value"
+
+
+def test_cli_returns_blocked_report_without_accepting_or_writing(monkeypatch: pytest.MonkeyPatch, capsys: Any) -> None:
+    reader = Reader([pr(191)])
+    reader.failure = 191
+    monkeypatch.setattr(review, "GitHubReadOnly", lambda *args, **kwargs: reader)
+    assert review.main(["--read-github", "--repository", REPO, "--pr", "191"]) == 3
+    result = json.loads(capsys.readouterr().out)
+    assert result["merge_authorized"] is False and result["candidates"][0]["technical_blockers"] == ["checks_failed"]
+
+
+@pytest.mark.parametrize("extra", [["--token", "DO_NOT_ECHO"], ["--execute"], ["--read"], ["--read-github=DO_NOT_ECHO"]])
+def test_cli_usage_errors_are_redacted_before_io(extra: list[str], monkeypatch: pytest.MonkeyPatch, capsys: Any) -> None:
+    def forbidden(*args: Any, **kwargs: Any) -> Any:
+        raise AssertionError("reader must not be constructed")
+    monkeypatch.setattr(review, "GitHubReadOnly", forbidden)
+    with pytest.raises(SystemExit) as caught:
+        review.main(["--read-github", "--repository", REPO, "--pr", "1", *extra])
+    assert caught.value.code == 2
+    output = capsys.readouterr()
+    assert output.out == "" and output.err == "PR stack review usage is invalid; no changes made\n"
+
+
+def test_cli_provider_failure_is_redacted(monkeypatch: pytest.MonkeyPatch, capsys: Any) -> None:
+    def read(path: str) -> Any:
+        raise RuntimeError("DO_NOT_ECHO")
+    monkeypatch.setattr(review, "GitHubReadOnly", lambda *args, **kwargs: read)
+    assert review.main(["--read-github", "--repository", REPO, "--pr", "1"]) == 1
+    output = capsys.readouterr()
+    assert output.out == "" and output.err == "PR stack review failed; no changes made\n"
+
+
+def test_predecessor_head_and_main_mismatches_remain_blockers() -> None:
+    first = pr(1, base_sha="b" * 40)
+    second = pr(2, base="feature/1", base_sha="c" * 40)
+    result = review.collect_stack(REPO, [1, 2], Reader([first, second]))
+    assert result["candidates"][0]["technical_blockers"] == ["base_main_mismatch"]
+    assert "predecessor_head_mismatch" in result["candidates"][1]["technical_blockers"]
+    assert result["tested_merge_tree_verified"] is False
+
+
+def test_duplicate_selected_head_branches_are_rejected() -> None:
+    first, second = pr(1), pr(2)
+    second["head"]["ref"] = first["head"]["ref"]
+    with pytest.raises(EvidenceError, match="ambiguous"):
+        review.collect_stack(REPO, [1, 2], Reader([first, second]))
+
+
+@pytest.mark.parametrize("bad", [{"behind_by": True}, {"base_commit": {"sha": "f" * 40}},
+                                 {"merge_base_commit": {"sha": "e" * 40}}])
+def test_comparison_must_reconcile_selected_base(bad: dict[str, Any]) -> None:
+    reader = Reader([pr(1)])
+    def read(suffix: str) -> dict[str, Any]:
+        value = reader(suffix)
+        return {**value, **bad} if suffix.startswith("compare/") else value
+    with pytest.raises(EvidenceError):
+        review.collect_stack(REPO, [1], read)
+
+
+def test_command_needs_explicit_read_flag_and_help_does_not_read(monkeypatch: pytest.MonkeyPatch, capsys: Any) -> None:
+    def forbidden(*args: Any, **kwargs: Any) -> Any:
+        raise AssertionError("no I/O")
+    monkeypatch.setattr(review, "GitHubReadOnly", forbidden)
+    for args, code in ((["--repository", REPO, "--pr", "1"], 2), (["--help"], 0)):
+        with pytest.raises(SystemExit) as caught:
+            review.main(args)
+        assert caught.value.code == code
+    assert "pr-stack-review" in capsys.readouterr().out
+
+
+def test_transport_http_error_does_not_echo_provider_or_authentication(monkeypatch: pytest.MonkeyPatch) -> None:
+    class Opener:
+        def open(self, *args: Any, **kwargs: Any) -> Any:
+            raise RuntimeError("SENSITIVE_HTTP_ERROR")
+    monkeypatch.setattr(review, "build_opener", lambda *args: Opener())
+    with pytest.raises(EvidenceError) as caught:
+        review.GitHubReadOnly(REPO)("pulls/1")
+    assert str(caught.value) == "unable to obtain bounded GitHub evidence"


### PR DESCRIPTION
## Goal and status

Closes #196 after acceptance and merge. Second acceptance-backlog increment under #76, stacked on #200. Primary arc42 block: engineering-controls.

**Implemented, final-head four-job CI and separate GitGuardian scan passed; draft and unmerged. Independent review, predecessor acceptance and explicit final-diff engineer acceptance remain pending.** This independent stack starts at accepted main and imports none of the pending notification/fixture/source/suspension implementations.

## Delivered behavior

Add `python -m scripts.pr_stack_review --read-github --repository owner/repo --pr N ...`. The collector validates selected same-repository PR identities, obtains the complete bounded latest-check and combined-status inventories, reuses #200's exact-head reconciler, and compares exact base/head commits. It rereads every PR identity and main after collection, rejecting changed refs or candidate state.

Dependency-first output distinguishes missing predecessors, heads behind their base, cyclic/ambiguous relationships and inherited technical failures. A passing child's checks cannot hide failed parent checks. Pending predecessor merge and engineer acceptance are separate from technical outcomes. Every candidate retains merge_authorized=false. Branch rules, independent review and the actual merge tree tested by CI are explicitly unverified by this command.

## Exact candidate and scope

- Base #200: `4cf5602041d53be89f52344265740c0edbec70af`.
- Final head: `456aad6af0ac292b908f97128ccab5b38ceedb13`.
- Tree: `ca3e37eb29a9885d8bea3626400395f8cfe4f704`.
- Tested synthetic merge: `437ef6b6da8a88715b664bca0e80bf8b6e690540`, combining that exact head and predecessor.
- Three additive files, **655 additions, zero deletions, one commit**: collector/CLI, regression suite and operating guide. Published changed-file inventory was checked; source blob `ed6e61e6fdd9c3e3e955ecea110df32bfffaa1c2` matched the locally tested bytes. No post-validation source changes.

## Final-head validation

[Actions run 478](https://github.com/alexmarinos87/financial-risk-data-platform/actions/runs/34063412746) passed Python readiness, PostgreSQL contract, Security guardrails and Infrastructure validation.

Python job `101567887289` confirms Ruff passed, **1,262 tests passed twice**, dependency integrity, pipeline replay and warehouse dry-run. The existing mypy command passed across 159 `src` files; it does not directly type-check the new `scripts` modules. PostgreSQL job `101567887250` completed all existing disposable contract and consistency steps. Separate GitGuardian check **101567885328** passed for this exact head.

All **65 new collector/CLI tests plus 45 predecessor tests passed locally: 110 passed, none skipped/deselected**, including a final rerun after publication. Compilation and staged whitespace checks passed in a source-subset worktree. The full suite is 1,152 accepted-main tests plus these 110 additions. Its lower count than #193's separate 1,354-test fixture branch is not a test deletion; this stack does not import that unaccepted branch.

Tests exercise the actual collector/entry point with injected API responses and actual urllib Request/handler construction. Cases include workflow-green/scanner-red propagation, missing/cyclic dependencies, reference movement, behind-base comparisons, pagination failures, strict selection, safe transport and redacted errors. They do not contact GitHub or use real credentials. Live repository state was inspected separately through the connected reader; **live execution of this new HTTP transport is not claimed**.

Full clone failed locally on DNS, and Ruff/mypy/Psycopg/Docker/Terraform were unavailable locally. Full repository checks and database/infrastructure validation ran in GitHub CI. Conversation, submitted-review and inline-comment inventory was empty when inspected. Self-review is not independent correctness/production review or human acceptance.

## Transport and limits

GET-only internal endpoint allowlist at api.github.com, verified HTTPS, no redirects or inherited proxy routing, 15-second socket timeout, 1 MiB per response, ten pages / 1,000 rows per source, and at most 25 selected PRs. Optional authentication comes only from GH_TOKEN, with no token or arbitrary URL argument. Fixed errors do not echo arguments or provider bodies. Bounded JSON output goes to stdout only. No file writes, subprocess, Git mutations, scanner dismissal, status override or merge operation.

The socket timeout is not a whole-command deadline. Ref-stable collection is not atomic: results can change or new checks can appear afterward. The fixed expected-check policy is repository-specific and logical dependencies not expressed by base branches need separate review. CI checkout logs, final diffs and independent review remain necessary.

## Acceptance and handoff

The guide includes the existing #167 → #168 → #169 → #176 → #177 → #181 → #191 → #193 chain as a usage example. #191's scanner incident remains failed and undisposed; this tool does not bypass it. No existing PR stack, workflow, setting, dependency, activation default, database or deployment was changed.

Accept #200 first; reconstruct this isolated delta on accepted main after its squash merge, rerun exact-head validation and obtain final-diff acceptance. Do not merge into an unaccepted predecessor. Exit 0 indicates only clear reported technical checks/base comparisons, not predecessor integration, independent approval or permission to merge.