### PR TITLE
Bound destination-transition rehearsal file intake

### DIFF
--- a/docs/transition-record-file-intake.md
+++ b/docs/transition-record-file-intake.md
@@ -1,0 +1,63 @@
+# Destination-transition rehearsal file intake
+
+Primary arc42 block: `warehouse`. Goal #198; prerequisite #186 / PR #192.
+
+## Decision and scope
+
+The transition history recorder delegates `_read_record` to the existing common
+bounded JSON reader and retains `MAX_RECORD_BYTES = 1_048_576`. Only this loader
+changes in product code. Rotation/disable/rollback validation, recorded identities,
+SQL, transaction behavior, replay handling, CLI functions and flags are unchanged.
+
+Previously, a file could grow between a size check and the unbounded text read.
+Duplicate names could also disappear during ordinary JSON decoding before the
+semantic validator saw the record. The new boundary rejects these ambiguous
+inputs before invoking persistence, rather than changing how history is stored.
+
+## Executable evidence
+
+```bash
+python -m pytest -q \
+  tests/unit/test_notification_destination_transition_rehearsal_recorder.py \
+  tests/unit/test_transition_record_file_intake.py
+make quality-check
+make security-check
+make readiness-check
+```
+
+The new tests construct actual canonical transition records using the existing
+no-network rehearsal fixture and record builder. They prove unchanged round-trip
+and CLI delegation, root/nested/escaped-equivalent duplicate rejection, exact
+byte boundaries, bounded reads after file growth, malformed/non-finite JSON,
+excessive nesting, unsafe file types and redacted read errors. Existing negative
+tests keep their rejection assertions; only two diagnostic matches change.
+
+Malformed intake must never call persistence. Semantically tampered but valid
+JSON must never call `psycopg.connect`. These guards record attempted calls so
+a swallowed provider exception cannot produce a false pass. Positive CLI tests
+inject persistence rather than connecting to any application database. A separate
+test blocks sockets, DNS and PostgreSQL connections while constructing and
+reading the synthetic rehearsal record; enabled configuration copies exist only
+inside temporary test directories.
+
+## Compatibility and trust
+
+Valid decoded record contents, ordinary formatting and trailing whitespace within
+the byte ceiling are preserved. The parser now rejects duplicate fields at all
+levels, non-finite tokens and floating-point overflow, malformed UTF-8, non-object
+roots and more than 64 nested containers. Intake failure remains exit 1; invalid
+CLI usage remains exit 2. The exact shared-reader diagnostic text differs from
+older loader messages. No new execution or recording option is introduced.
+
+See [bounded JSON evidence](bounded-json-evidence.md) for platform-specific
+no-follow/nonblocking flags and descriptor checks. Parent directories and the
+filesystem are trusted; concurrent in-place changes are not prevented, and reads
+have no I/O deadline. Use immutable reviewed files. Parsing and hashes are not
+source authentication, current readiness or runtime permission. The existing
+DSN/argparse interface and shell-history exposure are not redesigned here.
+
+This is an independent sibling of goal #197 / PR #201, not a successor to it or
+#194. Accept #192 first, then reconstruct each isolated consumer change on
+accepted main and rerun exact-head CI. Independent review and explicit engineer
+acceptance remain pending. No schema, workflow, dependency, committed activation,
+scheduler, transport or deployment change is included.

--- a/src/warehouse/notification_destination_transition_rehearsal_recorder.py
+++ b/src/warehouse/notification_destination_transition_rehearsal_recorder.py
@@ -202,19 +202,9 @@ def record_notification_destination_transition_rehearsal(
 
 
 def _read_record(path: Path) -> dict[str, Any]:
-    if path.is_symlink():
-        raise ValidationError("transition rehearsal record must not be a symbolic link")
-    if not path.is_file():
-        raise ValidationError("transition rehearsal record must be a regular file")
-    if path.stat().st_size > MAX_RECORD_BYTES:
-        raise ValidationError("transition rehearsal record exceeds 1 MB")
-    try:
-        value = json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, UnicodeError, ValueError):
-        raise ValidationError("transition rehearsal record could not be read") from None
-    if not isinstance(value, Mapping):
-        raise ValidationError("transition rehearsal record must be a JSON object")
-    return dict(value)
+    from src.common.bounded_json import load_bounded_json_object
+
+    return load_bounded_json_object(path, max_bytes=MAX_RECORD_BYTES)
 
 
 def _build_parser() -> argparse.ArgumentParser:

--- a/tests/unit/test_notification_destination_transition_rehearsal_recorder.py
+++ b/tests/unit/test_notification_destination_transition_rehearsal_recorder.py
@@ -38,10 +38,10 @@ def test_transition_record_reader_rejects_oversized_or_malformed_json(
 ) -> None:
     oversized = tmp_path / "oversized.json"
     oversized.write_bytes(b"x" * (MAX_RECORD_BYTES + 1))
-    with pytest.raises(ValidationError, match="exceeds 1 MB"):
+    with pytest.raises(ValidationError, match="byte limit"):
         _read_record(oversized)
 
     malformed = tmp_path / "malformed.json"
     malformed.write_text("{not-json", encoding="utf-8")
-    with pytest.raises(ValidationError, match="could not be read"):
+    with pytest.raises(ValidationError, match="unable to read valid JSON evidence"):
         _read_record(malformed)

--- a/tests/unit/test_transition_record_file_intake.py
+++ b/tests/unit/test_transition_record_file_intake.py
@@ -1,0 +1,252 @@
+from __future__ import annotations
+
+import json
+import os
+from datetime import timedelta
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from src.common import bounded_json
+from src.common.exceptions import ValidationError
+from src.warehouse import notification_destination_transition_rehearsal_recorder as recorder
+from src.warehouse.notification_destination_transition_rehearsal_contract import (
+    build_notification_destination_transition_rehearsal_record,
+    validate_notification_destination_transition_rehearsal_record,
+)
+from test_notification_destination_transition_rehearsal_contract import STARTED_AT, _rehearsal
+
+LIMIT = 1_048_576
+
+
+def _build(tmp_path: Path) -> dict[str, Any]:
+    return build_notification_destination_transition_rehearsal_record(
+        request_id="TRANSITION-INTAKE-001",
+        recorded_at=STARTED_AT + timedelta(seconds=4),
+        rehearsal=_rehearsal(tmp_path / "configuration"),
+    )
+
+
+def _reject_before_recording(
+    path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str],
+) -> None:
+    calls: list[dict[str, Any]] = []
+
+    def forbidden(**kwargs: Any) -> dict[str, Any]:
+        calls.append(kwargs)
+        pytest.fail("intake failure reached persistence")
+
+    monkeypatch.setattr(recorder, "record_notification_destination_transition_rehearsal", forbidden)
+    assert recorder.main(["--record", str(path), "--dsn", "private-unused-dsn"]) == 1
+    captured = capsys.readouterr()
+    assert calls == []
+    assert captured.out == ""
+    assert captured.err.startswith("Destination transition rehearsal rejected:")
+    assert "private" not in captured.err
+    assert str(path) not in captured.err
+
+
+def test_canonical_transition_record_round_trips(tmp_path: Path) -> None:
+    record = _build(tmp_path)
+    path = tmp_path / "record.json"
+    raw = json.dumps(record, indent=2).encode("utf-8") + b"\n"
+    path.write_bytes(raw)
+    loaded = recorder._read_record(path)
+    assert loaded == record
+    assert validate_notification_destination_transition_rehearsal_record(loaded) == record
+    assert path.read_bytes() == raw
+
+
+@pytest.mark.parametrize("target", ["root", "rehearsal", "escaped_root"])
+def test_duplicate_cannot_hide_behind_canonical_last_value(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str], target: str,
+) -> None:
+    record = _build(tmp_path)
+    text = json.dumps(record)
+    if target == "rehearsal":
+        marker = '"rehearsal_summary": {'
+        assert marker in text
+        text = text.replace(marker, marker + '"rehearsal_id":"private-shadow",', 1)
+    else:
+        key = 'record_id' if target == "root" else r'\u0072ecord_id'
+        text = '{"' + key + '":"private-shadow",' + text[1:]
+    # The legacy decoder loses the conflicting first field, even though the
+    # remaining last-value document satisfies the real semantic validator.
+    assert json.loads(text) == record
+    assert validate_notification_destination_transition_rehearsal_record(json.loads(text)) == record
+    path = tmp_path / "private-duplicate.json"
+    path.write_text(text, encoding="utf-8")
+    with pytest.raises(ValidationError, match="duplicate fields"):
+        recorder._read_record(path)
+    _reject_before_recording(path, monkeypatch, capsys)
+
+
+@pytest.mark.parametrize("extra", [0, 1])
+def test_exact_byte_ceiling(tmp_path: Path, extra: int) -> None:
+    record = _build(tmp_path)
+    raw = json.dumps(record).encode("utf-8")
+    assert len(raw) < LIMIT
+    raw += b" " * (LIMIT + extra - len(raw))
+    path = tmp_path / "record.json"
+    path.write_bytes(raw)
+    if extra:
+        with pytest.raises(ValidationError, match="byte limit"):
+            recorder._read_record(path)
+    else:
+        assert recorder._read_record(path) == record
+
+
+@pytest.mark.parametrize("raw", [
+    b'{"v":NaN}', b'{"v":Infinity}', b'{"v":-Infinity}', b'{"v":1e9999}',
+    b'{"private":"\xff"}', b'[]', b'null', b'{"private":',
+    b'{"v":' * 65 + b'0' + b'}' * 65,
+])
+def test_malformed_intake_never_records(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str], raw: bytes,
+) -> None:
+    path = tmp_path / "private-input.json"
+    path.write_bytes(raw)
+    _reject_before_recording(path, monkeypatch, capsys)
+
+
+@pytest.mark.parametrize("kind", ["directory", "missing", "symlink", "dangling", "fifo"])
+def test_unsafe_file_never_records(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str], kind: str,
+) -> None:
+    path = tmp_path / "private-input"
+    if kind == "directory":
+        path.mkdir()
+    elif kind in {"symlink", "dangling"}:
+        target = tmp_path / "target"
+        if kind == "symlink":
+            target.write_text("{}", encoding="utf-8")
+        path.symlink_to(target)
+    elif kind == "fifo":
+        if not hasattr(os, "mkfifo"):
+            pytest.skip("FIFO support is unavailable")
+        os.mkfifo(path)
+    _reject_before_recording(path, monkeypatch, capsys)
+
+
+def test_file_growth_is_bounded_before_recording(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str],
+) -> None:
+    path = tmp_path / "private-growing.json"
+    path.write_text("{}", encoding="utf-8")
+    real_open, real_read = os.open, os.read
+    consumed: list[int] = []
+
+    def growing(file: Any, flags: int, *args: Any, **kwargs: Any) -> int:
+        path.write_bytes(b" " * (LIMIT + 100))
+        return real_open(file, flags, *args, **kwargs)
+
+    def measured(fd: int, count: int) -> bytes:
+        chunk = real_read(fd, count)
+        consumed.append(len(chunk))
+        return chunk
+
+    monkeypatch.setattr(bounded_json.os, "open", growing)
+    monkeypatch.setattr(bounded_json.os, "read", measured)
+    _reject_before_recording(path, monkeypatch, capsys)
+    assert sum(consumed) == LIMIT + 1
+
+
+def test_exact_loader_delegation(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    result = {"only_intake": True}
+    calls: list[tuple[Path, int]] = []
+
+    def load(path: Path, *, max_bytes: int) -> dict[str, Any]:
+        calls.append((path, max_bytes))
+        return result
+
+    monkeypatch.setattr(bounded_json, "load_bounded_json_object", load)
+    path = tmp_path / "not-read"
+    assert recorder._read_record(path) is result
+    assert calls == [(path, LIMIT)]
+
+
+def test_valid_cli_delegates_without_altering_record(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str],
+) -> None:
+    record = _build(tmp_path)
+    path = tmp_path / "record.json"
+    path.write_text(json.dumps(record), encoding="utf-8")
+    calls: list[dict[str, Any]] = []
+
+    def capture(**kwargs: Any) -> dict[str, Any]:
+        calls.append(kwargs)
+        return {"record_id": kwargs["record"]["record_id"], "created": False}
+
+    monkeypatch.setattr(recorder, "record_notification_destination_transition_rehearsal", capture)
+    assert recorder.main(["--record", str(path), "--dsn", "injected-dsn"]) == 0
+    assert calls == [{"dsn": "injected-dsn", "record": record}]
+    output = capsys.readouterr()
+    assert json.loads(output.out) == {"record_id": record["record_id"], "created": False}
+    assert output.err == ""
+
+
+def test_semantic_validation_still_precedes_connection(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str],
+) -> None:
+    import psycopg
+
+    record = _build(tmp_path)
+    record["record_id"] = "tampered-identity"
+    path = tmp_path / "record.json"
+    path.write_text(json.dumps(record), encoding="utf-8")
+    calls: list[tuple[Any, ...]] = []
+
+    def forbidden(*args: Any, **kwargs: Any) -> Any:
+        calls.append(args)
+        pytest.fail("semantic rejection reached database connection")
+
+    monkeypatch.setattr(psycopg, "connect", forbidden)
+    assert recorder.main(["--record", str(path), "--dsn", "unused-dsn"]) == 1
+    assert calls == []
+    assert capsys.readouterr().out == ""
+
+
+def test_io_error_is_redacted_before_recording(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str],
+) -> None:
+    path = tmp_path / "private-input.json"
+    path.write_text("{}", encoding="utf-8")
+
+    def fail(*args: Any, **kwargs: Any) -> Any:
+        raise OSError("private filesystem diagnostic")
+
+    monkeypatch.setattr(bounded_json.os, "open", fail)
+    _reject_before_recording(path, monkeypatch, capsys)
+
+
+def test_cli_still_has_no_execute_flag() -> None:
+    with pytest.raises(SystemExit) as error:
+        recorder._build_parser().parse_args(["--record", "unused.json", "--execute"])
+    assert error.value.code == 2
+
+
+def test_transition_fixture_and_loader_are_offline(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import socket
+
+    import psycopg
+
+    calls: list[str] = []
+
+    def forbidden(*args: Any, **kwargs: Any) -> Any:
+        calls.append("external")
+        pytest.fail("offline fixture attempted network or database access")
+
+    monkeypatch.setattr(socket, "socket", forbidden)
+    monkeypatch.setattr(socket, "getaddrinfo", forbidden)
+    monkeypatch.setattr(psycopg, "connect", forbidden)
+    record = _build(tmp_path)
+    path = tmp_path / "record.json"
+    path.write_text(json.dumps(record), encoding="utf-8")
+    assert recorder._read_record(path) == record
+    assert calls == []


### PR DESCRIPTION
## Goal and dependency

Closes #198 after explicit acceptance and merge. Roadmap #76; primary arc42 block: warehouse. Depends only on common-reader #192/#186 at `1dc74d4d44898b02644b3b2689b8c690aadc5c27`. Independent sibling of #201 and #194, not a successor to either. No predecessor or concurrent worker-health/source branch was rewritten.

## Delivered change and exact scope

Replace only `notification_destination_transition_rehearsal_recorder._read_record` with the shared bounded reader and retain `MAX_RECORD_BYTES = 1_048_576`. The published source diff has one loader-only hunk. Rotation/disable/rollback validation, identities, SQL, transaction/replay behavior and CLI functions/flags/exit codes are unchanged.

Four intended paths, **320 additions and 15 deletions**: recorder loader; existing recorder tests (two diagnostic strings only); `tests/unit/test_transition_record_file_intake.py`; `docs/transition-record-file-intake.md`. No old rejection assertion is removed.

**27 new regression cases** construct real canonical transition records through the existing no-network rehearsal fixture. They cover unchanged round-trip/CLI delegation, root/nested/escaped duplicate names whose final occurrences form canonical records, exact byte boundaries, measured read budget during file growth, malformed/non-finite/over-depth JSON, unsafe and missing files, redacted I/O and semantic validation before database connection. Guards record attempted calls so a swallowed exception cannot create a false pass. The offline test blocks sockets, DNS and PostgreSQL while building and reading the real synthetic fixture. Positive CLI tests inject persistence.

## Exact-candidate validation

- Final head: `37ddb039ef62405a2f83bfc8ba1f42e8917d304e`.
- Tree: `a1a25cb39864c97356942a3696f87536c8007e96`.
- GitHub Actions **run 479 / 34063456951: success**.
- Python readiness, Security guardrails, PostgreSQL contract and Infrastructure validation all passed, including disposable database teardown.
- Python job `101568009734` confirms Ruff, mypy across **160 source files**, **1,226 tests passing twice**, dependency integrity, pipeline replay and warehouse dry-run.
- Tested synthetic merge: `d861da3aa675fc872947b88c3556e27f29472cc8`, combining this exact head with #192's exact prerequisite.

Each sibling has its own passing 1,226-test suite over the common 1,199-test prerequisite. No combined #201/#205/#194 integration run is claimed. The PostgreSQL job validates existing persistence contracts separately; the new unit/CLI tests establish file-intake behavior.

## Local evidence and review limitations

Copied baseline source and old tests matched Git blobs `8a863a0ad05a75fbe0847775962abd5fd798dd98` and `7fc8a5a3d2343d6ee372dedb7b3922c7e148ffb4`. AST comparison identifies `_read_record` as the sole changed product node. Compilation and staged whitespace checks passed. Fifteen extracted-loader checks and 18 extracted-CLI tests passed locally (36 extracted-CLI tests across both consumers). These source-subset harnesses execute the actual loader/CLI bodies but are not full-module semantic integration. Complete canonical-record tests, typing and repository validation ran in GitHub Actions.

Local GitHub cloning failed DNS resolution; Docker/Terraform are absent. No complete local PostgreSQL/infrastructure run or `make morning-review` package is claimed. Published source and old-test patches were inspected. Submitted reviews and inline review threads were empty at the final check. **Self-review and CI are evidence, not independent correctness/production review or final-diff engineer acceptance.**

## Acceptance and safety

**Validated draft, unmerged; #198 remains open.** Accept #192 first, then reconstruct this isolated consumer delta on accepted current main and rerun final-head checks. #201 and #205 can be considered in either order after the prerequisite is accepted; do not merge them into the unaccepted common-reader branch. Main remained `7316dd30ce5b445df0ac2c0ac019703add15aadc` at final reconciliation.

No schema, workflow, dependency, committed activation, application database access, external notification, scheduling or deployment. Enabled configuration copies are temporary test fixtures only. CI database effects remain inside the existing disposable service. Parent-directory trust, in-place mutability and lack of an I/O deadline remain documented limitations; parsing does not establish authenticated approval or runtime permission.