### PR TITLE
Add explicit read-only worker readiness inspection

### DIFF
--- a/docs/worker-readiness-inspection.md
+++ b/docs/worker-readiness-inspection.md
@@ -1,0 +1,82 @@
+# Inspect worker readiness without execution
+
+Primary arc42 block: `warehouse`. Goal: #204, under roadmap #76.
+
+The command wraps the existing read-only source reader. It does not evaluate
+failure histories, claim schedule slots, run preflight execution, suspend or
+activate workers, send notifications, or write database records.
+
+## Default: no database access
+
+```bash
+python -m src.warehouse.inspect_worker_readiness --worker-id example-worker
+```
+
+This returns `status: not_requested`, with both `database_read_attempted` and
+`database_read_completed` false. It does not look up a DSN environment variable
+or import the database reader. Help is also database-free. Argument abbreviations
+are disabled, and argument-error output does not echo supplied values.
+
+## Explicit read
+
+Supply an authorized database DSN through the environment using your normal
+secret-management mechanism. The command accepts an environment-variable name,
+not a DSN value on the command line:
+
+```bash
+python -m src.warehouse.inspect_worker_readiness \
+  --worker-id example-worker \
+  --read-database \
+  --dsn-env WAREHOUSE_POSTGRES_DSN
+```
+
+Only this mode calls `read_current_worker_readiness`. Its dedicated idle
+read-only autocommit session, query timeout, current authority selection, bounded
+source retrieval, canonical document verification and current-review comparison
+remain in force. The supplied target is the operator's responsibility; this
+command does not make an arbitrary DSN safe or prove a database is disposable.
+
+## Output and exit codes
+
+The report contains the observation time, selected authority reference, snapshot
+reference, per-kind retained record IDs/digests/status, missing execution kinds
+and allow-listed blocking reasons. It does not print full source documents,
+endpoint values, connection strings or raw provider errors. The projection checks
+identity and status coherence but is not another authority policy or independent
+source attestation; source validation belongs to the reader.
+
+Exit 0 means either no read was requested or the selected readiness sources were
+ready. Inspect `status` to distinguish those cases. Exit 2 means a completed read
+found blocked/missing authority, or the argument parser rejected the command.
+Exit 1 means configuration, reading or output validation failed. A failure report
+records whether the read was attempted, and does not claim that no database I/O
+occurred. `database_read_completed` is only true after the reader and report
+validation both complete successfully.
+
+Every report keeps `runtime_permission_granted` and `failure_history_verified`
+false. In particular, `ready_sources` and exit 0 do not authorize delivery or
+establish healthy per-worker failure history. An unknown worker cannot establish
+which execution kinds should exist, so its report uses `authority_missing`
+rather than inventing a successful empty inventory.
+
+## Evidence and boundaries
+
+Focused tests cover opt-in access, no default credential lookup, safe argument
+errors, environment indirection, each outcome and exit code, malformed/contradictory
+results, detached output and sanitized failures. A separate wiring test calls the
+real reader and semantic validators with only the database connection replaced:
+valid source records report both kinds, while a changed stored digest fails.
+The predecessor's PostgreSQL contract proves the actual SQL and session path.
+
+On a complete checkout, run:
+
+```bash
+python -m pytest -q \
+  tests/unit/test_worker_readiness_inspection.py \
+  tests/unit/test_worker_readiness_inspection_wiring.py
+```
+
+Then run repository quality/security/readiness checks. The command adds no schema,
+workflow, dependency, default DSN, activation switch or scheduler integration.
+No deployment or Terraform apply is performed. Explicit final-diff acceptance
+and accepted-main integration remain separate from passing tests.

--- a/src/warehouse/inspect_worker_readiness.py
+++ b/src/warehouse/inspect_worker_readiness.py
@@ -1,0 +1,163 @@
+"""Inspect retained worker readiness without granting execution permission."""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+from src.common.exceptions import ValidationError
+from src.warehouse.notification_worker_readiness_source import (
+    source_bytes, source_identifier, source_time,
+)
+
+MODEL_VERSION = "portfolio-risk-worker-readiness-inspection-v1"
+NO_AUTHORITY_FLAGS = (
+    "failure_history_verified", "runtime_permission_granted",
+    "notification_delivery_performed", "scheduler_mutated",
+)
+KINDS = {"initial", "retry"}
+BLOCKERS = {"worker_authority_not_active"} | {
+    f"{reason}:{kind}" for kind in KINDS for reason in (
+        "readiness_missing", "readiness_review_changed", "readiness_plan_mismatch",
+        "readiness_not_allowed",
+    )
+}
+
+
+def _read(*, dsn: str, worker_id: str) -> dict[str, Any]:
+    # No database dependency is imported by help or the default no-read path.
+    from src.warehouse.notification_worker_readiness_reader import read_current_worker_readiness
+    return read_current_worker_readiness(dsn=dsn, worker_id=worker_id)
+
+
+def _summary(result: Mapping[str, Any], *, worker_id: str) -> dict[str, Any]:
+    """Project trusted reader output, rejecting contradictory display evidence.
+
+    This is not an independent source validator. The reader verifies actual
+    documents; a caller-fabricated summary cannot authenticate a producer.
+    """
+    value = json.loads(source_bytes(result))
+    status = value.get("status")
+    if (
+        value.get("model_version") != "portfolio-risk-worker-readiness-read-v1"
+        or value.get("worker_id") != worker_id
+        or status not in ("authority_missing", "blocked", "ready_sources")
+        or value.get("database_read_performed") is not True
+        or value.get("single_statement_read_only") is not True
+        or any(value.get(flag) is not False for flag in NO_AUTHORITY_FLAGS)
+    ):
+        raise ValidationError("readiness inspection reader result is inconsistent")
+    report = {
+        "status": status, "worker_id": worker_id,
+        "observed_at": source_time(value["observed_at"]).isoformat(),
+        "authority_sequence": value.get("authority_sequence"),
+        "authority_transition_id": value.get("authority_transition_id"),
+    }
+    snapshot = value.get("snapshot")
+    if status == "authority_missing":
+        if any(item is not None for item in (
+            snapshot, report["authority_sequence"], report["authority_transition_id"],
+        )):
+            raise ValidationError("missing authority has contradictory evidence")
+        return {**report, "readiness": [], "missing_execution_kinds": [],
+                "blocking_reasons": ["authority_missing"], "snapshot_id": None}
+    sequence = report["authority_sequence"]
+    source_identifier(report["authority_transition_id"])
+    if type(sequence) is not int or sequence < 1 or not isinstance(snapshot, dict):
+        raise ValidationError("readiness inspection authority reference is invalid")
+    if (
+        snapshot.get("model_version") != "portfolio-risk-worker-readiness-snapshot-v1"
+        or snapshot.get("worker_id") != worker_id
+        or snapshot.get("authority_transition_id") != report["authority_transition_id"]
+        or snapshot.get("observed_at") != report["observed_at"]
+        or snapshot.get("outcome") != status
+        or snapshot.get("runtime_permission_granted") is not False
+        or snapshot.get("failure_history_verified") is not False
+        or snapshot.get("current_authority_verified") is not False
+    ):
+        raise ValidationError("readiness inspection snapshot is inconsistent")
+    snapshot_id = source_identifier(snapshot["snapshot_id"])
+    rows, missing, reasons = (
+        snapshot.get("readiness"), snapshot.get("missing_execution_kinds"),
+        snapshot.get("blocking_reasons"),
+    )
+    if not isinstance(rows, list) or len(rows) > 2:
+        raise ValidationError("readiness inspection rows exceed scope")
+    if not isinstance(missing, list) or len(missing) > 2 or any(kind not in KINDS for kind in missing):
+        raise ValidationError("readiness inspection missing kinds are invalid")
+    if not isinstance(reasons, list) or len(reasons) > len(BLOCKERS) or any(reason not in BLOCKERS for reason in reasons):
+        raise ValidationError("readiness inspection blocking reasons are invalid")
+    if reasons != sorted(set(reasons)):
+        raise ValidationError("readiness inspection blocking reasons are not canonical")
+    projected = []
+    kinds = list(missing)
+    for row in rows:
+        if not isinstance(row, dict) or row.get("execution_kind") not in KINDS:
+            raise ValidationError("readiness inspection execution kind is invalid")
+        kind, state = row["execution_kind"], row.get("status")
+        if state not in ("allowed", "blocked", "stale", "superseded"):
+            raise ValidationError("readiness inspection source status is invalid")
+        digest = row.get("document_sha256")
+        if not isinstance(digest, str) or re.fullmatch(r"[0-9a-f]{64}", digest) is None:
+            raise ValidationError("readiness inspection source digest is invalid")
+        kinds.append(kind)
+        projected.append({
+            "execution_kind": kind, "status": state,
+            "record_id": source_identifier(row["record_id"]), "document_sha256": digest,
+        })
+    if not kinds or len(kinds) != len(set(kinds)):
+        raise ValidationError("readiness inspection kind inventory is inconsistent")
+    if status == "ready_sources" and (
+        missing or reasons or any(row["status"] != "allowed" for row in projected)
+    ):
+        raise ValidationError("readiness inspection cannot promote blocked evidence")
+    if status == "blocked" and not reasons:
+        raise ValidationError("blocked readiness inspection requires a reason")
+    return {**report, "snapshot_id": snapshot_id, "readiness": projected,
+            "missing_execution_kinds": missing, "blocking_reasons": reasons}
+
+
+class _Parser(argparse.ArgumentParser):
+    def error(self, message: str) -> None:
+        # Unknown arguments may accidentally contain a DSN; do not echo values.
+        self.print_usage(sys.stderr)
+        self.exit(2, "Invalid readiness inspection arguments\n")
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = _Parser(description=__doc__, allow_abbrev=False)
+    parser.add_argument("--worker-id", required=True)
+    parser.add_argument("--read-database", action="store_true")
+    parser.add_argument("--dsn-env", default="WAREHOUSE_POSTGRES_DSN")
+    args = parser.parse_args(argv)
+    attempted = False
+    try:
+        worker_id = source_identifier(args.worker_id)
+        if re.fullmatch(r"[A-Z][A-Z0-9_]{2,127}", args.dsn_env) is None:
+            raise ValidationError("DSN environment variable name is invalid")
+        result: dict[str, Any] = {"status": "not_requested", "worker_id": worker_id}
+        if args.read_database:
+            dsn = os.environ.get(args.dsn_env)
+            if not dsn or not dsn.strip():
+                raise ValidationError("DSN environment variable is not configured")
+            attempted = True
+            result = _summary(_read(dsn=dsn, worker_id=worker_id), worker_id=worker_id)
+        report = {**result, "model_version": MODEL_VERSION,
+                  "database_read_attempted": attempted, "database_read_completed": attempted,
+                  **dict.fromkeys(NO_AUTHORITY_FLAGS, False)}
+        print(source_bytes(report).decode("ascii"))
+        return 2 if result["status"] in ("blocked", "authority_missing") else 0
+    except Exception:
+        # A failed read may have reached PostgreSQL; do not assert that no I/O ran.
+        print(json.dumps({"model_version": MODEL_VERSION, "status": "failed",
+                          "database_read_attempted": attempted, "database_read_completed": False,
+                          **dict.fromkeys(NO_AUTHORITY_FLAGS, False)}, sort_keys=True), file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/warehouse/inspect_worker_readiness.py
+++ b/src/warehouse/inspect_worker_readiness.py
@@ -7,7 +7,7 @@ import os
 import re
 import sys
 from collections.abc import Mapping, Sequence
-from typing import Any
+from typing import Any, NoReturn
 
 from src.common.exceptions import ValidationError
 from src.warehouse.notification_worker_readiness_source import (
@@ -122,7 +122,7 @@ def _summary(result: Mapping[str, Any], *, worker_id: str) -> dict[str, Any]:
 
 
 class _Parser(argparse.ArgumentParser):
-    def error(self, message: str) -> None:
+    def error(self, message: str) -> NoReturn:
         # Unknown arguments may accidentally contain a DSN; do not echo values.
         self.print_usage(sys.stderr)
         self.exit(2, "Invalid readiness inspection arguments\n")

--- a/tests/unit/test_worker_readiness_inspection.py
+++ b/tests/unit/test_worker_readiness_inspection.py
@@ -1,0 +1,168 @@
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any
+import json
+
+import pytest
+
+from src.common.exceptions import StorageError, ValidationError
+from src.warehouse import inspect_worker_readiness as command
+
+WORKER = "inspection-worker"
+OBSERVED = "2026-06-01T12:00:00+00:00"
+
+
+def reader_result(status: str = "ready_sources") -> dict[str, Any]:
+    # Boundary fixture only. Real reader integration has its own wiring test.
+    snapshot = {
+        "model_version": "portfolio-risk-worker-readiness-snapshot-v1",
+        "worker_id": WORKER, "authority_transition_id": "authority-1",
+        "observed_at": OBSERVED, "outcome": status,
+        "snapshot_id": "snapshot-1", "current_authority_verified": False,
+        "failure_history_verified": False, "runtime_permission_granted": False,
+        "readiness": [{"execution_kind": "initial", "status": "allowed",
+                       "record_id": "record-1", "document_sha256": "a" * 64}],
+        "missing_execution_kinds": [], "blocking_reasons": [],
+    }
+    result = {
+        "model_version": "portfolio-risk-worker-readiness-read-v1",
+        "worker_id": WORKER, "observed_at": OBSERVED,
+        "database_read_performed": True, "single_statement_read_only": True,
+        **dict.fromkeys(command.NO_AUTHORITY_FLAGS, False),
+        "status": status, "authority_sequence": 1,
+        "authority_transition_id": "authority-1", "snapshot": snapshot,
+    }
+    if status == "blocked":
+        snapshot["missing_execution_kinds"] = ["retry"]
+        snapshot["blocking_reasons"] = ["readiness_missing:retry"]
+    elif status == "authority_missing":
+        result.update(authority_sequence=None, authority_transition_id=None, snapshot=None)
+    return result
+
+
+def test_default_does_not_read_environment_or_call_reader(monkeypatch: Any, capsys: Any) -> None:
+    class NoEnvironment(dict):
+        def get(self, key: str, default: Any = None) -> Any:
+            if key == "WAREHOUSE_POSTGRES_DSN":
+                raise AssertionError("credential lookup is forbidden")
+            return super().get(key, default)
+    def forbidden(**kwargs: Any) -> Any:
+        raise AssertionError("database access is forbidden")
+    monkeypatch.setattr(command, "_read", forbidden)
+    monkeypatch.setattr(command.os, "environ", NoEnvironment())
+    assert command.main(["--worker-id", WORKER]) == 0
+    result = json.loads(capsys.readouterr().out)
+    assert result["status"] == "not_requested"
+    assert result["database_read_attempted"] is False
+    assert result["database_read_completed"] is False
+
+
+@pytest.mark.parametrize("status,code", [("ready_sources", 0), ("blocked", 2), ("authority_missing", 2)])
+def test_explicit_read_uses_environment_and_projects_bounded_evidence(status: str, code: int, monkeypatch: Any, capsys: Any) -> None:
+    calls = []
+    value = reader_result(status)
+    value["private_provider_detail"] = "must-not-be-printed"
+    def read(**kwargs: Any) -> Any:
+        calls.append(kwargs)
+        return value
+    monkeypatch.setattr(command, "_read", read)
+    monkeypatch.setenv("INSPECTION_TEST_DSN", "synthetic")
+    assert command.main(["--worker-id", WORKER, "--read-database", "--dsn-env", "INSPECTION_TEST_DSN"]) == code
+    output = capsys.readouterr().out
+    result = json.loads(output)
+    assert calls == [{"dsn": "synthetic", "worker_id": WORKER}]
+    assert result["status"] == status
+    assert result["database_read_attempted"] is True
+    assert result["database_read_completed"] is True
+    assert all(result[flag] is False for flag in command.NO_AUTHORITY_FLAGS)
+    assert "snapshot" not in result and "synthetic" not in output
+    assert "must-not-be-printed" not in output
+
+
+@pytest.mark.parametrize("failure", [StorageError, ValidationError, RuntimeError, OSError])
+def test_provider_or_validation_failure_never_leaks_diagnostics(failure: Any, monkeypatch: Any, capsys: Any) -> None:
+    def fail(**kwargs: Any) -> Any:
+        raise failure("private-provider-detail")
+    monkeypatch.setattr(command, "_read", fail)
+    monkeypatch.setenv("WAREHOUSE_POSTGRES_DSN", "synthetic")
+    assert command.main(["--worker-id", WORKER, "--read-database"]) == 1
+    output = capsys.readouterr()
+    assert output.out == "" and "private-provider-detail" not in output.err
+    result = json.loads(output.err)
+    assert result["status"] == "failed" and result["database_read_attempted"] is True
+    assert result["database_read_completed"] is False
+
+
+@pytest.mark.parametrize("args", [
+    ["--worker-id", "not valid"], ["--worker-id", WORKER, "--dsn-env", "not-valid"],
+    ["--worker-id", WORKER, "--read-database"],
+])
+def test_invalid_selection_or_missing_configuration_stops_before_read(args: list[str], monkeypatch: Any, capsys: Any) -> None:
+    def fail(**kwargs: Any) -> Any:
+        raise AssertionError("reader must not run")
+    monkeypatch.setattr(command, "_read", fail)
+    monkeypatch.delenv("WAREHOUSE_POSTGRES_DSN", raising=False)
+    assert command.main(args) == 1
+    result = json.loads(capsys.readouterr().err)
+    assert result["database_read_attempted"] is False
+
+
+@pytest.mark.parametrize("change", [
+    "runtime", "database", "worker", "sequence", "missing-authority", "source-status",
+    "duplicate-kind", "missing-kind", "reason", "time", "snapshot-outcome", "digest",
+])
+def test_contradictory_reader_results_cannot_report_success(change: str) -> None:
+    value = reader_result()
+    if change == "runtime":
+        value["runtime_permission_granted"] = True
+    elif change == "database":
+        value["database_read_performed"] = 1
+    elif change == "worker":
+        value["worker_id"] = "other-worker"
+    elif change == "sequence":
+        value["authority_sequence"] = True
+    elif change == "missing-authority":
+        value["status"] = "authority_missing"
+    elif change == "source-status":
+        value["snapshot"]["readiness"][0]["status"] = "stale"
+    elif change == "duplicate-kind":
+        value["snapshot"]["readiness"] *= 2
+    elif change == "missing-kind":
+        value["snapshot"]["missing_execution_kinds"] = ["retry"]
+    elif change == "reason":
+        value["snapshot"]["blocking_reasons"] = ["private-provider-detail"]
+    elif change == "time":
+        value["snapshot"]["observed_at"] = "2026-06-01T12:00:01+00:00"
+    elif change == "snapshot-outcome":
+        value["snapshot"]["outcome"] = "blocked"
+    else:
+        value["snapshot"]["readiness"][0]["document_sha256"] = "invalid"
+    with pytest.raises(ValidationError):
+        command._summary(value, worker_id=WORKER)
+
+
+def test_summary_does_not_mutate_reader_evidence() -> None:
+    value = reader_result("blocked")
+    before = deepcopy(value)
+    report = command._summary(value, worker_id=WORKER)
+    assert value == before
+    value["snapshot"]["readiness"][0]["record_id"] = "mutated"
+    assert report["readiness"][0]["record_id"] == "record-1"
+
+
+def test_help_does_not_resolve_database_dependency(monkeypatch: Any, capsys: Any) -> None:
+    def fail(**kwargs: Any) -> Any:
+        raise AssertionError("reader must not run")
+    monkeypatch.setattr(command, "_read", fail)
+    with pytest.raises(SystemExit) as caught:
+        command.main(["--help"])
+    assert caught.value.code == 0
+    assert "--read-database" in capsys.readouterr().out
+
+
+def test_unrecognised_arguments_are_not_echoed(capsys: Any) -> None:
+    with pytest.raises(SystemExit) as caught:
+        command.main(["--worker-id", WORKER, "--dsn", "private-connection-detail"])
+    assert caught.value.code == 2
+    assert "private-connection-detail" not in capsys.readouterr().err

--- a/tests/unit/test_worker_readiness_inspection_wiring.py
+++ b/tests/unit/test_worker_readiness_inspection_wiring.py
@@ -19,7 +19,8 @@ def test_command_reuses_real_reader_and_semantic_source_validation(tamper: bool,
     class Connection:
         closed = False
         autocommit = True
-        info = cursor.connection.info
+        def __init__(self) -> None:
+            self.info = cursor.connection.info
         def __enter__(self) -> Connection:
             return self
         def __exit__(self, *args: Any) -> None:

--- a/tests/unit/test_worker_readiness_inspection_wiring.py
+++ b/tests/unit/test_worker_readiness_inspection_wiring.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+
+from src.warehouse import inspect_worker_readiness as command
+from src.warehouse import notification_worker_readiness_reader as reader
+from test_worker_readiness_reader import Cursor, envelope
+
+
+@pytest.mark.parametrize("tamper", [False, True])
+def test_command_reuses_real_reader_and_semantic_source_validation(tamper: bool, monkeypatch: Any, capsys: Any) -> None:
+    value = envelope()
+    if tamper:
+        value[5][0]["document_sha256"] = "0" * 64
+    cursor = Cursor(value)
+    class Connection:
+        closed = False
+        autocommit = True
+        info = cursor.connection.info
+        def __enter__(self) -> Connection:
+            return self
+        def __exit__(self, *args: Any) -> None:
+            self.closed = True
+        def cursor(self) -> Cursor:
+            cursor.connection = self
+            return cursor
+    connection = Connection()
+    monkeypatch.setattr(reader, "_connect", lambda dsn: connection)
+    monkeypatch.setenv("WAREHOUSE_POSTGRES_DSN", "synthetic")
+    # Do not mock command._read, the snapshot builder or semantic validators.
+    code = command.main(["--worker-id", "authority-worker", "--read-database"])
+    output = capsys.readouterr()
+    assert code == (1 if tamper else 0)
+    report = json.loads(output.err if tamper else output.out)
+    assert report["status"] == ("failed" if tamper else "ready_sources")
+    assert connection.closed is True
+    assert len(cursor.calls) == 4
+    assert cursor.calls[-1] == (reader.READINESS_SOURCE_SQL, ("authority-worker",))
+    assert report["runtime_permission_granted"] is False
+    assert report["failure_history_verified"] is False
+    if not tamper:
+        assert [row["execution_kind"] for row in report["readiness"]] == ["initial", "retry"]
+        assert "record" not in report and "snapshot" not in report


### PR DESCRIPTION
## Goal and dependency

Refs #204; roadmap #76. Primary arc42 block: `warehouse`.

Expose the existing readiness-source reader through an opt-in inspection command. Dependency order: **#178 → #180 → repaired #183 → #202 → #206**. This does not import or duplicate the separate preflight-diagnostics or suspension implementations.

## Behaviour

- Default and --help perform no database access. The default does not look up credentials or import the database reader.
- --read-database explicitly delegates to the existing single-statement read-only reader for one worker.
- --dsn-env names an environment variable; no DSN value argument or default connection value is added.
- Output projects bounded authority/snapshot/record references, per-kind statuses, missing kinds and allow-listed reasons, not full source documents, connection values or raw provider diagnostics.
- Contradictory identities, unknown statuses, duplicate kinds, invalid digests and false ready outcomes are rejected.
- Reports distinguish no read, validated completion and failed attempted reads. Failure-history verification and runtime permission always remain false.
- Argument abbreviations are disabled; argument-parser errors do not echo supplied values.

## Exact final candidate

```text
Base #202:    aa8dbdf3f13ca52f6975f324a07ab71f99e7e531
Head:         5bd273960b908a91d00fc7210c483404afb28238
Tree:         cc9de530bb7dff14043e87053b92eeb0e38188db
CI checkout:  bfd85e85edea8448695abc8390eedad6b78bbd35
Scope:        4 additive paths; 460 additions; 0 deletions; 3 commits
```

Paths: command, focused tests, real-reader wiring tests and operating document.

## Validation

[CI run 482](https://github.com/alexmarinos87/financial-risk-data-platform/actions/runs/34063745412) passed all four jobs: **Python readiness, PostgreSQL contract, Security guardrails and Infrastructure validation**. The final Python log confirms **1,308 tests passed twice**, Ruff, mypy across **166 source files**, dependency integrity, pipeline demo and warehouse dry-run. Its checkout explicitly combines this final head with the intended #202 base.

**GitGuardian check 101568781737 passed** with no secrets detected across all three candidate commits.

This PR adds **28 test cases**: 26 focused command cases and two wiring cases. The wiring cases use the actual reader, snapshot builder and semantic record validators, replacing only the database connection. Valid records report both execution kinds; a changed stored digest fails. All remain enabled and passed in CI.

Locally, the 26 command cases and preceding 54 JSON/session cases were rerun after the final edits: **80 passed**. Default command and --help were also exercised without a database dependency. The two full-dependency wiring cases, complete repository suite, Ruff, mypy, infrastructure and real PostgreSQL execution ran in CI, not the incomplete local source subset.

## Findings resolved

- A local regression test exposed argparse accepting --dsn as an abbreviation for --dsn-env; abbreviations were disabled before publication.
- Self-review identified class-scope shadowing in the wiring fixture; connection state initialization was moved into __init__.
- The parser error override was annotated NoReturn to match its inherited non-returning contract.

Final validation is tied to the corrected head above, not either earlier candidate. No tests were disabled to obtain passing results.

## Review, boundaries and acceptance

Self-review covered opt-in access, lazy imports, credential indirection, error sanitization, per-kind report coherence, evidence projection and no permission promotion. No discussion/review comments were returned at inspection. **Independent review and exact-diff human acceptance remain pending.**

The command changes no database records, schema, workflow, dependency, authority or scheduler state. Database reads occur only when explicitly selected against an operator-authorized DSN. The presentation layer trusts the existing source reader; it is not independent source attestation or authentication. No provider request, notification, deployment or Terraform apply occurs.

Exit 0 means no read requested or ready source evidence; inspect status. Exit 2 means blocked/missing evidence or argument-parser rejection. Exit 1 means configuration/read/report failure. None grants execution permission or verifies per-worker failure history.

**Draft and unmerged.** Goal #204 stays open pending acceptance and integration. After each predecessor's accepted squash merge, reconstruct the next isolated delta on accepted main, rerun full CI and obtain exact-diff acceptance. Do not merge into unaccepted predecessor branches.